### PR TITLE
docs: config architecture doc and TracingArgs method rename

### DIFF
--- a/crates/node/commands/src/lib.rs
+++ b/crates/node/commands/src/lib.rs
@@ -42,10 +42,10 @@ where
     if let Some(stdout) = cli.logs().stdout_config() {
         tracer = tracer.with_stdout(stdout);
     }
-    if let Some(otlp) = cli.tracing().otlp_config() {
+    if let Some(otlp) = cli.tracing().tracing_config() {
         tracer = tracer.with_otlp(otlp);
     }
-    if let Some(otlp_logs) = cli.tracing().otlp_logs_config() {
+    if let Some(otlp_logs) = cli.tracing().tracing_logs_config() {
         tracer = tracer.with_otlp_logs(otlp_logs);
     }
 

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -2,10 +2,22 @@
 //!
 //! These args serve dual purposes:
 //! - CLI parsing via clap (`#[derive(Args)]`)
-//! - Configuration serialization via serde (`#[derive(Serialize, Deserialize)]`)
+//! - Configuration serialisation via serde (`#[derive(Serialize, Deserialize)]`)
 //!
 //! The structs implement config traits from `vertex_node_api`, allowing them
 //! to be passed directly to infrastructure components.
+//!
+//! ## Naming Convention
+//!
+//! Each `Args` struct exposes `*_config()` builder methods named after the
+//! **output domain**, not the struct. For example, `TracingArgs::tracing_config()`
+//! produces an `OtlpConfig`. When a struct yields multiple configs (e.g.
+//! `LogArgs` producing stdout and file configs), each method uses a more
+//! specific name such as `stdout_config()`.
+//!
+//! See `docs/architecture/config.md` for full details on the three-tier pattern.
+//!
+//! ## Aggregated Structs
 //!
 //! This module provides two aggregated structs for different use cases:
 //!

--- a/crates/node/core/src/args/tracing.rs
+++ b/crates/node/core/src/args/tracing.rs
@@ -60,10 +60,10 @@ impl Default for TracingArgs {
 }
 
 impl TracingArgs {
-    /// Build OTLP tracing config.
+    /// Build tracing config from CLI arguments.
     ///
-    /// Returns None if tracing is disabled.
-    pub fn otlp_config(&self) -> Option<OtlpConfig> {
+    /// Returns `None` if tracing is disabled.
+    pub fn tracing_config(&self) -> Option<OtlpConfig> {
         if !self.enabled {
             return None;
         }
@@ -75,10 +75,10 @@ impl TracingArgs {
         ))
     }
 
-    /// Build OTLP logs config.
+    /// Build tracing logs config from CLI arguments.
     ///
-    /// Returns None if OTLP log export is disabled.
-    pub fn otlp_logs_config(&self) -> Option<OtlpLogsConfig> {
+    /// Returns `None` if OTLP log export is disabled.
+    pub fn tracing_logs_config(&self) -> Option<OtlpLogsConfig> {
         if !self.logs_enabled {
             return None;
         }

--- a/crates/swarm/builder/src/config.rs
+++ b/crates/swarm/builder/src/config.rs
@@ -1,4 +1,15 @@
 //! Node-type-specific validated configurations holding runtime objects.
+//!
+//! These structs are the final tier of the configuration architecture: fully
+//! assembled configs that hold runtime objects such as `Arc<Identity>` and
+//! `Arc<Spec>`. They live in `vertex-swarm-builder` (not `vertex-node-core`)
+//! because they depend on swarm-specific types like `Identity`,
+//! `KademliaConfig`, and `Spec`.
+//!
+//! Each struct implements `NodeBuildsProtocol` so the builder can select the
+//! correct protocol stack at construction time.
+//!
+//! See `docs/architecture/config.md` for the full three-tier pattern.
 
 use std::sync::Arc;
 

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -1,0 +1,54 @@
+# Configuration Architecture
+
+This document describes the internal configuration architecture: how CLI arguments are parsed, validated, and assembled into the structs that node components consume.
+
+For the user-facing CLI reference, see [CLI Configuration](../cli/configuration.md).
+
+## Three-tier Pattern
+
+Configuration flows through three layers: **Args** (CLI + serde), then **Config** (validated), then **ValidatedConfig** (assembled, node-type-specific).
+
+1. **Args structs** (see `vertex_node_core::args`): flat, serialisable structs that derive both `clap::Args` and `serde::{Serialize, Deserialize}`. They carry raw user input and provide defaults. Each Args struct exposes one or more `*_config()` builder methods that produce validated config objects.
+
+2. **Config structs** (various crates): validated, domain-specific configuration produced by Args builder methods. Examples include `OtlpConfig`, `OtlpLogsConfig`, `DatabaseConfig`, and `MetricsConfig`. These are protocol-agnostic and live close to the component that consumes them.
+
+3. **ValidatedConfig structs** (see `vertex_swarm_builder::config`): fully assembled, node-type-specific configurations that hold runtime objects such as `Arc<Identity>` and `Arc<Spec>`. These are `BootnodeConfig`, `ClientConfig`, and `StorerConfig`.
+
+## Naming Convention for Builder Methods
+
+Builder methods on `Args` structs are named after the **output domain**, not the input struct. For example:
+
+| Struct | Method | Produces | Rationale |
+|--------|--------|----------|-----------|
+| `TracingArgs` | `tracing_config()` | `OtlpConfig` | Named for the tracing domain |
+| `TracingArgs` | `tracing_logs_config()` | `OtlpLogsConfig` | Named for the tracing-logs domain |
+| `LogArgs` | `stdout_config()` | `StdoutConfig` | Specific name because `LogArgs` produces multiple sub-configs |
+| `MetricsArgs` | `metrics_config()` | `MetricsConfig` | Named for the metrics domain |
+
+When a struct produces a single config, the method name matches `<domain>_config()`. When it produces multiple configs (like `LogArgs` producing stdout and potentially file configs), each method uses a more specific name to avoid ambiguity.
+
+## Why Aggregators Do Not Implement `NodeBuildsProtocol`
+
+`InfraArgs` and `NodeArgs` aggregate multiple `Args` structs but do not implement the `NodeBuildsProtocol` trait (in `vertex_node_api`). This is by design: `NodeBuildsProtocol` uses associated types (`type Protocol`) that bind to a specific protocol implementation. The aggregator structs are protocol-agnostic and serve purely as CLI composition helpers.
+
+## Crate Layering
+
+The configuration types are split across crates to respect the protocol-agnostic/protocol-specific boundary:
+
+- **`vertex_node_core`** contains `InfraConfig` and the Args structs. These are protocol-agnostic: they know nothing about swarm protocols, identity, or network topology.
+
+- **`vertex_swarm_builder`** contains `BootnodeConfig`, `ClientConfig`, and `StorerConfig`. These are protocol-specific: they hold `Arc<Identity>`, `Arc<Spec>`, `NetworkConfig<KademliaConfig>`, and other swarm runtime objects. They live in the builder crate because that is where protocol arguments are resolved and assembled into a running node.
+
+This separation is intentional. Moving the validated configs into `vertex_node_core` would force the core crate to depend on swarm-specific types, breaking the layering.
+
+## NodeBuildsProtocol Delegation
+
+The `NodeBuildsProtocol` trait (in `vertex_node_api`) provides a uniform interface for node-type-specific configuration. Each validated config struct implements `NodeBuildsProtocol`, which the swarm builder uses to select the correct protocol stack. The builder delegates to the config's getters (`spec()`, `identity()`, `network()`, `bandwidth()`, etc.) when constructing protocol components.
+
+Methods like `identity()` on validated config structs return runtime objects (`Arc<Identity>`), not configuration structs; they are not renamed to `*_config()` because they are not config builders.
+
+## See Also
+
+- [CLI Configuration](../cli/configuration.md): user-facing CLI reference
+- [Node Builder](node-builder.md): how configuration flows into the builder
+- [Node Types](node-types.md): node type descriptions

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -64,6 +64,7 @@ This ensures operators can set base configuration in a file and selectively over
 
 ## See Also
 
+- [Configuration Architecture](../architecture/config.md) - Internal three-tier config pattern (Args, Config, ValidatedConfig)
 - [Node Types](../architecture/node-types.md) - Detailed node type descriptions
 - [Node Builder](../architecture/node-builder.md) - How configuration flows into the builder
 - [Swarm API](../swarm/api.md) - Protocol traits and accounting


### PR DESCRIPTION
## What does this PR do?

Adds architecture documentation for the config system and standardises `TracingArgs` method naming to match the output-domain convention.

## Changes

- **New `docs/architecture/config.md`**: documents the three-tier config pattern (Args, Config, ValidatedConfig), naming conventions, crate layering rationale, and `NodeBuildsProtocol` delegation
- **Rename `TracingArgs::otlp_config()`** to `tracing_config()` and **`otlp_logs_config()`** to `tracing_logs_config()` to follow the `<domain>_config()` convention
- **Expand rustdoc** on `vertex_node_core::args` and `vertex_swarm_builder::config` modules
- **Cross-reference** from `docs/cli/configuration.md` to the new architecture doc

## Breaking changes

- `TracingArgs::otlp_config()` renamed to `tracing_config()`
- `TracingArgs::otlp_logs_config()` renamed to `tracing_logs_config()`

## Testing

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo doc --workspace --no-deps`

## Related issues

Closes #57

## AI assistance disclosure

This PR was authored with AI assistance.

## Notes for reviewers

`LogArgs::stdout_config()` is intentionally **not** renamed: `LogArgs` produces multiple sub-configs (stdout, potentially file), so the specific name avoids ambiguity. Similarly, `ProtocolConfig::identity()` returns `Arc<Identity>` (a runtime object), not a config struct, so it is not renamed.

## Checklist

- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally with my changes