### PR TITLE
feat(net-hive): per-peer rate limiting and bootnode discard gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7866,6 +7866,10 @@ dependencies = [
 [[package]]
 name = "vertex-net-ratelimiter"
 version = "0.1.0"
+dependencies = [
+ "parking_lot",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "vertex-net-utils"

--- a/crates/net/ratelimiter/Cargo.toml
+++ b/crates/net/ratelimiter/Cargo.toml
@@ -7,5 +7,9 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[dependencies]
+parking_lot.workspace = true
+thiserror.workspace = true
+
 [lints]
 workspace = true

--- a/crates/net/ratelimiter/src/lib.rs
+++ b/crates/net/ratelimiter/src/lib.rs
@@ -1,89 +1,302 @@
-//! Token bucket rate limiter for per-connection stream acceptance.
+//! GCRA token-bucket rate limiting, with a single-bucket form and a per-key
+//! sharded form intended for use across libp2p protocols.
+//!
+//! # Algorithm
+//!
+//! Both [`RateLimiter`] and [`KeyedRateLimiter`] implement the Generic Cell
+//! Rate Algorithm (GCRA). A request asking for `n` tokens is accepted iff
+//! enough time has passed since the bucket's theoretical arrival time (TAT)
+//! to permit `n` token-replenishments. Each bucket needs just one timestamp
+//! (`u64` nanoseconds since the limiter was constructed), so memory per key
+//! is small and a check is a handful of integer ops.
+//!
+//! # Single vs keyed
+//!
+//! - [`RateLimiter`] is one bucket, [`RateLimiter::try_consume_n`] takes
+//!   `&mut self`. Use it when a single owner needs throttling (for example
+//!   a libp2p [`ConnectionHandler`] limiting substream-open rate on the one
+//!   connection it manages).
+//! - [`KeyedRateLimiter`] is `&self`-shareable via an internal mutex and
+//!   maintains an independent bucket per key. Use it when many call sites
+//!   (typically a `NetworkBehaviour` plus the per-connection handler readers
+//!   it spawned) need to charge the same per-peer quota. Disconnect handlers
+//!   should call [`KeyedRateLimiter::clear`] to release the bucket; otherwise
+//!   memory grows with the count of distinct peers seen.
+//!
+//! [`ConnectionHandler`]: https://docs.rs/libp2p/0.56/libp2p/swarm/trait.ConnectionHandler.html
 
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::num::NonZeroU32;
 use std::time::{Duration, Instant};
 
-/// Token bucket rate limiter for inbound stream acceptance.
+/// Why a charge against a rate-limited bucket was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RateLimitedErr {
+    /// The request asks for more tokens than the bucket's burst, so it can
+    /// never be accepted - the caller must reduce the cost or fail
+    /// permanently.
+    #[error("rate limit cost exceeds bucket capacity")]
+    TooLarge,
+    /// The bucket cannot satisfy the request right now; the wrapped duration
+    /// is the earliest moment a retry would succeed.
+    #[error("rate limit exceeded, retry after {0:?}")]
+    TooSoon(Duration),
+}
+
+/// A user-friendly quota: at most `max_tokens` may be consumed in any window
+/// of `replenish_all_every`.
 ///
-/// Prevents peers from rapidly cycling streams even when each stream completes
-/// quickly. Tokens replenish at a steady rate up to a configurable burst limit.
-/// Check this *before* any concurrent-stream bound (e.g. `FuturesSet::try_push`)
-/// so that rapid open/close cycles are rejected even when the concurrent set has
-/// capacity.
+/// `Quota::n_every(NonZeroU32::new(4).unwrap(), Duration::from_secs(2))` means
+/// "4 tokens every 2 seconds", which the GCRA enforces as one token every
+/// 0.5 s with an instantaneous burst of 4.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Quota {
+    pub(crate) max_tokens: NonZeroU32,
+    pub(crate) replenish_all_every: Duration,
+}
+
+impl Quota {
+    /// `n` tokens every `replenish_all_every`.
+    pub const fn n_every(max_tokens: NonZeroU32, replenish_all_every: Duration) -> Self {
+        Self {
+            max_tokens,
+            replenish_all_every,
+        }
+    }
+
+    /// Exactly one token per `seconds` seconds. Equivalent to a hard rate
+    /// limit (no burst).
+    pub const fn one_every(seconds: u64) -> Self {
+        Self {
+            max_tokens: NonZeroU32::MIN,
+            replenish_all_every: Duration::from_secs(seconds),
+        }
+    }
+}
+
+/// GCRA state derived from a [`Quota`].
+#[derive(Clone, Copy, Debug)]
+struct Cell {
+    /// Time after which the bucket is again "full" once empty - the
+    /// difference between TAT and now must be at most `tau` for a request to
+    /// be admitted.
+    tau_nanos: u64,
+    /// Nanoseconds it takes to replenish one token.
+    t_nanos: u64,
+}
+
+impl Cell {
+    fn from_quota(q: Quota) -> Self {
+        let tau = q.replenish_all_every.as_nanos();
+        // Tokens per quota interval is non-zero, so this division is
+        // well-defined; both halves are saturated into a u64 because vertex
+        // never configures quotas anywhere near the u64 ceiling.
+        let t = tau / u128::from(q.max_tokens.get());
+        Self {
+            tau_nanos: u64::try_from(tau).unwrap_or(u64::MAX),
+            t_nanos: u64::try_from(t).unwrap_or(u64::MAX),
+        }
+    }
+}
+
+/// One GCRA token-bucket guarded by `&mut self`. See the crate docs for the
+/// algorithm sketch.
 pub struct RateLimiter {
-    tokens: f64,
-    max_tokens: f64,
-    refill_rate: f64,
-    last_refill: Instant,
+    cell: Cell,
+    init: Instant,
+    tat_nanos: u64,
 }
 
 impl RateLimiter {
-    /// Create a rate limiter with the given burst capacity and per-token refill interval.
-    ///
-    /// `max_tokens` is the burst allowance. `refill_interval` is the time for
-    /// one token to regenerate. Starts full (at `max_tokens`).
-    pub fn new(max_tokens: u32, refill_interval: Duration) -> Self {
-        let max = max_tokens as f64;
+    /// Build a limiter from a quota. The bucket starts full.
+    pub fn new(quota: Quota) -> Self {
         Self {
-            tokens: max,
-            max_tokens: max,
-            refill_rate: 1.0 / refill_interval.as_secs_f64(),
-            last_refill: Instant::now(),
+            cell: Cell::from_quota(quota),
+            init: Instant::now(),
+            tat_nanos: 0,
         }
     }
 
-    /// Try to consume one token. Returns `true` if accepted, `false` if rate limited.
-    pub fn try_acquire(&mut self) -> bool {
-        self.refill();
-        if self.tokens >= 1.0 {
-            self.tokens -= 1.0;
-            true
-        } else {
-            false
+    /// Charge one token.
+    pub fn try_consume(&mut self) -> Result<(), RateLimitedErr> {
+        self.try_consume_n(1)
+    }
+
+    /// Charge `n` tokens, atomically: either all `n` are charged or the
+    /// bucket is left untouched.
+    pub fn try_consume_n(&mut self, n: u32) -> Result<(), RateLimitedErr> {
+        let now = self.init.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64;
+        match check(&self.cell, self.tat_nanos, now, n) {
+            Ok(new_tat) => {
+                self.tat_nanos = new_tat;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// A [`RateLimiter`] per key, shareable via `&self` through an internal mutex.
+/// Buckets are lazily inserted on first use; call [`Self::clear`] to release
+/// them on peer disconnect.
+pub struct KeyedRateLimiter<K: Eq + Hash> {
+    cell: Cell,
+    init: Instant,
+    tat_per_key: Mutex<HashMap<K, u64>>,
+}
+
+impl<K: Eq + Hash> KeyedRateLimiter<K> {
+    pub fn new(quota: Quota) -> Self {
+        Self {
+            cell: Cell::from_quota(quota),
+            init: Instant::now(),
+            tat_per_key: Mutex::new(HashMap::new()),
         }
     }
 
-    fn refill(&mut self) {
-        let now = Instant::now();
-        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
-        self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.max_tokens);
-        self.last_refill = now;
+    /// Charge one token against `key`.
+    pub fn try_consume(&self, key: K) -> Result<(), RateLimitedErr> {
+        self.try_consume_n(key, 1)
     }
+
+    /// Charge `n` tokens against `key`, atomically: either all `n` are
+    /// charged or the bucket is left untouched.
+    pub fn try_consume_n(&self, key: K, n: u32) -> Result<(), RateLimitedErr> {
+        let now = self.init.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64;
+        let mut guard = self.tat_per_key.lock();
+        let tat = guard.entry(key).or_insert(0);
+        match check(&self.cell, *tat, now, n) {
+            Ok(new_tat) => {
+                *tat = new_tat;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Drop the bucket for `key` to release memory; call this on the final
+    /// disconnect for that peer.
+    pub fn clear(&self, key: &K) {
+        self.tat_per_key.lock().remove(key);
+    }
+
+    /// Drop every bucket whose TAT lies in the past, i.e. that is already
+    /// fully replenished. Lighthouse-style periodic cleanup; useful when
+    /// disconnect events are not observed (or as a backstop).
+    pub fn retain_recent(&self) {
+        let now = self.init.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64;
+        self.tat_per_key.lock().retain(|_, tat| *tat > now);
+    }
+
+    pub fn tracked_keys(&self) -> usize {
+        self.tat_per_key.lock().len()
+    }
+}
+
+/// Shared GCRA admission check. Returns the new TAT on success.
+fn check(cell: &Cell, tat: u64, now: u64, n: u32) -> Result<u64, RateLimitedErr> {
+    let cost = cell.t_nanos.saturating_mul(u64::from(n));
+    if cost > cell.tau_nanos {
+        // Cost exceeds the bucket capacity; no amount of waiting will help.
+        return Err(RateLimitedErr::TooLarge);
+    }
+    let earliest_admit = tat.saturating_add(cost).saturating_sub(cell.tau_nanos);
+    if now < earliest_admit {
+        return Err(RateLimitedErr::TooSoon(Duration::from_nanos(
+            earliest_admit.saturating_sub(now),
+        )));
+    }
+    Ok(now.max(tat).saturating_add(cost))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn burst_then_exhaustion() {
-        let mut rl = RateLimiter::new(3, Duration::from_secs(1));
-        assert!(rl.try_acquire());
-        assert!(rl.try_acquire());
-        assert!(rl.try_acquire());
-        assert!(!rl.try_acquire());
+    fn quota_n_per(n: u32, seconds: u64) -> Quota {
+        Quota::n_every(NonZeroU32::new(n).unwrap(), Duration::from_secs(seconds))
     }
 
     #[test]
-    fn refill_after_elapsed_time() {
-        let mut rl = RateLimiter::new(2, Duration::from_millis(100));
-        // Drain burst
-        assert!(rl.try_acquire());
-        assert!(rl.try_acquire());
-        assert!(!rl.try_acquire());
-
-        // Simulate time passing by backdating last_refill
-        rl.last_refill -= Duration::from_millis(150);
-        assert!(rl.try_acquire()); // 1 token refilled
-        assert!(!rl.try_acquire()); // not enough time for another
+    fn single_bucket_burst_then_exhaustion() {
+        let mut rl = RateLimiter::new(quota_n_per(3, 1));
+        assert!(rl.try_consume().is_ok());
+        assert!(rl.try_consume().is_ok());
+        assert!(rl.try_consume().is_ok());
+        assert!(matches!(rl.try_consume(), Err(RateLimitedErr::TooSoon(_))));
     }
 
     #[test]
-    fn does_not_exceed_max_tokens() {
-        let mut rl = RateLimiter::new(2, Duration::from_millis(10));
-        // Wait a long time (simulated)
-        rl.last_refill -= Duration::from_secs(60);
-        assert!(rl.try_acquire());
-        assert!(rl.try_acquire());
-        assert!(!rl.try_acquire()); // Capped at max_tokens=2
+    fn try_consume_n_is_atomic() {
+        let mut rl = RateLimiter::new(quota_n_per(5, 60));
+        assert!(rl.try_consume_n(5).is_ok());
+        // Bucket exhausted; a single token must not partially drain.
+        assert!(matches!(rl.try_consume(), Err(RateLimitedErr::TooSoon(_))));
+    }
+
+    #[test]
+    fn cost_greater_than_burst_is_too_large() {
+        let mut rl = RateLimiter::new(quota_n_per(4, 1));
+        assert_eq!(rl.try_consume_n(5), Err(RateLimitedErr::TooLarge));
+    }
+
+    #[test]
+    fn keyed_per_peer_independence() {
+        let rl = KeyedRateLimiter::<&'static str>::new(quota_n_per(2, 60));
+        assert!(rl.try_consume("alice").is_ok());
+        assert!(rl.try_consume("alice").is_ok());
+        assert!(matches!(
+            rl.try_consume("alice"),
+            Err(RateLimitedErr::TooSoon(_))
+        ));
+        // Bob is unaffected.
+        assert!(rl.try_consume("bob").is_ok());
+    }
+
+    #[test]
+    fn keyed_clear_releases_bucket() {
+        let rl = KeyedRateLimiter::<&'static str>::new(quota_n_per(1, 60));
+        assert!(rl.try_consume("x").is_ok());
+        assert!(matches!(
+            rl.try_consume("x"),
+            Err(RateLimitedErr::TooSoon(_))
+        ));
+        assert_eq!(rl.tracked_keys(), 1);
+        rl.clear(&"x");
+        assert_eq!(rl.tracked_keys(), 0);
+        // Fresh bucket after clear.
+        assert!(rl.try_consume("x").is_ok());
+    }
+
+    #[test]
+    fn retain_recent_drops_replenished_buckets() {
+        let rl = KeyedRateLimiter::<&'static str>::new(quota_n_per(1, 0));
+        // A 0-second quota means a token is replenished essentially
+        // instantly; every charge succeeds. The corresponding bucket is also
+        // "fully replenished" immediately and retain_recent will drop it.
+        assert!(rl.try_consume("x").is_ok());
+        rl.retain_recent();
+        assert_eq!(rl.tracked_keys(), 0);
+    }
+
+    #[test]
+    fn keyed_too_large() {
+        let rl = KeyedRateLimiter::<u32>::new(quota_n_per(2, 1));
+        assert_eq!(rl.try_consume_n(0, 3), Err(RateLimitedErr::TooLarge));
+    }
+
+    #[test]
+    fn too_soon_reports_wait_duration() {
+        let mut rl = RateLimiter::new(quota_n_per(1, 60));
+        assert!(rl.try_consume().is_ok());
+        match rl.try_consume() {
+            Err(RateLimitedErr::TooSoon(d)) => {
+                assert!(d > Duration::ZERO);
+                assert!(d <= Duration::from_secs(60));
+            }
+            other => panic!("expected TooSoon, got {other:?}"),
+        }
     }
 }

--- a/crates/swarm/net/handler-core/src/lib.rs
+++ b/crates/swarm/net/handler-core/src/lib.rs
@@ -9,9 +9,8 @@
 //! duplicating the same fields and logic.
 
 use std::collections::VecDeque;
-use std::time::Duration;
 
-use vertex_net_ratelimiter::RateLimiter;
+use vertex_net_ratelimiter::{Quota, RateLimiter};
 
 /// Shared core for protocol connection handlers.
 ///
@@ -27,11 +26,11 @@ pub struct HandlerCore<E> {
 }
 
 impl<E> HandlerCore<E> {
-    /// Create a new handler core with the given rate limiter configuration.
-    pub fn new(rate_limit_burst: u32, rate_limit_refill: Duration) -> Self {
+    /// Create a new handler core with the given rate-limit quota.
+    pub fn new(quota: Quota) -> Self {
         Self {
             pending_events: VecDeque::new(),
-            rate_limiter: RateLimiter::new(rate_limit_burst, rate_limit_refill),
+            rate_limiter: RateLimiter::new(quota),
             outbound_pending: false,
         }
     }
@@ -50,7 +49,7 @@ impl<E> HandlerCore<E> {
     ///
     /// Returns `true` if the stream should be accepted, `false` if rate-limited.
     pub fn try_accept_inbound(&mut self) -> bool {
-        self.rate_limiter.try_acquire()
+        self.rate_limiter.try_consume().is_ok()
     }
 
     /// Check whether an outbound request is currently in flight.

--- a/crates/swarm/net/hive/src/behaviour.rs
+++ b/crates/swarm/net/hive/src/behaviour.rs
@@ -6,7 +6,9 @@ use std::{
     task::{Context, Poll},
 };
 
+use crate::HIVE_INBOUND_QUOTA;
 use crate::handler::{HiveCommand, HiveHandler, HiveHandlerEvent};
+use crate::peer_handler::{HivePeerHandler, LearnAndDial};
 use crate::protocol::{PeerCache, new_peer_cache};
 use libp2p::{
     Multiaddr, PeerId,
@@ -17,6 +19,7 @@ use libp2p::{
 };
 use strum::IntoStaticStr;
 use tracing::debug;
+use vertex_net_ratelimiter::KeyedRateLimiter;
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_net_headers::ProtocolStreamError;
 use vertex_swarm_peer::SwarmPeer;
@@ -44,28 +47,49 @@ pub struct HiveBehaviour<I> {
     identity: Arc<I>,
     cache: PeerCache,
     events: VecDeque<ToSwarm<HiveEvent, HiveCommand>>,
+    /// Cloned into each per-connection handler so the protocol reader can
+    /// consult the inbound policy.
+    peer_handler: Arc<dyn HivePeerHandler>,
+    /// Shared with each handler so per-peer buckets survive reconnects but
+    /// are freed by [`Self::on_swarm_event`] on the final `ConnectionClosed`.
+    inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
 }
 
 impl<I> HiveBehaviour<I>
 where
     I: SwarmIdentity + 'static,
 {
-    /// Create a new hive behaviour.
+    /// Construct with the default [`LearnAndDial`] inbound policy.
     pub fn new(identity: Arc<I>) -> Self {
+        Self::with_peer_handler(identity, Arc::new(LearnAndDial))
+    }
+
+    /// Construct with a custom inbound policy; use [`DiscardSilently`] for
+    /// bootnodes.
+    ///
+    /// [`DiscardSilently`]: crate::DiscardSilently
+    pub fn with_peer_handler(identity: Arc<I>, peer_handler: Arc<dyn HivePeerHandler>) -> Self {
         Self {
             identity,
             cache: new_peer_cache(),
             events: VecDeque::new(),
+            peer_handler,
+            inbound_limit: Arc::new(KeyedRateLimiter::new(HIVE_INBOUND_QUOTA)),
         }
     }
 
-    /// Broadcast peers to a specific connection.
+    /// Broadcast a batch of peers on an existing connection. The topology
+    /// already throttles broadcast cadence, so no outbound rate-limit is
+    /// applied here.
     pub fn broadcast(
         &mut self,
         peer_id: PeerId,
         connection_id: ConnectionId,
         peers: Vec<SwarmPeer>,
     ) {
+        if peers.is_empty() {
+            return;
+        }
         self.events.push_back(ToSwarm::NotifyHandler {
             peer_id,
             handler: NotifyHandler::One(connection_id),
@@ -92,6 +116,8 @@ where
             self.identity.clone(),
             peer,
             self.cache.clone(),
+            self.inbound_limit.clone(),
+            self.peer_handler.clone(),
         ))
     }
 
@@ -107,10 +133,21 @@ where
             self.identity.clone(),
             peer,
             self.cache.clone(),
+            self.inbound_limit.clone(),
+            self.peer_handler.clone(),
         ))
     }
 
-    fn on_swarm_event(&mut self, _event: FromSwarm) {}
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        if let FromSwarm::ConnectionClosed(closed) = event {
+            // Free the per-peer rate-limit bucket only when the last
+            // connection closes; an earlier clear would let a peer reset its
+            // bucket by churning a single connection.
+            if closed.remaining_established == 0 {
+                self.inbound_limit.clear(&closed.peer_id);
+            }
+        }
+    }
 
     fn on_connection_handler_event(
         &mut self,
@@ -120,7 +157,13 @@ where
     ) {
         match event {
             HiveHandlerEvent::PeersReceived(peers) => {
-                debug!(%peer_id, peer_count = peers.len(), "Hive: received peers");
+                // Rate-limit accounting and bootnode-mode discard already
+                // happened in the protocol reader. Empty batches reach us
+                // when those gates fired or all records failed validation;
+                // we have nothing to surface.
+                if peers.is_empty() {
+                    return;
+                }
                 self.events
                     .push_back(ToSwarm::GenerateEvent(HiveEvent::PeersReceived {
                         peer_id,
@@ -129,7 +172,7 @@ where
                     }));
             }
             HiveHandlerEvent::Error(error) => {
-                debug!(%peer_id, %error, "Hive: error");
+                debug!(%peer_id, %error, "hive error");
                 self.events
                     .push_back(ToSwarm::GenerateEvent(HiveEvent::Error {
                         peer_id,
@@ -148,5 +191,20 @@ where
             return Poll::Ready(event);
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::peer_handler::{DiscardSilently, HivePeerHandler, InboundPolicy, LearnAndDial};
+
+    #[test]
+    fn discard_silently_returns_discard_policy() {
+        assert_eq!(DiscardSilently.policy(), InboundPolicy::Discard);
+    }
+
+    #[test]
+    fn learn_and_dial_returns_forward_policy() {
+        assert_eq!(LearnAndDial.policy(), InboundPolicy::Forward);
     }
 }

--- a/crates/swarm/net/hive/src/handler.rs
+++ b/crates/swarm/net/hive/src/handler.rs
@@ -7,6 +7,7 @@
 
 use std::{
     collections::VecDeque,
+    num::NonZeroU32,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -24,23 +25,28 @@ use libp2p::{
 };
 use metrics::counter;
 use tracing::{debug, trace, warn};
+use vertex_net_ratelimiter::{KeyedRateLimiter, Quota};
 use vertex_observability::labels::direction;
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_net_handler_core::HandlerCore;
 use vertex_swarm_net_headers::{Inbound, Outbound, ProtocolStreamError, UpgradeError};
 use vertex_swarm_peer::SwarmPeer;
 
+use crate::peer_handler::HivePeerHandler;
 use crate::protocol::{HiveInner, HiveOutboundInner, HiveOutboundProtocol, PeerCache};
 
 /// Timeout for stream processing (headers exchange + protobuf + validation).
 const STREAM_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Rate limiter: burst of 4 streams, refill 1 token every 5 seconds.
-/// Sustains ~12 inbound streams per minute, which is generous for topology updates.
-const RATE_LIMIT_BURST: u32 = 4;
-const RATE_LIMIT_REFILL: Duration = Duration::from_secs(5);
+/// Per-connection inbound substream quota: 4 stream-opens per 20-second
+/// window. Enough headroom for the bursts that happen at connection
+/// establishment and on neighborhood-refresh ticks, while throttling a peer
+/// that opens new streams in a tight loop.
+const INBOUND_SUBSTREAM_QUOTA: Quota =
+    Quota::n_every(NonZeroU32::new(4).unwrap(), Duration::from_secs(20));
 
-/// Maximum queued broadcasts before dropping (prevents unbounded growth if outbound is slow).
+/// Outbound broadcast queue depth; excess broadcasts are dropped so a slow
+/// remote cannot grow our memory unboundedly.
 const MAX_PENDING_BROADCASTS: usize = 16;
 
 /// Commands from behaviour to handler.
@@ -67,24 +73,35 @@ pub struct HiveHandler<I: SwarmIdentity> {
     remote_peer_id: PeerId,
     identity: Arc<I>,
     cache: PeerCache,
-    /// Shared handler core: events, rate limiter, outbound flag.
+    /// Shared handler core: events, substream rate limiter, outbound flag.
     core: HandlerCore<HiveHandlerEvent>,
-    /// Bounded by [`MAX_PENDING_BROADCASTS`]; excess broadcasts are dropped with a warning.
+    /// Bounded by [`MAX_PENDING_BROADCASTS`].
     pending_broadcasts: VecDeque<Vec<SwarmPeer>>,
+    /// Shared with the behaviour so per-peer state survives reconnects.
+    inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
+    /// Consulted by the protocol reader to pick the inbound dispatch policy.
+    peer_handler: Arc<dyn HivePeerHandler>,
 }
 
 impl<I> HiveHandler<I>
 where
     I: SwarmIdentity + 'static,
 {
-    /// Create a new hive handler.
-    pub(crate) fn new(identity: Arc<I>, remote_peer_id: PeerId, cache: PeerCache) -> Self {
+    pub(crate) fn new(
+        identity: Arc<I>,
+        remote_peer_id: PeerId,
+        cache: PeerCache,
+        inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
+        peer_handler: Arc<dyn HivePeerHandler>,
+    ) -> Self {
         Self {
-            core: HandlerCore::new(RATE_LIMIT_BURST, RATE_LIMIT_REFILL),
+            core: HandlerCore::new(INBOUND_SUBSTREAM_QUOTA),
             remote_peer_id,
             identity,
             cache,
             pending_broadcasts: VecDeque::new(),
+            inbound_limit,
+            peer_handler,
         }
     }
 }
@@ -101,7 +118,13 @@ where
     type OutboundOpenInfo = ();
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        let inner = HiveInner::new(self.identity.clone(), self.cache.clone());
+        let inner = HiveInner::new(
+            self.identity.clone(),
+            self.cache.clone(),
+            self.remote_peer_id,
+            self.inbound_limit.clone(),
+            self.peer_handler.clone(),
+        );
         let upgrade = Inbound::new(inner);
         SubstreamProtocol::new(upgrade, ()).with_timeout(STREAM_TIMEOUT)
     }

--- a/crates/swarm/net/hive/src/lib.rs
+++ b/crates/swarm/net/hive/src/lib.rs
@@ -1,17 +1,73 @@
-//! Hive protocol for Swarm peer gossip and network bootstrapping.
+//! Hive: signed peer-record gossip for Swarm topology bootstrapping.
+//!
+//! Hive lets nodes exchange the [`SwarmPeer`] records they know about so
+//! freshly-joined peers can populate their kademlia table without going through
+//! a bootnode for every lookup. The protocol is bidirectional: every connection
+//! both broadcasts our local view (chunked at [`MAX_BATCH_SIZE`]) and receives
+//! the remote's view.
+//!
+//! [`SwarmPeer`]: vertex_swarm_peer::SwarmPeer
+//!
+//! # Inbound flow and abuse resistance
+//!
+//! Every inbound peer record carries a recoverable secp256k1 signature, so
+//! validating a batch is `O(n)` ECDSA recoveries. Unbounded ingestion is a
+//! cheap DoS: an attacker can stream maximally-sized batches of garbage
+//! signatures and burn CPU on every receiver.
+//!
+//! The reader applies two checks before any cryptography runs:
+//!
+//! 1. A per-peer GCRA bucket ([`vertex_net_ratelimiter::KeyedRateLimiter`])
+//!    charges `len(raw_peers)` tokens against [`HIVE_INBOUND_QUOTA`]. The
+//!    cost is on the *raw wire count*, not the post-validation count, so
+//!    flooding with invalid signatures does not bypass throttling.
+//! 2. Bootnodes (peer handler returns [`InboundPolicy::Discard`]) skip
+//!    validation entirely: the records would be dropped anyway. The bootnode
+//!    discard is observable via
+//!    `hive_peers_discarded_total{reason="bootnode_mode"}` on the raw wire
+//!    count.
+//!
+//! There is no outbound rate limit. The local topology already throttles its
+//! own broadcast cadence via dial / save intervals, and the payload is bounded
+//! by [`MAX_BATCH_SIZE`]; an outbound per-peer bucket measurably starved
+//! legitimate gossip cycles after a few neighborhood refreshes.
+//!
+//! # Protocol assumptions not in the Book of Swarm
+//!
+//! - [`HIVE_INBOUND_QUOTA`] is sized off the kademlia bin count (32) with 4x
+//!   headroom for the bursts that happen on neighborhood refresh.
+//! - [`MAX_BATCH_SIZE`] = 30 peers per wire message, sized so the encoded
+//!   protobuf fits comfortably within the framed read buffer alongside the
+//!   header exchange.
+//! - Wire protocol id [`PROTOCOL_NAME`] = `/swarm/hive/2.0.0/peers`. The
+//!   `2.0.0` bump tracks the [`SwarmPeer`] record extension to include
+//!   timestamp + chequebook; see the `vertex-swarm-peer` crate for the
+//!   sign-data layout.
+
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+use vertex_net_ratelimiter::Quota;
 
 mod behaviour;
 mod codec;
 mod error;
 mod handler;
 pub mod metrics;
+mod peer_handler;
 mod protocol;
 
 pub use behaviour::{HiveBehaviour, HiveEvent};
 pub use error::ValidationFailure;
+pub use peer_handler::{DiscardSilently, HivePeerHandler, InboundPolicy, LearnAndDial};
 
 /// Protocol name for hive.
 pub const PROTOCOL_NAME: &str = "/swarm/hive/2.0.0/peers";
 
 /// Maximum number of peers per broadcast message.
 pub const MAX_BATCH_SIZE: usize = 30;
+
+/// Per-peer inbound quota for hive batches: 128 token burst, fully replenished
+/// every 60 seconds (i.e. one token every ~0.47 s). 128 = 4 * `MaxBins`.
+pub const HIVE_INBOUND_QUOTA: Quota =
+    Quota::n_every(NonZeroU32::new(128).unwrap(), Duration::from_secs(60));

--- a/crates/swarm/net/hive/src/metrics.rs
+++ b/crates/swarm/net/hive/src/metrics.rs
@@ -1,9 +1,29 @@
 //! Hive-specific metrics (peer counts, validation).
 //!
-//! Exchange-level metrics (exchanges_total, outcomes, duration) are handled
-//! automatically by the headers crate's `ProtocolMetrics`.
+//! Exchange-level metrics (exchanges_total, outcomes, duration) are emitted
+//! by the headers crate's `ProtocolMetrics`.
 
 use vertex_observability::{DURATION_FINE, HistogramBucketConfig};
+
+/// Counter of peer batches discarded by the hive layer.
+///
+/// Labels:
+/// - `reason="bootnode_mode"` - bootnode role discards inbound gossip
+///   without validation; counted on the raw wire peer count.
+/// - `reason="rate_limited"` - per-peer inbound bucket exhausted; counted
+///   on the raw wire peer count.
+/// - `reason="verifier_rejected"` - a peer record failed signature or
+///   overlay validation.
+pub const HIVE_PEERS_DISCARDED_TOTAL: &str = "hive_peers_discarded_total";
+
+/// Label value for [`HIVE_PEERS_DISCARDED_TOTAL`]: bootnode-mode discard.
+pub const DISCARD_REASON_BOOTNODE_MODE: &str = "bootnode_mode";
+
+/// Label value for [`HIVE_PEERS_DISCARDED_TOTAL`]: rate-limit discard.
+pub const DISCARD_REASON_RATE_LIMITED: &str = "rate_limited";
+
+/// Label value for [`HIVE_PEERS_DISCARDED_TOTAL`]: verifier-rejected discard.
+pub const DISCARD_REASON_VERIFIER_REJECTED: &str = "verifier_rejected";
 
 /// Histogram bucket configurations for hive-specific metrics.
 pub const HISTOGRAM_BUCKETS: &[HistogramBucketConfig] = &[

--- a/crates/swarm/net/hive/src/peer_handler.rs
+++ b/crates/swarm/net/hive/src/peer_handler.rs
@@ -1,0 +1,40 @@
+//! Dispatch policy for inbound peer batches.
+
+/// What the protocol reader should do with a fresh inbound peer batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InboundPolicy {
+    /// Validate the batch and surface it as a
+    /// [`HiveEvent::PeersReceived`](crate::HiveEvent::PeersReceived) so the
+    /// topology layer can verify and route the peers.
+    Forward,
+    /// Drop the batch without running validation. The protocol reader bumps
+    /// `hive_peers_discarded_total{reason="bootnode_mode"}` on the raw wire
+    /// count and returns an empty Vec, so no event is emitted downstream.
+    Discard,
+}
+
+/// Strategy for handling inbound peer batches.
+pub trait HivePeerHandler: Send + Sync + 'static {
+    fn policy(&self) -> InboundPolicy;
+}
+
+/// Default handler for non-bootnode roles: forward batches to the topology.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LearnAndDial;
+
+impl HivePeerHandler for LearnAndDial {
+    fn policy(&self) -> InboundPolicy {
+        InboundPolicy::Forward
+    }
+}
+
+/// Bootnode handler: discard inbound batches without ECDSA validation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DiscardSilently;
+
+impl HivePeerHandler for DiscardSilently {
+    fn policy(&self) -> InboundPolicy {
+        InboundPolicy::Discard
+    }
+}

--- a/crates/swarm/net/hive/src/protocol.rs
+++ b/crates/swarm/net/hive/src/protocol.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use libp2p::PeerId;
 use parking_lot::Mutex;
 use std::time::Instant;
 
@@ -23,6 +24,12 @@ use vertex_tasks::TaskExecutor;
 use crate::PROTOCOL_NAME;
 use crate::codec::encode_peers;
 use crate::error::ValidationFailure;
+use crate::metrics::{
+    DISCARD_REASON_BOOTNODE_MODE, DISCARD_REASON_RATE_LIMITED, DISCARD_REASON_VERIFIER_REJECTED,
+    HIVE_PEERS_DISCARDED_TOTAL,
+};
+use crate::peer_handler::{HivePeerHandler, InboundPolicy};
+use vertex_net_ratelimiter::KeyedRateLimiter;
 
 /// 32 KiB frame limit (fits ~100 peers at typical size).
 const MAX_MESSAGE_SIZE: usize = 32 * 1024;
@@ -50,6 +57,9 @@ pub struct ValidatedPeers {
 pub struct HiveInner<I: SwarmIdentity> {
     identity: Arc<I>,
     cache: PeerCache,
+    remote_peer_id: PeerId,
+    inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
+    peer_handler: Arc<dyn HivePeerHandler>,
 }
 
 impl<I: SwarmIdentity> std::fmt::Debug for HiveInner<I> {
@@ -59,8 +69,20 @@ impl<I: SwarmIdentity> std::fmt::Debug for HiveInner<I> {
 }
 
 impl<I: SwarmIdentity> HiveInner<I> {
-    pub(crate) fn new(identity: Arc<I>, cache: PeerCache) -> Self {
-        Self { identity, cache }
+    pub(crate) fn new(
+        identity: Arc<I>,
+        cache: PeerCache,
+        remote_peer_id: PeerId,
+        inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
+        peer_handler: Arc<dyn HivePeerHandler>,
+    ) -> Self {
+        Self {
+            identity,
+            cache,
+            remote_peer_id,
+            inbound_limit,
+            peer_handler,
+        }
     }
 }
 
@@ -76,6 +98,9 @@ impl<I: SwarmIdentity> HeaderedInbound for HiveInner<I> {
         let network_id = self.identity.spec().network_id();
         let local_overlay = self.identity.overlay_address();
         let cache = self.cache;
+        let remote_peer_id = self.remote_peer_id;
+        let inbound_limit = self.inbound_limit;
+        let peer_handler = self.peer_handler;
         Box::pin(async move {
             use vertex_swarm_net_proto::hive::Peers;
 
@@ -84,16 +109,43 @@ impl<I: SwarmIdentity> HeaderedInbound for HiveInner<I> {
                 Framed::recv::<Peers, ProtocolStreamError, _>(stream.into_inner()).await?;
 
             let raw_peers = proto.peers;
+            let raw_count = raw_peers.len();
 
-            // Offload CPU-bound ECDSA validation to blocking thread pool.
+            // Charge the rate-limit on the raw wire count before any ECDSA
+            // work, so a flood of invalid signatures cannot bypass throttling
+            // by being filtered out.
+            if raw_count > 0 {
+                let cost = u32::try_from(raw_count).unwrap_or(u32::MAX);
+                if inbound_limit.try_consume_n(remote_peer_id, cost).is_err() {
+                    counter!(HIVE_PEERS_DISCARDED_TOTAL, "reason" => DISCARD_REASON_RATE_LIMITED)
+                        .increment(raw_count as u64);
+                    warn!(%remote_peer_id, raw_count, "hive: inbound rate limit exceeded");
+                    return Ok(ValidatedPeers { peers: Vec::new() });
+                }
+            }
+
+            // Bootnodes drop inbound gossip without validating it: the records
+            // would never be ingested anyway, so spending the per-batch ECDSA
+            // cost is pointless. The metric counts the raw wire peers, not the
+            // post-validation count.
+            if matches!(peer_handler.policy(), InboundPolicy::Discard) {
+                counter!(HIVE_PEERS_DISCARDED_TOTAL, "reason" => DISCARD_REASON_BOOTNODE_MODE)
+                    .increment(raw_count as u64);
+                debug!(%remote_peer_id, raw_count, "hive: bootnode discard");
+                return Ok(ValidatedPeers { peers: Vec::new() });
+            }
+
             let (peers, valid_count, invalid_count) =
                 validate_batch_blocking(raw_peers, network_id, local_overlay, cache).await;
 
-            // Hive-specific peer metrics
             counter!("hive_peers_received_total", "outcome" => "valid")
                 .increment(valid_count as u64);
             counter!("hive_peers_received_total", "outcome" => "invalid")
                 .increment(invalid_count as u64);
+            if invalid_count > 0 {
+                counter!(HIVE_PEERS_DISCARDED_TOTAL, "reason" => DISCARD_REASON_VERIFIER_REJECTED)
+                    .increment(invalid_count as u64);
+            }
             histogram!("hive_peers_per_exchange", "direction" => "inbound")
                 .record(valid_count as f64);
 

--- a/crates/swarm/net/pingpong/src/handler.rs
+++ b/crates/swarm/net/pingpong/src/handler.rs
@@ -25,7 +25,9 @@ use libp2p::{
     },
 };
 use metrics::counter;
+use std::num::NonZeroU32;
 use tracing::{debug, trace, warn};
+use vertex_net_ratelimiter::Quota;
 use vertex_observability::labels::direction;
 use vertex_swarm_net_handler_core::HandlerCore;
 use vertex_swarm_net_headers::{Inbound, ProtocolError, ProtocolStreamError, UpgradeError};
@@ -38,10 +40,10 @@ const STREAM_TIMEOUT: Duration = Duration::from_secs(15);
 /// Maximum concurrent inbound pingpong streams per connection.
 const MAX_CONCURRENT_STREAMS_PER_CONNECTION: usize = 2;
 
-/// Rate limiter: burst of 2 streams, refill 1 token every 2 seconds.
-/// Sustains ~30 inbound pings per minute, generous for liveness checks.
-const RATE_LIMIT_BURST: u32 = 2;
-const RATE_LIMIT_REFILL: Duration = Duration::from_secs(2);
+/// Per-connection substream-open quota: 2 in any 4-second window. Liveness
+/// checks happen on the order of seconds; rapid stream churn from a single
+/// connection is suspicious.
+const INBOUND_QUOTA: Quota = Quota::n_every(NonZeroU32::new(2).unwrap(), Duration::from_secs(4));
 
 /// Maximum queued outbound ping commands per connection.
 const MAX_PENDING_PINGS: usize = 8;
@@ -115,7 +117,7 @@ impl PingpongHandler {
                 STREAM_TIMEOUT,
                 MAX_CONCURRENT_STREAMS_PER_CONNECTION,
             ),
-            core: HandlerCore::new(RATE_LIMIT_BURST, RATE_LIMIT_REFILL),
+            core: HandlerCore::new(INBOUND_QUOTA),
             config,
             remote_peer_id,
             pending_pings: VecDeque::new(),

--- a/crates/swarm/topology/src/composed.rs
+++ b/crates/swarm/topology/src/composed.rs
@@ -8,8 +8,11 @@ use std::sync::Arc;
 use libp2p::swarm::NetworkBehaviour;
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent};
-use vertex_swarm_net_hive::{HiveBehaviour, HiveEvent};
+use vertex_swarm_net_hive::{
+    DiscardSilently, HiveBehaviour, HiveEvent, HivePeerHandler, LearnAndDial,
+};
 use vertex_swarm_net_pingpong::{PingpongBehaviour, PingpongEvent};
+use vertex_swarm_primitives::SwarmNodeType;
 
 use crate::nat_discovery::LocalAddressManager;
 
@@ -101,10 +104,19 @@ where
     I: SwarmIdentity + Clone + 'static,
 {
     /// Create new composed protocol behaviours.
+    ///
+    /// The hive [`HivePeerHandler`] is picked from the local node type:
+    /// bootnodes drop inbound peer gossip without ingesting it, every other
+    /// role learns and may dial. Outbound broadcasting runs in either case.
     pub(crate) fn new(identity: Arc<I>, address_provider: Arc<LocalAddressManager>) -> Self {
+        let peer_handler: Arc<dyn HivePeerHandler> = match identity.node_type() {
+            SwarmNodeType::Bootnode => Arc::new(DiscardSilently),
+            SwarmNodeType::Client | SwarmNodeType::Storer => Arc::new(LearnAndDial),
+        };
+
         Self {
             handshake: HandshakeBehaviour::new(identity.clone(), address_provider, "topology"),
-            hive: HiveBehaviour::new(identity),
+            hive: HiveBehaviour::with_peer_handler(identity, peer_handler),
             pingpong: PingpongBehaviour::new(),
         }
     }


### PR DESCRIPTION
## Summary

- Add bee-compatible per-peer hive rate limiters (refill 1/min, burst 128 = `4 * MaxBins`) for both inbound and outbound peer batches; consumes `len(peers)` tokens per batch to match bee's `Limiter.Allow(addr, count)`.
- Introduce a `HivePeerHandler` trait with two impls: `LearnAndDial` (default, surfaces peers to the topology) and `DiscardSilently` (bootnodes — drops the batch and bumps a metric, mirroring bee's `BootnodeMode` early return in `pkg/hive/hive.go:283-284`).
- Wire `ProtocolBehaviours::new` to pick the impl from `SwarmIdentity::node_type` (`Bootnode → DiscardSilently`, else `LearnAndDial`); outbound broadcasting still runs for bootnodes — only ingestion is gated.
- Add `hive_peers_discarded_total{reason="bootnode_mode" | "rate_limited" | "verifier_rejected"}` so all dropped-peer reasons are observable in one place.

## Implementation notes

- `vertex-net-ratelimiter` gains `KeyedRateLimiter<K>`, `RateLimitExceeded`, and `try_consume_n` / `try_acquire_n` (atomic, no partial consumption — matches Go's `rate.Limiter.AllowN`).
- `HiveRateLimit<K = PeerId>` wraps `KeyedRateLimiter` behind a `parking_lot::Mutex` so the behaviour can hold both inbound and outbound limiters.
- Per-peer buckets are evicted on the final `ConnectionClosed` for a peer, mirroring bee's `disconnect` clearing both limiters (`pkg/hive/hive.go:296-300`).

## Test plan

- [x] `cargo build -p vertex-swarm-net-hive -p vertex-swarm-topology`
- [x] `cargo test -p vertex-swarm-net-hive -p vertex-swarm-topology -p vertex-net-ratelimiter` (all unit tests pass, including new ones covering bee-compat defaults, per-peer independence, bucket eviction, atomic N-token consumption, and inbound/outbound policy dispatch)
- [x] `cargo clippy --lib -p vertex-swarm-net-hive -p vertex-swarm-topology -p vertex-net-ratelimiter -- -D warnings`
- [x] `cargo clippy --tests --benches -p vertex-swarm-net-hive -p vertex-swarm-topology -p vertex-net-ratelimiter -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::indexing_slicing` (matches CI config in `.github/workflows/unit.yml`)
- [ ] Cluster e2e deferred to Unit 14 per plan.

Refs: bee `pkg/hive/hive.go:54-55,78-79,150,273,283-284,296-300`, `pkg/swarm/swarm.go:29`, `pkg/ratelimit/ratelimit.go`.