### PR TITLE
feat(swarm-wasm-lib): initial commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,6 +2712,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3133,21 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 [[package]]
 name = "swarm-tools"
 version = "0.1.0"
+
+[[package]]
+name = "swarm-wasm-lib"
+version = "0.1.0"
+dependencies = [
+ "bmt",
+ "console_error_panic_hook",
+ "hex",
+ "js-sys",
+ "postage",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+]
 
 [[package]]
 name = "syn"
@@ -3641,6 +3662,7 @@ dependencies = [
  "once_cell",
  "prost",
  "rand",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
@@ -3745,6 +3767,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6e302a7ea94f83a6d09e78e7dc7d9ca7b186bc2829c24a22d0753efd680671"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb993dd8c836930ed130e020e77d9b2e65dd0fbab1b67c790b0f5d80b11a575"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasm-playground"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "bin/swarm-tools",
     "bin/bee-rs",
     "bin/wasm-playground",
+    "bin/swarm-wasm-lib",
 ]
 default-members = [
     "bin/bee-rs",
@@ -63,6 +64,12 @@ tokio-util = { version = "0.7.8", features = ["codec"] }
 ## async
 async-trait = "0.1.57"
 futures = "0.3.21"
+
+## wasm
+wasm-bindgen = "0.2.87"
+wasm-bindgen-futures = "0.4.37"
+wasm-bindgen-test = "0.3.37"
+js-sys = "0.3.64"
 
 clap = { version = "4.3.0", features = ["derive", "env"] }
 chrono = "0.4.23"

--- a/bin/swarm-wasm-lib/Cargo.toml
+++ b/bin/swarm-wasm-lib/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "swarm-wasm-lib"
+version = "0.1.0"
+authors = ["mfw78 <mfw78@rndlabs.xyz>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+bmt = { path = "../../crates/bmt" }
+postage = { path = "../../crates/postage" }
+js-sys = { workspace = true }
+web-sys = { version = "0.3.64", features = ['console'] }
+hex = { workspace = true }
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.7", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true }
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/bin/swarm-wasm-lib/src/lib.rs
+++ b/bin/swarm-wasm-lib/src/lib.rs
@@ -1,0 +1,67 @@
+mod utils;
+
+// Use cases to meet:
+// 1. Given a Javascript function that can be used to retrieve a chunk from the bee api, return a tuple of:
+//    - the chunk address
+//    - the span
+//    - the payload data
+// 2. Given a Javascript function that can be used to send a chunk(s) to the bee api, a payload in a Uint8Array, a signing key, and a pat,
+//    upload the stamped chunk(s) to the bee api and return a tuple of:
+//    - the chunk address(es)
+//    - the cac for the payload (if spanning more than 1 chunk)
+
+pub mod bmt {
+    use std::convert::TryInto;
+
+    use bmt::chunk::{Chunk, Options};
+    use js_sys::Function;
+    use js_sys::{Promise, Uint8Array};
+    use wasm_bindgen::prelude::*;
+
+    pub struct ParsedApiChunk(String, u64, Uint8Array);
+
+    // Asynchronously evaluate the JavaScript Promise
+    async fn await_promise(promise: Promise) -> Result<JsValue, JsValue> {
+        let future = wasm_bindgen_futures::JsFuture::from(promise);
+        future.await.map_err(|err| err.into())
+    }
+
+    // Given a function that can be used to retrieve a raw chunk, return a ChunkInfo struct
+    #[wasm_bindgen]
+    pub async fn get_chunk(address: &str, get_chunk_fn: &Function) -> Result<ChunkInfo, JsValue> {
+        // Call the TypeScript function with the provided address
+        let promise = get_chunk_fn.call1(&JsValue::NULL, &JsValue::from_str(address))?;
+
+        // Await the JavaScript Promise in Rust
+        let ret = await_promise(Promise::from(promise)).await?;
+
+        // Convert the result into a ChunkInfo struct
+        Ok(get_chunk_info(&Uint8Array::from(ret)))
+    }
+
+    #[derive(Debug, Clone)]
+    #[wasm_bindgen(getter_with_clone)]
+    pub struct ChunkInfo {
+        pub address: String,
+        pub span: u64,
+        pub data: Uint8Array,
+    }
+
+    // Given a Uint8Array, calculate the chunk address, span, and payload data
+    #[wasm_bindgen]
+    pub fn get_chunk_info(data: &Uint8Array) -> ChunkInfo {
+        // The first 8 bytes of the data are the span in little endian
+        let span = u64::from_le_bytes(data.slice(0, 8).to_vec().try_into().unwrap());
+        // The remainder of the data is the payload
+        let mut data = data.slice(8, data.length()).to_vec();
+
+        // Create a new chunk from the data
+        let chunk = Chunk::new(&mut data, Some(span), Options::default(), None);
+
+        ChunkInfo {
+            address: hex::encode(chunk.address().to_vec()),
+            span,
+            data: Uint8Array::from(data.as_slice()),
+        }
+    }
+}

--- a/bin/swarm-wasm-lib/src/utils.rs
+++ b/bin/swarm-wasm-lib/src/utils.rs
@@ -1,0 +1,10 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}

--- a/bin/swarm-wasm-lib/tests/web.rs
+++ b/bin/swarm-wasm-lib/tests/web.rs
@@ -1,0 +1,13 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn pass() {
+    assert_eq!(1 + 1, 2);
+}


### PR DESCRIPTION
This PR:

1. New feature of `swarm-wasm-lib` for `npm` import in JavaScript / Typescript consuming projects. Initially supports `ChunkInfo`.