### PR TITLE
refactor: enforce task spawning conventions across crates

### DIFF
--- a/crates/node/builder/src/builder.rs
+++ b/crates/node/builder/src/builder.rs
@@ -162,12 +162,19 @@ where
             .into_server(grpc_addr)
             .map_err(InfrastructureError::GrpcReflection)?;
 
-        let shutdown = self.ctx.executor.on_shutdown_signal().clone();
-        self.ctx.executor.spawn_critical("grpc.server", async move {
-            if let Err(e) = grpc_handle.serve_with_shutdown(shutdown).await {
-                tracing::error!(error = %e, "gRPC server error");
-            }
-        });
+        self.ctx
+            .executor
+            .spawn_critical_with_graceful_shutdown_signal(
+                "grpc.server",
+                move |shutdown| async move {
+                    if let Err(e) = grpc_handle
+                        .serve_with_shutdown(shutdown.ignore_guard())
+                        .await
+                    {
+                        tracing::error!(error = %e, "gRPC server error");
+                    }
+                },
+            );
 
         Ok(NodeHandle::new(
             components,

--- a/crates/observability/src/metrics/mod.rs
+++ b/crates/observability/src/metrics/mod.rs
@@ -5,6 +5,7 @@ mod hooks;
 mod process;
 mod recorder;
 mod server;
+mod task;
 
 pub use buckets::{
     CONNECTION_LIFETIME, DURATION_FINE, DURATION_NETWORK, DURATION_SECONDS, LOCK_CONTENTION,

--- a/crates/observability/src/metrics/recorder.rs
+++ b/crates/observability/src/metrics/recorder.rs
@@ -113,27 +113,7 @@ impl PrometheusRecorder {
             return;
         }
 
-        let handle = self.handle.clone();
-        executor.spawn_with_graceful_shutdown_signal(
-            "metrics.upkeep",
-            move |shutdown| async move {
-                let mut shutdown = std::pin::pin!(shutdown);
-                let interval = std::time::Duration::from_secs(interval_secs);
-
-                loop {
-                    tokio::select! {
-                        guard = &mut shutdown => {
-                            tracing::debug!("Metrics upkeep task shutting down");
-                            drop(guard);
-                            break;
-                        }
-                        _ = tokio::time::sleep(interval) => {
-                            handle.run_upkeep();
-                        }
-                    }
-                }
-            },
-        );
+        super::task::spawn_upkeep_task(executor, self.handle.clone(), interval_secs);
     }
 }
 

--- a/crates/observability/src/metrics/server.rs
+++ b/crates/observability/src/metrics/server.rs
@@ -16,6 +16,7 @@ use tower_http::trace::TraceLayer;
 use vertex_tasks::TaskExecutor;
 
 use super::Hooks;
+use super::task::spawn_server_task;
 use crate::MetricsServerConfig;
 use crate::profiling;
 
@@ -68,21 +69,7 @@ impl MetricsServer {
         let addr = listener.local_addr()?;
         tracing::info!("Metrics server listening on {addr}");
 
-        // Use the executor's shutdown signal for graceful shutdown
-        executor.spawn_critical_with_graceful_shutdown_signal(
-            "metrics.server",
-            move |shutdown| async move {
-                tracing::debug!("Metrics server task started, beginning to serve");
-                let server =
-                    axum::serve(listener, app).with_graceful_shutdown(shutdown.ignore_guard());
-
-                match server.await {
-                    Ok(()) => tracing::debug!("Metrics server stopped gracefully"),
-                    Err(err) => tracing::error!("Metrics server error: {err}"),
-                }
-                tracing::debug!("Metrics server task exiting");
-            },
-        );
+        spawn_server_task(executor, listener, app);
 
         Ok(())
     }

--- a/crates/observability/src/metrics/task.rs
+++ b/crates/observability/src/metrics/task.rs
@@ -1,0 +1,38 @@
+//! Background tasks for metrics infrastructure.
+
+use axum::Router;
+use metrics_exporter_prometheus::PrometheusHandle;
+use tokio::net::TcpListener;
+use vertex_tasks::TaskExecutor;
+
+/// Spawn the metrics HTTP server as a critical task with graceful shutdown.
+pub(super) fn spawn_server_task(executor: &TaskExecutor, listener: TcpListener, app: Router) {
+    executor.spawn_critical_with_graceful_shutdown_signal(
+        "metrics.server",
+        move |shutdown| async move {
+            tracing::debug!("Metrics server task started, beginning to serve");
+            let server = axum::serve(listener, app).with_graceful_shutdown(shutdown.ignore_guard());
+
+            match server.await {
+                Ok(()) => tracing::debug!("Metrics server stopped gracefully"),
+                Err(err) => tracing::error!("Metrics server error: {err}"),
+            }
+            tracing::debug!("Metrics server task exiting");
+        },
+    );
+}
+
+/// Spawn the metrics upkeep task that periodically flushes idle/expired metrics.
+pub(super) fn spawn_upkeep_task(
+    executor: &TaskExecutor,
+    handle: PrometheusHandle,
+    interval_secs: u64,
+) {
+    executor.spawn_periodic(
+        "metrics.upkeep",
+        std::time::Duration::from_secs(interval_secs),
+        move || {
+            handle.run_upkeep();
+        },
+    );
+}

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -32,4 +32,5 @@ pub use protocol::{ClientCommand, ClientEvent, PseudosettleEvent};
 pub use swarm_client::{BootnodeClient, Client, FullClient};
 
 pub use bootnodes::BootnodeProvider;
-pub use node::stats::{StatsConfig, spawn_stats_task};
+pub use node::stats::StatsConfig;
+pub use node::task::spawn_stats_task;

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -353,7 +353,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
         }
 
         let executor = TaskExecutor::current();
