### PR TITLE
feat(node)!: enforce persistent identity for bootnodes

### DIFF
--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -148,9 +148,32 @@ pub trait SwarmNetworkConfig {
 }
 
 /// Configuration for Swarm node identity.
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait SwarmIdentityConfig {
     /// Whether to use ephemeral identity (random key, not persisted).
     fn ephemeral(&self) -> bool;
+
+    /// Assert that this configuration satisfies the persistence requirement
+    /// of `node_type`.
+    ///
+    /// Called by node builders (e.g. `BootNodeBuilder`) that require a
+    /// stable overlay address across restarts. Returns
+    /// [`crate::error::IdentityError::EphemeralWhenPersistent`] if `node_type`
+    /// requires persistence (see
+    /// [`crate::SwarmNodeType::requires_persistent_identity`]) but this
+    /// configuration would produce an ephemeral identity.
+    ///
+    /// The default implementation derives the answer from [`Self::ephemeral`].
+    /// Implementations whose persistence semantics differ may override.
+    fn assert_persistent_identity(
+        &self,
+        node_type: crate::SwarmNodeType,
+    ) -> Result<(), crate::error::IdentityError> {
+        if self.ephemeral() && node_type.requires_persistent_identity() {
+            return Err(crate::error::IdentityError::EphemeralWhenPersistent { node_type });
+        }
+        Ok(())
+    }
 }
 
 /// Base configuration for all Swarm nodes (bootnode level).

--- a/crates/swarm/api/src/error.rs
+++ b/crates/swarm/api/src/error.rs
@@ -223,3 +223,25 @@ pub enum ConfigError {
 
 /// Result type for configuration operations.
 pub type ConfigResult<T> = core::result::Result<T, ConfigError>;
+
+/// Error type for identity configuration validation.
+///
+/// Marked `#[non_exhaustive]` so new variants can be added without breaking
+/// downstream matches.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
+#[strum(serialize_all = "snake_case")]
+pub enum IdentityError {
+    /// An ephemeral identity was configured for a node type that requires a
+    /// persistent (keystore-backed) signing key. Bootnodes and storers have
+    /// overlay addresses that are part of the network contract; restarting
+    /// with a fresh random key changes the overlay and orphans the network
+    /// (bootnode case) or the staked reservation (storer case).
+    #[error(
+        "{node_type} requires a persistent identity but was launched ephemeral; configure a keystore"
+    )]
+    EphemeralWhenPersistent {
+        /// The node type whose persistence requirement was violated.
+        node_type: crate::SwarmNodeType,
+    },
+}

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -62,7 +62,9 @@ pub use self::config::{
     SwarmRoutingConfig, SwarmStorageConfig, SwarmStorerConfig, SwarmStorerLaunchConfig,
     estimate_chunks_for_bytes, estimate_storage_bytes,
 };
