### PR TITLE
chore: add justfile and clean up dead code

### DIFF
--- a/crates/swarm/topology/src/bootnode.rs
+++ b/crates/swarm/topology/src/bootnode.rs
@@ -9,9 +9,6 @@ use rand::seq::SliceRandom;
 const MAX_BOOTNODE_ATTEMPTS: usize = 6;
 const MIN_BOOTNODE_CONNECTIONS: usize = 1;
 
-#[allow(dead_code)]
-const BOOTNODE_CONNECT_TIMEOUT_SECS: u64 = 15;
-
 /// Bootnode connection strategy.
 #[derive(Debug, Clone)]
 pub struct BootnodeConnector {

--- a/justfile
+++ b/justfile
@@ -1,0 +1,72 @@
+default:
+    @just --list
+
+fmt:
+    cargo fmt
+
+fmt-check:
+    cargo fmt --check
+
+clippy:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+test:
+    cargo test --all-features
+
+nextest:
+    cargo nextest run --all-features
+
+check:
+    cargo check --all-features
+
+build:
+    cargo build --all-features
+
+build-release:
+    cargo build --release --all-features
+
+doc:
+    cargo doc --all-features --no-deps
+
+doc-open:
+    cargo doc --all-features --no-deps --open
+
+deny:
+    cargo deny check
+
+deny-licenses:
+    cargo deny check licenses
+
+deny-bans:
+    cargo deny check bans
+
+deny-sources:
+    cargo deny check sources
+
+audit:
+    cargo audit
+
+ci: fmt-check clippy test deny
+
+pre-commit: fmt clippy
+
+clean:
+    cargo clean
+
+update:
+    cargo update
+
+tree:
+    cargo tree
+
+outdated:
+    cargo outdated -R
+
+run *ARGS:
+    cargo run --release -- {{ARGS}}
+
+watch:
+    cargo watch -x check
+
+watch-test:
+    cargo watch -x test


### PR DESCRIPTION
## Summary

- Add justfile with common development commands (fmt, clippy, test, deny, audit, etc.)
- Remove unused `BOOTNODE_CONNECT_TIMEOUT_SECS` constant
- Remove redundant `PendingPing` struct (RTT already tracked via `TopologyOutboundInfo`)

Closes #33
Closes #35

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes