### PR TITLE
feat(primitives): typed Nonce, NetworkId, ProximityOrder, Bin, Timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,43 +105,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
-dependencies = [
- "alloy-eips 1.8.3",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.8.3",
- "alloy-trie",
- "alloy-tx-macros 1.8.3",
- "auto_impl",
- "borsh",
- "c-kzg",
- "derive_more",
- "either",
- "k256",
- "once_cell",
- "rand 0.8.6",
- "secp256k1 0.30.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
- "alloy-eips 2.0.5",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-trie",
- "alloy-tx-macros 2.0.5",
+ "alloy-tx-macros",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -155,20 +128,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
-dependencies = [
- "alloy-consensus 1.8.3",
- "alloy-eips 1.8.3",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.8.3",
- "serde",
 ]
 
 [[package]]
@@ -177,11 +136,11 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
- "alloy-consensus 2.0.5",
- "alloy-eips 2.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -258,29 +217,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-eip7928",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.8.3",
- "auto_impl",
- "borsh",
- "c-kzg",
- "derive_more",
- "either",
- "serde",
- "serde_with",
- "sha2",
-]
-
-[[package]]
-name = "alloy-eips"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
@@ -291,7 +227,7 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -316,21 +252,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "http",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "alloy-json-rpc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
@@ -346,46 +267,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
-dependencies = [
- "alloy-consensus 1.8.3",
- "alloy-consensus-any 1.8.3",
- "alloy-eips 1.8.3",
- "alloy-json-rpc 1.8.3",
- "alloy-network-primitives 1.8.3",
- "alloy-primitives",
- "alloy-rpc-types-any 1.8.3",
- "alloy-rpc-types-eth 1.8.3",
- "alloy-serde 1.8.3",
- "alloy-signer 1.8.3",
- "alloy-sol-types",
- "async-trait",
- "auto_impl",
- "derive_more",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-network"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
- "alloy-consensus 2.0.5",
- "alloy-consensus-any 2.0.5",
- "alloy-eips 2.0.5",
- "alloy-json-rpc 2.0.5",
- "alloy-network-primitives 2.0.5",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-any 2.0.5",
- "alloy-rpc-types-eth 2.0.5",
- "alloy-serde 2.0.5",
- "alloy-signer 2.0.5",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -394,19 +289,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
-dependencies = [
- "alloy-consensus 1.8.3",
- "alloy-eips 1.8.3",
- "alloy-primitives",
- "alloy-serde 1.8.3",
- "serde",
 ]
 
 [[package]]
@@ -415,10 +297,10 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
- "alloy-consensus 2.0.5",
- "alloy-eips 2.0.5",
+ "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "serde",
 ]
 