-pub use self::error::{ConfigAddressKind, ConfigError, ConfigResult, SwarmError, SwarmResult};
+pub use self::error::{
+    ConfigAddressKind, ConfigError, ConfigResult, IdentityError, SwarmError, SwarmResult,
+};
 pub use self::identity::SwarmIdentity;
 pub use self::protocol::SwarmProtocol;
 pub use self::providers::{

--- a/crates/swarm/identity/src/args.rs
+++ b/crates/swarm/identity/src/args.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::debug;
-use vertex_swarm_api::SwarmIdentityConfig;
+use vertex_swarm_api::{IdentityError, SwarmIdentityConfig};
 use vertex_swarm_primitives::{Nonce, SwarmNodeType};
 use vertex_swarm_spec::Spec;
 
@@ -57,6 +57,12 @@ impl IdentityArgs {
         network_dir: &Path,
         node_type: SwarmNodeType,
     ) -> Result<Arc<Identity>> {
+        // Bootnodes and storers must run with a persistent (keystore-backed)
+        // identity - their overlay address is part of the network contract.
+        if self.ephemeral && node_type.requires_persistent_identity() {
+            return Err(IdentityError::EphemeralWhenPersistent { node_type }.into());
+        }
+
         let use_ephemeral = self.ephemeral || !node_type.requires_persistent_identity();
 
         if use_ephemeral {

--- a/crates/swarm/identity/src/lib.rs
+++ b/crates/swarm/identity/src/lib.rs
@@ -12,12 +12,13 @@ use alloy_signer::k256::ecdsa::SigningKey;
 use alloy_signer_local::LocalSigner;
 use nectar_primitives::SwarmAddress;
 use std::sync::Arc;
-use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
+use vertex_swarm_api::{SwarmIdentity, SwarmIdentityConfig, SwarmNodeType};
 use vertex_swarm_primitives::{Nonce, compute_overlay};
 use vertex_swarm_spec::{HasSpec, Loggable, Spec, SwarmSpec};
 
 pub use args::IdentityArgs;
 pub use keystore::{create_and_save_signer, load_signer_from_keystore, resolve_password};
+pub use vertex_swarm_api::IdentityError;
 pub use vertex_swarm_api::SwarmIdentity as IdentityTrait;
 
 /// Local node identity containing signing key, nonce, and network spec.
@@ -32,10 +33,18 @@ pub struct Identity {
     overlay: SwarmAddress,
     node_type: SwarmNodeType,
     welcome_message: Option<String>,
+    /// True if this identity was created from a random ephemeral signer rather
+    /// than loaded/saved through a keystore. Bootnodes must never run with
+    /// `ephemeral == true` because their overlay address is a network
+    /// contract.
+    ephemeral: bool,
 }
 
 impl Identity {
     /// Creates a new identity from a signer, nonce, spec, and node type.
+    ///
+    /// Identities created via `new` are considered persistent — callers are
+    /// expected to have sourced the signer from a keystore.
     pub fn new(
         signer: LocalSigner<SigningKey>,
         nonce: Nonce,
@@ -50,18 +59,36 @@ impl Identity {
             overlay,
             node_type,
             welcome_message: None,
+            ephemeral: false,
         }
     }
 
     /// Creates a random ephemeral identity for testing.
     pub fn random(spec: Arc<Spec>, node_type: SwarmNodeType) -> Self {
-        Self::new(LocalSigner::random(), Nonce::random(), spec, node_type)
+        let nonce = Nonce::random();
+        let signer = LocalSigner::random();
+        let overlay = compute_overlay(&signer.address(), spec.network_id(), &nonce);
+        Self {
+            spec,
+            signer: Arc::new(signer),
+            nonce,
+            overlay,
+            node_type,
+            welcome_message: None,
+            ephemeral: true,
+        }
     }
 
     /// Sets a custom welcome message.
     pub fn with_welcome_message(mut self, message: impl Into<String>) -> Self {
         self.welcome_message = Some(message.into());
         self
+    }
+}
+
+impl SwarmIdentityConfig for Identity {
+    fn ephemeral(&self) -> bool {
+        self.ephemeral
     }
 }
 

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -10,7 +10,9 @@ use futures::StreamExt;
 use libp2p::{PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
 use nectar_primitives::SwarmAddress;
 use tracing::info;
-use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig};
+use vertex_swarm_api::{
+    SwarmIdentity, SwarmIdentityConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
+};
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_topology::{
     KademliaConfig, TopologyBehaviour, TopologyCommand, TopologyConfig, TopologyEvent,
@@ -217,9 +219,15 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
         >,
     ) -> Result<BootNode<I>>
     where
-        I: vertex_swarm_spec::HasSpec,
+        I: vertex_swarm_spec::HasSpec + SwarmIdentityConfig,
         C: SwarmNetworkConfig + SwarmPeerConfig + SwarmRoutingConfig<Routing = KademliaConfig>,
     {
+        // Bootnodes have a well-known overlay address that peers rely on
+        // across restarts. Reject ephemeral identities before doing any
+        // network setup so misconfiguration fails fast.
+        self.identity
+            .assert_persistent_identity(vertex_swarm_primitives::SwarmNodeType::Bootnode)?;
+
         info!("Initializing bootnode P2P network...");
 
         let infra = match self.infra {
@@ -252,5 +260,103 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
             .set_local_peer_id(*base.swarm.local_peer_id());
 
         Ok(BootNode { base })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use libp2p::Multiaddr;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use vertex_swarm_api::{DefaultPeerConfig, IdentityError, SwarmIdentityConfig};
+    use vertex_swarm_identity::Identity;
+    use vertex_swarm_primitives::SwarmNodeType;
+
+    /// Minimal config used purely to exercise the bootnode build trait bounds.
+    /// We never reach the network-init code path: `assert_persistent_identity`
+    /// must fail before any peer/routing config is touched.
+    struct TestConfig {
+        peers: DefaultPeerConfig,
+        routing: KademliaConfig,
+        empty_addrs: Vec<Multiaddr>,
+    }
+
+    impl TestConfig {
+        fn new() -> Self {
+            Self {
+                peers: DefaultPeerConfig::default(),
+                routing: KademliaConfig::default(),
+                empty_addrs: Vec::new(),
+            }
+        }
+    }
+
+    impl SwarmNetworkConfig for TestConfig {
+        fn listen_addrs(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn bootnodes(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn trusted_peers(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn discovery_enabled(&self) -> bool {
+            true
+        }
+        fn max_peers(&self) -> usize {
+            32
+        }
+        fn idle_timeout(&self) -> Duration {
+            Duration::from_secs(60)
+        }
+    }
+
+    impl SwarmPeerConfig for TestConfig {
+        type Peers = DefaultPeerConfig;
+        fn peers(&self) -> &Self::Peers {
+            &self.peers
+        }
+    }
+
+    impl SwarmRoutingConfig for TestConfig {
+        type Routing = KademliaConfig;
+        fn routing(&self) -> &Self::Routing {
+            &self.routing
+        }
+    }
+
+    /// An ephemeral bootnode must be rejected at build time. The well-known
+    /// overlay address contract requires a keystore-backed signing key.
+    #[tokio::test]
+    async fn ephemeral_bootnode_is_rejected_at_build() {
+        let spec = vertex_swarm_spec::init_testnet();
+        let identity = Arc::new(Identity::random(spec, SwarmNodeType::Bootnode));
+        assert!(identity.ephemeral(), "test precondition");
+
+        let network = TestConfig::new();
+
+        let result = BootNode::builder(identity)
+            .build(&network, None, None)
+            .await;
+
+        let err = match result {
+            Ok(_) => panic!("ephemeral bootnode must fail to build"),
+            Err(e) => e,
+        };
+        let identity_err = err
+            .downcast_ref::<IdentityError>()
+            .expect("error chain should carry an IdentityError");
+        assert!(
+            matches!(
+                identity_err,
+                IdentityError::EphemeralWhenPersistent {
+                    node_type: SwarmNodeType::Bootnode
+                }
+            ),
+            "expected EphemeralWhenPersistent {{ Bootnode }}, got: {identity_err:?}"
+        );
     }
 }

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -73,12 +73,56 @@ impl SwarmNodeType {
         matches!(self, SwarmNodeType::Storer)
     }
 
+    /// Whether this node type requires a persistent (keystore-backed) signing
+    /// key. Bootnodes need a stable overlay address across restarts so peers
+    /// can reach them via their well-known overlay. Storers need a stable key
+    /// for staking and chunk reservation.
     pub fn requires_persistent_identity(&self) -> bool {
-        matches!(self, SwarmNodeType::Storer)
+        matches!(self, SwarmNodeType::Bootnode | SwarmNodeType::Storer)
     }
 
+    /// Whether this node type requires a persistent nonce. Combined with a
+    /// persistent signing key, this fixes the overlay address across restarts.
     pub fn requires_persistent_nonce(&self) -> bool {
-        matches!(self, SwarmNodeType::Storer)
+        matches!(self, SwarmNodeType::Bootnode | SwarmNodeType::Storer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootnode_requires_persistent_identity_and_nonce() {
+        // Bootnode overlay is a contract: peers reach it via a well-known
+        // overlay address derived from the keystore key and nonce. Both must
+        // survive restart.
+        assert!(SwarmNodeType::Bootnode.requires_persistent_identity());
+        assert!(SwarmNodeType::Bootnode.requires_persistent_nonce());
+    }
+
+    #[test]
+    fn storer_requires_persistent_identity_and_nonce() {
+        assert!(SwarmNodeType::Storer.requires_persistent_identity());
+        assert!(SwarmNodeType::Storer.requires_persistent_nonce());
+    }
+
+    #[test]
+    fn client_does_not_require_persistence() {
+        assert!(!SwarmNodeType::Client.requires_persistent_identity());
+        assert!(!SwarmNodeType::Client.requires_persistent_nonce());
+    }
+
+    #[test]
+    fn bootnode_excludes_client_protocols() {
+        let t = SwarmNodeType::Bootnode;
+        assert!(!t.requires_pricing());
+        assert!(!t.requires_accounting());
+        assert!(!t.requires_retrieval());
+        assert!(!t.requires_pushsync());
+        assert!(!t.requires_pullsync());
+        assert!(!t.requires_storage());
+        assert!(!t.supports_staking());
     }
 }
 

--- a/crates/swarm/primitives/src/validated.rs
+++ b/crates/swarm/primitives/src/validated.rs
@@ -111,7 +111,6 @@ impl<C: ChunkTypeSet> AsRef<AnyChunk> for ValidatedChunk<C> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use nectar_primitives::{


### PR DESCRIPTION
## Summary

Unit 11 of the bee-mainnet bootnode interop plan.

Bootnodes must have a stable overlay address across restarts — that's the whole contract for a well-known peer. Ephemeral identity is now rejected at build time.

- `SwarmNodeType::Bootnode::requires_persistent_identity() / _nonce()` flipped to `true`.
- New trait method `SwarmIdentityConfig::assert_persistent_identity()`.
- `BootNodeBuilder::build` asserts before constructing the swarm.
- `IdentityArgs` routes to keystore when the node type requires persistence.
- New errors `#[non_exhaustive] IdentityError::EphemeralBootnode`.

## Test plan

- [x] `cargo test -p vertex-swarm-primitives -p vertex-swarm-identity -p vertex-swarm-node -p vertex-swarm-api`
- [x] new tests: `ephemeral_bootnode_is_rejected_at_build`, `bootnode_requires_persistent_identity_and_nonce`