-        let _stats_handle = super::stats::spawn_stats_task(
+        super::task::spawn_stats_task(
             Arc::new(base.topology_handle.clone()),
             Arc::clone(base.topology_handle.peer_manager().score_distribution()),
             super::stats::StatsConfig::default(),

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -13,6 +13,7 @@ mod client;
 mod error;
 pub(crate) mod stats;
 mod storer;
+pub(crate) mod task;
 
 pub use base::BaseNode;
 pub use bootnode::{BootNode, BootNodeBuilder};

--- a/crates/swarm/node/src/node/stats.rs
+++ b/crates/swarm/node/src/node/stats.rs
@@ -1,15 +1,12 @@
-//! Node statistics reporting task.
+//! Node statistics configuration and reporting.
 //!
-//! Provides periodic logging of node health and topology statistics.
+//! Provides configuration and logging for node health and topology statistics.
+//! The background task that drives periodic reporting lives in [`super::task`].
 
-use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
 use tracing::info;
 use vertex_swarm_api::{SwarmTopologyState, SwarmTopologyStats};
-use vertex_swarm_peer_manager::ScoreDistribution;
-use vertex_tasks::TaskExecutor;
 
 const DEFAULT_STATS_INTERVAL: Duration = Duration::from_secs(20);
 
@@ -33,33 +30,7 @@ impl StatsConfig {
     }
 }
 
-/// Spawns a background task that periodically reports node statistics.
-pub fn spawn_stats_task<T: SwarmTopologyState + SwarmTopologyStats + 'static>(
-    topology: Arc<T>,
-    score_distribution: Arc<ScoreDistribution>,
-    config: StatsConfig,
-    executor: &TaskExecutor,
-) -> JoinHandle<()> {
-    executor.spawn_with_graceful_shutdown_signal("node.stats", |shutdown| async move {
-        let mut shutdown = std::pin::pin!(shutdown);
-
-        loop {
-            tokio::select! {
-                guard = &mut shutdown => {
-                    tracing::debug!("stats task shutting down");
-                    drop(guard);
-                    break;
-                }
-                _ = tokio::time::sleep(config.interval) => {
-                    log_stats(&*topology);
-                    score_distribution.push_gauges();
-                }
-            }
-        }
-    })
-}
-
-fn log_stats<T: SwarmTopologyState + SwarmTopologyStats>(topology: &T) {
+pub(crate) fn log_stats<T: SwarmTopologyState + SwarmTopologyStats>(topology: &T) {
     let connected = topology.connected_peers_count();
     let routing = topology.routing_peers_count();
     let stored = topology.stored_peers_count();

--- a/crates/swarm/node/src/node/task.rs
+++ b/crates/swarm/node/src/node/task.rs
@@ -1,0 +1,22 @@
+//! Background tasks for node operations.
+
+use std::sync::Arc;
+
+use vertex_swarm_api::{SwarmTopologyState, SwarmTopologyStats};
+use vertex_swarm_peer_manager::ScoreDistribution;
+use vertex_tasks::TaskExecutor;
+
+use super::stats::{StatsConfig, log_stats};
+
+/// Spawns a background task that periodically reports node statistics.
+pub fn spawn_stats_task<T: SwarmTopologyState + SwarmTopologyStats + 'static>(
+    topology: Arc<T>,
+    score_distribution: Arc<ScoreDistribution>,
+    config: StatsConfig,
+    executor: &TaskExecutor,
+) {
+    executor.spawn_periodic("node.stats", config.interval, move || {
+        log_stats(&*topology);
+        score_distribution.push_gauges();
+    });
+}

--- a/crates/swarm/peers/peer-manager/src/tasks.rs
+++ b/crates/swarm/peers/peer-manager/src/tasks.rs
@@ -94,20 +94,7 @@ pub fn spawn_purge_task<I: SwarmIdentity>(
     config: PurgeConfig,
     executor: &TaskExecutor,
 ) {
-    executor.spawn_with_graceful_shutdown_signal("peers.purge", move |shutdown| async move {
-        let mut shutdown = std::pin::pin!(shutdown);
-
-        loop {
-            tokio::select! {
-                guard = &mut shutdown => {
-                    debug!("peer purger shutting down");
-                    drop(guard);
-                    break;
-                }
-                () = tokio::time::sleep(config.check_interval) => {
-                    manager.purge_stale();
-                }
-            }
-        }
+    executor.spawn_periodic("peers.purge", config.check_interval, move || {
+        manager.purge_stale();
     });
 }

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -323,7 +323,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             .map_err(|e| TopologyError::TaskSpawn(e.to_string()))?;
 
         // Spawn background connection evaluator
-        let evaluator_handle = routing.spawn_evaluator(&executor);
+        let evaluator_handle = crate::kademlia::spawn_evaluator(routing.clone(), &executor);
 
         // Spawn interface watcher for push-based subnet discovery.
         crate::tasks::spawn_interface_watcher(&executor);

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -319,56 +319,14 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         // Queue static NAT addresses to emit as external addresses on first poll
         let pending_nat_external_addrs = nat_discovery.nat_addrs().to_vec();
 
+        let executor = vertex_tasks::TaskExecutor::try_current()
+            .map_err(|e| TopologyError::TaskSpawn(e.to_string()))?;
+
         // Spawn background connection evaluator
-        let evaluator_handle = routing
-            .spawn_evaluator()
-            .map_err(TopologyError::VerifierSpawn)?;
+        let evaluator_handle = routing.spawn_evaluator(&executor);
 
         // Spawn interface watcher for push-based subnet discovery.
-        // if-watch subscribes to netlink address events and fires initial Up
-        // events for all existing addresses, then ongoing Up/Down as interfaces change.
-        {
-            let executor = vertex_tasks::TaskExecutor::try_current()
-                .map_err(|e| TopologyError::VerifierSpawn(e.to_string()))?;
-            executor.spawn_with_graceful_shutdown_signal(
-                "net.interface_watcher",
-                move |shutdown| async move {
-                    use futures::StreamExt;
-
-                    let mut watcher = match if_watch::tokio::IfWatcher::new() {
-                        Ok(w) => w,
-                        Err(e) => {
-                            tracing::error!(error = %e, "failed to create interface watcher");
-                            return;
-                        }
-                    };
-
-                    let mut shutdown = std::pin::pin!(shutdown);
-                    loop {
-                        tokio::select! {
-                            guard = &mut shutdown => {
-                                drop(guard);
-                                break;
-                            }
-                            event = watcher.next() => {
-                                match event {
-                                    Some(Ok(if_watch::IfEvent::Up(net))) => {
-                                        vertex_net_local::add_subnet(net);
-                                    }
-                                    Some(Ok(if_watch::IfEvent::Down(net))) => {
-                                        vertex_net_local::remove_subnet(net);
-                                    }
-                                    Some(Err(e)) => {
-                                        tracing::warn!(error = %e, "interface watcher error");
-                                    }
-                                    None => break,
-                                }
-                            }
-                        }
-                    }
-                },
-            );
-        }
+        crate::tasks::spawn_interface_watcher(&executor);
 
         // Spawn the gossip task (merged peer exchange + verification).
         let spec = <I as HasSpec>::spec(&*identity).clone();
@@ -379,8 +337,9 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             connection_registry.clone(),
             evaluator_handle.clone(),
             local_capabilities.clone(),
+            &executor,
         )
-        .map_err(|e| TopologyError::VerifierSpawn(e.to_string()))?;
+        .map_err(|e| TopologyError::TaskSpawn(e.to_string()))?;
 
         let behaviour = Self {
             identity,

--- a/crates/swarm/topology/src/error.rs
+++ b/crates/swarm/topology/src/error.rs
@@ -95,9 +95,9 @@ pub enum TopologyError {
     #[error("topology service has shut down")]
     ServiceShutdown,
 
-    /// Failed to spawn the gossip verifier task.
-    #[error("failed to spawn gossip verifier: {0}")]
-    VerifierSpawn(String),
+    /// Failed to spawn a background task.
+    #[error("failed to spawn task: {0}")]
+    TaskSpawn(String),
 }
 
 impl TopologyError {

--- a/crates/swarm/topology/src/gossip/mod.rs
+++ b/crates/swarm/topology/src/gossip/mod.rs
@@ -3,13 +3,13 @@
 mod error;
 mod events;
 mod filter;
-mod task;
+mod tasks;
 mod verifier;
 
 use tokio::sync::mpsc;
 
 pub(crate) use events::{GossipAction, GossipInput};
-pub(crate) use task::spawn_gossip_task;
+pub(crate) use tasks::spawn_gossip_task;
 
 /// Handle for communicating with the gossip task.
 pub(crate) struct GossipHandle {

--- a/crates/swarm/topology/src/gossip/tasks.rs
+++ b/crates/swarm/topology/src/gossip/tasks.rs
@@ -667,6 +667,7 @@ pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
     connection_registry: Arc<ConnectionRegistry>,
     evaluator_handle: RoutingEvaluatorHandle,
     local_capabilities: Arc<vertex_net_local::LocalCapabilities>,
+    executor: &vertex_tasks::TaskExecutor,
 ) -> Result<super::GossipHandle, Box<dyn std::error::Error + Send + Sync>> {
     let (input_tx, input_rx) = mpsc::channel(INPUT_CHANNEL_CAPACITY);
     let (output_tx, output_rx) = mpsc::channel(OUTPUT_CHANNEL_CAPACITY);
@@ -730,9 +731,6 @@ pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
         cancelled_exchanges: HashSet::new(),
         evaluator_handle,
     };
-
-    let executor = vertex_tasks::TaskExecutor::try_current()
-        .map_err(|e| format!("No task executor available: {e}"))?;
 
     executor.spawn_critical_with_graceful_shutdown_signal(
         "topology.gossip",

--- a/crates/swarm/topology/src/kademlia/mod.rs
+++ b/crates/swarm/topology/src/kademlia/mod.rs
@@ -4,10 +4,10 @@ mod args;
 mod candidate_queues;
 mod candidates;
 mod config;
-mod evaluator_task;
 mod limits;
 pub(crate) mod peer_selection;
 mod routing;
+mod task;
 
 pub use args::RoutingArgs;
 pub(crate) use candidates::{
@@ -15,10 +15,10 @@ pub(crate) use candidates::{
     select_neighborhood_candidates,
 };
 pub use config::KademliaConfig;
-pub(crate) use evaluator_task::RoutingEvaluatorHandle;
 pub(crate) use limits::DepthAwareLimits;
 pub(crate) use limits::LimitsSnapshot;
 pub(crate) use routing::KademliaRouting;
+pub(crate) use task::RoutingEvaluatorHandle;
 
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};

--- a/crates/swarm/topology/src/kademlia/mod.rs
+++ b/crates/swarm/topology/src/kademlia/mod.rs
@@ -18,7 +18,7 @@ pub use config::KademliaConfig;
 pub(crate) use limits::DepthAwareLimits;
 pub(crate) use limits::LimitsSnapshot;
 pub(crate) use routing::KademliaRouting;
-pub(crate) use task::RoutingEvaluatorHandle;
+pub(crate) use task::{RoutingEvaluatorHandle, spawn_evaluator};
 
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -15,13 +15,14 @@ use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use vertex_swarm_peer_manager::PeerManager;
 use vertex_swarm_peer_manager::ProximityIndex;
 use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
+use vertex_tasks::TaskExecutor;
 
 use super::{
     CandidateSelector, CandidateSnapshot, DepthAwareLimits, KademliaConfig, LimitsSnapshot,
     RoutingCapacity, SwarmRouting,
     candidate_queues::CandidateQueues,
-    evaluator_task::{RoutingEvaluatorHandle, spawn_evaluator},
     select_balanced_candidates, select_neighborhood_candidates,
+    task::{RoutingEvaluatorHandle, spawn_evaluator},
 };
 use crate::metrics::{phase, record_phase_transition};
 
@@ -535,8 +536,11 @@ impl<I: SwarmIdentity> SwarmRouting<I> for KademliaRouting<I> {
 // and topology behaviour within the routing module.
 impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
     /// Spawn background evaluator. Returns handle for triggering evaluation.
-    pub(crate) fn spawn_evaluator(self: &Arc<Self>) -> Result<RoutingEvaluatorHandle, String> {
-        spawn_evaluator(self.clone())
+    pub(crate) fn spawn_evaluator(
+        self: &Arc<Self>,
+        executor: &TaskExecutor,
+    ) -> RoutingEvaluatorHandle {
+        spawn_evaluator(self.clone(), executor)
     }
 
     /// Drain all pending candidates (called from poll loop). O(bins).

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -8,6 +8,12 @@ use std::{
     },
 };
 
+use super::{
+    CandidateSelector, CandidateSnapshot, DepthAwareLimits, KademliaConfig, LimitsSnapshot,
+    RoutingCapacity, SwarmRouting, candidate_queues::CandidateQueues, select_balanced_candidates,
+    select_neighborhood_candidates,
+};
+use crate::metrics::{phase, record_phase_transition};
 use nectar_primitives::ChunkAddress;
 use parking_lot::RwLock;
 use tracing::{debug, info, trace};
@@ -15,16 +21,6 @@ use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use vertex_swarm_peer_manager::PeerManager;
 use vertex_swarm_peer_manager::ProximityIndex;
 use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
-use vertex_tasks::TaskExecutor;
-
-use super::{
-    CandidateSelector, CandidateSnapshot, DepthAwareLimits, KademliaConfig, LimitsSnapshot,
-    RoutingCapacity, SwarmRouting,
-    candidate_queues::CandidateQueues,
-    select_balanced_candidates, select_neighborhood_candidates,
-    task::{RoutingEvaluatorHandle, spawn_evaluator},
-};
-use crate::metrics::{phase, record_phase_transition};
 
 /// Connection phase for capacity tracking.
 #[derive(PartialEq, Eq)]
@@ -535,14 +531,6 @@ impl<I: SwarmIdentity> SwarmRouting<I> for KademliaRouting<I> {
 // Methods internalized from the poll loop — called only by the background evaluator task
 // and topology behaviour within the routing module.
 impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
-    /// Spawn background evaluator. Returns handle for triggering evaluation.
-    pub(crate) fn spawn_evaluator(
-        self: &Arc<Self>,
-        executor: &TaskExecutor,
-    ) -> RoutingEvaluatorHandle {
-        spawn_evaluator(self.clone(), executor)
-    }
-
     /// Drain all pending candidates (called from poll loop). O(bins).
     pub(crate) fn drain_candidates(&self) -> Vec<OverlayAddress> {
         self.candidate_queues.drain_all()

--- a/crates/swarm/topology/src/kademlia/task.rs
+++ b/crates/swarm/topology/src/kademlia/task.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use tokio::sync::Notify;
 use tracing::debug;
 use vertex_swarm_api::SwarmIdentity;
+use vertex_tasks::{GracefulShutdown, TaskExecutor};
 
 use super::routing::KademliaRouting;
 
@@ -29,12 +30,18 @@ struct RoutingEvaluatorTask<I: SwarmIdentity> {
 }
 
 impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
-    async fn run(self) {
+    async fn run(self, shutdown: GracefulShutdown) {
         let debounce = Duration::from_millis(100);
         let periodic = Duration::from_secs(5);
+        let mut shutdown = std::pin::pin!(shutdown);
 
         loop {
             tokio::select! {
+                guard = &mut shutdown => {
+                    debug!("routing evaluator shutting down");
+                    drop(guard);
+                    return;
+                }
                 _ = self.notify.notified() => {
                     tokio::time::sleep(debounce).await;
                 }
@@ -48,7 +55,8 @@ impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
 /// Spawn the routing evaluator task. Returns a handle for triggering evaluation.
 pub(crate) fn spawn_evaluator<I: SwarmIdentity + 'static>(
     routing: Arc<KademliaRouting<I>>,
-) -> Result<RoutingEvaluatorHandle, String> {
+    executor: &TaskExecutor,
+) -> RoutingEvaluatorHandle {
     let notify = Arc::new(Notify::new());
     let handle = RoutingEvaluatorHandle {
         notify: notify.clone(),
@@ -56,21 +64,9 @@ pub(crate) fn spawn_evaluator<I: SwarmIdentity + 'static>(
 
     let task = RoutingEvaluatorTask { routing, notify };
 
-    let executor = vertex_tasks::TaskExecutor::try_current()
-        .map_err(|e| format!("No task executor available: {e}"))?;
+    executor.spawn_critical_with_graceful_shutdown_signal("topology.evaluator", move |shutdown| {
+        task.run(shutdown)
+    });
 
-    executor.spawn_critical_with_graceful_shutdown_signal(
-        "topology.evaluator",
-        |shutdown| async move {
-            tokio::select! {
-                _ = task.run() => {}
-                guard = shutdown => {
-                    debug!("routing evaluator shutting down");
-                    drop(guard);
-                }
-            }
-        },
-    );
-
-    Ok(handle)
+    handle
 }

--- a/crates/swarm/topology/src/lib.rs
+++ b/crates/swarm/topology/src/lib.rs
@@ -20,6 +20,7 @@ mod protocol_handlers;
 mod composed;
 mod error;
 mod gossip;
+mod tasks;
 
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/crates/swarm/topology/src/tasks.rs
+++ b/crates/swarm/topology/src/tasks.rs
@@ -1,0 +1,48 @@
+//! Background tasks for topology infrastructure.
+
+use vertex_tasks::TaskExecutor;
+
+/// Spawn a background task that watches network interface changes for subnet discovery.
+///
+/// Subscribes to netlink address events via `if-watch` and fires initial `Up` events
+/// for all existing addresses, then ongoing `Up`/`Down` as interfaces change.
+pub(crate) fn spawn_interface_watcher(executor: &TaskExecutor) {
+    executor.spawn_with_graceful_shutdown_signal(
+        "net.interface_watcher",
+        move |shutdown| async move {
+            use futures::StreamExt;
+
+            let mut watcher = match if_watch::tokio::IfWatcher::new() {
+                Ok(w) => w,
+                Err(e) => {
+                    tracing::error!(error = %e, "failed to create interface watcher");
+                    return;
+                }
+            };
+
+            let mut shutdown = std::pin::pin!(shutdown);
+            loop {
+                tokio::select! {
+                    guard = &mut shutdown => {
+                        drop(guard);
+                        break;
+                    }
+                    event = watcher.next() => {
+                        match event {
+                            Some(Ok(if_watch::IfEvent::Up(net))) => {
+                                vertex_net_local::add_subnet(net);
+                            }
+                            Some(Ok(if_watch::IfEvent::Down(net))) => {
+                                vertex_net_local::remove_subnet(net);
+                            }
+                            Some(Err(e)) => {
+                                tracing::warn!(error = %e, "interface watcher error");
+                            }
+                            None => break,
+                        }
+                    }
+                }
+            }
+        },
+    );
+}

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -8,9 +8,10 @@
 use std::{
     any::Any,
     fmt::{Display, Formatter},
-    pin::{Pin, pin},
+    pin::Pin,
     sync::{Arc, OnceLock},
     task::{Context, Poll, ready},
+    time::Duration,
 };
 
 use dyn_clone::DynClone;
@@ -488,7 +489,7 @@ impl TaskExecutor {
     {
         let on_shutdown = self.on_shutdown.clone();
         let fut = async move {
-            let fut = pin!(fut);
+            let fut = std::pin::pin!(fut);
             let _ = select(on_shutdown, fut).await;
         };
         self.spawn_task_as(fut, TaskKind::Default, "<unnamed>", false)
@@ -504,7 +505,7 @@ impl TaskExecutor {
     {
         let on_shutdown = self.on_shutdown.clone();
         let fut = async move {
-            let fut = pin!(fut);
+            let fut = std::pin::pin!(fut);
             let _ = select(on_shutdown, fut).await;
         };
         self.spawn_task_as(fut, TaskKind::Blocking, name, false)
@@ -521,7 +522,7 @@ impl TaskExecutor {
         debug!(task = name, "spawning critical task");
         let on_shutdown = self.on_shutdown.clone();
         let fut = async move {
-            let fut = pin!(fut);
+            let fut = std::pin::pin!(fut);
             match select(on_shutdown, fut).await {
                 Either::Left(_) => {
                     debug!(task = name, "critical task cancelled by shutdown signal");
@@ -544,7 +545,7 @@ impl TaskExecutor {
     {
         let on_shutdown = self.on_shutdown.clone();
         let fut = async move {
-            let fut = pin!(fut);
+            let fut = std::pin::pin!(fut);
             let _ = select(on_shutdown, fut).await;
         };
         self.spawn_critical_as(name, fut, TaskKind::Blocking, false)
@@ -628,6 +629,44 @@ impl TaskExecutor {
         self.spawn_critical_with_graceful_shutdown_signal(name, |shutdown| {
             service.into_task(shutdown)
         })
+    }
+
+    /// Spawns a periodic background task with graceful shutdown support.
+    ///
+    /// The callback `f` runs every `interval`. On shutdown the current iteration
+    /// completes before the task exits.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn t(executor: vertex_tasks::TaskExecutor) {
+    /// use std::time::Duration;
+    ///
+    /// executor.spawn_periodic("my_task", Duration::from_secs(10), || {
+    ///     // periodic work
+    /// });
+    /// # }
+    /// ```
+    pub fn spawn_periodic(
+        &self,
+        name: &'static str,
+        interval: Duration,
+        mut f: impl FnMut() + Send + 'static,
+    ) {
+        self.spawn_with_graceful_shutdown_signal(name, move |shutdown| async move {
+            let mut shutdown = std::pin::pin!(shutdown);
+            loop {
+                tokio::select! {
+                    guard = &mut shutdown => {
+                        drop(guard);
+                        break;
+                    }
+                    _ = tokio::time::sleep(interval) => {
+                        f();
+                    }
+                }
+            }
+        });
     }
 
     /// Sends a request to the `TaskManager` to initiate a graceful shutdown.


### PR DESCRIPTION
## What does this PR do?

Enforces the project's task management architecture by moving all background task spawning into dedicated `task.rs`/`tasks.rs` modules and standardising executor injection.

## Changes

- **`TaskExecutor::spawn_periodic`**: new method for the common single-interval-with-shutdown pattern, eliminating repeated `pin! + select! + drop(guard)` boilerplate across four call sites
- **Dedicated task modules**: extracted task spawning from inline code into dedicated modules:
  - `crates/observability/src/metrics/task.rs`: metrics server and upkeep tasks (from `server.rs`/`recorder.rs`)
  - `crates/swarm/topology/src/tasks.rs`: interface watcher task (from `behaviour.rs`)
  - `crates/swarm/node/src/node/task.rs`: stats reporter task (from `stats.rs`)
- **Module renames** to follow conventions:
  - `gossip/task.rs` -> `gossip/tasks.rs`
  - `kademlia/evaluator_task.rs` -> `kademlia/task.rs`
- **Executor injection**: gossip and kademlia task spawners now accept `&TaskExecutor` as a parameter instead of calling `try_current()` internally; single `try_current()` call in `TopologyBehaviour::new()` serves all three spawns
- **gRPC graceful shutdown**: `grpc.server` now uses `spawn_critical_with_graceful_shutdown_signal` with `shutdown.ignore_guard()` instead of manually cloning the shutdown signal
- **Kademlia evaluator cooperative shutdown**: `GracefulShutdown` integrated into the evaluator's `run()` loop for prompt shutdown between evaluation cycles
- **Error variant rename**: `TopologyError::VerifierSpawn` -> `TopologyError::TaskSpawn` (the variant was used for all task spawn failures, not just verifier)
- **`pin!` consistency**: `vertex-tasks` now uses `std::pin::pin!` (fully qualified) matching all other crates

## Breaking changes

- `TopologyError::VerifierSpawn` renamed to `TopologyError::TaskSpawn`
- `spawn_stats_task` no longer returns `JoinHandle<()>` (no caller used it)
- `spawn_evaluator` and `spawn_gossip_task` now require `&TaskExecutor` parameter
- `KademliaRouting::spawn_evaluator` returns `RoutingEvaluatorHandle` directly instead of `Result<RoutingEvaluatorHandle, String>`

## Testing

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets` passes (no new warnings)
- [x] `cargo test --workspace` passes (all tests green)
- [x] Verified all task metrics flow correctly through `spawn_task_as`/`spawn_critical_as`

## AI assistance disclosure

This PR was authored with AI assistance.

## Notes for reviewers

All task names are unchanged, so metrics dashboards and Grafana panels require no updates. The `spawn_periodic` utility covers the three simplest periodic tasks (metrics upkeep, node stats, peers purge); the persistence task with multiple intervals and shutdown cleanup remains hand-written.