### PR TITLE
refactor(swarm-node): align type naming with Swarm/Node convention

### DIFF
--- a/bin/vertex/src/cli.rs
+++ b/bin/vertex/src/cli.rs
@@ -15,7 +15,7 @@ use vertex_swarm_builder::{
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::SwarmConfig;
-use vertex_swarm_node::args::SwarmArgs;
+use vertex_swarm_node::args::ProtocolArgs;
 use vertex_swarm_peermanager::{FilePeerStore, PeerStore};
 use vertex_swarmspec::{Hive, SwarmSpec, init_mainnet, init_testnet};
 use vertex_tasks::TaskExecutor;
@@ -57,7 +57,7 @@ pub struct SwarmRunNodeArgs {
 
     /// Swarm protocol configuration.
     #[command(flatten)]
-    pub swarm: SwarmArgs,
+    pub swarm: ProtocolArgs,
 }
 
 /// Run the Swarm node CLI with a user-provided closure.
@@ -162,7 +162,7 @@ async fn build_launch_context(args: &SwarmRunNodeArgs) -> Result<SwarmLaunchCont
 }
 
 /// Resolve the network specification from CLI arguments.
-fn resolve_network_spec(args: &SwarmArgs) -> Result<Arc<Hive>> {
+fn resolve_network_spec(args: &ProtocolArgs) -> Result<Arc<Hive>> {
     if args.is_mainnet() {
         Ok(init_mainnet())
     } else if args.is_testnet() {

--- a/crates/node/api/src/config.rs
+++ b/crates/node/api/src/config.rs
@@ -138,7 +138,7 @@ pub trait NodeConfig {
 /// }
 ///
 /// impl NodeProtocolConfig for SwarmConfig {
-///     type Args = SwarmArgs;
+///     type Args = ProtocolArgs;
 ///
 ///     fn apply_args(&mut self, args: &Self::Args) {
 ///         self.node_type = args.node_type;

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -17,7 +17,7 @@
 //! ```ignore
 //! use clap::Parser;
 //! use vertex_node_core::args::{LogArgs, InfraArgs};
-//! use vertex_swarm_core::args::SwarmArgs;
+//! use vertex_swarm_core::args::ProtocolArgs;
 //!
 //! #[derive(Parser)]
 //! struct Cli {
@@ -37,7 +37,7 @@
 //!     infra: InfraArgs,        // Generic infrastructure
 //!
 //!     #[command(flatten)]
-//!     swarm: SwarmArgs,        // Protocol-specific
+//!     swarm: ProtocolArgs,        // Protocol-specific
 //! }
 //! ```
 

--- a/crates/swarm/builder/src/node.rs
+++ b/crates/swarm/builder/src/node.rs
@@ -35,7 +35,7 @@ use vertex_swarm_api::{
 use vertex_swarm_bandwidth::{Accounting, DefaultAccountingConfig};
 use vertex_swarm_bandwidth_pseudosettle::{PseudosettleProvider, create_pseudosettle_actor};
 use vertex_swarm_identity::Identity;
-use vertex_swarm_node::args::SwarmArgs;
+use vertex_swarm_node::args::ProtocolArgs;
 use vertex_swarm_node::{ClientCommand, SwarmNode};
 use vertex_swarm_peermanager::PeerStore;
 use vertex_swarmspec::Hive;
@@ -78,7 +78,7 @@ impl<N: NodeTypeDefaults> SwarmNodeBuilder<N> {
     /// Create a new builder with default components for the node type.
     ///
     /// Extracts configuration from the launch context and swarm args.
-    pub fn new(ctx: &SwarmLaunchContext, _args: &SwarmArgs) -> Self {
+    pub fn new(ctx: &SwarmLaunchContext, _args: &ProtocolArgs) -> Self {
         let network_config = DefaultNetworkConfig {
             listen_addrs: ctx.config.protocol.network.listen_addrs(),
             bootnodes: ctx.config.protocol.network.bootnodes(),

--- a/crates/swarm/node/src/args/mod.rs
+++ b/crates/swarm/node/src/args/mod.rs
@@ -6,4 +6,4 @@ mod swarm;
 
 pub use network::NetworkArgs;
 pub use storage::StorageIncentiveArgs;
-pub use swarm::{NodeTypeArg, SwarmArgs};
+pub use swarm::{NodeTypeArg, ProtocolArgs};

--- a/crates/swarm/node/src/args/swarm.rs
+++ b/crates/swarm/node/src/args/swarm.rs
@@ -56,7 +56,7 @@ impl From<SwarmNodeType> for NodeTypeArg {
 /// for use with clap.
 #[derive(Debug, Args, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
-pub struct SwarmArgs {
+pub struct ProtocolArgs {
     /// Node mode: bootnode, client, or storer.
     #[arg(long = "mode", value_enum, default_value_t = NodeTypeArg::Client)]
     pub node_type: NodeTypeArg,
@@ -95,7 +95,7 @@ pub struct SwarmArgs {
     pub swarmspec: Option<PathBuf>,
 }
 
-impl SwarmArgs {
+impl ProtocolArgs {
     /// Validate argument combinations.
     pub fn validate(&self) -> Result<(), String> {
         self.bandwidth.validate()?;

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -8,7 +8,7 @@ use vertex_swarm_identity::IdentityArgs;
 use vertex_swarm_localstore::LocalStoreArgs;
 use vertex_swarm_primitives::{BandwidthMode, SwarmNodeType};
 
-use crate::args::{NetworkArgs, StorageIncentiveArgs, SwarmArgs};
+use crate::args::{NetworkArgs, ProtocolArgs, StorageIncentiveArgs};
 
 /// Swarm protocol configuration.
 ///
@@ -27,7 +27,7 @@ pub struct SwarmConfig {
 }
 
 impl NodeProtocolConfig for SwarmConfig {
-    type Args = SwarmArgs;
+    type Args = ProtocolArgs;
 
     fn apply_args(&mut self, args: &Self::Args) {
         self.node_type = args.node_type.into();

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate is the libp2p boundary layer for the Swarm protocol.
 //!
-//! With the `cli` feature enabled, also provides [`SwarmArgs`] and [`SwarmConfig`]
+//! With the `cli` feature enabled, also provides [`ProtocolArgs`] and [`SwarmConfig`]
 //! for CLI argument parsing and protocol configuration.
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -22,7 +22,7 @@ pub mod protocol;
 mod service;
 mod stats;
 
-pub use node::behaviour::{NodeEvent, SwarmNodeBehaviour};
+pub use node::behaviour::{NodeBehaviour, NodeEvent};
 pub use node::bootnode::{BootNode, BootNodeBuilder, BootnodeBehaviour, BootnodeEvent};
 pub use node::{SwarmNode, SwarmNodeBuilder};
 
@@ -38,8 +38,8 @@ pub use protocol::{PseudosettleEvent, SwapEvent};
 
 // Re-export protocol behaviour types
 pub use protocol::{
-    BehaviourConfig as ClientBehaviourConfig, HandlerConfig as ClientHandlerConfig,
-    SwarmClientBehaviour, SwarmClientHandler,
+    BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, ClientHandler,
+    HandlerConfig as ClientHandlerConfig,
 };
 
 pub use client::{BootnodeClient, BuiltSwarmComponents, Client, FullClient};

--- a/crates/swarm/node/src/node/behaviour.rs
+++ b/crates/swarm/node/src/node/behaviour.rs
@@ -11,9 +11,7 @@
 
 use std::sync::Arc;
 
-use crate::protocol::{
-    BehaviourConfig as ClientBehaviourConfig, ClientEvent, SwarmClientBehaviour,
-};
+use crate::protocol::{BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, ClientEvent};
 use libp2p::{identify, identity::PublicKey, swarm::NetworkBehaviour};
 use vertex_swarm_api::SwarmNodeTypes;
 use vertex_swarm_peermanager::AddressManager;
@@ -27,7 +25,7 @@ use vertex_swarm_topology::{
 /// Generic over `N: SwarmNodeTypes` to support different node configurations.
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "NodeEvent")]
-pub struct SwarmNodeBehaviour<N: SwarmNodeTypes> {
+pub struct NodeBehaviour<N: SwarmNodeTypes> {
     /// Identify protocol - exchange peer info.
     pub identify: identify::Behaviour,
 
@@ -35,10 +33,10 @@ pub struct SwarmNodeBehaviour<N: SwarmNodeTypes> {
     pub topology: SwarmTopologyBehaviour<N>,
 
     /// Client behaviour - pricing, retrieval, pushsync.
-    pub client: SwarmClientBehaviour,
+    pub client: ClientBehaviour,
 }
 
-impl<N: SwarmNodeTypes> SwarmNodeBehaviour<N> {
+impl<N: SwarmNodeTypes> NodeBehaviour<N> {
     /// Create a new node behaviour.
     pub fn new(local_public_key: PublicKey, identity: N::Identity) -> Self {
         Self {
@@ -47,7 +45,7 @@ impl<N: SwarmNodeTypes> SwarmNodeBehaviour<N> {
                 local_public_key,
             )),
             topology: SwarmTopologyBehaviour::new(identity, TopologyBehaviourConfig::default()),
-            client: SwarmClientBehaviour::new(ClientBehaviourConfig::default()),
+            client: ClientBehaviour::new(ClientBehaviourConfig::default()),
         }
     }
 
@@ -67,7 +65,7 @@ impl<N: SwarmNodeTypes> SwarmNodeBehaviour<N> {
                 TopologyBehaviourConfig::default(),
                 address_manager,
             ),
-            client: SwarmClientBehaviour::new(ClientBehaviourConfig::default()),
+            client: ClientBehaviour::new(ClientBehaviourConfig::default()),
         }
     }
 }

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -31,7 +31,7 @@ use crate::BootnodeProvider;
 
 /// Bootnode network behaviour with only topology protocols.
 ///
-/// Unlike [`SwarmNodeBehaviour`](super::behaviour::SwarmNodeBehaviour), this excludes
+/// Unlike [`NodeBehaviour`](super::behaviour::NodeBehaviour), this excludes
 /// client protocols (pricing, retrieval, pushsync, settlement).
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "BootnodeEvent")]

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -85,7 +85,7 @@ use vertex_tasks::TaskExecutor;
 
 use crate::{
     BootnodeProvider, ClientEvent, ClientHandle, ClientService,
-    node::behaviour::{NodeEvent, SwarmNodeBehaviour},
+    node::behaviour::{NodeBehaviour, NodeEvent},
 };
 
 /// A Swarm node generic over the node type hierarchy.
@@ -96,7 +96,7 @@ use crate::{
 /// - `N: SwarmStorerNodeTypes` - can also store and sync chunks (storer)
 pub struct SwarmNode<N: SwarmNodeTypes> {
     /// The libp2p swarm.
-    swarm: Swarm<SwarmNodeBehaviour<N>>,
+    swarm: Swarm<NodeBehaviour<N>>,
 
     /// Swarm identity.
     identity: N::Identity,
@@ -700,15 +700,14 @@ impl<N: SwarmNodeTypes> SwarmNodeBuilder<N> {
             .with_dns()?
             .with_behaviour(|keypair| {
                 let behaviour = match address_manager_for_behaviour {
-                    Some(mgr) => SwarmNodeBehaviour::with_address_manager(
+                    Some(mgr) => NodeBehaviour::with_address_manager(
                         keypair.public().clone(),
                         identity_for_behaviour.clone(),
                         mgr,
                     ),
-                    None => SwarmNodeBehaviour::new(
-                        keypair.public().clone(),
-                        identity_for_behaviour.clone(),
-                    ),
+                    None => {
+                        NodeBehaviour::new(keypair.public().clone(), identity_for_behaviour.clone())
+                    }
                 };
                 Ok(behaviour)
             })?

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -1,6 +1,6 @@
 //! Connection handler for client protocols.
 //!
-//! The `SwarmClientHandler` manages multiple protocols on a single connection:
+//! The `ClientHandler` manages multiple protocols on a single connection:
 //! - Pricing: Payment threshold exchange
 //! - Retrieval: Chunk request/response
 //! - PushSync: Chunk push with receipt
@@ -278,7 +278,7 @@ pub(super) enum OutboundOutput {
 /// Swarm client connection handler.
 ///
 /// Manages multiple client protocols on a single peer connection.
-pub struct SwarmClientHandler {
+pub struct ClientHandler {
     config: Config,
     state: State,
     /// Counter for request IDs.
@@ -294,7 +294,7 @@ pub struct SwarmClientHandler {
 }
 
 #[allow(dead_code)]
-impl SwarmClientHandler {
+impl ClientHandler {
     /// Create a new handler in dormant state.
     pub fn new(config: Config) -> Self {
         Self {
@@ -458,7 +458,7 @@ impl SwarmClientHandler {
 /// Uses `ClientOutboundUpgrade` for outbound requests with `ClientOutboundInfo`
 /// to track which request type is in flight.
 #[allow(deprecated)]
-impl ConnectionHandler for SwarmClientHandler {
+impl ConnectionHandler for ClientHandler {
     type FromBehaviour = HandlerCommand;
     type ToBehaviour = HandlerEvent;
     type InboundProtocol = ClientInboundUpgrade;
@@ -625,7 +625,7 @@ impl ConnectionHandler for SwarmClientHandler {
     }
 }
 
-impl SwarmClientHandler {
+impl ClientHandler {
     /// Handle an inbound protocol completion.
     fn handle_inbound_output(&mut self, output: ClientInboundOutput) {
         match output {

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -1,6 +1,6 @@
 //! Swarm client behaviour for the Vertex node.
 //!
-//! This module provides the `SwarmClientBehaviour` which handles all client-side
+//! This module provides the `ClientBehaviour` which handles all client-side
 //! protocols on the Swarm network:
 //!
 //! - **Pricing**: Payment threshold exchange
@@ -20,7 +20,7 @@
 //!
 //! # Handler Lifecycle
 //!
-//! The `SwarmClientHandler` is created in dormant state when a connection is
+//! The `ClientHandler` is created in dormant state when a connection is
 //! established. After the handshake completes (signaled by `TopologyEvent::PeerAuthenticated`),
 //! the node sends an `ActivatePeer` command which transitions the handler to
 //! active state with:
@@ -39,7 +39,7 @@
 //!                              ▲ events    │ commands
 //!                              │           ▼
 //! ┌─────────────────────────────────────────────────────────────┐
-//! │                  SwarmClientBehaviour                        │
+//! │                  ClientBehaviour                        │
 //! │                  (protocol plumbing)                         │
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
@@ -49,9 +49,9 @@ mod events;
 mod handler;
 pub mod upgrade;
 
-pub use behaviour::{Config as BehaviourConfig, SwarmClientBehaviour};
+pub use behaviour::{ClientBehaviour, Config as BehaviourConfig};
 pub use events::{ClientCommand, ClientEvent, PseudosettleEvent, SwapEvent};
-pub use handler::{Config as HandlerConfig, HandlerCommand, HandlerEvent, SwarmClientHandler};
+pub use handler::{ClientHandler, Config as HandlerConfig, HandlerCommand, HandlerEvent};
 pub use upgrade::{
     ClientInboundOutput, ClientInboundUpgrade, ClientOutboundInfo, ClientOutboundOutput,
     ClientOutboundRequest, ClientOutboundUpgrade, ClientUpgradeError,

--- a/crates/swarm/node/src/service.rs
+++ b/crates/swarm/node/src/service.rs
@@ -1,7 +1,7 @@
 //! Client service for managing network interactions.
 //!
 //! The `ClientService` bridges the business logic layer with the network layer.
-//! It owns channels to communicate with `SwarmClientBehaviour` and processes
+//! It owns channels to communicate with `ClientBehaviour` and processes
 //! incoming events.
 
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary

Apply naming convention where `Swarm`-prefixed types are reserved for traits only, and concrete implementations use unprefixed names:

- `SwarmNodeBehaviour` → `NodeBehaviour`
- `SwarmClientBehaviour` → `ClientBehaviour`
- `SwarmClientHandler` → `ClientHandler`
- `SwarmArgs` → `ProtocolArgs`

## Motivation

This follows the established pattern in `vertex-swarm-api` and `vertex-node-api` where trait names use prefixes (`SwarmTopology`, `NodeProtocol`) while implementations do not (`KademliaTopology`, `Identity`).

`ProtocolArgs` is used instead of `SwarmArgs` because the crate context (`vertex-swarm-node`) already provides the Swarm namespace, and it aligns with the `NodeProtocolConfig` trait it implements.

## Changes

- Renamed 4 types across 15 files
- Updated all imports and exports
- Updated doc comments referencing old names
- No functional changes

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` applied
- [x] `cargo clippy` passes with no warnings