### PR TITLE
feat(net-core): introduce SwarmProtocol trait abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8109,6 +8109,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-swarm-net-core"
+version = "0.1.0"
+dependencies = [
+ "libp2p",
+]
+
+[[package]]
 name = "vertex-swarm-net-handler-core"
 version = "0.1.0"
 dependencies = [
@@ -8149,6 +8156,7 @@ dependencies = [
  "vertex-observability",
  "vertex-swarm-api",
  "vertex-swarm-identity",
+ "vertex-swarm-net-core",
  "vertex-swarm-net-proto",
  "vertex-swarm-peer",
  "vertex-swarm-spec",
@@ -8198,6 +8206,7 @@ dependencies = [
  "vertex-net-utils",
  "vertex-observability",
  "vertex-swarm-api",
+ "vertex-swarm-net-core",
  "vertex-swarm-net-handler-core",
  "vertex-swarm-net-headers",
  "vertex-swarm-net-proto",
@@ -8247,6 +8256,7 @@ dependencies = [
  "vertex-net-codec",
  "vertex-net-ratelimiter",
  "vertex-observability",
+ "vertex-swarm-net-core",
  "vertex-swarm-net-handler-core",
  "vertex-swarm-net-headers",
  "vertex-swarm-net-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/net/utils",
 
     # Swarm Network Protocols (crates/swarm/net/)
+    "crates/swarm/net/core",
     "crates/swarm/net/proto",
     "crates/swarm/net/handler-core",
     "crates/swarm/net/handshake",
@@ -138,6 +139,7 @@ vertex-net-ratelimiter = { path = "crates/net/ratelimiter" }
 vertex-net-utils = { path = "crates/net/utils" }
 
 # Swarm network protocols (crates/swarm/net/)
+vertex-swarm-net-core = { path = "crates/swarm/net/core" }
 vertex-swarm-net-proto = { path = "crates/swarm/net/proto" }
 vertex-swarm-net-handler-core = { path = "crates/swarm/net/handler-core" }
 vertex-swarm-net-handshake = { path = "crates/swarm/net/handshake" }

--- a/crates/swarm/net/core/Cargo.toml
+++ b/crates/swarm/net/core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vertex-swarm-net-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+libp2p.workspace = true

--- a/crates/swarm/net/core/src/lib.rs
+++ b/crates/swarm/net/core/src/lib.rs
@@ -1,0 +1,17 @@
+//! Core abstractions for Swarm wire protocols.
+//!
+//! This crate defines the [`SwarmProtocol`] trait — a single shape every Swarm
+//! protocol implements so the rest of the stack (handlers, behaviours, dialers)
+//! can speak about protocols generically instead of with ad-hoc per-protocol
+//! constants. It also exposes [`SemanticVersion`], the version newtype used in
+//! Swarm protocol IDs, and the [`swarm_protocol_id!`] macro that constructs the
+//! canonical `/swarm/{name}/{version}/{stream}` string at compile time.
+//!
+//! The concrete codecs and message types continue to live in their respective
+//! protocol crates; this crate only fixes the *shape* they must expose.
+
+mod protocol;
+mod version;
+
+pub use protocol::{ProtoCodec, SwarmProtocol};
+pub use version::SemanticVersion;

--- a/crates/swarm/net/core/src/protocol.rs
+++ b/crates/swarm/net/core/src/protocol.rs
@@ -1,0 +1,93 @@
+//! The [`SwarmProtocol`] trait — one shape for every Swarm wire protocol.
+
+use libp2p::StreamProtocol;
+
+use crate::SemanticVersion;
+
+/// A protobuf codec for a Swarm protocol message.
+///
+/// This is intentionally a minimal marker trait: it associates a codec type
+/// with the domain message it encodes, without prescribing how that codec is
+/// implemented. Concrete codecs (built on `quick-protobuf-codec`, `prost`, or
+/// the `vertex-net-codec` framed wrapper) live in their respective protocol
+/// crates and implement this trait to plug into the [`SwarmProtocol`] shape.
+pub trait ProtoCodec {
+    /// The decoded domain message this codec produces.
+    type Message;
+}
+
+/// One shape for every Swarm wire protocol.
+///
+/// Implementors describe themselves via compile-time metadata:
+///
+/// - [`NAME`](Self::NAME) — the second segment of the protocol ID
+///   (`/swarm/{NAME}/.../...`),
+/// - [`VERSION`](Self::VERSION) — the semantic version segment,
+/// - [`STREAM_NAME`](Self::STREAM_NAME) — the trailing segment that
+///   distinguishes streams that share a protocol name (e.g. `hive`'s `peers`),
+/// - [`Codec`](Self::Codec) — the wire codec, and
+/// - [`Message`](Self::Message) — the domain message it produces.
+///
+/// The full libp2p `StreamProtocol` ID is composed from those parts by
+/// [`full_protocol_id`](Self::full_protocol_id), guaranteeing every Swarm
+/// protocol agrees on the `/swarm/{name}/{version}/{stream}` layout.
+///
+/// This trait is metadata-only: implementing it does not change runtime
+/// behaviour, dispatch, or the wire format of any existing protocol.
+pub trait SwarmProtocol {
+    /// Protocol family name, e.g. `"handshake"`, `"hive"`, `"pingpong"`.
+    const NAME: &'static str;
+
+    /// Semantic version of this protocol.
+    const VERSION: SemanticVersion;
+
+    /// Trailing stream segment of the protocol ID. Usually equal to
+    /// [`NAME`](Self::NAME), but some families (e.g. `hive`) use a distinct
+    /// stream name such as `"peers"`.
+    const STREAM_NAME: &'static str;
+
+    /// Wire codec used to frame [`Message`](Self::Message) on this protocol.
+    type Codec: ProtoCodec<Message = Self::Message>;
+
+    /// Decoded domain message this protocol exchanges.
+    type Message;
+
+    /// Compose the full `/swarm/{name}/{version}/{stream}` libp2p protocol ID.
+    fn full_protocol_id() -> StreamProtocol;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyCodec;
+
+    impl ProtoCodec for DummyCodec {
+        type Message = u32;
+    }
+
+    struct Dummy;
+
+    impl SwarmProtocol for Dummy {
+        const NAME: &'static str = "dummy";
+        const VERSION: SemanticVersion = SemanticVersion::new(2, 3, 4);
+        const STREAM_NAME: &'static str = "stream";
+        type Codec = DummyCodec;
+        type Message = u32;
+
+        fn full_protocol_id() -> StreamProtocol {
+            StreamProtocol::new("/swarm/dummy/2.3.4/stream")
+        }
+    }
+
+    #[test]
+    fn metadata_round_trip() {
+        assert_eq!(Dummy::NAME, "dummy");
+        assert_eq!(Dummy::STREAM_NAME, "stream");
+        assert_eq!(Dummy::VERSION, SemanticVersion::new(2, 3, 4));
+        assert_eq!(
+            Dummy::full_protocol_id().as_ref(),
+            "/swarm/dummy/2.3.4/stream"
+        );
+    }
+}

--- a/crates/swarm/net/core/src/version.rs
+++ b/crates/swarm/net/core/src/version.rs
@@ -1,0 +1,144 @@
+//! Semantic version newtype for Swarm protocol IDs.
+
+use std::fmt;
+
+/// A semantic version triple (`MAJOR.MINOR.PATCH`) as used in Swarm protocol
+/// identifiers.
+///
+/// Swarm protocol IDs follow the layout `/swarm/{name}/{MAJOR.MINOR.PATCH}/{stream}`,
+/// where the version segment is parsed and compared with the same rule used by
+/// `go-libp2p` / Bee's `protocolSemverMatcher`: a remote (client) version
+/// matches the local (server) version iff the majors are equal and the server's
+/// minor is at least the client's minor. Patch differences are ignored.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+pub struct SemanticVersion(u16, u16, u16);
+
+impl SemanticVersion {
+    /// Construct a [`SemanticVersion`] from its three components.
+    pub const fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self(major, minor, patch)
+    }
+
+    /// Major version component.
+    pub const fn major(self) -> u16 {
+        self.0
+    }
+
+    /// Minor version component.
+    pub const fn minor(self) -> u16 {
+        self.1
+    }
+
+    /// Patch version component.
+    pub const fn patch(self) -> u16 {
+        self.2
+    }
+
+    /// Compatibility check between a `client`-advertised version and the local
+    /// `server` version.
+    ///
+    /// Mirrors Bee's `protocolSemverMatcher`: a client request is accepted iff
+    /// `server.major == client.major && server.minor >= client.minor`.
+    pub const fn matches(client: Self, server: Self) -> bool {
+        server.0 == client.0 && server.1 >= client.1
+    }
+}
+
+impl fmt::Debug for SemanticVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+    }
+}
+
+impl fmt::Display for SemanticVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+    }
+}
+
+/// Compose a canonical Swarm protocol ID at compile time.
+///
+/// Expands to a `&'static str` of the form `/swarm/{name}/{MAJOR.MINOR.PATCH}/{stream}`.
+///
+/// # Example
+///
+/// ```
+/// use vertex_swarm_net_core::swarm_protocol_id;
+/// const ID: &str = swarm_protocol_id!("pingpong", 1, 0, 0, "pingpong");
+/// assert_eq!(ID, "/swarm/pingpong/1.0.0/pingpong");
+/// ```
+#[macro_export]
+macro_rules! swarm_protocol_id {
+    ($name:literal, $major:literal, $minor:literal, $patch:literal, $stream:literal) => {
+        ::core::concat!(
+            "/swarm/",
+            $name,
+            "/",
+            ::core::stringify!($major),
+            ".",
+            ::core::stringify!($minor),
+            ".",
+            ::core::stringify!($patch),
+            "/",
+            $stream,
+        )
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_same_version_is_true() {
+        let v = SemanticVersion::new(1, 0, 0);
+        assert!(SemanticVersion::matches(v, v));
+    }
+
+    #[test]
+    fn matches_requires_equal_major() {
+        let client = SemanticVersion::new(1, 5, 0);
+        let server = SemanticVersion::new(2, 5, 0);
+        assert!(!SemanticVersion::matches(client, server));
+        assert!(!SemanticVersion::matches(server, client));
+    }
+
+    #[test]
+    fn matches_server_minor_must_be_at_least_client() {
+        let client = SemanticVersion::new(1, 2, 0);
+        let newer_server = SemanticVersion::new(1, 5, 0);
+        let older_server = SemanticVersion::new(1, 1, 0);
+
+        // server has a strictly newer minor — backwards compatible, accepted.
+        assert!(SemanticVersion::matches(client, newer_server));
+        // server has an older minor — cannot serve this client, rejected.
+        assert!(!SemanticVersion::matches(client, older_server));
+    }
+
+    #[test]
+    fn matches_ignores_patch() {
+        let a = SemanticVersion::new(3, 4, 0);
+        let b = SemanticVersion::new(3, 4, 99);
+        assert!(SemanticVersion::matches(a, b));
+        assert!(SemanticVersion::matches(b, a));
+    }
+
+    #[test]
+    fn display_uses_dotted_triple() {
+        let v = SemanticVersion::new(14, 0, 0);
+        assert_eq!(v.to_string(), "14.0.0");
+        assert_eq!(format!("{v:?}"), "14.0.0");
+    }
+
+    #[test]
+    fn macro_composes_protocol_id() {
+        const ID: &str = swarm_protocol_id!("handshake", 14, 0, 0, "handshake");
+        assert_eq!(ID, "/swarm/handshake/14.0.0/handshake");
+    }
+
+    #[test]
+    fn macro_composes_protocol_id_with_distinct_stream() {
+        const ID: &str = swarm_protocol_id!("hive", 1, 1, 0, "peers");
+        assert_eq!(ID, "/swarm/hive/1.1.0/peers");
+    }
+}

--- a/crates/swarm/net/handshake/Cargo.toml
+++ b/crates/swarm/net/handshake/Cargo.toml
@@ -16,6 +16,7 @@ vertex-net-codec.workspace = true
 vertex-net-peer-registry.workspace = true
 vertex-swarm-api.workspace = true
 vertex-swarm-identity.workspace = true
+vertex-swarm-net-core.workspace = true
 vertex-swarm-net-proto.workspace = true
 vertex-swarm-peer.workspace = true
 vertex-net-utils.workspace = true

--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use libp2p::{Multiaddr, PeerId};
+use vertex_swarm_net_core::{ProtoCodec, SemanticVersion, SwarmProtocol, swarm_protocol_id};
 use vertex_swarm_peer::{SwarmNodeType, SwarmPeer};
 
 mod behaviour;
@@ -24,7 +25,35 @@ mod address;
 pub use address::{AddressProvider, NoAddresses};
 
 /// Protocol name for handshake.
-pub const PROTOCOL: &str = "/swarm/handshake/14.0.0/handshake";
+pub const PROTOCOL: &str = swarm_protocol_id!("handshake", 14, 0, 0, "handshake");
+
+/// Marker codec type for the [`SwarmProtocol`] impl on [`Handshake`].
+///
+/// Handshake's wire framing lives in `protocol.rs` (built on
+/// `vertex_net_codec::FramedProto`); this struct exists only to satisfy the
+/// trait's `Codec` slot.
+#[derive(Debug)]
+pub struct HandshakeCodec;
+
+impl ProtoCodec for HandshakeCodec {
+    type Message = HandshakeInfo;
+}
+
+/// Marker type identifying the Swarm handshake protocol family.
+#[derive(Debug)]
+pub struct Handshake;
+
+impl SwarmProtocol for Handshake {
+    const NAME: &'static str = "handshake";
+    const VERSION: SemanticVersion = SemanticVersion::new(14, 0, 0);
+    const STREAM_NAME: &'static str = "handshake";
+    type Codec = HandshakeCodec;
+    type Message = HandshakeInfo;
+
+    fn full_protocol_id() -> libp2p::StreamProtocol {
+        libp2p::StreamProtocol::new(PROTOCOL)
+    }
+}
 
 /// Timeout for handshake operations.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);

--- a/crates/swarm/net/hive/Cargo.toml
+++ b/crates/swarm/net/hive/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 ## vertex
 vertex-net-codec.workspace = true
 vertex-net-ratelimiter.workspace = true
+vertex-swarm-net-core.workspace = true
 vertex-swarm-net-handler-core.workspace = true
 vertex-swarm-net-headers.workspace = true
 vertex-swarm-net-proto.workspace = true

--- a/crates/swarm/net/hive/src/lib.rs
+++ b/crates/swarm/net/hive/src/lib.rs
@@ -10,8 +10,37 @@ mod protocol;
 pub use behaviour::{HiveBehaviour, HiveEvent};
 pub use error::ValidationFailure;
 
+use vertex_swarm_net_core::{ProtoCodec, SemanticVersion, SwarmProtocol, swarm_protocol_id};
+
 /// Protocol name for hive.
-pub const PROTOCOL_NAME: &str = "/swarm/hive/1.1.0/peers";
+pub const PROTOCOL_NAME: &str = swarm_protocol_id!("hive", 1, 1, 0, "peers");
 
 /// Maximum number of peers per broadcast message.
 pub const MAX_BATCH_SIZE: usize = 30;
+
+/// Marker codec type for the [`SwarmProtocol`] impl on [`Hive`].
+///
+/// The actual wire framing lives in `protocol.rs`; this struct exists only to
+/// satisfy the trait's `Codec` slot and pin the wire message type.
+#[derive(Debug)]
+pub struct HiveCodec;
+
+impl ProtoCodec for HiveCodec {
+    type Message = vertex_swarm_net_proto::hive::Peers;
+}
+
+/// Marker type identifying the Swarm hive (peer-exchange) protocol family.
+#[derive(Debug)]
+pub struct Hive;
+
+impl SwarmProtocol for Hive {
+    const NAME: &'static str = "hive";
+    const VERSION: SemanticVersion = SemanticVersion::new(1, 1, 0);
+    const STREAM_NAME: &'static str = "peers";
+    type Codec = HiveCodec;
+    type Message = vertex_swarm_net_proto::hive::Peers;
+
+    fn full_protocol_id() -> libp2p::StreamProtocol {
+        libp2p::StreamProtocol::new(PROTOCOL_NAME)
+    }
+}

--- a/crates/swarm/net/pingpong/Cargo.toml
+++ b/crates/swarm/net/pingpong/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 ## vertex
 vertex-net-codec.workspace = true
 vertex-net-ratelimiter.workspace = true
+vertex-swarm-net-core.workspace = true
 vertex-swarm-net-handler-core.workspace = true
 vertex-observability.workspace = true
 vertex-swarm-net-headers.workspace = true

--- a/crates/swarm/net/pingpong/src/lib.rs
+++ b/crates/swarm/net/pingpong/src/lib.rs
@@ -12,5 +12,34 @@ pub(crate) use protocol::{PingpongOutboundProtocol, outbound};
 
 pub mod metrics;
 
+use vertex_swarm_net_core::{ProtoCodec, SemanticVersion, SwarmProtocol, swarm_protocol_id};
+
 /// Protocol name for pingpong.
-pub const PROTOCOL_NAME: &str = "/swarm/pingpong/1.0.0/pingpong";
+pub const PROTOCOL_NAME: &str = swarm_protocol_id!("pingpong", 1, 0, 0, "pingpong");
+
+/// Marker codec type for the [`SwarmProtocol`] impl on [`Pingpong`].
+///
+/// The actual wire framing lives in `protocol.rs`; this struct exists only to
+/// satisfy the trait's `Codec` slot and pin the wire message type.
+#[derive(Debug)]
+pub struct PingpongCodec;
+
+impl ProtoCodec for PingpongCodec {
+    type Message = vertex_swarm_net_proto::pingpong::Ping;
+}
+
+/// Marker type identifying the Swarm pingpong protocol family.
+#[derive(Debug)]
+pub struct Pingpong;
+
+impl SwarmProtocol for Pingpong {
+    const NAME: &'static str = "pingpong";
+    const VERSION: SemanticVersion = SemanticVersion::new(1, 0, 0);
+    const STREAM_NAME: &'static str = "pingpong";
+    type Codec = PingpongCodec;
+    type Message = vertex_swarm_net_proto::pingpong::Ping;
+
+    fn full_protocol_id() -> libp2p::StreamProtocol {
+        libp2p::StreamProtocol::new(PROTOCOL_NAME)
+    }
+}


### PR DESCRIPTION
## Summary

Unit 3 of the bee-mainnet bootnode interop plan.

Introduces a uniform `SwarmProtocol` trait so handshake, hive, pingpong and future protocols share one shape. Pure additive surface; no runtime behaviour change.

- New `vertex-swarm-net-core` crate (`crates/swarm/net/core/`) with:
  - `SwarmProtocol` trait (`NAME`, `VERSION`, `STREAM_NAME`, `Codec`, `Message`, `full_protocol_id()`).
  - `SemanticVersion(u16, u16, u16)` with libp2p-compatible matching (same major, server-minor ≥ client-minor).
  - `swarm_protocol_id!(name, version, stream)` compile-time macro composing `/swarm/{name}/{version}/{stream}`.
- Metadata-only impls on the existing handshake, hive, pingpong modules.
- Existing `PROTOCOL` constants are preserved unchanged (verified by tests).

## Test plan

- [x] `cargo test -p vertex-swarm-net-core --no-fail-fast` (8 unit + 1 doctest passing)
- [x] `cargo build -p vertex-swarm-net-{core,handshake,hive,pingpong}`
- [ ] downstream regression once dependent units land