### PR TITLE
fix(observability): drop push-gateway default to keep aws-lc-rs out of the tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,28 +994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,15 +1566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,16 +1786,6 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2703,12 +2662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3308,22 +3261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
- "core-foundation 0.9.4",
+ "core-foundation",
  "fnv",
  "futures",
  "if-addrs",
@@ -4407,7 +4344,6 @@ dependencies = [
  "base64 0.22.1",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "indexmap 2.14.0",
  "ipnet",
@@ -4884,12 +4820,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -6285,25 +6215,12 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -6322,7 +6239,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6378,15 +6294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6485,29 +6392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.13.0",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -7022,7 +6906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 
@@ -7263,16 +7147,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -25,7 +25,9 @@ vertex-tasks = { workspace = true }
 
 # Metrics
 metrics = { workspace = true }
-metrics-exporter-prometheus = "0.17"
+# Disable default features to avoid pulling in push-gateway → hyper-rustls →
+# aws-lc-rs which fails to cross-compile with old ARM toolchains.
+metrics-exporter-prometheus = { version = "0.17", default-features = false, features = ["http-listener"] }
 metrics-process = "2.3"
 metrics-util = "0.19"
 

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -25,7 +25,11 @@ vertex-tasks = { workspace = true }
 
 # Metrics
 metrics = { workspace = true }
-metrics-exporter-prometheus = "0.17"
+# We only serve metrics over the HTTP listener; Prometheus scrapes us and never
+# pushes. Dropping the default push-gateway feature avoids hyper-rustls and its
+# aws-lc-rs backend, which is C/assembly that breaks the wasm32 target and old
+# ARM cross-toolchains. Push-based export, if ever needed, belongs on OTLP.
+metrics-exporter-prometheus = { version = "0.17", default-features = false, features = ["http-listener"] }
 metrics-process = "2.3"
 metrics-util = "0.19"
 


### PR DESCRIPTION
## Summary

Drop the default `push-gateway` feature of `metrics-exporter-prometheus` in `vertex-observability` and enable only `http-listener`. This removes the `hyper-rustls -> rustls -> aws-lc-rs` chain from the entire workspace.

## Why

`aws-lc-rs` is C plus ARMv8 assembly. It breaks the `wasm32-unknown-unknown` target the client node must build for, and fails to cross-compile with old ARM toolchains (e.g. Linaro GCC 4.9, used by Kobo e-readers). `metrics-exporter-prometheus` was the sole consumer of `hyper-rustls` in the tree, reached only through its default `push-gateway` feature.

## We never push metrics, so no feature gate

Vertex serves metrics over an HTTP listener and Prometheus scrapes us (pull model); logs and traces are pushed over OTLP (Loki, Tempo). `push-gateway` exists for ephemeral jobs that exit before they can be scraped, which a long-running node is not. If a NAT'd or browser/wasm client ever needs to push metrics, the consistent path is OTLP (already a dependency, already wired for logs and traces), not Prometheus push-gateway, whose `hyper-rustls` backend cannot build for wasm anyway. So this is a clean removal rather than an off-by-default feature gate; a disabled feature would only document how to drag `aws-lc-rs` back in and reintroduce the wasm/cross-compile hazard the moment someone flipped it.

## Verification

- `cargo tree -i aws-lc-sys` is now empty (was `aws-lc-sys -> aws-lc-rs -> rustls -> hyper-rustls -> metrics-exporter-prometheus`).
- `Cargo.lock` drops `aws-lc-rs`, `aws-lc-sys`, `hyper-rustls`, `tokio-rustls`, `rustls-native-certs`.
- `cargo check -p vertex` (binary) builds; `vertex-observability` builds with metrics serving unaffected (`http-listener` retained).

## Notes

Rebased onto current `main` (the branch was 21 commits behind) and reframed from the original ARM-only motivation to the broader wasm-cone rationale.