### PR TITLE
feat(node-bootnode): wire pricing stub for bee-mainnet interop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8351,8 +8351,10 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "asynchronous-codec",
+ "auto_impl",
  "bytes",
  "futures",
+ "futures-bounded",
  "libp2p",
  "quick-protobuf",
  "quick-protobuf-codec",

--- a/crates/swarm/net/pricing/Cargo.toml
+++ b/crates/swarm/net/pricing/Cargo.toml
@@ -18,6 +18,7 @@ vertex-swarm-net-proto.workspace = true
 
 ## async
 futures.workspace = true
+futures-bounded = "0.2"
 
 ## p2p
 asynchronous-codec.workspace = true
@@ -29,6 +30,7 @@ libp2p.workspace = true
 alloy-primitives.workspace = true
 
 ## misc
+auto_impl.workspace = true
 bytes.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/crates/swarm/net/pricing/src/behaviour.rs
+++ b/crates/swarm/net/pricing/src/behaviour.rs
@@ -1,0 +1,281 @@
+//! `NetworkBehaviour` for the pricing protocol.
+//!
+//! Two orthogonal axes of configuration:
+//!
+//! * **Listen-only vs. announce-on-connect** ([`PricingRole`]). Bootnodes
+//!   advertise the protocol but never dial a stream of their own; clients
+//!   and full nodes both advertise AND queue an announce on every new
+//!   connection. The interop requirement is satisfied as soon as we accept
+//!   inbound streams, so the announce side is only needed when WE want our
+//!   threshold tracked by the remote (i.e. when we participate in chunk
+//!   accounting).
+//! * **Observer for inbound thresholds** ([`PricingMode`]). Stub-mode
+//!   discards them; full mode forwards them to a
+//!   [`PaymentThresholdObserver`] that hooks into the accounting subsystem.
+
+use std::{
+    collections::VecDeque,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use libp2p::{
+    Multiaddr, PeerId,
+    core::Endpoint,
+    swarm::{
+        ConnectionClosed, ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour,
+        NotifyHandler, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
+    },
+};
+use tracing::{debug, warn};
+
+use crate::{
+    AnnouncePaymentThreshold,
+    handler::{PricingHandler, PricingHandlerCommand, PricingHandlerEvent},
+    stub::{PaymentThresholdObserver, StubObserver, stub_announcement},
+};
+
+/// Maximum pending swarm events before we start dropping with a warning.
+const MAX_PENDING_EVENTS: usize = 1024;
+
+/// Behaviour role: whether we open an outbound stream to announce our own
+/// threshold on every new connection. Bootnodes use [`Self::ListenOnly`];
+/// nodes participating in chunk accounting use [`Self::Announcer`].
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub enum PricingRole {
+    /// Listen-only: advertise the protocol so the remote's `ConnectIn`/`ConnectOut`
+    /// succeeds, accept inbound threshold announcements, never dial an
+    /// outbound stream of our own. Used by bootnodes.
+    #[default]
+    ListenOnly,
+    /// Announce-on-connect: queue an outbound `AnnouncePaymentThreshold` to
+    /// the remote on every new connection. Used by clients and full nodes
+    /// that participate in chunk accounting.
+    Announcer(AnnouncePaymentThreshold),
+}
+
+/// How received thresholds are routed.
+///
+/// `Stub` is the default for bootnodes — incoming thresholds are observed
+/// (so we still emit a `PricingEvent::ThresholdReceived` for visibility) but
+/// not forwarded to any accounting subsystem. `Full` accepts an
+/// `Arc<dyn PaymentThresholdObserver>` that forwards thresholds into
+/// accounting.
+#[derive(Default)]
+#[non_exhaustive]
+pub enum PricingMode {
+    /// Stub mode: observe inbound thresholds but do not feed an accounting
+    /// subsystem.
+    #[default]
+    Stub,
+    /// Full mode: forward inbound thresholds to the supplied observer.
+    Full(Arc<dyn PaymentThresholdObserver>),
+}
+
+impl std::fmt::Debug for PricingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stub => f.write_str("Stub"),
+            Self::Full(_) => f.write_str("Full(<observer>)"),
+        }
+    }
+}
+
+/// Events emitted by [`PricingBehaviour`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum PricingEvent {
+    /// A peer announced its payment threshold.
+    ThresholdReceived {
+        peer: PeerId,
+        threshold: AnnouncePaymentThreshold,
+    },
+    /// We sent our payment threshold to a peer.
+    AnnouncementSent { peer: PeerId },
+    /// An inbound stream failed. Informational; the connection is not torn
+    /// down.
+    InboundError { peer: PeerId, error: String },
+    /// An outbound announcement failed. Informational; the connection is not
+    /// torn down (peers without a pricing implementation must still keep
+    /// the connection).
+    OutboundError { peer: PeerId, error: String },
+    /// An outbound announce was discarded because the behaviour-level event
+    /// queue was full or the per-handler queue was full. Surfaced so
+    /// operators see when the announce path silently failed to deliver our
+    /// threshold to a peer.
+    AnnouncementDropped { peer: PeerId },
+}
+
+/// `NetworkBehaviour` for the pricing protocol.
+pub struct PricingBehaviour {
+    /// Observer for received thresholds.
+    observer: Arc<dyn PaymentThresholdObserver>,
+    /// Role: listen-only or announcer.
+    role: PricingRole,
+    /// Queued swarm events.
+    events: VecDeque<ToSwarm<PricingEvent, PricingHandlerCommand>>,
+}
+
+impl PricingBehaviour {
+    /// Construct a behaviour with the given role and inbound mode.
+    pub fn new(role: PricingRole, mode: PricingMode) -> Self {
+        let observer: Arc<dyn PaymentThresholdObserver> = match mode {
+            PricingMode::Stub => Arc::new(StubObserver),
+            PricingMode::Full(obs) => obs,
+        };
+        Self {
+            observer,
+            role,
+            events: VecDeque::new(),
+        }
+    }
+
+    /// Listen-only stub for bootnodes. Advertises the protocol and accepts
+    /// inbound threshold announcements but never dials a stream of its own.
+    pub fn new_bootnode() -> Self {
+        Self::new(PricingRole::ListenOnly, PricingMode::Stub)
+    }
+
+    /// Announce-on-connect for non-bootnode roles. `threshold` is the value
+    /// announced to every newly-established peer; the inbound mode controls
+    /// how received thresholds are routed.
+    pub fn new_announcer(threshold: u64, mode: PricingMode) -> Self {
+        Self::new(PricingRole::Announcer(stub_announcement(threshold)), mode)
+    }
+
+    /// The protocol name this behaviour speaks.
+    pub const fn protocol_name() -> &'static str {
+        crate::PROTOCOL_NAME
+    }
+
+    fn push_event(&mut self, event: ToSwarm<PricingEvent, PricingHandlerCommand>) {
+        if self.events.len() >= MAX_PENDING_EVENTS {
+            warn!("Pricing behaviour event queue full, dropping event");
+            return;
+        }
+        self.events.push_back(event);
+    }
+
+    /// Queue an outbound announce on a freshly-established connection.
+    /// No-op for [`PricingRole::ListenOnly`].
+    fn announce_to(&mut self, peer_id: PeerId) {
+        let PricingRole::Announcer(threshold) = &self.role else {
+            return;
+        };
+        debug!(%peer_id, threshold = %threshold.payment_threshold, "Pricing: queuing announcement to peer");
+        let threshold = threshold.clone();
+        self.push_event(ToSwarm::NotifyHandler {
+            peer_id,
+            handler: NotifyHandler::Any,
+            event: PricingHandlerCommand::Announce(threshold),
+        });
+    }
+}
+
+impl NetworkBehaviour for PricingBehaviour {
+    type ConnectionHandler = PricingHandler;
+    type ToSwarm = PricingEvent;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.announce_to(peer);
+        Ok(PricingHandler::new())
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: Endpoint,
+        _port_use: libp2p::core::transport::PortUse,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.announce_to(peer);
+        Ok(PricingHandler::new())
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm<'_>) {
+        if let FromSwarm::ConnectionClosed(ConnectionClosed { peer_id, .. }) = event {
+            debug!(%peer_id, "Pricing: connection closed");
+        }
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        _connection_id: ConnectionId,
+        event: THandlerOutEvent<Self>,
+    ) {
+        match event {
+            PricingHandlerEvent::ThresholdReceived(threshold) => {
+                self.observer
+                    .record_threshold(peer_id, threshold.payment_threshold);
+                self.push_event(ToSwarm::GenerateEvent(PricingEvent::ThresholdReceived {
+                    peer: peer_id,
+                    threshold,
+                }));
+            }
+            PricingHandlerEvent::AnnouncementSent => {
+                self.push_event(ToSwarm::GenerateEvent(PricingEvent::AnnouncementSent {
+                    peer: peer_id,
+                }));
+            }
+            PricingHandlerEvent::InboundError(error) => {
+                self.push_event(ToSwarm::GenerateEvent(PricingEvent::InboundError {
+                    peer: peer_id,
+                    error,
+                }));
+            }
+            PricingHandlerEvent::OutboundError(error) => {
+                self.push_event(ToSwarm::GenerateEvent(PricingEvent::OutboundError {
+                    peer: peer_id,
+                    error,
+                }));
+            }
+            PricingHandlerEvent::OutboundDropped => {
+                self.push_event(ToSwarm::GenerateEvent(PricingEvent::AnnouncementDropped {
+                    peer: peer_id,
+                }));
+            }
+        }
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(event);
+        }
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_name_matches_const() {
+        assert_eq!(PricingBehaviour::protocol_name(), crate::PROTOCOL_NAME);
+    }
+
+    #[test]
+    fn bootnode_constructor_is_listen_only() {
+        // Bootnodes must not announce: they have no payment state of their own.
+        let b = PricingBehaviour::new_bootnode();
+        assert!(matches!(b.role, PricingRole::ListenOnly));
+    }
+
+    #[test]
+    fn announcer_constructor_carries_threshold() {
+        let b = PricingBehaviour::new_announcer(13_500_000, PricingMode::Stub);
+        assert!(matches!(b.role, PricingRole::Announcer(_)));
+    }
+}

