### PR TITLE
chore: enforce clippy::indexing_slicing lint

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Clippy (production)
         run: cargo clippy --lib --all-features -- -D warnings
       - name: Clippy (tests)
-        run: cargo clippy --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used
+        run: cargo clippy --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::indexing_slicing
 
   test:
     name: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6164,9 +6164,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ rust.unused_must_use = "deny"
 [workspace.lints.clippy]
 unwrap_used = "warn"
 expect_used = "warn"
+indexing_slicing = "warn"
 
 [workspace.dependencies]
 ## nectar

--- a/crates/net/codec/src/utils.rs
+++ b/crates/net/codec/src/utils.rs
@@ -10,8 +10,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[inline]
 pub fn encode_u256_be(value: U256) -> Vec<u8> {
     let bytes = value.to_be_bytes::<32>();
-    match bytes.iter().position(|&b| b != 0) {
-        Some(pos) => bytes[pos..].to_vec(),
+    let start = bytes.iter().position(|&b| b != 0);
+    match start.and_then(|pos| bytes.get(pos..)) {
+        Some(trimmed) => trimmed.to_vec(),
         None => vec![],
     }
 }

--- a/crates/swarm/forks/src/digest.rs
+++ b/crates/swarm/forks/src/digest.rs
@@ -45,8 +45,8 @@ impl ForkDigest {
             data.extend_from_slice(&timestamp.to_le_bytes());
         }
 
-        let hash = keccak256(&data);
-        Self(FixedBytes::from_slice(&hash[..4]))
+        let hash: [u8; 32] = keccak256(&data).into();
+        Self(FixedBytes::new([hash[0], hash[1], hash[2], hash[3]]))
     }
 }
 

--- a/crates/swarm/peers/peer/src/serde_multiaddr.rs
+++ b/crates/swarm/peers/peer/src/serde_multiaddr.rs
@@ -38,9 +38,9 @@ pub fn serialize_multiaddrs(addrs: &[Multiaddr]) -> Vec<u8> {
 /// - 0x99 prefix: list format
 /// - Otherwise: single legacy multiaddr
 pub fn deserialize_multiaddrs(data: &[u8]) -> Result<Vec<Multiaddr>, MultiAddrError> {
-    match data.first() {
+    match data.split_first() {
         None => Ok(Vec::new()),
-        Some(&MULTIADDR_LIST_PREFIX) => deserialize_list(&data[1..]),
+        Some((&MULTIADDR_LIST_PREFIX, rest)) => deserialize_list(rest),
         Some(_) => {
             let addr = Multiaddr::try_from(data.to_vec())?;
             Ok(vec![addr])

--- a/crates/swarm/storer/src/store.rs
+++ b/crates/swarm/storer/src/store.rs
@@ -90,15 +90,10 @@ impl<S: ChunkStore> LocalStoreImpl<S> {
     fn deserialize_chunk(address: ChunkAddress, bytes: &[u8]) -> SwarmResult<AnyChunk> {
         use nectar_primitives::ContentChunk;
 
-        if bytes.is_empty() {
-            return Err(SwarmError::InvalidChunk {
-                address: Some(address),
-                reason: "empty data".to_string(),
-            });
-        }
-
-        let type_byte = bytes[0];
-        let data = &bytes[1..];
+        let (&type_byte, data) = bytes.split_first().ok_or(SwarmError::InvalidChunk {
+            address: Some(address),
+            reason: "empty data".to_string(),
+        })?;
 
         match type_byte {
             0..=2 => {

--- a/crates/swarm/test-utils/src/lib.rs
+++ b/crates/swarm/test-utils/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 //! Test utilities and mocks for vertex-swarm crates.
 //!
 //! This crate provides shared test infrastructure to reduce duplication

--- a/crates/swarm/topology/src/gossip/verifier.rs
+++ b/crates/swarm/topology/src/gossip/verifier.rs
@@ -109,11 +109,12 @@ impl GossipVerifier {
         gossiper: &OverlayAddress,
         existing_peer: Option<&SwarmPeer>,
     ) -> Result<GossipCheckOk, GossipCheckError> {
-        if gossiped_peer.multiaddrs().is_empty() {
-            return Err(GossipCheckError::NoMultiaddrs);
-        }
+        let first_addr = gossiped_peer
+            .multiaddrs()
+            .first()
+            .ok_or(GossipCheckError::NoMultiaddrs)?;
 
-        let Some(peer_id) = extract_peer_id(&gossiped_peer.multiaddrs()[0]) else {
+        let Some(peer_id) = extract_peer_id(first_addr) else {
             return Err(GossipCheckError::NoPeerId);
         };
 

--- a/crates/swarm/topology/src/kademlia/peer_selection.rs
+++ b/crates/swarm/topology/src/kademlia/peer_selection.rs
@@ -97,7 +97,9 @@ pub(crate) fn select_for_distant<I: SwarmIdentity>(
     }
 
     for &idx in indices.iter().take(CLOSE_PEERS_COUNT) {
-        if selected_indices.insert(idx) && let Some(entry) = storers.get(idx) {
+        if selected_indices.insert(idx)
+            && let Some(entry) = storers.get(idx)
+        {
             selected.push((entry.0.clone(), entry.2));
         }
     }

--- a/crates/swarm/topology/src/kademlia/peer_selection.rs
+++ b/crates/swarm/topology/src/kademlia/peer_selection.rs
@@ -82,16 +82,23 @@ pub(crate) fn select_for_distant<I: SwarmIdentity>(
 
     // Phase 1: Top CLOSE_PEERS_COUNT by proximity to recipient (O(p) partition)
     let mut indices: Vec<usize> = (0..storers.len()).collect();
+    let cmp_proximity = |a: &usize, b: &usize| {
+        let pa = storers.get(*a).map(|s| s.1);
+        let pb = storers.get(*b).map(|s| s.1);
+        pb.cmp(&pa)
+    };
     if indices.len() > CLOSE_PEERS_COUNT {
-        indices.select_nth_unstable_by(CLOSE_PEERS_COUNT, |&a, &b| storers[b].1.cmp(&storers[a].1));
-        indices[..CLOSE_PEERS_COUNT].sort_by(|&a, &b| storers[b].1.cmp(&storers[a].1));
+        indices.select_nth_unstable_by(CLOSE_PEERS_COUNT, |a, b| cmp_proximity(a, b));
+        if let Some(top) = indices.get_mut(..CLOSE_PEERS_COUNT) {
+            top.sort_by(|a, b| cmp_proximity(a, b));
+        }
     } else {
-        indices.sort_by(|&a, &b| storers[b].1.cmp(&storers[a].1));
+        indices.sort_by(|a, b| cmp_proximity(a, b));
     }
 
     for &idx in indices.iter().take(CLOSE_PEERS_COUNT) {
-        if selected_indices.insert(idx) {
-            selected.push((storers[idx].0.clone(), storers[idx].2));
+        if selected_indices.insert(idx) && let Some(entry) = storers.get(idx) {
+            selected.push((entry.0.clone(), entry.2));
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds the `clippy::indexing_slicing` lint to the workspace configuration, fixes all existing violations using safe access patterns, and updates `rustls-webpki` to patch RUSTSEC-2026-0049.

## Changes

- Added `indexing_slicing = "warn"` to `[workspace.lints.clippy]` in workspace `Cargo.toml`
- Added `-A clippy::indexing_slicing` to CI test/bench clippy step (matching existing unwrap/expect exemptions)
- Added `clippy::indexing_slicing` to the test-utils crate-level allow
- Fixed violations across 6 files using safe alternatives:
  - `split_first()` for prefix-then-remainder patterns (`storer/store.rs`, `serde_multiaddr.rs`)
  - `.first().ok_or(...)` for guarded first-element access (`gossip/verifier.rs`)
  - `.get()` with closures for dynamic index lookups (`peer_selection.rs`)
  - `.get(pos..)` via `and_then` for position-based slicing (`codec/utils.rs`)
  - Fixed-size array conversion for compile-time verifiable indices (`forks/digest.rs`)
- Updated `rustls-webpki` from 0.103.9 to 0.103.10 (RUSTSEC-2026-0049)

## Breaking changes

None.

## Testing

- [x] `cargo clippy --lib --all-features -- -D warnings` passes
- [x] `cargo clippy --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::indexing_slicing` passes
- [x] `cargo test --all-features` passes

## Related issues

Closes #20
Closes #81

## AI assistance disclosure

This PR was authored with AI assistance.

## Checklist

- [x] Oxford English used throughout
- [x] No em dashes
- [x] One PR, one thing