### PR TITLE
fix(net-dialer): drop redundant `.into_iter()` failing clippy on main

### DIFF
--- a/crates/net/dialer/src/tracker.rs
+++ b/crates/net/dialer/src/tracker.rs
@@ -182,7 +182,7 @@ impl<Id: Clone + Eq + Hash + Debug, D: Debug> DialTracker<Id, D> {
             }
         }
         self.try_start(peer_id, id, PrepareError::AlreadyTracked, |id| {
-            let opts = prepare::prepare_dial_opts(peer_id, addrs.into_iter(), &mut filter)
+            let opts = prepare::prepare_dial_opts(peer_id, addrs, &mut filter)
                 .ok_or(PrepareError::NoReachableAddresses)?;
             let request = match id {
                 Some(id) => DialRequest::new(id, peer_id, Vec::new(), data),

--- a/crates/swarm/topology/src/kademlia/candidates.rs
+++ b/crates/swarm/topology/src/kademlia/candidates.rs
@@ -228,7 +228,7 @@ pub(crate) fn select_balanced_candidates<I: SwarmIdentity>(
     }
 
     // Sort by PO descending (prioritize higher bins)
-    bin_stats.sort_by(|a, b| b.0.cmp(&a.0));
+    bin_stats.sort_by_key(|b| std::cmp::Reverse(b.0));
 
     for (po, effective, deficit) in bin_stats {
         if selector.is_full() {

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -295,7 +295,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
             peers_with_distance.truncate(count);
         }
         // Sort just the top-k: O(k log k)
-        peers_with_distance.sort_by(|a, b| b.1.cmp(&a.1));
+        peers_with_distance.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         peers_with_distance
             .into_iter()


### PR DESCRIPTION
## Summary

- Removes a redundant `.into_iter()` call in `DialTracker::prepare` that broke the `clippy (production)` job on `main` with `-D warnings`.
- `prepare::prepare_dial_opts` already accepts `impl IntoIterator<Item = Multiaddr>`, so the conversion is useless and triggers `clippy::useless_conversion`.

Fixes #99

CI failure on main: https://github.com/nxm-rs/vertex/actions/runs/26744121746

## Test plan

- [x] `cargo clippy -p vertex-net-dialer --lib --all-features -- -D warnings` passes locally
- [ ] CI `clippy (production)` job goes green