--- a/crates/swarm/net/pricing/src/handler.rs
+++ b/crates/swarm/net/pricing/src/handler.rs
@@ -1,0 +1,247 @@
+//! Per-connection handler for the pricing protocol.
+//!
+//! Accepts inbound `/swarm/pricing/1.0.0/pricing` streams and emits the
+//! received [`AnnouncePaymentThreshold`] to the behaviour. The handler also
+//! supports opening an outbound stream to announce our own threshold; the
+//! behaviour decides whether to issue such announcements (bootnodes do not,
+//! client and full nodes do).
+//!
+//! Outbound failures are reported as events but never tear down the
+//! connection: a peer without a pricing implementation must still keep the
+//! connection open.
+
+use std::{
+    collections::VecDeque,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures_bounded::Timeout;
+use libp2p::{
+    InboundUpgrade,
+    core::upgrade::ReadyUpgrade,
+    swarm::{
+        StreamProtocol, SubstreamProtocol,
+        handler::{
+            ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, FullyNegotiatedInbound,
+            FullyNegotiatedOutbound, ListenUpgradeError,
+        },
+    },
+};
+use tracing::{debug, warn};
+use vertex_swarm_net_headers::{Inbound, ProtocolError};
+
+use crate::{
+    AnnouncePaymentThreshold, PROTOCOL_NAME, PricingOutboundProtocol, outbound,
+    protocol::PricingInner,
+};
+
+/// Timeout for inbound stream processing.
+const STREAM_TIMEOUT: Duration = Duration::from_secs(15);
+/// Maximum concurrent inbound pricing streams per connection.
+const MAX_CONCURRENT_INBOUND: usize = 2;
+/// Maximum queued outbound announcements per connection. Sized comfortably
+/// above the steady-state of "one announce per fresh connection" so a burst
+/// does not silently drop the one event the announce path exists to deliver.
+const MAX_PENDING_OUTBOUND: usize = 16;
+/// Outbound stream operation timeout.
+const OUTBOUND_TIMEOUT: Duration = Duration::from_secs(30);
+
+const PRICING_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new(PROTOCOL_NAME);
+
+/// Commands from behaviour to handler.
+#[derive(Debug)]
+pub enum PricingHandlerCommand {
+    /// Open an outbound stream and announce our threshold.
+    Announce(AnnouncePaymentThreshold),
+}
+
+/// Events from handler to behaviour.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum PricingHandlerEvent {
+    /// Remote announced its payment threshold.
+    ThresholdReceived(AnnouncePaymentThreshold),
+    /// Our outbound announcement completed.
+    AnnouncementSent,
+    /// An inbound stream failed.
+    InboundError(String),
+    /// An outbound stream failed. Logged at warn; **not** propagated as a
+    /// behaviour-level error.
+    OutboundError(String),
+    /// An outbound announce was discarded because the per-handler queue was
+    /// full. Surfaced so operators see when the announce path silently
+    /// failed to deliver.
+    OutboundDropped,
+}
+
+/// Marker info for outbound substream requests.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PricingOutboundInfo;
+
+/// Per-connection handler for pricing.
+pub struct PricingHandler {
+    /// Bounded set of inbound stream futures.
+    inbound: futures_bounded::FuturesSet<Result<AnnouncePaymentThreshold, ProtocolError>>,
+    /// Pending outbound announcements.
+    pending_outbound: VecDeque<AnnouncePaymentThreshold>,
+    /// Whether an outbound substream request is in flight.
+    outbound_in_flight: bool,
+    /// Events to emit to the behaviour.
+    pending_events: VecDeque<PricingHandlerEvent>,
+}
+
+impl PricingHandler {
+    /// Construct a new pricing handler.
+    pub fn new() -> Self {
+        Self {
+            inbound: futures_bounded::FuturesSet::new(STREAM_TIMEOUT, MAX_CONCURRENT_INBOUND),
+            pending_outbound: VecDeque::new(),
+            outbound_in_flight: false,
+            pending_events: VecDeque::new(),
+        }
+    }
+}
+
+impl Default for PricingHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConnectionHandler for PricingHandler {
+    type FromBehaviour = PricingHandlerCommand;
+    type ToBehaviour = PricingHandlerEvent;
+    type InboundProtocol = ReadyUpgrade<StreamProtocol>;
+    type OutboundProtocol = PricingOutboundProtocol;
+    type InboundOpenInfo = ();
+    type OutboundOpenInfo = PricingOutboundInfo;
+
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        SubstreamProtocol::new(ReadyUpgrade::new(PRICING_STREAM_PROTOCOL), ())
+    }
+
+    fn connection_keep_alive(&self) -> bool {
+        // Keep alive only while pricing has actual work to do; topology
+        // owns the long-term keep-alive decision once we have nothing
+        // pending or in-flight.
+        self.outbound_in_flight
+            || !self.pending_outbound.is_empty()
+            || !self.pending_events.is_empty()
+            || !self.inbound.is_empty()
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<
+        ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
+    > {
+        // Drain inbound unconditionally so its waker is re-registered with
+        // the current context; pushing the result through `pending_events`
+        // means a Ready return from an earlier branch does not leave a
+        // finished inbound stream un-noticed.
+        if let Poll::Ready(result) = self.inbound.poll_unpin(cx) {
+            let event = match result {
+                Ok(Ok(threshold)) => PricingHandlerEvent::ThresholdReceived(threshold),
+                Ok(Err(err)) => {
+                    warn!(error = %err, "Pricing inbound stream error");
+                    PricingHandlerEvent::InboundError(err.to_string())
+                }
+                Err(Timeout { .. }) => {
+                    warn!("Pricing inbound stream timed out");
+                    PricingHandlerEvent::InboundError("inbound timeout".to_string())
+                }
+            };
+            self.pending_events.push_back(event);
+        }
+
+        if let Some(event) = self.pending_events.pop_front() {
+            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
+        }
+
+        if !self.outbound_in_flight
+            && let Some(threshold) = self.pending_outbound.pop_front()
+        {
+            self.outbound_in_flight = true;
+            debug!(threshold = %threshold.payment_threshold, "Pricing: opening outbound stream");
+            return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
+                protocol: SubstreamProtocol::new(outbound(threshold), PricingOutboundInfo)
+                    .with_timeout(OUTBOUND_TIMEOUT),
+            });
+        }
+
+        Poll::Pending
+    }
+
+    fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
+        match event {
+            PricingHandlerCommand::Announce(threshold) => {
+                if self.pending_outbound.len() >= MAX_PENDING_OUTBOUND {
+                    warn!("Dropping pricing announcement: pending queue full");
+                    self.pending_events
+                        .push_back(PricingHandlerEvent::OutboundDropped);
+                    return;
+                }
+                self.pending_outbound.push_back(threshold);
+            }
+        }
+    }
+
+    fn on_connection_event(
+        &mut self,
+        event: ConnectionEvent<
+            Self::InboundProtocol,
+            Self::OutboundProtocol,
+            Self::InboundOpenInfo,
+            Self::OutboundOpenInfo,
+        >,
+    ) {
+        match event {
+            ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
+                protocol: stream,
+                ..
+            }) => {
+                if self
+                    .inbound
+                    .try_push(async move {
+                        let upgrade = Inbound::new(PricingInner);
+                        upgrade.upgrade_inbound(stream, PROTOCOL_NAME).await
+                    })
+                    .is_err()
+                {
+                    warn!("Dropping inbound pricing stream: at capacity");
+                    self.pending_events
+                        .push_back(PricingHandlerEvent::InboundError(
+                            "inbound stream dropped: handler at capacity".to_string(),
+                        ));
+                }
+            }
+            ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound { .. }) => {
+                self.outbound_in_flight = false;
+                debug!("Pricing: outbound announcement complete");
+                self.pending_events
+                    .push_back(PricingHandlerEvent::AnnouncementSent);
+            }
+            ConnectionEvent::DialUpgradeError(error) => {
+                // Never propagate as a hard error: peers without a pricing
+                // implementation must still keep the connection.
+                self.outbound_in_flight = false;
+                let msg = error.error.to_string();
+                warn!(error = %msg, "Pricing outbound upgrade failed (ignored)");
+                self.pending_events
+                    .push_back(PricingHandlerEvent::OutboundError(msg));
+            }
+            ConnectionEvent::ListenUpgradeError(ListenUpgradeError { error, .. }) => {
+                // Surface inbound upgrade failures so operators see when an
+                // inbound dial from a peer fails libp2p-side negotiation,
+                // rather than silently swallowing the event.
+                let msg = error.to_string();
+                warn!(error = %msg, "Pricing inbound upgrade failed");
+                self.pending_events
+                    .push_back(PricingHandlerEvent::InboundError(msg));
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/swarm/net/pricing/src/lib.rs
+++ b/crates/swarm/net/pricing/src/lib.rs
@@ -1,13 +1,28 @@
 //! Pricing protocol for Swarm payment threshold announcement.
+//!
+//! Provides:
+//! - Wire codec and stream upgrades for `/swarm/pricing/1.0.0/pricing`.
+//! - A configurable [`PricingBehaviour`] (libp2p `NetworkBehaviour`) used by
+//!   every node type that speaks the protocol. Bootnodes use the listen-only
+//!   shape ([`PricingBehaviour::new_bootnode`]); clients and full nodes use
+//!   the announce-on-connect shape ([`PricingBehaviour::new_announcer`]).
+//!
+//! Advertising this protocol is required for interop with peers that close
+//! the connection when their pricing `ConnectIn` / `ConnectOut` hook fails.
 
+mod behaviour;
 mod codec;
-pub use codec::AnnouncePaymentThreshold;
-
 mod error;
-pub use error::PricingError;
-
+mod handler;
 mod protocol;
+mod stub;
+
+pub use behaviour::{PricingBehaviour, PricingEvent, PricingMode, PricingRole};
+pub use codec::AnnouncePaymentThreshold;
+pub use error::PricingError;
+pub use handler::{PricingHandler, PricingHandlerCommand, PricingHandlerEvent};
 pub use protocol::{PricingInboundProtocol, PricingOutboundProtocol, inbound, outbound};
+pub use stub::{PaymentThresholdObserver, StubObserver};
 
 /// Protocol name for pricing.
 pub const PROTOCOL_NAME: &str = "/swarm/pricing/1.0.0/pricing";

--- a/crates/swarm/net/pricing/src/stub.rs
+++ b/crates/swarm/net/pricing/src/stub.rs
@@ -1,0 +1,42 @@
+//! Stub-mode observer for the pricing protocol.
+//!
+//! Used by node types that advertise the protocol for interop but do not
+//! participate in chunk accounting (bootnodes today). Inbound thresholds are
+//! observed at `debug` and discarded.
+
+use alloy_primitives::U256;
+use libp2p::PeerId;
+use tracing::debug;
+
+use crate::AnnouncePaymentThreshold;
+
+/// Observer notified when a peer announces its payment threshold.
+///
+/// The trait is used to decouple the pricing behaviour from concrete accounting
+/// implementations. The stub variant ([`StubObserver`]) discards updates; a full
+/// implementation (e.g. a colocated client node) can implement this trait to
+/// receive thresholds into the accounting subsystem.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait PaymentThresholdObserver: Send + Sync {
+    /// Record an announced payment threshold from a remote peer.
+    fn record_threshold(&self, peer: PeerId, threshold: U256);
+}
+
+/// No-op observer used in bootnode stub mode.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StubObserver;
+
+impl PaymentThresholdObserver for StubObserver {
+    fn record_threshold(&self, peer: PeerId, threshold: U256) {
+        debug!(
+            %peer,
+            %threshold,
+            "Pricing stub: discarding peer threshold (bootnode does not account)"
+        );
+    }
+}
+
+/// Helper for constructing a stub-mode announcement payload from a u64 default.
+pub(crate) fn stub_announcement(default_threshold: u64) -> AnnouncePaymentThreshold {
+    AnnouncePaymentThreshold::new(U256::from(default_threshold))
+}

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -1,7 +1,9 @@
-//! Bootnode - minimal Swarm node with topology protocols only.
+//! Bootnode - minimal Swarm node with topology protocols and pricing stub.
 //!