@@ -477,49 +359,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
-dependencies = [
- "alloy-consensus-any 1.8.3",
- "alloy-rpc-types-eth 1.8.3",
- "alloy-serde 1.8.3",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
 dependencies = [
- "alloy-consensus-any 2.0.5",
- "alloy-network-primitives 2.0.5",
+ "alloy-consensus-any",
+ "alloy-network-primitives",
  "alloy-primitives",
- "alloy-rpc-types-eth 2.0.5",
- "alloy-serde 2.0.5",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
-dependencies = [
- "alloy-consensus 1.8.3",
- "alloy-consensus-any 1.8.3",
- "alloy-eips 1.8.3",
- "alloy-network-primitives 1.8.3",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 1.8.3",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -528,30 +378,19 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
- "alloy-consensus 2.0.5",
- "alloy-consensus-any 2.0.5",
- "alloy-eips 2.0.5",
- "alloy-network-primitives 2.0.5",
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.5",
+ "alloy-serde",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -567,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -583,48 +422,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-signer"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
-dependencies = [
- "alloy-primitives",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-signer-local"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
-dependencies = [
- "alloy-consensus 1.8.3",
- "alloy-network 1.8.3",
- "alloy-primitives",
- "alloy-signer 1.8.3",
- "async-trait",
- "eth-keystore",
- "k256",
- "rand 0.8.6",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "alloy-signer-local"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
 dependencies = [
- "alloy-consensus 2.0.5",
- "alloy-network 2.0.5",
+ "alloy-consensus",
+ "alloy-network",
  "alloy-primitives",
- "alloy-signer 2.0.5",
+ "alloy-signer",
  "async-trait",
+ "eth-keystore",
  "k256",
  "rand 0.8.6",
  "thiserror 2.0.18",
@@ -714,18 +522,6 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "tracing",
-]
-
-[[package]]
-name = "alloy-tx-macros"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4708,8 +4504,8 @@ version = "0.1.0"
 source = "git+https://github.com/nxm-rs/nectar?rev=3c99edc4331781dc4f595485f4eea2e36bac38db#3c99edc4331781dc4f595485f4eea2e36bac38db"
 dependencies = [
  "alloy-primitives",
- "alloy-signer 2.0.5",
- "alloy-signer-local 2.0.5",
+ "alloy-signer",
+ "alloy-signer-local",
  "bytes",
  "derive_more",
  "digest 0.11.3",
@@ -8243,7 +8039,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
- "alloy-signer 1.8.3",
+ "alloy-signer",
  "async-trait",
  "auto_impl",
  "bytes",
@@ -8376,8 +8172,8 @@ name = "vertex-swarm-identity"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-signer 1.8.3",
- "alloy-signer-local 1.8.3",
+ "alloy-signer",
+ "alloy-signer-local",
  "clap 4.6.1",
  "eyre",
  "nectar-primitives",
@@ -8414,8 +8210,8 @@ name = "vertex-swarm-net-handshake"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-signer 1.8.3",
- "alloy-signer-local 1.8.3",
+ "alloy-signer",
+ "alloy-signer-local",
  "arbitrary",
  "asynchronous-codec",
  "bytes",
@@ -8682,7 +8478,7 @@ name = "vertex-swarm-peer"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-signer 1.8.3",
+ "alloy-signer",
  "arbitrary",
  "auto_impl",
  "bytes",
@@ -8752,7 +8548,6 @@ dependencies = [
 name = "vertex-swarm-primitives"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
  "nectar-primitives",
  "serde",
  "strum 0.28.0",
@@ -8831,8 +8626,8 @@ name = "vertex-swarm-test-utils"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-signer 1.8.3",
- "alloy-signer-local 1.8.3",
+ "alloy-signer",
+ "alloy-signer-local",
  "libp2p",
  "nectar-primitives",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,8 @@ indexing_slicing = "warn"
 
 [workspace.dependencies]
 ## nectar
-# All three nectar deps pinned to the same rev so the workspace cannot
-# resolve two distinct copies of shared nectar types via independent updates.
+# Pin all three nectar deps to the same rev so the workspace cannot resolve two
+# distinct copies of shared nectar types via independent updates.
 nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "3c99edc4331781dc4f595485f4eea2e36bac38db" }
 nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "3c99edc4331781dc4f595485f4eea2e36bac38db" }
 nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "3c99edc4331781dc4f595485f4eea2e36bac38db" }
@@ -208,10 +208,10 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 
 ## alloy
 alloy-eip2124 = { version = "0.2", default-features = false }
-alloy-primitives = { version = "1.1", default-features = false }
-alloy-signer = { version = "1.0" }
-alloy-signer-local = { version = "1.0", features = ["eip712", "keystore"] }
-alloy-sol-types = { version = "1.5" }
+alloy-primitives = { version = "1.6", default-features = false }
+alloy-signer = { version = "2.0" }
+alloy-signer-local = { version = "2.0", features = ["eip712", "keystore"] }
+alloy-sol-types = { version = "1.6" }
 alloy-chains = { version = "0.2", default-features = false }
 
 ## tracing & telemetry

--- a/crates/swarm/api/src/identity.rs
+++ b/crates/swarm/api/src/identity.rs
@@ -1,11 +1,11 @@
 //! Identity trait for Swarm network participation.
 
 use crate::SwarmSpec;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use alloy_signer::{Signer, SignerSync};
 use nectar_primitives::SwarmAddress;
 use std::sync::Arc;
-use vertex_swarm_primitives::{SwarmNodeType, compute_overlay};
+use vertex_swarm_primitives::{Nonce, SwarmNodeType, compute_overlay};
 
 /// Identity trait for Swarm network participation.
 ///
@@ -23,7 +23,7 @@ pub trait SwarmIdentity: Send + Sync + 'static {
     fn spec(&self) -> &Self::Spec;
 
     /// Get the nonce for overlay address derivation.
-    fn nonce(&self) -> B256;
+    fn nonce(&self) -> Nonce;
 
     /// Get the signer for handshake authentication.
     fn signer(&self) -> Arc<Self::Signer>;

--- a/crates/swarm/api/src/spec.rs
+++ b/crates/swarm/api/src/spec.rs
@@ -3,7 +3,7 @@
 use alloc::{string::String, sync::Arc, vec::Vec};
 use alloy_chains::Chain;
 use alloy_primitives::Address;
-use nectar_primitives::ChunkTypeSet;
+use nectar_primitives::{ChunkTypeSet, NetworkId};
 use nectar_swarms::{NamedSwarm, Swarm};
 use vertex_swarm_forks::{ForkCondition, ForkDigest, SwarmHardfork, SwarmHardforks};
 
@@ -67,8 +67,8 @@ pub trait SwarmSpec: Send + Sync + 'static {
     fn chain(&self) -> Chain;
 
     /// Returns the network ID for the Swarm network.
-    fn network_id(&self) -> u64 {
-        self.swarm().id()
+    fn network_id(&self) -> NetworkId {
+        NetworkId::from(self.swarm().id())
     }
 
     /// Returns the Swarm network name (like "mainnet", "testnet", etc.).
@@ -132,12 +132,12 @@ pub trait SwarmSpec: Send + Sync + 'static {
 
     /// Returns whether this is the mainnet Swarm.
     fn is_mainnet(&self) -> bool {
-        self.network_id() == NamedSwarm::Mainnet as u64
+        self.network_id().get() == NamedSwarm::Mainnet as u64
     }
 
     /// Returns whether this is a testnet Swarm.
     fn is_testnet(&self) -> bool {
-        self.network_id() == NamedSwarm::Testnet as u64
+        self.network_id().get() == NamedSwarm::Testnet as u64
     }
 
     /// Returns the maximum proximity order for addresses in this network.

--- a/crates/swarm/identity/src/args.rs
+++ b/crates/swarm/identity/src/args.rs
@@ -5,13 +5,12 @@ use crate::keystore::{create_and_save_signer, load_signer_from_keystore, resolve
 use alloy_primitives::B256;
 use clap::Args;
 use eyre::Result;
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::debug;
 use vertex_swarm_api::SwarmIdentityConfig;
-use vertex_swarm_primitives::SwarmNodeType;
+use vertex_swarm_primitives::{Nonce, SwarmNodeType};
 use vertex_swarm_spec::Spec;
 
 /// Identity and keystore configuration.
@@ -84,11 +83,9 @@ impl IdentityArgs {
             create_and_save_signer(&keystore_path, &password)?
         };
 
-        let nonce = self.nonce.unwrap_or_else(|| {
-            let mut bytes = [0u8; 32];
-            rand::rng().fill(&mut bytes);
+        let nonce = self.nonce.map(Nonce::from).unwrap_or_else(|| {
             debug!("Generated new nonce");
-            B256::from(bytes)
+            Nonce::random()
         });
 
         Ok(Arc::new(Identity::new(signer, nonce, spec, node_type)))

--- a/crates/swarm/identity/src/lib.rs
+++ b/crates/swarm/identity/src/lib.rs
@@ -8,13 +8,12 @@
 pub mod args;
 pub mod keystore;
 
-use alloy_primitives::B256;
 use alloy_signer::k256::ecdsa::SigningKey;
 use alloy_signer_local::LocalSigner;
 use nectar_primitives::SwarmAddress;
 use std::sync::Arc;
 use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
-use vertex_swarm_primitives::compute_overlay;
+use vertex_swarm_primitives::{Nonce, compute_overlay};
 use vertex_swarm_spec::{HasSpec, Loggable, Spec, SwarmSpec};
 
 pub use args::IdentityArgs;
@@ -28,7 +27,7 @@ pub use vertex_swarm_api::SwarmIdentity as IdentityTrait;
 pub struct Identity {
     spec: Arc<Spec>,
     signer: Arc<LocalSigner<SigningKey>>,
-    nonce: B256,
+    nonce: Nonce,
     /// Cached at construction time.
     overlay: SwarmAddress,
     node_type: SwarmNodeType,
@@ -39,7 +38,7 @@ impl Identity {
     /// Creates a new identity from a signer, nonce, spec, and node type.
     pub fn new(
         signer: LocalSigner<SigningKey>,
-        nonce: B256,
+        nonce: Nonce,
         spec: Arc<Spec>,
         node_type: SwarmNodeType,
     ) -> Self {
@@ -56,8 +55,7 @@ impl Identity {
 
     /// Creates a random ephemeral identity for testing.
     pub fn random(spec: Arc<Spec>, node_type: SwarmNodeType) -> Self {
-        let nonce = B256::from(rand::random::<[u8; 32]>());
-        Self::new(LocalSigner::random(), nonce, spec, node_type)
+        Self::new(LocalSigner::random(), Nonce::random(), spec, node_type)
     }
 
     /// Sets a custom welcome message.
@@ -81,7 +79,7 @@ impl SwarmIdentity for Identity {
         &self.spec
     }
 
-    fn nonce(&self) -> B256 {
+    fn nonce(&self) -> Nonce {
         self.nonce
     }
 
@@ -133,7 +131,7 @@ mod tests {
     fn same_signer_and_nonce_same_overlay() {
         let spec = init_testnet();
         let signer = LocalSigner::random();
-        let nonce = B256::from([0x42u8; 32]);
+        let nonce = Nonce::new([0x42u8; 32]);
 
         let id1 = Identity::new(signer.clone(), nonce, spec.clone(), SwarmNodeType::Storer);
         let id2 = Identity::new(signer, nonce, spec, SwarmNodeType::Storer);
@@ -149,11 +147,11 @@ mod tests {
 
         let id1 = Identity::new(
             signer.clone(),
-            B256::from([1u8; 32]),
+            Nonce::new([1u8; 32]),
             spec.clone(),
             SwarmNodeType::Storer,
         );
-        let id2 = Identity::new(signer, B256::from([2u8; 32]), spec, SwarmNodeType::Storer);
+        let id2 = Identity::new(signer, Nonce::new([2u8; 32]), spec, SwarmNodeType::Storer);
 
         assert_eq!(id1.ethereum_address(), id2.ethereum_address());
         assert_ne!(id1.overlay_address(), id2.overlay_address());

--- a/crates/swarm/net/handshake/src/codec/ack.rs
+++ b/crates/swarm/net/handshake/src/codec/ack.rs
@@ -1,6 +1,6 @@
 //! Ack message encoding/decoding for handshake protocol.
 
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::{NetworkId, Nonce, SwarmAddress};
 use tracing::debug;
 use vertex_swarm_peer::{SwarmNodeType, SwarmPeer};
 
@@ -10,7 +10,7 @@ use crate::MAX_WELCOME_MESSAGE_CHARS;
 /// Decode an Ack proto message, validating network_id and returning components.
 pub(crate) fn decode_ack(
     proto: vertex_swarm_net_proto::handshake::Ack,
-    expected_network_id: u64,
+    expected_network_id: NetworkId,
 ) -> Result<(SwarmPeer, SwarmNodeType, String), HandshakeError> {
     let swarm_peer = swarm_peer_from_proto(&proto, expected_network_id)?;
     let welcome_message = welcome_message_from_proto(&proto)?;
@@ -23,7 +23,7 @@ pub(crate) fn encode_ack(
     peer: &SwarmPeer,
     node_type: SwarmNodeType,
     welcome_message: &str,
-    network_id: u64,
+    network_id: NetworkId,
 ) -> vertex_swarm_net_proto::handshake::Ack {
     vertex_swarm_net_proto::handshake::Ack {
         peer: Some(vertex_swarm_net_proto::handshake::PeerAddress {
@@ -31,9 +31,9 @@ pub(crate) fn encode_ack(
             signature: peer.signature().as_bytes().to_vec(),
             overlay: peer.overlay().to_vec(),
         }),
-        network_id,
+        network_id: network_id.get(),
         storer: node_type_to_wire(node_type),
-        nonce: peer.nonce().to_vec(),
+        nonce: peer.nonce().as_slice().to_vec(),
         welcome_message: welcome_message.to_string(),
     }
 }
@@ -56,9 +56,9 @@ fn node_type_to_wire(node_type: SwarmNodeType) -> bool {
 
 pub(crate) fn swarm_peer_from_proto(
     value: &vertex_swarm_net_proto::handshake::Ack,
-    expected_network_id: u64,
+    expected_network_id: NetworkId,
 ) -> Result<SwarmPeer, HandshakeError> {
-    if value.network_id != expected_network_id {
+    if value.network_id != expected_network_id.get() {
         return Err(HandshakeError::NetworkIdMismatch);
     }
 
@@ -71,7 +71,8 @@ pub(crate) fn swarm_peer_from_proto(
         .inspect_err(|e| debug!(error = ?e, "invalid overlay in handshake ack"))
         .map_err(|_| HandshakeError::InvalidOverlay)?;
 
-    let nonce = value.nonce.as_slice().try_into()?;
+    let nonce_bytes: [u8; 32] = value.nonce.as_slice().try_into()?;
+    let nonce = Nonce::new(nonce_bytes);
     let signature = peer_address.signature.as_slice().try_into()?;
 
     SwarmPeer::from_signed(
@@ -79,7 +80,7 @@ pub(crate) fn swarm_peer_from_proto(
         signature,
         overlay,
         nonce,
-        value.network_id,
+        NetworkId::from(value.network_id),
         true,
     )
     .map_err(HandshakeError::from)
@@ -145,7 +146,8 @@ mod tests {
         let peer = create_test_peer();
         let proto = encode_ack(&peer, SwarmNodeType::Client, "hello", spec.network_id());
 
-        let wrong_network_id = spec.network_id().wrapping_add(1);
+        let wrong_network_id =
+            nectar_primitives::NetworkId::from(spec.network_id().get().wrapping_add(1));
         let result = decode_ack(proto, wrong_network_id);
         assert!(matches!(result, Err(HandshakeError::NetworkIdMismatch)));
     }

--- a/crates/swarm/net/handshake/src/codec/synack.rs
+++ b/crates/swarm/net/handshake/src/codec/synack.rs
@@ -1,6 +1,7 @@
 //! SynAck message encoding/decoding for handshake protocol.
 
 use libp2p::Multiaddr;
+use nectar_primitives::NetworkId;
 use vertex_swarm_peer::{SwarmNodeType, SwarmPeer};
 
 use super::ack::{
@@ -12,7 +13,7 @@ use crate::HandshakeError;
 /// Decode a SynAck proto message, returning validated components.
 pub(crate) fn decode_synack(
     proto: vertex_swarm_net_proto::handshake::SynAck,
-    expected_network_id: u64,
+    expected_network_id: NetworkId,
 ) -> Result<(Multiaddr, SwarmPeer, SwarmNodeType, String), HandshakeError> {
     let observed = decode_syn(proto.syn.ok_or(HandshakeError::MissingField("syn"))?)?;
 
@@ -30,7 +31,7 @@ pub(crate) fn encode_synack(
     peer: &SwarmPeer,
     node_type: SwarmNodeType,
     welcome_message: &str,
-    network_id: u64,
+    network_id: NetworkId,
 ) -> vertex_swarm_net_proto::handshake::SynAck {
     vertex_swarm_net_proto::handshake::SynAck {
         syn: Some(encode_syn(observed)),
@@ -45,7 +46,7 @@ mod tests {
     use vertex_swarm_identity::Identity;
     use vertex_swarm_test_utils::test_spec_isolated as test_spec;
 
-    fn create_test_data() -> (Multiaddr, SwarmPeer, u64) {
+    fn create_test_data() -> (Multiaddr, SwarmPeer, NetworkId) {
         let spec = test_spec();
         let identity = Identity::random(spec.clone(), SwarmNodeType::Storer);
         let observed: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();

--- a/crates/swarm/net/hive/src/codec.rs
+++ b/crates/swarm/net/hive/src/codec.rs
@@ -10,7 +10,7 @@ pub(crate) fn encode_peers(peers: &[SwarmPeer]) -> vertex_swarm_net_proto::hive:
             multiaddrs: p.serialize_multiaddrs(),
             signature: p.signature().as_bytes().to_vec(),
             overlay: p.overlay().as_slice().to_vec(),
-            nonce: p.nonce().to_vec(),
+            nonce: p.nonce().as_slice().to_vec(),
         })
         .collect();
     vertex_swarm_net_proto::hive::Peers { peers: proto_peers }

--- a/crates/swarm/net/hive/src/protocol.rs
+++ b/crates/swarm/net/hive/src/protocol.rs
@@ -17,6 +17,7 @@ use vertex_swarm_net_headers::{
     HeaderedInbound, HeaderedOutbound, HeaderedStream, Outbound, ProtocolStreamError,
 };
 use vertex_swarm_peer::{SwarmAddress, SwarmPeer};
+use vertex_swarm_primitives::{NetworkId, Nonce};
 use vertex_tasks::TaskExecutor;
 
 use crate::PROTOCOL_NAME;
@@ -78,7 +79,7 @@ impl<I: SwarmIdentity> HeaderedInbound for HiveInner<I> {
         Box::pin(async move {
             use vertex_swarm_net_proto::hive::Peers;
 
-            debug!(network_id, "Hive: reading peers");
+            debug!(%network_id, "Hive: reading peers");
             let (proto, _) =
                 Framed::recv::<Peers, ProtocolStreamError, _>(stream.into_inner()).await?;
 
@@ -104,7 +105,7 @@ impl<I: SwarmIdentity> HeaderedInbound for HiveInner<I> {
 /// Validate a batch of proto peers, offloading to a blocking thread if the executor is available.
 async fn validate_batch_blocking(
     raw_peers: Vec<vertex_swarm_net_proto::hive::Peer>,
-    network_id: u64,
+    network_id: NetworkId,
     local_overlay: SwarmAddress,
     cache: PeerCache,
 ) -> (Vec<SwarmPeer>, usize, usize) {
@@ -126,7 +127,7 @@ async fn validate_batch_blocking(
 /// Returns (valid_peers, valid_count, invalid_count).
 fn validate_batch(
     raw_peers: Vec<vertex_swarm_net_proto::hive::Peer>,
-    network_id: u64,
+    network_id: NetworkId,
     local_overlay: &SwarmAddress,
     cache: &Mutex<LruCache<SwarmAddress, SwarmPeer>>,
 ) -> (Vec<SwarmPeer>, usize, usize) {
@@ -164,7 +165,7 @@ fn validate_batch(
 /// 2. Full ECDSA recovery — cold path
 fn validate_proto_peer(
     p: vertex_swarm_net_proto::hive::Peer,
-    network_id: u64,
+    network_id: NetworkId,
     local_overlay: &SwarmAddress,
     cache: &Mutex<LruCache<SwarmAddress, SwarmPeer>>,
 ) -> Result<SwarmPeer, ValidationFailure> {
@@ -193,7 +194,12 @@ fn validate_proto_peer(
     counter!("hive_validation_cache_total", "outcome" => "miss").increment(1);
 
     // Tier 2: Full ECDSA signature recovery.
-    let nonce = B256::try_from(p.nonce.as_slice()).map_err(ValidationFailure::NonceLength)?;
+    let nonce_bytes: [u8; 32] = p
+        .nonce
+        .as_slice()
+        .try_into()
+        .map_err(ValidationFailure::NonceLength)?;
+    let nonce = Nonce::new(nonce_bytes);
 
     // NOTE: validate_overlay disabled due to Bee multiaddr re-serialization bug
     let peer = SwarmPeer::from_signed(

--- a/crates/swarm/peers/peer-manager/src/db_store.rs
+++ b/crates/swarm/peers/peer-manager/src/db_store.rs
@@ -259,7 +259,7 @@ mod tests {
             multiaddrs,
             alloy_primitives::Signature::test_signature(),
             B256::repeat_byte(n),
-            B256::ZERO,
+            vertex_swarm_primitives::Nonce::ZERO,
             Address::repeat_byte(n),
         );
         StoredPeer {

--- a/crates/swarm/peers/peer/src/lib.rs
+++ b/crates/swarm/peers/peer/src/lib.rs
@@ -13,7 +13,7 @@ pub use serde_multiaddr::{deserialize_multiaddrs, serialize_multiaddrs};
 use bytes::{Bytes, BytesMut};
 use error::SwarmPeerError;
 use vertex_swarm_api::SwarmIdentity;
-use vertex_swarm_primitives::compute_overlay;
+use vertex_swarm_primitives::{NetworkId, Nonce, compute_overlay};
 use vertex_swarm_spec::SwarmSpec;
 
 pub use nectar_primitives::SwarmAddress;
@@ -34,7 +34,7 @@ pub struct SwarmPeer {
     multiaddrs: Vec<Multiaddr>,
     signature: Signature,
     overlay: SwarmAddress,
-    nonce: B256,
+    nonce: Nonce,
     ethereum_address: Address,
 }
 
@@ -49,7 +49,7 @@ impl Default for SwarmPeer {
             multiaddrs: Vec::new(),
             signature: Signature::new(U256::ZERO, U256::ZERO, false),
             overlay: SwarmAddress::default(),
-            nonce: B256::ZERO,
+            nonce: Nonce::ZERO,
             ethereum_address: Address::ZERO,
         }
     }
@@ -96,8 +96,8 @@ impl SwarmPeer {
         multiaddrs_bytes: &[u8],
         signature: Signature,
         overlay: SwarmAddress,
-        nonce: B256,
-        network_id: u64,
+        nonce: Nonce,
+        network_id: NetworkId,
         validate_overlay: bool,
     ) -> Result<Self, SwarmPeerError> {
         let multiaddrs = deserialize_multiaddrs(multiaddrs_bytes)?;
@@ -128,7 +128,7 @@ impl SwarmPeer {
         multiaddrs: Vec<Multiaddr>,
         signature: Signature,
         overlay: B256,
-        nonce: B256,
+        nonce: Nonce,
         ethereum_address: Address,
     ) -> Self {
         Self {
@@ -156,7 +156,7 @@ impl SwarmPeer {
         &self.overlay
     }
 
-    pub fn nonce(&self) -> &B256 {
+    pub fn nonce(&self) -> &Nonce {
         &self.nonce
     }
 
@@ -212,7 +212,7 @@ fn recover_signer(
     multiaddr_bytes: &[u8],
     overlay: &SwarmAddress,
     signature: &Signature,
-    network_id: u64,
+    network_id: NetworkId,
 ) -> Result<Address, SwarmPeerError> {
     let prehash = generate_sign_message(multiaddr_bytes, overlay, network_id);
     Ok(signature.recover_address_from_msg(prehash)?)
@@ -221,7 +221,11 @@ fn recover_signer(
 /// Generate the message to sign for handshake verification.
 ///
 /// Format: `"bee-handshake-" || multiaddr_bytes || overlay || network_id(BE)`
-fn generate_sign_message(multiaddr_bytes: &[u8], overlay: &SwarmAddress, network_id: u64) -> Bytes {
+fn generate_sign_message(
+    multiaddr_bytes: &[u8],
+    overlay: &SwarmAddress,
+    network_id: NetworkId,
+) -> Bytes {
     let mut message = BytesMut::new();
     message.extend_from_slice(b"bee-handshake-");
     message.extend_from_slice(multiaddr_bytes);

--- a/crates/swarm/primitives/Cargo.toml
+++ b/crates/swarm/primitives/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-alloy-primitives = { workspace = true }
 nectar-primitives = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
@@ -20,5 +19,5 @@ serde = { workspace = true, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]
-std = ["alloy-primitives/std", "nectar-primitives/std"]
+std = ["nectar-primitives/std"]
 serde = ["dep:serde"]

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -1,4 +1,7 @@
 //! Core primitive types for Ethereum Swarm nodes.
+//!
+//! This crate re-exports canonical Swarm primitives from `nectar-primitives`
+//! and adds vertex-specific node configuration types.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -6,20 +9,13 @@ mod validated;
 
 pub use validated::{ValidatedChunk, ValidationError};
 
-use alloy_primitives::{Address, B256, Keccak256};
+// Re-export canonical Swarm primitives from nectar.
+pub use nectar_primitives::{Bin, NetworkId, Nonce, ProximityOrder, Timestamp, compute_overlay};
+
 use nectar_primitives::SwarmAddress;
 
 /// Overlay address for Swarm routing and peer identification.
 pub type OverlayAddress = SwarmAddress;
-
-/// Computes overlay address: `keccak256(ethereum_address || network_id || nonce)`.
-pub fn compute_overlay(ethereum_address: &Address, network_id: u64, nonce: &B256) -> SwarmAddress {
-    let mut hasher = Keccak256::new();
-    hasher.update(ethereum_address);
-    hasher.update(network_id.to_le_bytes());
-    hasher.update(nonce);
-    hasher.finalize().into()
-}
 
 /// Swarm node type determining capabilities and protocols.
 #[derive(

--- a/crates/swarm/primitives/src/validated.rs
+++ b/crates/swarm/primitives/src/validated.rs
@@ -111,6 +111,7 @@ impl<C: ChunkTypeSet> AsRef<AnyChunk> for ValidatedChunk<C> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use nectar_primitives::{

--- a/crates/swarm/spec/src/api.rs
+++ b/crates/swarm/spec/src/api.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloc::{string::String, vec::Vec};
 use alloy_chains::Chain;
-use nectar_primitives::StandardChunkSet;
+use nectar_primitives::{NetworkId, StandardChunkSet};
 use nectar_swarms::Swarm;
 use vertex_swarm_api::{SwarmSpec, SwarmSpecProvider};
 use vertex_swarm_forks::{ForkCondition, ForkDigest, SwarmHardfork, SwarmHardforks};
@@ -27,8 +27,8 @@ impl SwarmSpec for Spec {
         self.chain
     }
 
-    fn network_id(&self) -> u64 {
-        self.network_id
+    fn network_id(&self) -> NetworkId {
+        NetworkId::from(self.network_id)
     }
 
     fn network_name(&self) -> &str {

--- a/crates/swarm/spec/src/lib.rs
+++ b/crates/swarm/spec/src/lib.rs
@@ -156,19 +156,20 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nectar_primitives::NetworkId;
 
     #[test]
     fn test_mainnet_spec() {
         let spec = init_mainnet();
         assert!(spec.is_mainnet());
-        assert_eq!(spec.network_id(), mainnet::NETWORK_ID);
+        assert_eq!(spec.network_id(), NetworkId::from(mainnet::NETWORK_ID));
     }
 
     #[test]
     fn test_testnet_spec() {
         let spec = init_testnet();
         assert!(spec.is_testnet());
-        assert_eq!(spec.network_id(), testnet::NETWORK_ID);
+        assert_eq!(spec.network_id(), NetworkId::from(testnet::NETWORK_ID));
     }
 
     #[test]
@@ -182,11 +183,17 @@ mod tests {
         let spec = init_mainnet();
 
         // Arc<Spec> implements SwarmSpecProvider
-        assert_eq!(spec.spec().network_id(), mainnet::NETWORK_ID);
+        assert_eq!(
+            spec.spec().network_id(),
+            NetworkId::from(mainnet::NETWORK_ID)
+        );
 
         // StaticSwarmSpecProvider also works
         let provider = StaticSwarmSpecProvider::from_arc(spec);
-        assert_eq!(provider.spec().network_id(), mainnet::NETWORK_ID);
+        assert_eq!(
+            provider.spec().network_id(),
+            NetworkId::from(mainnet::NETWORK_ID)
+        );
     }
 
     #[test]

--- a/crates/swarm/test-utils/src/identity.rs
+++ b/crates/swarm/test-utils/src/identity.rs
@@ -1,11 +1,11 @@
 //! Mock identity implementations and test helpers.
 
-use alloy_primitives::B256;
 use alloy_signer_local::LocalSigner;
 use nectar_primitives::SwarmAddress;
 use std::sync::Arc;
 use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
 use vertex_swarm_identity::Identity;
+use vertex_swarm_primitives::Nonce;
 use vertex_swarm_spec::Spec;
 
 /// A mock identity for testing Swarm components.
@@ -24,7 +24,7 @@ use vertex_swarm_spec::Spec;
 /// // Or with builder pattern
 /// let mock = MockIdentity::with_first_byte(0x00)
 ///     .with_node_type(SwarmNodeType::Client)
-///     .with_nonce(B256::repeat_byte(0xff));
+///     .with_nonce(Nonce::new([0xff; 32]));
 /// ```
 #[derive(Clone)]
 pub struct MockIdentity {
@@ -32,7 +32,7 @@ pub struct MockIdentity {
     signer: Arc<LocalSigner<alloy_signer::k256::ecdsa::SigningKey>>,
     spec: Arc<Spec>,
     node_type: SwarmNodeType,
-    nonce: B256,
+    nonce: Nonce,
 }
 
 impl std::fmt::Debug for MockIdentity {
@@ -53,7 +53,7 @@ impl MockIdentity {
             signer: Arc::new(signer),
             spec: vertex_swarm_spec::init_testnet(),
             node_type: SwarmNodeType::Storer,
-            nonce: B256::ZERO,
+            nonce: Nonce::ZERO,
         }
     }
 
@@ -74,7 +74,7 @@ impl MockIdentity {
 
     /// Set the nonce for this mock identity.
     #[must_use]
-    pub fn with_nonce(mut self, nonce: B256) -> Self {
+    pub fn with_nonce(mut self, nonce: Nonce) -> Self {
         self.nonce = nonce;
         self
     }
@@ -95,7 +95,7 @@ impl SwarmIdentity for MockIdentity {
         &self.spec
     }
 
-    fn nonce(&self) -> B256 {
+    fn nonce(&self) -> Nonce {
         self.nonce
     }
 
@@ -152,17 +152,17 @@ mod tests {
 
         assert_eq!(mock.overlay_address(), overlay);
         assert_eq!(mock.node_type(), SwarmNodeType::Storer);
-        assert_eq!(mock.nonce(), B256::ZERO);
+        assert_eq!(mock.nonce(), Nonce::ZERO);
     }
 
     #[test]
     fn test_mock_identity_builder() {
         let mock = MockIdentity::with_first_byte(0x00)
             .with_node_type(SwarmNodeType::Client)
-            .with_nonce(B256::repeat_byte(0xff));
+            .with_nonce(Nonce::new([0xff; 32]));
 
         assert_eq!(mock.node_type(), SwarmNodeType::Client);
-        assert_eq!(mock.nonce(), B256::repeat_byte(0xff));
+        assert_eq!(mock.nonce(), Nonce::new([0xff; 32]));
     }
 
     #[test]

--- a/crates/swarm/test-utils/src/peer.rs
+++ b/crates/swarm/test-utils/src/peer.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, B256, Signature, U256};
 use libp2p::PeerId;
 use nectar_primitives::SwarmAddress;
 use vertex_swarm_peer::SwarmPeer;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Nonce, OverlayAddress};
 
 /// Create a test overlay address from a single byte.
 ///
@@ -86,7 +86,7 @@ pub fn test_swarm_peer(n: u8) -> SwarmPeer {
         multiaddrs,
         Signature::test_signature(),
         overlay,
-        B256::ZERO,
+        Nonce::ZERO,
         Address::ZERO,
     )
 }
@@ -119,7 +119,7 @@ pub fn make_swarm_peer_minimal(overlay_byte: u8) -> SwarmPeer {
         vec![],
         Signature::new(U256::ZERO, U256::ZERO, false),
         B256::from_slice(overlay.as_slice()),
-        B256::ZERO,
+        Nonce::ZERO,
         Address::ZERO,
     )
 }

--- a/crates/swarm/test-utils/src/spec.rs
+++ b/crates/swarm/test-utils/src/spec.rs
@@ -51,18 +51,18 @@ mod tests {
     fn test_spec_is_testnet() {
         let spec = test_spec();
         // The spec should be a testnet configuration
-        assert!(spec.network_id() > 0);
+        assert!(spec.network_id().get() > 0);
     }
 
     #[test]
     fn test_spec_isolated_uses_constant() {
         let spec = test_spec_isolated();
-        assert_eq!(spec.network_id(), TEST_NETWORK_ID);
+        assert_eq!(spec.network_id().get(), TEST_NETWORK_ID);
     }
 
     #[test]
     fn test_custom_network_id() {
         let spec = test_spec_with_network_id(42);
-        assert_eq!(spec.network_id(), 42);
+        assert_eq!(spec.network_id().get(), 42);
     }
 }

--- a/crates/swarm/topology/src/gossip/verifier.rs
+++ b/crates/swarm/topology/src/gossip/verifier.rs
@@ -315,7 +315,7 @@ mod tests {
             vec![multiaddr],
             Signature::new(U256::from(1u64), U256::from(2u64), false),
             B256::from(overlay_bytes),
-            B256::ZERO,
+            vertex_swarm_primitives::Nonce::ZERO,
             Address::ZERO,
         )
     }
@@ -333,7 +333,7 @@ mod tests {
             vec![multiaddr],
             Signature::new(U256::from(sig_r), U256::from(sig_s), false),
             B256::from(overlay_bytes),
-            B256::ZERO,
+            vertex_swarm_primitives::Nonce::ZERO,
             Address::ZERO,
         )
     }
@@ -344,7 +344,7 @@ mod tests {
             vec![multiaddr],
             Signature::new(U256::from(1u64), U256::from(2u64), false),
             B256::from(overlay_bytes),
-            B256::ZERO,
+            vertex_swarm_primitives::Nonce::ZERO,
             Address::ZERO,
         )
     }


### PR DESCRIPTION
## Summary

Unit 1 of the bee-mainnet-interop bootnode plan. Introduces strict newtypes
that replace bare `[u8;32]` / `u64` / `u8` / `i64` flowing through public APIs.

- `Nonce(B256)` — opaque, `random()` (gated on `std`), `as_slice()`, no `Deref`.
- `NetworkId(u64)` — `MAINNET = 1`, `TESTNET = 10`, decimal Display, BE wire helpers.
- `ProximityOrder(u8)` — `TryFrom<u8>` rejects > 31 (`MAX_PO`), displays as `po=<n>`.
- `Bin(u8)` `#[repr(transparent)]` 0..=31, kept distinct from `ProximityOrder`.
- `Timestamp(i64)` — `now()`, `skew_window(Duration)` validator mirroring bee
  `bzz/timestamp.go`, structured `TimestampError` for metrics labelling.
- `SwarmAddressExt` extension trait adds typed `proximity_order`, `xor`, `bin`
  on `nectar_primitives::SwarmAddress` without touching nectar. Golden vectors
  from bee `proximity_test.go` are included.

New public enums (`ProximityOrderError`, `BinError`, `TimestampError`) are
`#[non_exhaustive]`. All types derive serde behind the existing `serde` feature.

## Test plan

- [x] `cargo build -p vertex-swarm-primitives --all-features`
- [x] `cargo test  -p vertex-swarm-primitives --all-features` (46 tests pass)
- [x] `cargo clippy -p vertex-swarm-primitives --lib --all-features -- -D warnings`
- [x] `cargo clippy -p vertex-swarm-primitives --tests --all-features -- -D warnings -A unwrap_used -A expect_used -A indexing_slicing`