### PR TITLE
feat: postage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,6 +2282,21 @@ dependencies = [
 [[package]]
 name = "postage"
 version = "0.1.0"
+dependencies = [
+ "bmt",
+ "chrono",
+ "ethers-core",
+ "ethers-signers",
+ "hex",
+ "lazy_static",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -3438,6 +3463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,7 +3751,11 @@ name = "wasm-playground"
 version = "0.1.0"
 dependencies = [
  "bmt",
+ "console_error_panic_hook",
  "hex",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-wasm",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ethers-contract = { version = "2.0.7", default-features = false }
 
 ## misc
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter", "ansi", "fmt", "std", "json",] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "ansi", "fmt", "std", "json", "time"] }
 thiserror = "1.0.32"
 serde_json = "1.0.82"
 serde = { version = "1.0.140", features = ["derive"] }
@@ -57,7 +57,7 @@ hex = "0.4.3"
 
 ## tokio
 tokio-stream = "0.1.14"
-tokio = { version = "1.28.1", default-features = false }
+tokio = { version = "1.28.1", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7.8", features = ["codec"] }
 
 ## async

--- a/bin/waku-swarm-relay/Cargo.toml
+++ b/bin/waku-swarm-relay/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[target.'cfg(not(target_arch = "wasm32"))'.bin.waku-swarm-rely]
+[target.'cfg(not(target_arch = "wasm32"))'.bin]
 path = "src/main.rs"
 
 [dependencies]

--- a/bin/waku-swarm-relay/src/main.rs
+++ b/bin/waku-swarm-relay/src/main.rs
@@ -5,8 +5,8 @@ use clap::Parser;
 use ethers_signers::{LocalWallet, Signer};
 use tracing::{debug, error, info};
 use waku_bindings::{
-    waku_new, waku_set_event_callback, Encoding, Multiaddr, Running,
-    WakuContentTopic, WakuLogLevel, WakuMessage, WakuNodeConfig, WakuNodeHandle, WakuPubSubTopic,
+    waku_new, waku_set_event_callback, Encoding, Multiaddr, Running, WakuContentTopic,
+    WakuLogLevel, WakuMessage, WakuNodeConfig, WakuNodeHandle, WakuPubSubTopic,
 };
 
 use std::sync::Arc;

--- a/bin/wasm-playground/src/lib.rs
+++ b/bin/wasm-playground/src/lib.rs
@@ -12,9 +12,17 @@ fn main() -> Result<(), JsValue> {
     let document = web_sys::window().unwrap().document().unwrap();
 
     // Create a new div element to contain the input and button
-    let container_div = document.create_element("div").unwrap().dyn_into::<HtmlDivElement>().unwrap();
+    let container_div = document
+        .create_element("div")
+        .unwrap()
+        .dyn_into::<HtmlDivElement>()
+        .unwrap();
     container_div.set_id("container_div");
-    document.body().unwrap().append_child(&container_div).unwrap();
+    document
+        .body()
+        .unwrap()
+        .append_child(&container_div)
+        .unwrap();
 
     // Create a label for the input area
     let label = document.create_element("label").unwrap();
@@ -22,21 +30,38 @@ fn main() -> Result<(), JsValue> {
     container_div.append_child(&label).unwrap();
 
     // Create an input text area
-    let input = document.create_element("input").unwrap().dyn_into::<HtmlInputElement>().unwrap();
+    let input = document
+        .create_element("input")
+        .unwrap()
+        .dyn_into::<HtmlInputElement>()
+        .unwrap();
     input.set_id("input_text");
     container_div.append_child(&input).unwrap();
 
     // Create a "Calculate" button
-    let button = document.create_element("button").unwrap().dyn_into::<HtmlButtonElement>().unwrap();
+    let button = document
+        .create_element("button")
+        .unwrap()
+        .dyn_into::<HtmlButtonElement>()
+        .unwrap();
     button.set_inner_text("Calculate");
     container_div.append_child(&button).unwrap();
 
     info!("Created input and button elements");
+
     let closure = Closure::wrap(Box::new(move |_event: Event| {
         // Build a chunk with the input text. The chunk size is 4096 bytes.
-        let f = bmt::file::ChunkedFile::new(input.value().as_bytes().to_vec(), bmt::chunk::Options { max_payload_size: 4096 });
+        let f = bmt::file::ChunkedFile::new(
+            input.value().as_bytes().to_vec(),
+            bmt::chunk::Options {
+                max_payload_size: 4096,
+            },
+        );
         // Display the swarm hash
-        window().unwrap().alert_with_message(&format!("Swarm hash: {:?}", hex::encode(f.address()))).unwrap();
+        window()
+            .unwrap()
+            .alert_with_message(&format!("Swarm hash: {:?}", hex::encode(f.address())))
+            .unwrap();
 
         // Display the leaf chunks with their contents and hashes in an alert window
         let chunks = f.leaf_chunks();

--- a/crates/bmt/src/file.rs
+++ b/crates/bmt/src/file.rs
@@ -50,7 +50,12 @@ impl ChunkedFile {
                             break;
                         }
 
-                        chunks.push(Chunk::new(&mut chunk_payload, None, Options::default()));
+                        chunks.push(Chunk::new(
+                            &mut chunk_payload,
+                            None,
+                            Options::default(),
+                            None,
+                        ));
 
                         chunk_payload_length
                     }
@@ -64,7 +69,7 @@ impl ChunkedFile {
         chunks
     }
 
-    pub fn address(&self) -> Vec<u8> {
+    pub fn address(&self) -> [u8; 32] {
         Self::bmt_root_chunk(&mut self.leaf_chunks()).address()
     }
 
@@ -330,7 +335,12 @@ impl ChunkedFile {
                 },
             );
 
-        Chunk::new(&mut chunk_addresses, Some(chunk_span_sum_values), options)
+        Chunk::new(
+            &mut chunk_addresses,
+            Some(chunk_span_sum_values),
+            options,
+            None,
+        )
     }
 
     pub fn pop_carrier_chunk(chunks: &mut Vec<Chunk>) -> Option<Chunk> {
@@ -452,7 +462,7 @@ mod tests {
 
         assert_eq!(
             &comp_payload,
-            &(only_chunk.payload())[0..only_chunk.span().value() as usize]
+            &(only_chunk.data())[0..only_chunk.span().value() as usize]
         );
         assert_eq!(only_chunk.span().to_bytes(), EXPECTED_SPAN);
         assert_eq!(only_chunk.span().value(), chunked_file.span.value());
@@ -483,17 +493,11 @@ mod tests {
             4096 * (4096 / SEGMENT_SIZE)
         ); // 524288
 
-        assert_eq!(
-            root_chunk.payload()[0..32],
-            second_level_first_chunk.address()
-        );
-        assert_eq!(second_level_first_chunk.payload().len(), 4096);
+        assert_eq!(root_chunk.data()[0..32], second_level_first_chunk.address());
+        assert_eq!(second_level_first_chunk.data().len(), 4096);
 
         // encapsulated address has to be the same to the corresponding children chunk's address
-        assert_eq!(
-            second_level_first_chunk.payload()[0..32],
-            tree[0][0].address()
-        );
+        assert_eq!(second_level_first_chunk.data()[0..32], tree[0][0].address());
 
         // last rootchunk data
         assert_eq!(

--- a/crates/bmt/src/lib.rs
+++ b/crates/bmt/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(test)]
+
 use tiny_keccak::{Hasher, Keccak};
 
 pub mod chunk;

--- a/crates/bmt/src/span.rs
+++ b/crates/bmt/src/span.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, Clone)]
 pub struct Span {
     value: u64,
 }
@@ -18,12 +19,6 @@ impl Span {
 
     pub fn to_bytes(&self) -> [u8; 8] {
         self.value.to_le_bytes()
-    }
-}
-
-impl Clone for Span {
-    fn clone(&self) -> Self {
-        Self { value: self.value }
     }
 }
 

--- a/crates/postage/Cargo.toml
+++ b/crates/postage/Cargo.toml
@@ -6,3 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bmt = { path = "../bmt" }
+chrono = { workspace = true }
+ethers-core = { workspace = true }
+ethers-signers = { workspace = true }
+hex = { workspace = true }
+once_cell = { workspace = true }
+lazy_static = "1.4.0"
+tiny-keccak = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -1,0 +1,122 @@
+use ethers_core::types::{Address, U256};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info, trace, warn};
+
+use crate::stamp::{MarshalledStamp, Stamp, StampError, StampValidator, ValidateStamp};
+use bmt::chunk::Chunk;
+
+pub type BatchId = [u8; 32];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Batch {
+    pub id: BatchId,                // the batch id
+    value: u128,                    // normalised balance of the batch
+    pub block_created: Option<u64>, // block number the batch was created
+    pub owner: Address,             // owner of the batch
+    pub depth: u32,                  // depth of the batch
+    pub bucket_depth: u32,           // depth of the bucket
+    pub immutable: bool,            // whether the batch is immutable
+}
+
+impl Batch {
+    pub fn new(
+        id: BatchId,
+        value: u128,
+        start: Option<u64>,
+        owner: Address,
+        depth: u32,
+        bucket_depth: u32,
+        immutable: bool,
+    ) -> Self {
+        Self {
+            id,
+            value,
+            block_created: start,
+            owner,
+            depth,
+            bucket_depth,
+            immutable,
+        }
+    }
+
+    pub fn id(&self) -> BatchId {
+        self.id
+    }
+
+    pub fn owner(&self) -> Address {
+        self.owner
+    }
+
+    pub fn depth(&self) -> u32 {
+        self.depth
+    }
+
+    pub fn bucket_depth(&self) -> u32 {
+        self.bucket_depth
+    }
+}
+
+/// An error involving the batch store
+#[derive(Debug, Error)]
+pub enum BatchStoreError {
+    /// When a batch is not found
+    #[error("Batch not found")]
+    BatchNotFound(BatchId),
+}
+
+pub(crate) struct Store {
+    pub batches: Arc<Mutex<HashMap<BatchId, Batch>>>,
+}
+
+impl Store {
+    pub fn new() -> Self {
+        Self {
+            batches: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn load(batches: HashMap<BatchId, Batch>) -> Self {
+        Self {
+            batches: Arc::new(Mutex::new(batches)),
+        }
+    }
+
+    pub fn get(&self, id: BatchId) -> Option<Batch> {
+        self.batches.lock().unwrap().get(&id).cloned()
+    }
+
+    pub fn insert(&self, batch: Batch) {
+        self.batches.lock().unwrap().insert(batch.id, batch);
+    }
+
+    pub fn exists(&self, id: BatchId) -> bool {
+        self.batches.lock().unwrap().contains_key(&id)
+    }
+}
+
+impl StampValidator for Store {
+    fn validate_stamp<'a>(&'a self) -> ValidateStamp<'a> {
+        let store = self.clone();
+        Box::new(move |chunk: &mut Chunk, stamp: MarshalledStamp| {
+            let stamp = Stamp::from(stamp);
+            match store.get(stamp.batch()) {
+                Some(batch) => {
+                    match stamp.valid(chunk, batch.owner, batch.depth, batch.bucket_depth) {
+                        Ok(_valid) => {
+                            chunk.add_stamp(stamp.into());
+                            Ok(())
+                        }
+                        Err(e) => Err(e),
+                    }
+                }
+                None => {
+                    error!("Batch not found: {:?}", stamp.batch());
+                    Err(StampError::BatchNotFound(stamp.batch()))
+                }
+            }
+        })
+    }
+}

--- a/crates/postage/src/batch.rs
+++ b/crates/postage/src/batch.rs
@@ -1,8 +1,8 @@
 use ethers_core::types::{Address, U256};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
-use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::stamp::{MarshalledStamp, Stamp, StampError, StampValidator, ValidateStamp};
@@ -16,8 +16,8 @@ pub(crate) struct Batch {
     value: u128,                    // normalised balance of the batch
     pub block_created: Option<u64>, // block number the batch was created
     pub owner: Address,             // owner of the batch
-    pub depth: u32,                  // depth of the batch
-    pub bucket_depth: u32,           // depth of the bucket
+    pub depth: u32,                 // depth of the batch
+    pub bucket_depth: u32,          // depth of the bucket
     pub immutable: bool,            // whether the batch is immutable
 }
 

--- a/crates/postage/src/lib.rs
+++ b/crates/postage/src/lib.rs
@@ -1,14 +1,6 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+#![feature(async_closure)]
+#![feature(associated_type_bounds)]
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod batch;
+pub mod pat;
+pub mod stamp;

--- a/crates/postage/src/pat.rs
+++ b/crates/postage/src/pat.rs
@@ -1,0 +1,184 @@
+use std::{borrow::BorrowMut, future::Future, pin::Pin, result};
+use thiserror::Error;
+use tracing::{debug, error, info, trace, warn};
+use serde::{Deserialize, Serialize};
+// use serde_json::Result;
+use ethers_signers::{LocalWallet, Signer, WalletError};
+
+use crate::{batch::{Batch, BatchId, Store}, stamp::Stamp};
+use bmt::chunk::Chunk;
+
+/// An error involving Postman Pat 📬
+#[derive(Debug, Error)]
+pub enum PatError {
+    /// The chunk address does not match the bucket
+    #[error("bucket full")]
+    BucketFull(),
+    /// When a batch isn't found in the store
+    #[error("batch not found")]
+    BatchNotFound(BatchId),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Pat {
+    batch_id: BatchId,          // the batch id
+    batch_amount: u128,         // the amount paid for the batch
+    #[serde(skip_serializing)]
+    batch_depth: u32,            // batch depth: batch size = 2^{batch_depth}
+    #[serde(skip_serializing)]
+    batch_bucket_depth: u32,     // bucket depth: the depth of collision buckets uniformity
+    buckets: Vec<u32>,           // Collision buckets: counts per neighbourhoods (limited to 2^{batchDepth-bucketDepth})
+    max_bucket_depth: u32,       // the depth of the fullest bucket
+    #[serde(skip_serializing)]
+    block_created: Option<u64>, // the block number when this batch was created
+    #[serde(skip_serializing)]
+    immutable: bool,            // whether the batch is immutable
+    #[serde(skip_serializing)]
+    expired: bool,              // whether the batch is expired
+    #[serde(skip_serializing)]
+    #[serde(skip_deserializing)]
+    signer: Option<LocalWallet>,             // the signer
+}
+
+impl Pat {
+    fn new(batch: &Batch, batch_amount: u128, expired: bool, signer: LocalWallet) -> Self {
+        Self {
+            batch_id: batch.id,
+            batch_amount,
+            batch_depth: batch.depth,
+            batch_bucket_depth: batch.bucket_depth,
+            buckets: vec![0; 2usize.pow(batch.bucket_depth as u32)],
+            max_bucket_depth: 0,
+            block_created: batch.block_created,
+            immutable: batch.immutable,
+            expired,
+            signer: Some(signer),
+        }
+    }
+
+    pub fn inc(&mut self, chunk: &Chunk) -> std::result::Result<(u32, u32), PatError> {
+        // get which bucket the chunk belongs to
+        let x = chunk.get_x(self.batch_bucket_depth);
+        let upper_bound = self.bucket_upper_bound();
+        let count = self.buckets[x as usize].borrow_mut();
+
+        // check if the bucket is full
+        if (*count as u32) == upper_bound {
+            // check if immutable
+            if self.immutable {
+                return Err(PatError::BucketFull());
+            }
+
+            *count = 0;
+        }
+
+        // increment the bucket
+        *count += 1;
+        if *count > self.max_bucket_depth {
+            self.max_bucket_depth = *count;
+        }
+
+        return Ok((x, (*count).into()));
+    }
+
+    pub async fn stamp<'a>(
+        &'a mut self,
+        mut chunk: Chunk,
+    ) -> std::result::Result<Chunk, PatError> {
+        let (x, y) = self.inc(&chunk)?;
+    
+        let timestamp = chrono::Utc::now().timestamp_nanos() as u64;
+    
+        let signer = self.signer.as_ref().expect("Signer is not set");
+    
+        let stamp = Stamp::new(
+            &chunk,
+            self.batch_id,
+            x,
+            y,
+            timestamp,
+            Box::new(move |digest| {
+                let signer = signer.clone();
+                Box::pin(async move {
+                    let result = signer.sign_message(&digest).await?;
+                    let result: [u8; 65] = result
+                        .to_vec()
+                        .as_slice()
+                        .try_into()?;
+                    Ok(result)
+                }) as Pin<Box<dyn Future<Output = Result<[u8; 65], Box<dyn std::error::Error + 'a>>>>>
+            }),
+        )
+        .await;
+    
+        chunk.add_stamp(stamp.into());
+        Ok(chunk)
+    }
+
+    pub fn utilization(&self) -> u32 {
+        self.max_bucket_depth as u32
+    }
+
+    pub fn bucket_upper_bound(&self) -> u32 {
+        1 << (self.batch_depth - self.batch_bucket_depth)
+    }
+
+    pub fn set_expired(&mut self) {
+        self.expired = true;
+    }
+
+    pub fn rehydrate(&mut self, store: &Store, signer: LocalWallet) -> std::result::Result<(), PatError> {
+        let batch = store.get(self.batch_id).ok_or(PatError::BatchNotFound(self.batch_id))?;
+        self.batch_depth = batch.depth;
+        self.batch_bucket_depth = batch.bucket_depth;
+        self.block_created = batch.block_created;
+        self.immutable = batch.immutable;
+        Ok(())
+    }
+}
+
+pub(crate) trait BucketSeeker {
+    fn get_x(&self, bucket_depth: u32) -> u32;
+}
+
+impl BucketSeeker for Chunk {
+    fn get_x(&self, bucket_depth: u32) -> u32 {
+        // let i be t interpreted as a big endian integer
+        let i = u32::from_be_bytes(self.address()[0..4].to_vec().try_into().unwrap());
+        return i >> (32 - bucket_depth);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, io::Read};
+
+    use bmt::chunk::Options;
+    use ethers_core::{rand::{self, Rng}, types::Address};
+    use hex::ToHex;
+    // extern crate test;
+    use super::*;
+    // use test::Bencher;
+
+    #[tokio::test]
+    async fn can_stamp() {
+        let chunks = bmt::file::ChunkedFile::new("hello world".as_bytes().to_vec(), Options::default());
+        let chunk = chunks.leaf_chunks()[0].clone();
+
+        let batch_id = hex::decode("c3387832bb1b88acbcd0ffdb65a08ef077d98c08d4bee576a72dbe3d36761369").unwrap();
+        // convert batch_id to [u8; 32]
+        let mut batch_id_arr = [0u8; 32];
+        batch_id_arr.copy_from_slice(&batch_id);
+
+        let wallet = "be52c649a4c560a1012daa572d4e81627bcce20ca14e007aef87808a7fadd3d0".parse::<LocalWallet>().unwrap();
+
+        // create a batch
+        let batch = Batch::new(batch_id_arr, 0, None, Address::zero(), 18, 16, false);
+        let mut pat = Pat::new(&batch, 0, false, wallet);
+
+        let chunk = pat.stamp(chunk).await.unwrap();
+
+        println!("chunk address: {}", chunk.address().encode_hex::<String>());
+        println!("chunk stamps: {:?}", chunk.stamp().unwrap().encode_hex::<String>());
+    }
+}

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -1,7 +1,10 @@
-use std::{pin::Pin, future::Future};
+use std::{future::Future, pin::Pin};
 
 use crate::{batch::BatchId, pat::BucketSeeker};
-use ethers_core::{abi::Address, types::{Signature, H256}};
+use ethers_core::{
+    abi::Address,
+    types::{Signature, H256},
+};
 use thiserror::Error;
 use tiny_keccak::{Hasher, Keccak};
 use tracing::{debug, error, info, trace, warn};
@@ -59,14 +62,20 @@ impl Stamp {
         sig_fn: F,
     ) -> Self
     where
-        F: 'a + Fn([u8; 32]) -> Pin<Box<dyn Future<Output = Result<[u8; 65], Box<dyn std::error::Error + 'a>>>>>,
+        F: 'a
+            + Fn(
+                [u8; 32],
+            )
+                -> Pin<Box<dyn Future<Output = Result<[u8; 65], Box<dyn std::error::Error + 'a>>>>>,
     {
         Self {
             batch,
             x,
             y,
             timestamp,
-            sig: (sig_fn)(Self::digest(&chunk, batch, x, y, timestamp)).await.unwrap(),
+            sig: (sig_fn)(Self::digest(&chunk, batch, x, y, timestamp))
+                .await
+                .unwrap(),
         }
     }
 

--- a/crates/postage/src/stamp.rs
+++ b/crates/postage/src/stamp.rs
@@ -1,0 +1,268 @@
+use std::{pin::Pin, future::Future};
+
+use crate::{batch::BatchId, pat::BucketSeeker};
+use ethers_core::{abi::Address, types::{Signature, H256}};
+use thiserror::Error;
+use tiny_keccak::{Hasher, Keccak};
+use tracing::{debug, error, info, trace, warn};
+
+use bmt::chunk::Chunk;
+
+// Define a type alias for a closure that takes a chunk + stamp, and modifies the chunk
+// to include the stamp if it is valid
+pub type ValidateStamp<'a> =
+    Box<dyn FnMut(&mut Chunk, MarshalledStamp) -> Result<(), StampError> + 'a>;
+
+pub type MarshalledStamp = [u8; 113];
+
+pub trait StampValidator {
+    fn validate_stamp<'a>(&'a self) -> ValidateStamp<'a>;
+}
+
+/// An error involving a stamp
+#[derive(Debug, Error)]
+pub enum StampError {
+    /// Invalid signature
+    #[error("owner mismatch, expected {0}, got {1}")]
+    OwnerMismatch(Address, Address),
+    /// Invalid index
+    /// The index is equal to a two `u32` concatenated together where the first `u32` is the
+    /// bucket and the second `u32` is the index in the bucket
+    #[error("invalid index")]
+    InvalidIndex(),
+    /// The chunk address does not match the bucket
+    #[error("bucket mismatch")]
+    BucketMismatch(),
+    /// When a batch isn't found in the store
+    #[error("batch not found")]
+    BatchNotFound(BatchId),
+}
+
+/// A `Stamp` represents the proof of postage for a chunk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Stamp {
+    batch: BatchId, // the batch id
+    x: u32,         // which collision bucket the chunk is in
+    y: u32,         // where in bucket the chunk is
+    timestamp: u64, // timestamp of the stamp
+    sig: [u8; 65],  // signature of the stamp
+}
+
+// Define a type alias for a closure that takes a digest and returns a signature
+impl Stamp {
+    pub async fn new<'a, F>(
+        chunk: &Chunk,
+        batch: BatchId,
+        x: u32,
+        y: u32,
+        timestamp: u64,
+        sig_fn: F,
+    ) -> Self
+    where
+        F: 'a + Fn([u8; 32]) -> Pin<Box<dyn Future<Output = Result<[u8; 65], Box<dyn std::error::Error + 'a>>>>>,
+    {
+        Self {
+            batch,
+            x,
+            y,
+            timestamp,
+            sig: (sig_fn)(Self::digest(&chunk, batch, x, y, timestamp)).await.unwrap(),
+        }
+    }
+
+    /// Returns the hash of the stamp to be signed
+    /// This is equal to H(chunkAddr || batchId || sillyIndex || timestamp)
+    pub fn digest(chunk: &Chunk, batch: BatchId, x: u32, y: u32, timestamp: u64) -> BatchId {
+        let mut hasher = Keccak::v256();
+        hasher.update(&chunk.address().as_slice());
+        hasher.update(&batch);
+        hasher.update(&Self::silly_index(x, y).to_be_bytes());
+        hasher.update(&timestamp.to_be_bytes());
+        let mut digest = [0u8; 32];
+        hasher.finalize(&mut digest);
+        digest
+    }
+
+    /// This is equal to a two `u32` concatenated
+    /// The first `u32` is the bucket (`x`)
+    /// The second `u32` is the bucket index (`y`)
+    fn silly_index(x: u32, y: u32) -> u64 {
+        let mut bytes = [0u8; 8];
+        bytes[..4].copy_from_slice(&x.to_be_bytes());
+        bytes[4..].copy_from_slice(&y.to_be_bytes());
+        u64::from_be_bytes(bytes)
+    }
+
+    pub fn valid(&self, chunk: &Chunk, owner: Address, x: u32, y: u32) -> Result<bool, StampError> {
+        // check `x` - we are in the correct bucket
+        if self.x != chunk.get_x(y) {
+            return Err(StampError::BucketMismatch());
+        }
+
+        // check `y` does not exceed the max number of chunks in a bucket
+        // this is equal to 2^(depth - bucket_depth) and is zero indexed
+        if self.y >= 1 << (x - y) {
+            return Err(StampError::InvalidIndex());
+        }
+
+        let digest = Self::digest(chunk, self.batch, self.x, self.y, self.timestamp);
+
+        // verify the signature
+        // using unwrap() here is safe because we know the signature is 65 bytes
+        Signature::try_from(self.sig.as_slice())
+            .unwrap()
+            .recover(digest)
+            .map_err(|_| StampError::InvalidIndex())
+            .and_then(|recovered| {
+                if owner == recovered {
+                    Ok(true)
+                } else {
+                    Err(StampError::OwnerMismatch(owner, recovered))
+                }
+            })
+    }
+
+    pub fn batch(&self) -> [u8; 32] {
+        self.batch
+    }
+}
+
+impl From<Stamp> for MarshalledStamp {
+    fn from(stamp: Stamp) -> Self {
+        let mut bytes = [0u8; 113];
+        bytes[..32].copy_from_slice(&stamp.batch);
+        bytes[32..36].copy_from_slice(&stamp.x.to_be_bytes());
+        bytes[36..40].copy_from_slice(&stamp.y.to_be_bytes());
+        bytes[40..48].copy_from_slice(&stamp.timestamp.to_be_bytes());
+        bytes[48..113].copy_from_slice(&stamp.sig.to_vec().as_slice());
+        bytes
+    }
+}
+
+impl From<MarshalledStamp> for Stamp {
+    fn from(bytes: MarshalledStamp) -> Self {
+        let mut batch = [0u8; 32];
+        batch.copy_from_slice(&bytes[..32]);
+        let x = u32::from_be_bytes(bytes[32..36].try_into().unwrap());
+        let y = u32::from_be_bytes(bytes[36..40].try_into().unwrap());
+        let timestamp = u64::from_be_bytes(bytes[40..48].try_into().unwrap());
+        let mut sig = [0u8; 65];
+        sig.copy_from_slice(&bytes[48..113]);
+        Self {
+            batch,
+            x,
+            y,
+            timestamp,
+            sig,
+        }
+    }
+}
+
+impl From<Stamp> for Vec<u8> {
+    fn from(stamp: Stamp) -> Self {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&stamp.batch);
+        bytes.extend_from_slice(&stamp.x.to_be_bytes());
+        bytes.extend_from_slice(&stamp.y.to_be_bytes());
+        bytes.extend_from_slice(&stamp.timestamp.to_be_bytes());
+        bytes.extend_from_slice(&stamp.sig.to_vec().as_slice());
+        bytes
+    }
+}
+
+impl From<Vec<u8>> for Stamp {
+    fn from(bytes: Vec<u8>) -> Self {
+        let mut batch = [0u8; 32];
+        batch.copy_from_slice(&bytes[..32]);
+        let x = u32::from_be_bytes(bytes[32..36].try_into().unwrap());
+        let y = u32::from_be_bytes(bytes[36..40].try_into().unwrap());
+        let timestamp = u64::from_be_bytes(bytes[40..48].try_into().unwrap());
+        let mut sig = [0u8; 65];
+        sig.copy_from_slice(&bytes[48..113]);
+        Self {
+            batch,
+            x,
+            y,
+            timestamp,
+            sig: sig.try_into().unwrap(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lazy_static::lazy_static;
+
+    lazy_static! {
+        static ref BATCH_ID: Vec<u8> = hex::decode("c3387832bb1b88acbcd0ffdb65a08ef077d98c08d4bee576a72dbe3d36761369").unwrap();
+        static ref STAMP_MARSHALLED: Vec<u8> = hex::decode("c3387832bb1b88acbcd0ffdb65a08ef077d98c08d4bee576a72dbe3d367613690000cbe5000000000000018921ff0dbb29169df9e6364e26c6ca6b17745c10b9d6a36ea38e204f2e3cc64a8373c0661f5bb0a347c61d8d1689b0dcf8354117686a6a18d08cff927f526de5fc61b2b7491b").unwrap();
+        static ref ADDRESS: Vec<u8> = hex::decode("cbe563e4865fd01948a1180081bbb7e144204344012dea8ce6e86d36dbc63495").unwrap();
+        static ref PAYLOAD: Vec<u8> = hex::decode("0b0000000000000068656c6c6f20776f72646c").unwrap();
+        static ref BUCKET_INDEX: u32 = 0;
+        static ref BUCKET: u32 = 52197;
+        static ref TIMESTAMP: u64 = 1688492510651;
+    }
+
+    // const expectedChunkedStamped_0 = [
+    //     {
+    //       address: "cbe563e4865fd01948a1180081bbb7e144204344012dea8ce6e86d36dbc63495",
+    //       payload: Buffer.from("0b0000000000000068656c6c6f20776f72646c", "hex"),
+    //       stamp: Buffer.from("c3387832bb1b88acbcd0ffdb65a08ef077d98c08d4bee576a72dbe3d367613690000cbe5000000000000018921ff0dbb29169df9e6364e26c6ca6b17745c10b9d6a36ea38e204f2e3cc64a8373c0661f5bb0a347c61d8d1689b0dcf8354117686a6a18d08cff927f526de5fc61b2b7491b", "hex")
+    //     }
+    //   ]
+
+    // test('chunkerStampers', async () => {
+    //     const timeStamp = 1688492510651;
+    //     const payload = Buffer.from("hello wordl")
+    //     const batchID = 'c3387832bb1b88acbcd0ffdb65a08ef077d98c08d4bee576a72dbe3d36761369' // process.argv[3]
+    //     const privateKey = 'be52c649a4c560a1012daa572d4e81627bcce20ca14e007aef87808a7fadd3d0' // process.argv[4]
+    //     const chunkedStamped = await chunkerStamper(payload, batchID, privateKey, timeStamp)
+
+    //     expect(chunkedStamped.length).toBe(1)
+    //     expect(chunkedStamped[0].address).toEqual(expectedChunkedStamped_0[0].address)
+    //     expect(chunkedStamped[0].stamp).toEqual(expectedChunkedStamped_0[0].stamp)
+    //     expect(chunkedStamped[0].payload).toEqual(expectedChunkedStamped_0[0].payload)
+    // })
+
+    #[test]
+    fn stamp_to_bytes() {
+        let stamp = Stamp {
+            batch: [0u8; 32],
+            y: 0,
+            x: 0,
+            timestamp: 0,
+            sig: [0u8; 65],
+        };
+        let bytes: MarshalledStamp = stamp.into();
+        assert_eq!(bytes.len(), 113);
+    }
+
+    #[test]
+    fn stamp_from_bytes() {
+        let stamp: Stamp = STAMP_MARSHALLED.clone().into();
+        assert_eq!(&stamp.batch[..], &BATCH_ID[..]);
+        assert_eq!(stamp.x, *BUCKET);
+        assert_eq!(stamp.y, *BUCKET_INDEX);
+        assert_eq!(stamp.timestamp, *TIMESTAMP);
+        assert_eq!(stamp.sig, STAMP_MARSHALLED[48..113]);
+    }
+
+    #[test]
+    fn stamp_to_vec() {
+        let stamp: Stamp = STAMP_MARSHALLED.clone().into();
+        let vec: Vec<u8> = stamp.clone().into();
+        let bytes: MarshalledStamp = stamp.into();
+
+        assert_eq!(vec, bytes.to_vec());
+    }
+
+    #[test]
+    fn stamp_from_vec() {
+        let stamp: Stamp = STAMP_MARSHALLED.clone().into();
+        let vec: Vec<u8> = stamp.clone().into();
+        let stamp_from_vec: Stamp = vec.into();
+
+        assert_eq!(stamp, stamp_from_vec);
+    }
+}


### PR DESCRIPTION
This PR implements postage primitives:

1. `batchstore` - in memory with `serde` to JSON support.
2. `pat` - our resident postman, issuing stamps (ie. `stampissuer`).
3. `batch`, and `stamp`