-//! A [`BootNode`] participates in peer discovery via handshake, hive, and pingpong
-//! but does not run client protocols (pricing, retrieval, pushsync, settlement).
+//! A [`BootNode`] participates in peer discovery via handshake, hive, and
+//! pingpong and advertises the pricing protocol in listen-only mode so peers
+//! that disconnect on a failed pricing handshake stay connected. It does not
+//! run the other client protocols (retrieval, pushsync, settlement).
 //!
 //! Use this for dedicated bootnode servers that help new nodes join the network.
 
@@ -9,11 +11,12 @@ use eyre::Result;
 use futures::StreamExt;
 use libp2p::{PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
 use nectar_primitives::SwarmAddress;
-use tracing::info;
+use tracing::{debug, info};
 use vertex_swarm_api::{
     SwarmIdentity, SwarmIdentityConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
 };
 use vertex_swarm_net_identify as identify;
+use vertex_swarm_net_pricing::{PricingBehaviour, PricingEvent};
 use vertex_swarm_topology::{
     KademliaConfig, TopologyBehaviour, TopologyCommand, TopologyConfig, TopologyEvent,
     TopologyHandle,
@@ -23,12 +26,18 @@ use vertex_tasks::GracefulShutdown;
 use super::base::BaseNode;
 use super::builder::BuiltInfrastructure;
 
-/// Network behaviour for a bootnode (topology only, no client protocols).
+/// Network behaviour for a bootnode (topology + pricing stub).
+///
+/// The pricing stub is mandatory for interop with peers that close the
+/// connection when their pricing handshake fails; advertising the protocol
+/// is enough. Bootnodes never dial an outbound pricing stream of their own
+/// because they have no payment state to announce.
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "BootnodeEvent")]
 pub struct BootnodeBehaviour<I: SwarmIdentity + Clone> {
     pub identify: identify::Behaviour,
     pub topology: TopologyBehaviour<I>,
+    pub pricing: PricingBehaviour,
 }
 
 impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
