### PR TITLE
fix: no waku when wasm

### DIFF
--- a/bin/waku-swarm-relay/Cargo.toml
+++ b/bin/waku-swarm-relay/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[target.'cfg(not(target_arch = "wasm32"))'.bin.waku-swarm-rely]
+path = "src/main.rs"
+
 [dependencies]
 once_cell = { workspace = true }
 dotenv = { workspace = true }


### PR DESCRIPTION
This PR:

1. Enforces that `waku-swarm-relay` **NOT** be built when the target is `wasm32`.