@@ -36,23 +45,40 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
     pub fn from_parts(local_public_key: PublicKey, topology: TopologyBehaviour<I>) -> Self {
         let agent_versions = topology.agent_versions();
         Self {
-            // Send listen addresses (even private IPs) so bee's peerstore has entries.
-            // waitPeerAddrs() returns immediately if len(addrs) > 0, regardless of
-            // whether addresses match or are reachable. The handshake protocol uses
-            // RemoteMultiaddr directly. Private IPs in gossip are harmless.
+            // Advertise listen addresses (even private IPs). Peers gate on
+            // "we have at least one addr" rather than reachability, and the
+            // handshake itself uses the libp2p-observed remote multiaddr, so
+            // private IPs in the identify payload are harmless.
             identify: identify::Behaviour::new(
                 identify::Config::new(local_public_key),
                 agent_versions,
             ),
             topology,
+            // Bootnodes advertise pricing for interop but never dial an
+            // outbound stream of their own and discard inbound thresholds.
+            pricing: PricingBehaviour::new_bootnode(),
         }
+    }
+
+    /// Protocols advertised by this behaviour above the topology layer.
+    ///
+    /// Used in tests and diagnostics to verify mainnet interop coverage.
+    /// Topology protocols (handshake, hive, pingpong) are owned by
+    /// [`TopologyBehaviour`] and tested there; this list covers only the
+    /// extra protocols that the bootnode itself mounts (currently the
+    /// pricing stub required for bee mainnet interop).
+    #[allow(dead_code)] // Reserved for integration tests and operator diagnostics.
+    pub fn supported_protocols() -> &'static [&'static str] {
+        &[vertex_swarm_net_pricing::PROTOCOL_NAME]
     }
 }
 
 /// Events from the bootnode behaviour.
+#[allow(clippy::large_enum_variant)]
 pub enum BootnodeEvent {
     Identify(Box<identify::Event>),
     Topology(()),
+    Pricing(PricingEvent),
 }
 
 impl From<identify::Event> for BootnodeEvent {
@@ -64,6 +90,12 @@ impl From<identify::Event> for BootnodeEvent {
 impl From<()> for BootnodeEvent {
     fn from(_: ()) -> Self {
         BootnodeEvent::Topology(())
+    }
+}
+
+impl From<PricingEvent> for BootnodeEvent {
+    fn from(event: PricingEvent) -> Self {
+        BootnodeEvent::Pricing(event)
     }
 }
 
@@ -160,6 +192,27 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
                 self.handle_identify_event(*boxed_event);
             }
             BootnodeEvent::Topology(_) => {}
+            BootnodeEvent::Pricing(event) => {
+                // Bootnodes do not perform accounting; observability only.
+                match event {
+                    PricingEvent::ThresholdReceived { peer, threshold } => {
+                        debug!(
+                            %peer,
+                            threshold = %threshold.payment_threshold,
+                            "Bootnode: received pricing threshold (discarded)"
+                        );
+                    }
+                    PricingEvent::InboundError { peer, error } => {
+                        debug!(%peer, %error, "Bootnode: pricing inbound error");
+                    }
+                    // Variants associated with announcing our own threshold
+                    // cannot fire in listen-only mode.
+                    PricingEvent::AnnouncementSent { .. }
+                    | PricingEvent::OutboundError { .. }
+                    | PricingEvent::AnnouncementDropped { .. } => {}
+                    _ => {}
+                }
+            }
         }
     }
 
@@ -357,6 +410,17 @@ mod tests {
                 }
             ),
             "expected EphemeralWhenPersistent {{ Bootnode }}, got: {identity_err:?}"
+        );
+    }
+
+    /// The bootnode must advertise the pricing protocol so peers that
+    /// disconnect on a failed pricing handshake stay connected.
+    #[test]
+    fn supported_protocols_includes_pricing() {
+        let protocols = BootnodeBehaviour::<Arc<Identity>>::supported_protocols();
+        assert!(
+            protocols.contains(&vertex_swarm_net_pricing::PROTOCOL_NAME),
+            "bootnode must advertise pricing protocol; got {protocols:?}"
         );
     }
 }


### PR DESCRIPTION
Unit 15 — the **critical** bee-mainnet interop requirement. Without it bee disconnects every vertex bootnode after handshake (libp2p.go:697-702/1191-1198: any ConnectIn/Out failure triggers Disconnect; pricing init opens a stream). Stub responds to AnnouncePaymentThreshold + announces ours outbound. 11 tests pass.