### PR TITLE
feat(net-handshake)!: bee-mainnet 15.0.0 handshake + typestate phases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8151,6 +8151,7 @@ dependencies = [
  "vertex-swarm-identity",
  "vertex-swarm-net-proto",
  "vertex-swarm-peer",
+ "vertex-swarm-primitives",
  "vertex-swarm-spec",
  "vertex-swarm-test-utils",
 ]
@@ -8390,6 +8391,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
+ "alloy-signer-local",
  "arbitrary",
  "auto_impl",
  "bytes",

--- a/crates/swarm/net/handshake/Cargo.toml
+++ b/crates/swarm/net/handshake/Cargo.toml
@@ -64,4 +64,5 @@ arbitrary.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 rand.workspace = true
+vertex-swarm-primitives.workspace = true
 vertex-swarm-test-utils = { workspace = true }

--- a/crates/swarm/net/handshake/src/codec/ack.rs
+++ b/crates/swarm/net/handshake/src/codec/ack.rs
@@ -1,240 +1,372 @@
-//! Ack message encoding/decoding for handshake protocol.
+//! Ack message encoding/decoding for handshake 15.0.0.
+//!
+//! Wire layout (matches bee `pb/handshake.proto::Ack`):
+//!
+//! ```text
+//! Ack {
+//!   BzzAddress address     = 1;
+//!   uint64     network_id  = 2;
+//!   bool       full_node   = 3;
+//!   string     welcome_msg = 99;
+//! }
+//! BzzAddress {
+//!   bytes underlay           = 1;
+//!   bytes signature          = 2;
+//!   bytes overlay            = 3;
+//!   bytes nonce              = 4;
+//!   int64 timestamp          = 5;
+//!   bytes chequebook_address = 6;
+//! }
+//! ```
 
-use nectar_primitives::SwarmAddress;
+use alloy_primitives::Signature;
 use tracing::debug;
-use vertex_swarm_peer::{SwarmNodeType, SwarmPeer};
+use vertex_swarm_peer::{BzzAddress, Nonce, SwarmAddress, SwarmNodeType, Timestamp};
 
 use crate::HandshakeError;
-use crate::MAX_WELCOME_MESSAGE_CHARS;
+use crate::welcome::WelcomeMessage;
 
-/// Decode an Ack proto message, validating network_id and returning components.
+/// Validated contents of a decoded [`Ack`](vertex_swarm_net_proto::handshake::Ack).
+///
+/// Exposed publicly so the [`crate::session`] typestate API can consume it.
+/// `ethereum_address` is recovered from the signature; consumers building a
+/// legacy [`SwarmPeer`] should pass it to
+/// [`SwarmPeer::from_validated`](vertex_swarm_peer::SwarmPeer::from_validated).
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct DecodedAck {
+    /// Verified bee-mainnet wire address.
+    pub bzz_address: BzzAddress,
+    /// Ethereum address recovered from the signature.
+    pub ethereum_address: alloy_primitives::Address,
+    /// Node type advertised by the peer.
+    pub node_type: SwarmNodeType,
+    /// Welcome message advertised by the peer.
+    pub welcome_message: WelcomeMessage,
+}
+
+/// Decode an Ack proto message.
+///
+/// Validates `network_id`, signature, overlay, and (when `now` is `Some`) the
+/// timestamp's clock skew. Returns a [`DecodedAck`] bundle ready for
+/// [`crate::HandshakeInfo`].
 pub(crate) fn decode_ack(
     proto: vertex_swarm_net_proto::handshake::Ack,
     expected_network_id: u64,
-) -> Result<(SwarmPeer, SwarmNodeType, String), HandshakeError> {
-    let swarm_peer = swarm_peer_from_proto(&proto, expected_network_id)?;
-    let welcome_message = welcome_message_from_proto(&proto)?;
-    let node_type = node_type_from_wire(proto.storer);
-    Ok((swarm_peer, node_type, welcome_message))
+    now: Option<Timestamp>,
+) -> Result<DecodedAck, HandshakeError> {
+    if proto.network_id != expected_network_id {
+        return Err(HandshakeError::NetworkIdMismatch);
+    }
+
+    let address = proto
+        .address
+        .ok_or(HandshakeError::MissingField("address"))?;
+
+    // Per-field validation up front so we produce specific errors.
+    let overlay = SwarmAddress::from_slice(address.overlay.as_slice())
+        .inspect_err(|e| debug!(error = ?e, "invalid overlay in handshake ack"))
+        .map_err(|_| HandshakeError::InvalidOverlay)?;
+
+    let nonce_bytes: [u8; 32] = address.nonce.as_slice().try_into()?;
+    let nonce = Nonce::from(nonce_bytes);
+
+    let signature = Signature::try_from(address.signature.as_slice())?;
+    let timestamp = Timestamp::from_secs(address.timestamp);
+
+    let (bzz_address, ethereum_address) = BzzAddress::parse(
+        &address.underlay,
+        signature,
+        overlay,
+        nonce,
+        timestamp,
+        proto.network_id,
+        &address.chequebook_address,
+        now,
+    )
+    .map_err(|err| map_parse_error(err, overlay, timestamp, now))?;
+
+    let welcome_message = welcome_from_proto(&proto.welcome_message)?;
+    let node_type = node_type_from_wire(proto.full_node);
+
+    Ok(DecodedAck {
+        bzz_address,
+        ethereum_address,
+        node_type,
+        welcome_message,
+    })
 }
 
-/// Encode identity into an Ack proto message.
+/// Encode a verified [`BzzAddress`] + identity bits into an Ack proto message.
 pub(crate) fn encode_ack(
-    peer: &SwarmPeer,
+    bzz: &BzzAddress,
     node_type: SwarmNodeType,
-    welcome_message: &str,
+    welcome_message: &WelcomeMessage,
     network_id: u64,
 ) -> vertex_swarm_net_proto::handshake::Ack {
     vertex_swarm_net_proto::handshake::Ack {
-        peer: Some(vertex_swarm_net_proto::handshake::PeerAddress {
-            multiaddrs: peer.serialize_multiaddrs(),
-            signature: peer.signature().as_bytes().to_vec(),
-            overlay: peer.overlay().to_vec(),
+        address: Some(vertex_swarm_net_proto::handshake::BzzAddress {
+            underlay: bzz.serialize_underlay(),
+            signature: bzz.signature().as_bytes().to_vec(),
+            overlay: bzz.overlay().to_vec(),
+            nonce: bzz.nonce().as_bytes().to_vec(),
+            timestamp: bzz.timestamp().as_secs(),
+            chequebook_address: bzz
+                .chequebook()
+                .map(|cb| cb.as_slice().to_vec())
+                .unwrap_or_default(),
         }),
         network_id,
-        storer: node_type_to_wire(node_type),
-        nonce: peer.nonce().to_vec(),
-        welcome_message: welcome_message.to_string(),
+        full_node: node_type_to_wire(node_type),
+        welcome_message: welcome_message.as_str().to_owned(),
     }
 }
 
-/// Convert wire format bool to SwarmNodeType.
+/// Map a [`SwarmPeerError`] into a typed [`HandshakeError`].
 ///
-/// Wire format uses `bool storer` for backwards compatibility with existing peers.
-/// Bootnodes don't participate in handshake (topology-only).
-pub(crate) fn node_type_from_wire(storer: bool) -> SwarmNodeType {
-    if storer {
+/// The peer crate's parser collapses skew failures into a single variant; we
+/// re-attach overlay and drift so operators can correlate the rejection.
+fn map_parse_error(
+    err: vertex_swarm_peer::error::SwarmPeerError,
+    overlay: SwarmAddress,
+    timestamp: Timestamp,
+    now: Option<Timestamp>,
+) -> HandshakeError {
+    use vertex_swarm_peer::error::SwarmPeerError;
+    match err {
+        SwarmPeerError::TimestampOutsideSkewWindow => {
+            let drift_seconds = now
+                .map(|n| timestamp.as_secs().saturating_sub(n.as_secs()))
+                .unwrap_or(0);
+            HandshakeError::TimestampOutsideSkewWindow {
+                peer_overlay: overlay,
+                drift_seconds,
+            }
+        }
+        other => HandshakeError::InvalidPeer(other),
+    }
+}
+
+/// Convert wire `full_node` bool to [`SwarmNodeType`].
+///
+/// The wire format is binary (storer vs not); bootnodes do not handshake.
+pub(crate) fn node_type_from_wire(full_node: bool) -> SwarmNodeType {
+    if full_node {
         SwarmNodeType::Storer
     } else {
         SwarmNodeType::Client
     }
 }
 
-fn node_type_to_wire(node_type: SwarmNodeType) -> bool {
+pub(crate) fn node_type_to_wire(node_type: SwarmNodeType) -> bool {
     node_type.requires_storage()
 }
 
-pub(crate) fn swarm_peer_from_proto(
-    value: &vertex_swarm_net_proto::handshake::Ack,
-    expected_network_id: u64,
-) -> Result<SwarmPeer, HandshakeError> {
-    if value.network_id != expected_network_id {
-        return Err(HandshakeError::NetworkIdMismatch);
-    }
-
-    let peer_address = value
-        .peer
-        .as_ref()
-        .ok_or(HandshakeError::MissingField("peer"))?;
-
-    let overlay = SwarmAddress::from_slice(peer_address.overlay.as_slice())
-        .inspect_err(|e| debug!(error = ?e, "invalid overlay in handshake ack"))
-        .map_err(|_| HandshakeError::InvalidOverlay)?;
-
-    let nonce = value.nonce.as_slice().try_into()?;
-    let signature = peer_address.signature.as_slice().try_into()?;
-
-    SwarmPeer::from_signed(
-        &peer_address.multiaddrs,
-        signature,
-        overlay,
-        nonce,
-        value.network_id,
-        true,
-    )
-    .map_err(HandshakeError::from)
-}
-
-pub(crate) fn welcome_message_from_proto(
-    value: &vertex_swarm_net_proto::handshake::Ack,
-) -> Result<String, HandshakeError> {
-    let char_count = value.welcome_message.chars().count();
-    if char_count > MAX_WELCOME_MESSAGE_CHARS {
-        return Err(HandshakeError::FieldTooLong {
-            field: "welcome_message",
-            max: MAX_WELCOME_MESSAGE_CHARS,
-            actual: char_count,
-        });
-    }
-    Ok(value.welcome_message.clone())
+pub(crate) fn welcome_from_proto(s: &str) -> Result<WelcomeMessage, HandshakeError> {
+    Ok(WelcomeMessage::new(s)?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::welcome::MAX_WELCOME_MESSAGE_CHARS;
+    use alloy_primitives::{Address, B256};
+    use alloy_signer_local::PrivateKeySigner;
     use libp2p::Multiaddr;
-    use vertex_swarm_api::SwarmSpec;
-    use vertex_swarm_identity::Identity;
-    use vertex_swarm_test_utils::test_spec_isolated as test_spec;
+    use vertex_swarm_primitives::compute_overlay;
 
-    fn create_test_peer() -> SwarmPeer {
-        let spec = test_spec();
-        let identity = Identity::random(spec.clone(), SwarmNodeType::Storer);
-        let multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
-        SwarmPeer::from_identity(&identity, vec![multiaddr]).expect("should create peer")
+    fn fixed_now() -> Timestamp {
+        Timestamp::from_secs(1_700_000_000)
+    }
+
+    fn build_bzz(
+        signer: &PrivateKeySigner,
+        network_id: u64,
+        nonce: Nonce,
+        timestamp: Timestamp,
+        chequebook: Option<Address>,
+    ) -> BzzAddress {
+        let overlay = compute_overlay(&signer.address(), network_id, nonce.as_b256());
+        let underlay: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+        BzzAddress::sign(
+            signer, underlay, overlay, network_id, nonce, timestamp, chequebook,
+        )
+        .unwrap()
     }
 
     #[test]
-    fn test_ack_roundtrip() {
-        let spec = test_spec();
-        let peer = create_test_peer();
-        let node_type = SwarmNodeType::Storer;
-        let welcome = "hello";
+    fn ack_roundtrip_no_chequebook() {
+        let network_id = 10u64;
+        let nonce = Nonce::from([0x11u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, network_id, nonce, fixed_now(), None);
+        let welcome = WelcomeMessage::new("buzz buzz").unwrap();
 
-        let proto = encode_ack(&peer, node_type, welcome, spec.network_id());
-        let (decoded_peer, decoded_type, decoded_welcome) =
-            decode_ack(proto, spec.network_id()).unwrap();
+        let proto = encode_ack(&bzz, SwarmNodeType::Storer, &welcome, network_id);
+        let decoded = decode_ack(proto, network_id, Some(fixed_now())).unwrap();
 
-        assert_eq!(peer, decoded_peer);
-        assert_eq!(node_type, decoded_type);
-        assert_eq!(welcome, decoded_welcome);
+        assert_eq!(decoded.bzz_address, bzz);
+        assert_eq!(decoded.node_type, SwarmNodeType::Storer);
+        assert_eq!(decoded.welcome_message, welcome);
+        assert_eq!(decoded.ethereum_address, signer.address());
     }
 
     #[test]
-    fn test_wire_format_backwards_compat() {
-        assert_eq!(node_type_from_wire(true), SwarmNodeType::Storer);
-        assert_eq!(node_type_from_wire(false), SwarmNodeType::Client);
-        assert!(node_type_to_wire(SwarmNodeType::Storer));
-        assert!(!node_type_to_wire(SwarmNodeType::Client));
-        assert!(!node_type_to_wire(SwarmNodeType::Bootnode));
+    fn ack_roundtrip_with_chequebook() {
+        let network_id = 1u64;
+        let nonce = Nonce::from([0x22u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let chequebook = Some(Address::from([0xAB; 20]));
+        let bzz = build_bzz(&signer, network_id, nonce, fixed_now(), chequebook);
+        let welcome = WelcomeMessage::empty();
+
+        let proto = encode_ack(&bzz, SwarmNodeType::Client, &welcome, network_id);
+        let decoded = decode_ack(proto, network_id, Some(fixed_now())).unwrap();
+
+        assert_eq!(decoded.bzz_address.chequebook(), chequebook.as_ref());
+        assert_eq!(decoded.node_type, SwarmNodeType::Client);
     }
 
     #[test]
-    fn test_network_id_mismatch() {
-        let spec = test_spec();
-        let peer = create_test_peer();
-        let proto = encode_ack(&peer, SwarmNodeType::Client, "hello", spec.network_id());
-
-        let wrong_network_id = spec.network_id().wrapping_add(1);
-        let result = decode_ack(proto, wrong_network_id);
-        assert!(matches!(result, Err(HandshakeError::NetworkIdMismatch)));
+    fn network_id_mismatch_rejected() {
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let proto = encode_ack(&bzz, SwarmNodeType::Storer, &WelcomeMessage::empty(), 1);
+        let err = decode_ack(proto, 2, Some(fixed_now())).unwrap_err();
+        assert!(matches!(err, HandshakeError::NetworkIdMismatch));
     }
 
     #[test]
-    fn test_missing_peer_field() {
-        let spec = test_spec();
-        let peer = create_test_peer();
-        let mut proto = encode_ack(&peer, SwarmNodeType::Client, "test", spec.network_id());
-        proto.peer = None;
-
-        let result = decode_ack(proto, spec.network_id());
-        assert!(matches!(result, Err(HandshakeError::MissingField("peer"))));
+    fn missing_address_field_rejected() {
+        let proto = vertex_swarm_net_proto::handshake::Ack {
+            network_id: 1,
+            ..Default::default()
+        };
+        let err = decode_ack(proto, 1, Some(fixed_now())).unwrap_err();
+        assert!(matches!(err, HandshakeError::MissingField("address")));
     }
 
     #[test]
-    fn test_empty_multiaddrs_rejected() {
-        let spec = test_spec();
-        let peer = create_test_peer();
-        let mut proto = encode_ack(&peer, SwarmNodeType::Client, "test", spec.network_id());
+    fn invalid_nonce_length_rejected() {
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let mut proto = encode_ack(&bzz, SwarmNodeType::Client, &WelcomeMessage::empty(), 1);
+        proto.address.as_mut().unwrap().nonce = vec![0u8; 16];
+        let err = decode_ack(proto, 1, Some(fixed_now())).unwrap_err();
+        assert!(matches!(err, HandshakeError::InvalidData(_)));
+    }
 
-        if let Some(ref mut peer_addr) = proto.peer {
-            peer_addr.multiaddrs = vec![];
-        }
-
-        let result = decode_ack(proto, spec.network_id());
+    #[test]
+    fn invalid_signature_rejected() {
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let mut proto = encode_ack(&bzz, SwarmNodeType::Client, &WelcomeMessage::empty(), 1);
+        proto.address.as_mut().unwrap().signature = vec![0u8; 65];
+        let err = decode_ack(proto, 1, Some(fixed_now())).unwrap_err();
+        // All-zero signature is either rejected by EIP-191 recovery
+        // (`InvalidSignature`) or recovers to a different address and trips
+        // the overlay check — both are valid failure modes.
         assert!(
             matches!(
-                result,
-                Err(HandshakeError::InvalidPeer(
-                    vertex_swarm_peer::error::SwarmPeerError::NoMultiaddrs
-                ))
+                err,
+                HandshakeError::InvalidPeer(
+                    vertex_swarm_peer::error::SwarmPeerError::InvalidOverlay
+                ) | HandshakeError::InvalidPeer(
+                    vertex_swarm_peer::error::SwarmPeerError::InvalidSignature(_)
+                )
             ),
-            "expected NoMultiaddrs error, got: {:?}",
-            result
+            "unexpected error variant: {err:?}"
         );
     }
 
     #[test]
-    fn test_welcome_message_max_length() {
-        let spec = test_spec();
-        let peer = create_test_peer();
-
-        // At max length - should succeed
-        let max_message = "x".repeat(MAX_WELCOME_MESSAGE_CHARS);
+    fn timestamp_outside_skew_window_typed() {
+        let network_id = 1u64;
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let far_future = Timestamp::from_secs(fixed_now().as_secs() + 24 * 60 * 60);
+        let bzz = build_bzz(&signer, network_id, nonce, far_future, None);
         let proto = encode_ack(
-            &peer,
-            SwarmNodeType::Client,
-            &max_message,
-            spec.network_id(),
+            &bzz,
+            SwarmNodeType::Storer,
+            &WelcomeMessage::empty(),
+            network_id,
         );
-        assert!(decode_ack(proto, spec.network_id()).is_ok());
-
-        // Over max length - should fail
-        let mut proto = encode_ack(&peer, SwarmNodeType::Client, "", spec.network_id());
-        proto.welcome_message = "x".repeat(MAX_WELCOME_MESSAGE_CHARS + 1);
-        assert!(matches!(
-            decode_ack(proto, spec.network_id()),
-            Err(HandshakeError::FieldTooLong { .. })
-        ));
-    }
-
-    #[test]
-    fn test_invalid_signature() {
-        let spec = test_spec();
-        let peer = create_test_peer();
-        let mut proto = encode_ack(&peer, SwarmNodeType::Client, "test", spec.network_id());
-
-        if let Some(ref mut peer_addr) = proto.peer {
-            peer_addr.signature = vec![0u8; 65];
+        let err = decode_ack(proto, network_id, Some(fixed_now())).unwrap_err();
+        match err {
+            HandshakeError::TimestampOutsideSkewWindow {
+                peer_overlay,
+                drift_seconds,
+            } => {
+                assert_eq!(peer_overlay, *bzz.overlay());
+                assert_eq!(drift_seconds, 24 * 60 * 60);
+            }
+            other => panic!("unexpected error: {other:?}"),
         }
+    }
 
-        let result = decode_ack(proto, spec.network_id());
+    #[test]
+    fn invalid_overlay_bytes_rejected() {
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let mut proto = encode_ack(&bzz, SwarmNodeType::Client, &WelcomeMessage::empty(), 1);
+        proto.address.as_mut().unwrap().overlay = vec![0u8; 16];
+        let err = decode_ack(proto, 1, Some(fixed_now())).unwrap_err();
+        assert!(matches!(err, HandshakeError::InvalidOverlay));
+    }
+
+    #[test]
+    fn welcome_message_max_length_accepted() {
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let welcome = WelcomeMessage::new("x".repeat(MAX_WELCOME_MESSAGE_CHARS)).unwrap();
+        let proto = encode_ack(&bzz, SwarmNodeType::Storer, &welcome, 1);
+        let decoded = decode_ack(proto, 1, Some(fixed_now())).unwrap();
+        assert_eq!(decoded.welcome_message, welcome);
+    }
+
+    #[test]
+    fn welcome_message_over_max_rejected() {
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let mut proto = encode_ack(&bzz, SwarmNodeType::Storer, &WelcomeMessage::empty(), 1);
+        proto.welcome_message = "x".repeat(MAX_WELCOME_MESSAGE_CHARS + 1);
+        let err = decode_ack(proto, 1, Some(fixed_now())).unwrap_err();
+        assert!(matches!(err, HandshakeError::InvalidWelcomeMessage(_)));
+    }
+
+    #[test]
+    fn invalid_chequebook_length_rejected() {
+        let nonce = Nonce::from([0u8; 32]);
+        let signer = PrivateKeySigner::random();
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let mut proto = encode_ack(&bzz, SwarmNodeType::Storer, &WelcomeMessage::empty(), 1);
+        proto.address.as_mut().unwrap().chequebook_address = vec![0u8; 19];
+        let err = decode_ack(proto, 1, Some(fixed_now())).unwrap_err();
         assert!(matches!(
-            result,
-            Err(HandshakeError::InvalidPeer(
-                vertex_swarm_peer::error::SwarmPeerError::InvalidSignature(_)
-            ))
+            err,
+            HandshakeError::InvalidPeer(
+                vertex_swarm_peer::error::SwarmPeerError::InvalidChequebook
+            )
         ));
     }
 
     #[test]
-    fn test_invalid_nonce_length() {
-        let spec = test_spec();
-        let peer = create_test_peer();
-        let mut proto = encode_ack(&peer, SwarmNodeType::Client, "test", spec.network_id());
-        proto.nonce = vec![0u8; 16]; // Wrong length
-
-        let result = decode_ack(proto, spec.network_id());
-        assert!(matches!(result, Err(HandshakeError::InvalidData(_))));
+    fn ack_signed_by_fixed_keypair_recovers() {
+        // Deterministic vector: sign with a fixed key, encode, decode, assert
+        // the recovered ethereum address matches.
+        let raw = B256::repeat_byte(0x42);
+        let signer = PrivateKeySigner::from_bytes(&raw).expect("test key");
+        let nonce = Nonce::from([0x5Au8; 32]);
+        let bzz = build_bzz(&signer, 1, nonce, fixed_now(), None);
+        let proto = encode_ack(&bzz, SwarmNodeType::Storer, &WelcomeMessage::empty(), 1);
+        let decoded = decode_ack(proto, 1, Some(fixed_now())).unwrap();
+        assert_eq!(decoded.bzz_address, bzz);
     }
 }

--- a/crates/swarm/net/handshake/src/codec/mod.rs
+++ b/crates/swarm/net/handshake/src/codec/mod.rs
@@ -5,6 +5,8 @@ mod ack;
 mod syn_msg;
 mod synack;
 
+pub use ack::DecodedAck;
 pub(crate) use ack::{decode_ack, encode_ack};
 pub(crate) use syn_msg::{decode_syn, encode_syn};
+pub use synack::DecodedSynAck;
 pub(crate) use synack::{decode_synack, encode_synack};

--- a/crates/swarm/net/handshake/src/codec/syn.rs
+++ b/crates/swarm/net/handshake/src/codec/syn.rs
@@ -9,18 +9,18 @@ use crate::HandshakeError;
 pub(crate) fn decode_syn(
     proto: vertex_swarm_net_proto::handshake::Syn,
 ) -> Result<Multiaddr, HandshakeError> {
-    let multiaddrs = deserialize_multiaddrs(&proto.observed_multiaddr)?;
+    let multiaddrs = deserialize_multiaddrs(&proto.observed_underlay)?;
 
     multiaddrs
         .into_iter()
         .next()
-        .ok_or(HandshakeError::MissingField("observed_multiaddr"))
+        .ok_or(HandshakeError::MissingField("observed_underlay"))
 }
 
 /// Encode an observed multiaddr into a Syn proto message.
 pub(crate) fn encode_syn(observed: &Multiaddr) -> vertex_swarm_net_proto::handshake::Syn {
     vertex_swarm_net_proto::handshake::Syn {
-        observed_multiaddr: observed.to_vec(),
+        observed_underlay: observed.to_vec(),
     }
 }
 
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn test_syn_rejects_malformed_multiaddr() {
         let proto = vertex_swarm_net_proto::handshake::Syn {
-            observed_multiaddr: vec![0x01, 0x02, 0x03],
+            observed_underlay: vec![0x01, 0x02, 0x03],
         };
         let result = decode_syn(proto);
         assert!(matches!(result, Err(HandshakeError::InvalidMultiaddr(_))));
@@ -52,12 +52,12 @@ mod tests {
     #[test]
     fn test_syn_rejects_empty_multiaddr() {
         let proto = vertex_swarm_net_proto::handshake::Syn {
-            observed_multiaddr: vec![],
+            observed_underlay: vec![],
         };
         let result = decode_syn(proto);
         assert!(matches!(
             result,
-            Err(HandshakeError::MissingField("observed_multiaddr"))
+            Err(HandshakeError::MissingField("observed_underlay"))
         ));
     }
 }

--- a/crates/swarm/net/handshake/src/codec/synack.rs
+++ b/crates/swarm/net/handshake/src/codec/synack.rs
@@ -1,104 +1,122 @@
-//! SynAck message encoding/decoding for handshake protocol.
+//! SynAck message encoding/decoding for handshake 15.0.0.
 
 use libp2p::Multiaddr;
-use vertex_swarm_peer::{SwarmNodeType, SwarmPeer};
+use vertex_swarm_peer::{BzzAddress, SwarmNodeType, Timestamp};
 
-use super::ack::{
-    encode_ack, node_type_from_wire, swarm_peer_from_proto, welcome_message_from_proto,
-};
+use super::ack::{DecodedAck, decode_ack, encode_ack};
 use super::syn_msg::{decode_syn, encode_syn};
 use crate::HandshakeError;
+use crate::welcome::WelcomeMessage;
+
+/// Validated contents of a decoded
+/// [`SynAck`](vertex_swarm_net_proto::handshake::SynAck).
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct DecodedSynAck {
+    /// Address the peer observed us at, echoed back.
+    pub observed_multiaddr: Multiaddr,
+    /// Inner Ack with verified peer identity.
+    pub ack: DecodedAck,
+}
 
 /// Decode a SynAck proto message, returning validated components.
 pub(crate) fn decode_synack(
     proto: vertex_swarm_net_proto::handshake::SynAck,
     expected_network_id: u64,
-) -> Result<(Multiaddr, SwarmPeer, SwarmNodeType, String), HandshakeError> {
-    let observed = decode_syn(proto.syn.ok_or(HandshakeError::MissingField("syn"))?)?;
-
+    now: Option<Timestamp>,
+) -> Result<DecodedSynAck, HandshakeError> {
+    let observed_multiaddr = decode_syn(proto.syn.ok_or(HandshakeError::MissingField("syn"))?)?;
     let proto_ack = proto.ack.ok_or(HandshakeError::MissingField("ack"))?;
-    let swarm_peer = swarm_peer_from_proto(&proto_ack, expected_network_id)?;
-    let welcome_message = welcome_message_from_proto(&proto_ack)?;
-    let node_type = node_type_from_wire(proto_ack.storer);
-
-    Ok((observed, swarm_peer, node_type, welcome_message))
+    let ack = decode_ack(proto_ack, expected_network_id, now)?;
+    Ok(DecodedSynAck {
+        observed_multiaddr,
+        ack,
+    })
 }
 
 /// Encode components into a SynAck proto message.
 pub(crate) fn encode_synack(
     observed: &Multiaddr,
-    peer: &SwarmPeer,
+    bzz: &BzzAddress,
     node_type: SwarmNodeType,
-    welcome_message: &str,
+    welcome_message: &WelcomeMessage,
     network_id: u64,
 ) -> vertex_swarm_net_proto::handshake::SynAck {
     vertex_swarm_net_proto::handshake::SynAck {
         syn: Some(encode_syn(observed)),
-        ack: Some(encode_ack(peer, node_type, welcome_message, network_id)),
+        ack: Some(encode_ack(bzz, node_type, welcome_message, network_id)),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vertex_swarm_api::SwarmSpec;
-    use vertex_swarm_identity::Identity;
-    use vertex_swarm_test_utils::test_spec_isolated as test_spec;
+    use alloy_signer_local::PrivateKeySigner;
+    use vertex_swarm_peer::Nonce;
+    use vertex_swarm_primitives::compute_overlay;
 
-    fn create_test_data() -> (Multiaddr, SwarmPeer, u64) {
-        let spec = test_spec();
-        let identity = Identity::random(spec.clone(), SwarmNodeType::Storer);
+    fn fixed_now() -> Timestamp {
+        Timestamp::from_secs(1_700_000_000)
+    }
+
+    fn signed_bzz(network_id: u64) -> BzzAddress {
+        let signer = PrivateKeySigner::random();
+        let nonce = Nonce::from([0u8; 32]);
+        let overlay = compute_overlay(&signer.address(), network_id, nonce.as_b256());
+        let underlay: Vec<Multiaddr> = vec!["/ip4/192.168.1.1/tcp/5678".parse().unwrap()];
+        BzzAddress::sign(
+            &signer,
+            underlay,
+            overlay,
+            network_id,
+            nonce,
+            fixed_now(),
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn synack_roundtrip() {
         let observed: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
-        let peer_addr: Multiaddr = "/ip4/192.168.1.1/tcp/5678".parse().unwrap();
-        let peer = SwarmPeer::from_identity(&identity, vec![peer_addr]).unwrap();
-        (observed, peer, spec.network_id())
+        let bzz = signed_bzz(1);
+        let welcome = WelcomeMessage::new("hi").unwrap();
+        let proto = encode_synack(&observed, &bzz, SwarmNodeType::Storer, &welcome, 1);
+        let decoded = decode_synack(proto, 1, Some(fixed_now())).unwrap();
+
+        assert_eq!(decoded.observed_multiaddr, observed);
+        assert_eq!(decoded.ack.bzz_address, bzz);
+        assert_eq!(decoded.ack.node_type, SwarmNodeType::Storer);
+        assert_eq!(decoded.ack.welcome_message, welcome);
     }
 
     #[test]
-    fn test_synack_roundtrip() {
-        let (observed, peer, network_id) = create_test_data();
-        let node_type = SwarmNodeType::Storer;
-        let welcome = "test";
-
-        let proto = encode_synack(&observed, &peer, node_type, welcome, network_id);
-        let (dec_observed, dec_peer, dec_type, dec_welcome) =
-            decode_synack(proto, network_id).unwrap();
-
-        assert_eq!(observed, dec_observed);
-        assert_eq!(peer, dec_peer);
-        assert_eq!(node_type, dec_type);
-        assert_eq!(welcome, dec_welcome);
-    }
-
-    #[test]
-    fn test_synack_missing_syn() {
-        let (_, peer, network_id) = create_test_data();
+    fn synack_missing_syn() {
+        let bzz = signed_bzz(1);
         let mut proto = encode_synack(
             &"/ip4/127.0.0.1/tcp/1234".parse().unwrap(),
-            &peer,
+            &bzz,
             SwarmNodeType::Client,
-            "test",
-            network_id,
+            &WelcomeMessage::empty(),
+            1,
         );
         proto.syn = None;
-
-        let result = decode_synack(proto, network_id);
-        assert!(matches!(result, Err(HandshakeError::MissingField("syn"))));
+        let err = decode_synack(proto, 1, Some(fixed_now())).unwrap_err();
+        assert!(matches!(err, HandshakeError::MissingField("syn")));
     }
 
     #[test]
-    fn test_synack_missing_ack() {
-        let (_, peer, network_id) = create_test_data();
+    fn synack_missing_ack() {
+        let bzz = signed_bzz(1);
         let mut proto = encode_synack(
             &"/ip4/127.0.0.1/tcp/1234".parse().unwrap(),
-            &peer,
+            &bzz,
             SwarmNodeType::Client,
-            "test",
-            network_id,
+            &WelcomeMessage::empty(),
+            1,
         );
         proto.ack = None;
-
-        let result = decode_synack(proto, network_id);
-        assert!(matches!(result, Err(HandshakeError::MissingField("ack"))));
+        let err = decode_synack(proto, 1, Some(fixed_now())).unwrap_err();
+        assert!(matches!(err, HandshakeError::MissingField("ack")));
     }
 }

--- a/crates/swarm/net/handshake/src/error.rs
+++ b/crates/swarm/net/handshake/src/error.rs
@@ -3,11 +3,15 @@
 use std::convert::Infallible;
 
 use strum::IntoStaticStr;
+use vertex_swarm_peer::SwarmAddress;
 use vertex_swarm_peer::error::{MultiAddrError, SwarmPeerError};
+
+use crate::welcome::WelcomeMessageError;
 
 /// Handshake protocol errors.
 #[derive(Debug, thiserror::Error, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
 pub enum HandshakeError {
     /// Handshake timeout.
     #[error("timeout")]
@@ -33,6 +37,10 @@ pub enum HandshakeError {
         actual: usize,
     },
 
+    /// Welcome message failed length validation.
+    #[error("welcome message: {0}")]
+    InvalidWelcomeMessage(#[from] WelcomeMessageError),
+
     /// Invalid data conversion (e.g., slice to fixed-size array).
     #[error("invalid data: {0}")]
     InvalidData(#[from] std::array::TryFromSliceError),
@@ -56,6 +64,18 @@ pub enum HandshakeError {
     /// Observed address has wrong or missing peer ID.
     #[error("invalid observed address")]
     InvalidObservedAddress,
+
+    /// Peer's signed timestamp falls outside the permitted clock-skew window.
+    ///
+    /// `peer_overlay` is the overlay the peer advertised; `drift_seconds`
+    /// is the signed delta `peer_timestamp - local_now` in seconds — positive
+    /// means the peer's clock is ahead of ours.
+    #[error("timestamp outside clock-skew window: peer={peer_overlay} drift={drift_seconds}s")]
+    #[strum(serialize = "timestamp_outside_skew_window")]
+    TimestampOutsideSkewWindow {
+        peer_overlay: SwarmAddress,
+        drift_seconds: i64,
+    },
 
     /// Protobuf encoding/decoding error.
     #[error("protobuf error: {0}")]

--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -1,9 +1,18 @@
 //! Handshake protocol for Swarm peer authentication and identity exchange.
+//!
+//! Wire-compatible with bee `/swarm/handshake/15.0.0/handshake` — every
+//! payload binds the peer's nonce, a wall-clock timestamp and an optional
+//! chequebook address into the EIP-191 signature (see
+//! [`vertex_swarm_peer::BzzAddress`]).
+//!
+//! The exchange itself is modelled as a typestate (see [`session`]): each
+//! protocol step transitions a zero-sized phase marker so the state machine
+//! cannot observe an invalid sequence of operations at compile time.
 
 use std::time::Duration;
 
 use libp2p::{Multiaddr, PeerId};
-use vertex_swarm_peer::{SwarmNodeType, SwarmPeer};
+use vertex_swarm_peer::{BzzAddress, SwarmNodeType, SwarmPeer};
 
 mod behaviour;
 pub use behaviour::{HandshakeBehaviour, HandshakeEvent};
@@ -11,6 +20,7 @@ pub use behaviour::{HandshakeBehaviour, HandshakeEvent};
 mod handler;
 
 mod codec;
+pub use codec::{DecodedAck, DecodedSynAck};
 
 mod protocol;
 
@@ -23,23 +33,35 @@ pub use metrics::HandshakeStage;
 mod address;
 pub use address::{AddressProvider, NoAddresses};
 
-/// Protocol name for handshake.
-pub const PROTOCOL: &str = "/swarm/handshake/14.0.0/handshake";
+mod welcome;
+pub use welcome::{MAX_WELCOME_MESSAGE_CHARS, WelcomeMessage, WelcomeMessageError};
+
+pub mod session;
+
+/// Protocol name for the handshake (matches bee `15.0.0`).
+pub const PROTOCOL: &str = "/swarm/handshake/15.0.0/handshake";
 
 /// Timeout for handshake operations.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// Maximum length of welcome message in characters.
-const MAX_WELCOME_MESSAGE_CHARS: usize = 140;
-
 /// Information from a completed handshake.
+///
+/// `bzz_address` carries the verified wire address (including timestamp and
+/// chequebook); `swarm_peer` is a legacy projection retained so existing
+/// consumers can read overlay/multiaddrs without depending on the bzz module.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct HandshakeInfo {
+    /// libp2p peer ID this handshake belongs to.
     pub peer_id: PeerId,
+    /// Verified bee-mainnet wire address.
+    pub bzz_address: BzzAddress,
+    /// Legacy projection of `bzz_address` into the [`SwarmPeer`] type.
     pub swarm_peer: SwarmPeer,
     /// The peer's node type (capability level).
     pub node_type: SwarmNodeType,
-    pub welcome_message: String,
-    /// Can be reported to an AddressManager for NAT discovery.
+    /// Welcome message advertised by the peer.
+    pub welcome_message: WelcomeMessage,
+    /// Can be reported to an `AddressManager` for NAT discovery.
     pub observed_multiaddr: Multiaddr,
 }

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -1,14 +1,24 @@
+//! Network driver for the typestate handshake.
+//!
+//! `protocol.rs` glues [`session::Handshake`] to an `AsyncRead + AsyncWrite`
+//! stream and to the local [`SwarmIdentity`]. It owns no protocol state of
+//! its own: every step lives in the typestate and the wire codec.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId, Stream};
 use tracing::{Instrument, Span, debug_span, instrument, warn};
 use vertex_net_codec::FramedProto;
 use vertex_net_utils::extract_peer_id;
 use vertex_swarm_api::SwarmIdentity;
-use vertex_swarm_peer::SwarmPeer;
+use vertex_swarm_peer::{BzzAddress, Nonce, Timestamp};
 use vertex_swarm_spec::SwarmSpec;
 
-use crate::codec::{decode_ack, decode_syn, decode_synack, encode_ack, encode_syn, encode_synack};
+use crate::codec::{encode_ack, encode_syn, encode_synack};
 use crate::metrics::HandshakeMetrics;
+use crate::session::{Handshake, Initiator, Responder, SessionInputs};
+use crate::welcome::WelcomeMessage;
 use crate::{HandshakeError, HandshakeInfo};
 
 /// Maximum size for handshake message buffers.
@@ -36,22 +46,60 @@ fn validate_observed_addr(
     }
 }
 
-/// Combine additional addresses with the observed address and create a signed SwarmPeer.
-///
-/// Additional addresses come first, observed address is appended last (most important).
-/// Duplicates of the observed address are filtered from additional addresses.
-fn prepare_local_peer<I: SwarmIdentity>(
+/// Build a signed [`BzzAddress`] for the local identity using `observed` as
+/// the highest-priority underlay (filtered out of `additional`, then
+/// appended last). Mirrors bee's address-construction order.
+fn build_local_bzz<I: SwarmIdentity + ?Sized>(
     identity: &I,
-    additional_addrs: &[Multiaddr],
-    observed_addr: &Multiaddr,
-) -> Result<SwarmPeer, HandshakeError> {
-    let mut addrs: Vec<Multiaddr> = additional_addrs
+    additional: &[Multiaddr],
+    observed: &Multiaddr,
+    timestamp: Timestamp,
+) -> Result<BzzAddress, HandshakeError> {
+    let mut underlay: Vec<Multiaddr> = additional
         .iter()
-        .filter(|a| *a != observed_addr)
+        .filter(|a| *a != observed)
         .cloned()
         .collect();
-    addrs.push(observed_addr.clone());
-    SwarmPeer::from_identity(identity, addrs).map_err(HandshakeError::from)
+    underlay.push(observed.clone());
+
+    let signer = identity.signer();
+    let nonce = Nonce::from(identity.nonce());
+    let overlay = identity.overlay_address();
+    let network_id = identity.spec().network_id();
+
+    let bzz = BzzAddress::sign(
+        signer.as_ref(),
+        underlay,
+        overlay,
+        network_id,
+        nonce,
+        timestamp,
+        None,
+    )?;
+    Ok(bzz)
+}
+
+/// `SystemTime::now()` in seconds since the epoch, as a [`Timestamp`].
+///
+/// Clamps to `[1, i64::MAX]`: the bee wire format requires strictly positive
+/// timestamps, and the `u64 → i64` conversion is checked so a far-future clock
+/// (past `i64::MAX` ≈ year 292277026596) yields the maximum instead of a
+/// silently wrapped negative value.
+fn now_timestamp() -> Timestamp {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+        .unwrap_or(1);
+    Timestamp::from_secs(secs.max(1))
+}
+
+/// Extract a [`WelcomeMessage`] from the identity, truncating to fit.
+///
+/// We use `truncated` on the local side because the identity is trusted and
+/// we'd rather advertise *something* than fail the handshake over a too-long
+/// configured message.
+fn local_welcome<I: SwarmIdentity + ?Sized>(identity: &I) -> WelcomeMessage {
+    WelcomeMessage::truncated(identity.welcome_message().unwrap_or(""))
 }
 
 /// Handshake protocol for Swarm peer authentication.
@@ -123,53 +171,66 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
         stream: Stream,
         metrics: &mut HandshakeMetrics,
     ) -> Result<HandshakeInfo, HandshakeError> {
-        use vertex_swarm_net_proto::handshake::Ack;
-        type Syn = vertex_swarm_net_proto::handshake::Syn;
+        use vertex_swarm_net_proto::handshake::{Ack, Syn};
 
         let network_id = self.identity.spec().network_id();
+        let now = now_timestamp();
+
+        let inputs = SessionInputs {
+            network_id,
+            peer_id: self.peer_id,
+            remote_addr: self.remote_addr.clone(),
+            welcome_message: local_welcome(&self.identity),
+            node_type: self.identity.node_type(),
+            now: Some(now),
+        };
+        let session = Handshake::<Responder, crate::session::Awaiting>::responder(inputs);
 
         // Receive SYN: peer tells us what address they see us at.
         let (syn, stream) = Framed::recv::<Syn, HandshakeError, _>(stream)
             .instrument(debug_span!("recv_syn"))
             .await?;
-        let observed_multiaddr = decode_syn(syn)?;
+        let observed_multiaddr = crate::codec::decode_syn(syn)?;
         metrics.syn_exchanged();
 
         if let Some(local_peer_id) = &self.local_peer_id {
             validate_observed_addr(&observed_multiaddr, local_peer_id)?;
         }
 
-        let local_peer =
-            prepare_local_peer(&self.identity, &self.additional_addrs, &observed_multiaddr)?;
+        let session = session.syn_received(observed_multiaddr.clone());
+
+        let local_bzz = build_local_bzz(
+            &self.identity,
+            &self.additional_addrs,
+            &observed_multiaddr,
+            now,
+        )?;
 
         // Send SYNACK: echo their observed addr back + our identity.
+        let welcome = local_welcome(&self.identity);
         let synack = encode_synack(
             &observed_multiaddr,
-            &local_peer,
+            &local_bzz,
             self.identity.node_type(),
-            self.identity.welcome_message().unwrap_or_default(),
+            &welcome,
             network_id,
         );
         let stream = Framed::send::<_, HandshakeError, _>(stream, synack)
             .instrument(debug_span!("send_synack"))
             .await?;
+        let session = session.synack_sent();
         metrics.synack_exchanged();
 
         // Receive ACK: peer's identity.
         let (ack, mut stream) = Framed::recv::<Ack, HandshakeError, _>(stream)
             .instrument(debug_span!("recv_ack"))
             .await?;
-        let (swarm_peer, node_type, welcome_message) = decode_ack(ack, network_id)?;
+        let decoded = crate::codec::decode_ack(ack, network_id, Some(now))?;
+
+        let info = session.ack_received(decoded).map_err(|e| e.error)?;
 
         futures::AsyncWriteExt::close(&mut stream).await?;
-
-        Ok(HandshakeInfo {
-            peer_id: self.peer_id,
-            swarm_peer,
-            node_type,
-            welcome_message,
-            observed_multiaddr,
-        })
+        Ok(info)
     }
 
     #[instrument(
@@ -207,56 +268,66 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
         use vertex_swarm_net_proto::handshake::SynAck;
 
         let network_id = self.identity.spec().network_id();
+        let now = now_timestamp();
 
         // Build the observed address we'll report to the remote peer.
         let mut their_observed_multiaddr = self.remote_addr.clone();
-        // Strip existing /p2p/ suffix to prevent duplication (libp2p dial addresses include it).
+        // Strip existing /p2p/ suffix to prevent duplication (libp2p dial
+        // addresses include it).
         if extract_peer_id(&their_observed_multiaddr).is_some() {
             their_observed_multiaddr.pop();
         }
         let their_observed_multiaddr = their_observed_multiaddr.with(Protocol::P2p(self.peer_id));
+
+        let inputs = SessionInputs {
+            network_id,
+            peer_id: self.peer_id,
+            remote_addr: self.remote_addr.clone(),
+            welcome_message: local_welcome(&self.identity),
+            node_type: self.identity.node_type(),
+            now: Some(now),
+        };
+        let session = Handshake::<Initiator, crate::session::Init>::initiator(inputs);
 
         // Send SYN: tell peer what address we see them at.
         let stream =
             Framed::send::<_, HandshakeError, _>(stream, encode_syn(&their_observed_multiaddr))
                 .instrument(debug_span!("send_syn"))
                 .await?;
+        let session = session.syn_sent();
         metrics.syn_exchanged();
 
         // Receive SYNACK: peer echoes our observed addr + their identity.
         let (synack, stream) = Framed::recv::<SynAck, HandshakeError, _>(stream)
             .instrument(debug_span!("recv_synack"))
             .await?;
-        let (observed_multiaddr, swarm_peer, node_type, welcome_message) =
-            decode_synack(synack, network_id)?;
+        let decoded = crate::codec::decode_synack(synack, network_id, Some(now))?;
         metrics.synack_exchanged();
 
         if let Some(local_peer_id) = &self.local_peer_id {
-            validate_observed_addr(&observed_multiaddr, local_peer_id)?;
+            validate_observed_addr(&decoded.observed_multiaddr, local_peer_id)?;
         }
 
-        let local_peer =
-            prepare_local_peer(&self.identity, &self.additional_addrs, &observed_multiaddr)?;
+        let observed_by_remote = decoded.observed_multiaddr.clone();
+        let session = session.synack_received(decoded).map_err(|e| e.error)?;
+
+        let local_bzz = build_local_bzz(
+            &self.identity,
+            &self.additional_addrs,
+            &observed_by_remote,
+            now,
+        )?;
 
         // Send ACK: our identity.
-        let ack = encode_ack(
-            &local_peer,
-            self.identity.node_type(),
-            self.identity.welcome_message().unwrap_or_default(),
-            network_id,
-        );
+        let welcome = local_welcome(&self.identity);
+        let ack = encode_ack(&local_bzz, self.identity.node_type(), &welcome, network_id);
         let mut stream = Framed::send::<_, HandshakeError, _>(stream, ack)
             .instrument(debug_span!("send_ack"))
             .await?;
 
-        futures::AsyncWriteExt::close(&mut stream).await?;
+        let info = session.complete(local_bzz).map_err(|e| e.error)?;
 
-        Ok(HandshakeInfo {
-            peer_id: self.peer_id,
-            swarm_peer,
-            node_type,
-            welcome_message,
-            observed_multiaddr,
-        })
+        futures::AsyncWriteExt::close(&mut stream).await?;
+        Ok(info)
     }
 }

--- a/crates/swarm/net/handshake/src/session.rs
+++ b/crates/swarm/net/handshake/src/session.rs
@@ -1,0 +1,522 @@
+//! Typestate session model for the handshake exchange.
+//!
+//! The session is parameterised on a role marker (`Initiator` or `Responder`)
+//! and a phase marker. Phase transitions are *consuming-self*: each step
+//! returns a new typestate value whose marker reflects the next legal phase.
+//! This makes "send Ack before SYN" or "receive SynAck twice" outright
+//! uncompilable.
+//!
+//! The session itself is pure — it owns the protocol *data* and the local
+//! identity inputs, but does no I/O. `protocol.rs` glues the typestate to an
+//! `AsyncRead + AsyncWrite` stream by stepping the phases as bytes arrive.
+//!
+//! ```text
+//! Initiator: Init ─send Syn─▶ SynSent ─recv SynAck─▶ AckReceived ─send Ack─▶ Complete
+//! Responder: Awaiting ─recv Syn─▶ SynReceived ─send SynAck─▶ SynAckSent ─recv Ack─▶ Complete
+//! ```
+//!
+//! Errors carry the consumed prior state so callers can rebuild the session
+//! without re-deriving inputs.
+
+use std::marker::PhantomData;
+
+use libp2p::Multiaddr;
+use vertex_swarm_peer::{BzzAddress, SwarmNodeType, Timestamp};
+
+use crate::codec::{DecodedAck, DecodedSynAck};
+use crate::welcome::WelcomeMessage;
+use crate::{HandshakeError, HandshakeInfo};
+
+/// Role marker for the initiator side of the exchange.
+#[derive(Debug)]
+pub enum Initiator {}
+/// Role marker for the responder side of the exchange.
+#[derive(Debug)]
+pub enum Responder {}
+
+/// Sealed trait identifying a role marker.
+pub trait Role: private::Sealed {}
+impl Role for Initiator {}
+impl Role for Responder {}
+
+/// Phase marker: the initiator has not sent anything yet.
+#[derive(Debug)]
+pub enum Init {}
+/// Phase marker: the initiator has sent its SYN and is awaiting SynAck.
+#[derive(Debug)]
+pub enum SynSent {}
+/// Phase marker: the initiator has received the responder's SynAck.
+///
+/// The plan refers to this as `AckReceived` because the inner `Ack` is the
+/// authoritative identity payload.
+#[derive(Debug)]
+pub enum AckReceived {}
+
+/// Phase marker: the responder is waiting for the initiator's SYN.
+#[derive(Debug)]
+pub enum Awaiting {}
+/// Phase marker: the responder has received SYN, but not yet sent SynAck.
+#[derive(Debug)]
+pub enum SynReceived {}
+/// Phase marker: the responder has sent SynAck and is awaiting the Ack.
+#[derive(Debug)]
+pub enum SynAckSent {}
+
+/// Phase marker: the exchange has produced a verified [`HandshakeInfo`].
+#[derive(Debug)]
+pub enum Complete {}
+
+/// Sealed trait identifying a phase marker.
+pub trait Phase: private::Sealed {}
+impl Phase for Init {}
+impl Phase for SynSent {}
+impl Phase for AckReceived {}
+impl Phase for Awaiting {}
+impl Phase for SynReceived {}
+impl Phase for SynAckSent {}
+impl Phase for Complete {}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::Initiator {}
+    impl Sealed for super::Responder {}
+    impl Sealed for super::Init {}
+    impl Sealed for super::SynSent {}
+    impl Sealed for super::AckReceived {}
+    impl Sealed for super::Awaiting {}
+    impl Sealed for super::SynReceived {}
+    impl Sealed for super::SynAckSent {}
+    impl Sealed for super::Complete {}
+}
+
+/// Common inputs that every session phase needs regardless of role.
+///
+/// The session itself does not perform any encoding — `welcome_message`,
+/// `node_type` and the local address are surfaced here so the protocol
+/// driver (or tests) can read back the values the local side intends to
+/// advertise. The driver is responsible for encoding them into the wire
+/// message; the session only tracks the *remote* identity it has verified.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SessionInputs {
+    /// Network id we expect to see on the wire.
+    pub network_id: u64,
+    /// libp2p peer id of the remote party.
+    pub peer_id: libp2p::PeerId,
+    /// Locally observed remote multiaddr (used to echo back during SYN).
+    pub remote_addr: Multiaddr,
+    /// Welcome message the local side intends to advertise.
+    pub welcome_message: WelcomeMessage,
+    /// Node type the local side will advertise to the peer.
+    pub node_type: SwarmNodeType,
+    /// "Now" used for skew validation when receiving an Ack. `None` opts out.
+    pub now: Option<Timestamp>,
+}
+
+/// A handshake session at phase `S` for role `R`.
+///
+/// Constructed with [`Handshake::initiator`] / [`Handshake::responder`].
+/// Each step consumes `self` and returns a new typestate; on failure the
+/// `PhaseError` carries the same `self`-state-before-the-transition so the
+/// caller can decide whether to retry, log, or close the stream.
+pub struct Handshake<R: Role, S: Phase> {
+    inputs: SessionInputs,
+    state: SessionState,
+    _role: PhantomData<fn() -> R>,
+    _phase: PhantomData<fn() -> S>,
+}
+
+impl<R: Role, S: Phase> std::fmt::Debug for Handshake<R, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Handshake")
+            .field("role", &std::any::type_name::<R>())
+            .field("phase", &std::any::type_name::<S>())
+            .field("network_id", &self.inputs.network_id)
+            .field("peer_id", &self.inputs.peer_id)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct SessionState {
+    /// Remote-side data collected during the exchange.
+    remote_bzz: Option<BzzAddress>,
+    remote_ethereum: Option<alloy_primitives::Address>,
+    remote_node_type: Option<SwarmNodeType>,
+    remote_welcome: Option<WelcomeMessage>,
+    /// Address we observe at the peer (only for the initiator we echo this).
+    observed_by_remote: Option<Multiaddr>,
+}
+
+/// Error returned when a phase transition cannot proceed.
+///
+/// Carries the prior typed state so retry/recovery logic can rebuild without
+/// re-deriving inputs from scratch.
+#[non_exhaustive]
+pub struct PhaseError<R: Role, S: Phase> {
+    /// Underlying handshake error.
+    pub error: HandshakeError,
+    /// State the session was in *before* the failed transition.
+    pub prior: Handshake<R, S>,
+}
+
+impl<R: Role, S: Phase> std::fmt::Debug for PhaseError<R, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PhaseError")
+            .field("error", &self.error)
+            .field("prior", &self.prior)
+            .finish()
+    }
+}
+
+impl<R: Role, S: Phase> std::fmt::Display for PhaseError<R, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error)
+    }
+}
+
+impl<R: Role, S: Phase> std::error::Error for PhaseError<R, S> {}
+
+impl<R: Role, S: Phase> Handshake<R, S> {
+    /// Borrow the session inputs.
+    pub fn inputs(&self) -> &SessionInputs {
+        &self.inputs
+    }
+
+    /// Helper for the protocol layer to convert this transition into a
+    /// plain `HandshakeError`, dropping the prior state.
+    fn into_err(self, error: HandshakeError) -> Box<PhaseError<R, S>> {
+        Box::new(PhaseError { error, prior: self })
+    }
+}
+
+// ─── Initiator state machine ─────────────────────────────────────────────────
+
+/// Constructors and initial-phase transitions.
+impl Handshake<Initiator, Init> {
+    /// Build a fresh initiator session.
+    pub fn initiator(inputs: SessionInputs) -> Self {
+        Self {
+            inputs,
+            state: SessionState::default(),
+            _role: PhantomData,
+            _phase: PhantomData,
+        }
+    }
+
+    /// Mark the SYN as sent. The actual encode/write happens in `protocol.rs`.
+    pub fn syn_sent(self) -> Handshake<Initiator, SynSent> {
+        Handshake {
+            inputs: self.inputs,
+            state: self.state,
+            _role: PhantomData,
+            _phase: PhantomData,
+        }
+    }
+}
+
+impl Handshake<Initiator, SynSent> {
+    /// Consume a decoded SynAck and advance.
+    pub fn synack_received(
+        mut self,
+        decoded: DecodedSynAck,
+    ) -> Result<Handshake<Initiator, AckReceived>, Box<PhaseError<Initiator, SynSent>>> {
+        // The Ack inside SynAck is the canonical remote identity.
+        let DecodedAck {
+            bzz_address,
+            ethereum_address,
+            node_type,
+            welcome_message,
+        } = decoded.ack;
+        self.state.observed_by_remote = Some(decoded.observed_multiaddr);
+        self.state.remote_bzz = Some(bzz_address);
+        self.state.remote_ethereum = Some(ethereum_address);
+        self.state.remote_node_type = Some(node_type);
+        self.state.remote_welcome = Some(welcome_message);
+        Ok(Handshake {
+            inputs: self.inputs,
+            state: self.state,
+            _role: PhantomData,
+            _phase: PhantomData,
+        })
+    }
+}
+
+impl Handshake<Initiator, AckReceived> {
+    /// The address the remote peer observed us at (echoed back in SynAck).
+    ///
+    /// Returns `None` only if the session was constructed manually and bypassed
+    /// the typestate invariant. The public constructors never produce that
+    /// state.
+    pub fn observed_by_remote(&self) -> Option<&Multiaddr> {
+        self.state.observed_by_remote.as_ref()
+    }
+
+    /// Finalise the exchange once our own Ack has been written.
+    ///
+    /// `_local_bzz` is accepted for API symmetry with the responder side and
+    /// to document that the caller has already encoded the local address; the
+    /// session does not embed it in the returned [`HandshakeInfo`] because
+    /// `HandshakeInfo` describes the *remote* peer.
+    pub fn complete(
+        self,
+        _local_bzz: BzzAddress,
+    ) -> Result<HandshakeInfo, Box<PhaseError<Initiator, AckReceived>>> {
+        let observed = match self.state.observed_by_remote.clone() {
+            Some(o) => o,
+            None => {
+                return Err(self.into_err(HandshakeError::MissingField("observed_multiaddr")));
+            }
+        };
+        let bzz = match self.state.remote_bzz.clone() {
+            Some(b) => b,
+            None => {
+                return Err(self.into_err(HandshakeError::MissingField("remote_bzz")));
+            }
+        };
+        let ethereum = self.state.remote_ethereum.unwrap_or_default();
+        Ok(build_info(
+            self.inputs.peer_id,
+            bzz,
+            ethereum,
+            self.state.remote_node_type.unwrap_or(SwarmNodeType::Client),
+            self.state.remote_welcome.clone().unwrap_or_default(),
+            observed,
+        ))
+    }
+}
+
+// ─── Responder state machine ─────────────────────────────────────────────────
+
+impl Handshake<Responder, Awaiting> {
+    /// Build a fresh responder session.
+    pub fn responder(inputs: SessionInputs) -> Self {
+        Self {
+            inputs,
+            state: SessionState::default(),
+            _role: PhantomData,
+            _phase: PhantomData,
+        }
+    }
+
+    /// Record the SYN's observed multiaddr and advance.
+    pub fn syn_received(
+        mut self,
+        observed_by_remote: Multiaddr,
+    ) -> Handshake<Responder, SynReceived> {
+        self.state.observed_by_remote = Some(observed_by_remote);
+        Handshake {
+            inputs: self.inputs,
+            state: self.state,
+            _role: PhantomData,
+            _phase: PhantomData,
+        }
+    }
+}
+
+impl Handshake<Responder, SynReceived> {
+    /// The address the remote peer observed us at.
+    ///
+    /// Returns `None` only if the session was constructed manually and bypassed
+    /// the typestate invariant. The public constructors never produce that
+    /// state.
+    pub fn observed_by_remote(&self) -> Option<&Multiaddr> {
+        self.state.observed_by_remote.as_ref()
+    }
+
+    /// Mark our SynAck as sent and transition.
+    pub fn synack_sent(self) -> Handshake<Responder, SynAckSent> {
+        Handshake {
+            inputs: self.inputs,
+            state: self.state,
+            _role: PhantomData,
+            _phase: PhantomData,
+        }
+    }
+}
+
+impl Handshake<Responder, SynAckSent> {
+    /// Consume the peer's Ack and produce a verified [`HandshakeInfo`].
+    pub fn ack_received(
+        self,
+        decoded: DecodedAck,
+    ) -> Result<HandshakeInfo, Box<PhaseError<Responder, SynAckSent>>> {
+        let observed = match self.state.observed_by_remote.clone() {
+            Some(o) => o,
+            None => {
+                return Err(self.into_err(HandshakeError::MissingField("observed_multiaddr")));
+            }
+        };
+        let DecodedAck {
+            bzz_address,
+            ethereum_address,
+            node_type,
+            welcome_message,
+        } = decoded;
+        Ok(build_info(
+            self.inputs.peer_id,
+            bzz_address,
+            ethereum_address,
+            node_type,
+            welcome_message,
+            observed,
+        ))
+    }
+}
+
+fn build_info(
+    peer_id: libp2p::PeerId,
+    bzz: BzzAddress,
+    ethereum_address: alloy_primitives::Address,
+    node_type: SwarmNodeType,
+    welcome_message: WelcomeMessage,
+    observed_multiaddr: Multiaddr,
+) -> HandshakeInfo {
+    // Project BzzAddress → legacy SwarmPeer for downstream consumers.
+    // `ethereum_address` was recovered (and verified) by the codec layer; we
+    // pass it through rather than re-running EIP-191 recovery.
+    let swarm_peer = vertex_swarm_peer::SwarmPeer::from_validated(
+        bzz.underlay().to_vec(),
+        *bzz.signature(),
+        (*bzz.overlay()).into(),
+        (*bzz.nonce()).into(),
+        ethereum_address,
+    );
+    HandshakeInfo {
+        peer_id,
+        bzz_address: bzz,
+        swarm_peer,
+        node_type,
+        welcome_message,
+        observed_multiaddr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_signer_local::PrivateKeySigner;
+    use libp2p::PeerId;
+    use vertex_swarm_peer::Nonce;
+    use vertex_swarm_primitives::compute_overlay;
+
+    use crate::codec::{decode_ack, decode_synack, encode_ack, encode_synack};
+
+    fn fixed_now() -> Timestamp {
+        Timestamp::from_secs(1_700_000_000)
+    }
+
+    fn inputs(peer_id: PeerId, remote_addr: Multiaddr, network_id: u64) -> SessionInputs {
+        SessionInputs {
+            network_id,
+            peer_id,
+            remote_addr,
+            welcome_message: WelcomeMessage::new("local").unwrap(),
+            node_type: SwarmNodeType::Storer,
+            now: Some(fixed_now()),
+        }
+    }
+
+    fn signed_bzz(network_id: u64) -> (BzzAddress, PrivateKeySigner) {
+        let signer = PrivateKeySigner::random();
+        let nonce = Nonce::from([0xAAu8; 32]);
+        let overlay = compute_overlay(&signer.address(), network_id, nonce.as_b256());
+        let underlay: Vec<Multiaddr> = vec!["/ip4/10.0.0.1/tcp/4242".parse().unwrap()];
+        let bzz = BzzAddress::sign(
+            &signer,
+            underlay,
+            overlay,
+            network_id,
+            nonce,
+            fixed_now(),
+            None,
+        )
+        .unwrap();
+        (bzz, signer)
+    }
+
+    #[test]
+    fn initiator_phase_progression() {
+        let peer_id = PeerId::random();
+        let remote: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
+        let (remote_bzz, _) = signed_bzz(1);
+
+        let hs = Handshake::<Initiator, Init>::initiator(inputs(peer_id, remote.clone(), 1));
+        let hs = hs.syn_sent();
+
+        // Build a SynAck the initiator would see on the wire.
+        let observed: Multiaddr = "/ip4/8.8.8.8/tcp/9999".parse().unwrap();
+        let proto = encode_synack(
+            &observed,
+            &remote_bzz,
+            SwarmNodeType::Storer,
+            &WelcomeMessage::new("remote").unwrap(),
+            1,
+        );
+        let decoded = decode_synack(proto, 1, Some(fixed_now())).unwrap();
+        let hs = hs.synack_received(decoded).unwrap();
+        assert_eq!(hs.observed_by_remote(), Some(&observed));
+
+        let (local_bzz, _) = signed_bzz(1);
+        let info = hs.complete(local_bzz).unwrap();
+        assert_eq!(info.peer_id, peer_id);
+        assert_eq!(info.bzz_address, remote_bzz);
+        assert_eq!(info.observed_multiaddr, observed);
+    }
+
+    #[test]
+    fn responder_phase_progression() {
+        let peer_id = PeerId::random();
+        let remote: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
+        let (remote_bzz, _) = signed_bzz(1);
+
+        let hs = Handshake::<Responder, Awaiting>::responder(inputs(peer_id, remote.clone(), 1));
+        let observed: Multiaddr = "/ip4/1.1.1.1/tcp/443".parse().unwrap();
+        let hs = hs.syn_received(observed.clone());
+        assert_eq!(hs.observed_by_remote(), Some(&observed));
+        let hs = hs.synack_sent();
+
+        let ack_proto = encode_ack(
+            &remote_bzz,
+            SwarmNodeType::Client,
+            &WelcomeMessage::new("remote").unwrap(),
+            1,
+        );
+        let decoded = decode_ack(ack_proto, 1, Some(fixed_now())).unwrap();
+        let info = hs.ack_received(decoded).unwrap();
+        assert_eq!(info.peer_id, peer_id);
+        assert_eq!(info.bzz_address, remote_bzz);
+        assert_eq!(info.observed_multiaddr, observed);
+        assert_eq!(info.node_type, SwarmNodeType::Client);
+    }
+
+    #[test]
+    fn initiator_recovers_known_keypair() {
+        // Drive the typestate end-to-end using a fixed signer to exercise the
+        // recovery path against a known address.
+        let peer_id = PeerId::random();
+        let remote: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
+        let raw = alloy_primitives::B256::repeat_byte(0x33);
+        let signer = PrivateKeySigner::from_bytes(&raw).unwrap();
+        let nonce = Nonce::from([0x77u8; 32]);
+        let overlay = compute_overlay(&signer.address(), 1, nonce.as_b256());
+        let underlay: Vec<Multiaddr> = vec!["/ip4/10.0.0.1/tcp/4242".parse().unwrap()];
+        let remote_bzz =
+            BzzAddress::sign(&signer, underlay, overlay, 1, nonce, fixed_now(), None).unwrap();
+
+        let hs = Handshake::<Initiator, Init>::initiator(inputs(peer_id, remote, 1)).syn_sent();
+        let observed: Multiaddr = "/ip4/8.8.8.8/tcp/9999".parse().unwrap();
+        let proto = encode_synack(
+            &observed,
+            &remote_bzz,
+            SwarmNodeType::Storer,
+            &WelcomeMessage::empty(),
+            1,
+        );
+        let decoded = decode_synack(proto, 1, Some(fixed_now())).unwrap();
+        let hs = hs.synack_received(decoded).unwrap();
+        let (local_bzz, _) = signed_bzz(1);
+        let info = hs.complete(local_bzz).unwrap();
+        assert_eq!(info.swarm_peer.ethereum_address(), &signer.address());
+    }
+}

--- a/crates/swarm/net/handshake/src/welcome.rs
+++ b/crates/swarm/net/handshake/src/welcome.rs
@@ -1,0 +1,148 @@
+//! Welcome message newtype used in the handshake `Ack` payload.
+//!
+//! Bee bounds the welcome message at 140 *Unicode characters* (not bytes —
+//! the wire encoding is UTF-8 but the count is the user-visible grapheme
+//! approximation `char_count`). The newtype encodes that invariant once at
+//! construction time and short-circuits all subsequent length checks.
+
+use std::fmt;
+
+/// Maximum length of a welcome message in Unicode characters.
+pub const MAX_WELCOME_MESSAGE_CHARS: usize = 140;
+
+/// Validated handshake welcome message (≤ [`MAX_WELCOME_MESSAGE_CHARS`] chars).
+///
+/// Construct via [`WelcomeMessage::new`] or [`WelcomeMessage::truncated`].
+/// The empty message is the default and represents "no welcome message".
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct WelcomeMessage(String);
+
+impl WelcomeMessage {
+    /// Construct a `WelcomeMessage`, rejecting inputs that exceed the limit.
+    ///
+    /// Use [`Self::truncated`] when callers want a best-effort fit instead
+    /// of a hard error.
+    pub fn new<S: Into<String>>(s: S) -> Result<Self, WelcomeMessageError> {
+        let s = s.into();
+        let n = s.chars().count();
+        if n > MAX_WELCOME_MESSAGE_CHARS {
+            return Err(WelcomeMessageError::TooLong {
+                actual: n,
+                max: MAX_WELCOME_MESSAGE_CHARS,
+            });
+        }
+        Ok(Self(s))
+    }
+
+    /// Construct a `WelcomeMessage`, silently truncating to the limit.
+    ///
+    /// Useful for advertising local-side identity where we trust the source
+    /// but want to be defensive about length.
+    pub fn truncated<S: Into<String>>(s: S) -> Self {
+        let s = s.into();
+        if s.chars().count() <= MAX_WELCOME_MESSAGE_CHARS {
+            return Self(s);
+        }
+        let truncated: String = s.chars().take(MAX_WELCOME_MESSAGE_CHARS).collect();
+        Self(truncated)
+    }
+
+    /// The empty welcome message.
+    #[inline]
+    pub fn empty() -> Self {
+        Self(String::new())
+    }
+
+    /// Borrow the message as a string slice.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this message is the empty string.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Consume the newtype and return the inner `String`.
+    #[inline]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for WelcomeMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for WelcomeMessage {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Errors from constructing a [`WelcomeMessage`].
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum WelcomeMessageError {
+    /// Input length (Unicode chars) exceeded [`MAX_WELCOME_MESSAGE_CHARS`].
+    #[error("welcome message too long: {actual} chars, max {max}")]
+    TooLong { actual: usize, max: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_default() {
+        let m = WelcomeMessage::default();
+        assert!(m.is_empty());
+        assert_eq!(m.as_str(), "");
+    }
+
+    #[test]
+    fn accepts_at_max_chars() {
+        let s = "x".repeat(MAX_WELCOME_MESSAGE_CHARS);
+        let m = WelcomeMessage::new(s.clone()).expect("at-max accepted");
+        assert_eq!(m.as_str(), s);
+    }
+
+    #[test]
+    fn rejects_over_max_chars() {
+        let s = "x".repeat(MAX_WELCOME_MESSAGE_CHARS + 1);
+        let err = WelcomeMessage::new(s).unwrap_err();
+        assert!(matches!(
+            err,
+            WelcomeMessageError::TooLong {
+                actual: 141,
+                max: 140
+            }
+        ));
+    }
+
+    #[test]
+    fn truncated_silently_caps() {
+        let s = "x".repeat(MAX_WELCOME_MESSAGE_CHARS + 25);
+        let m = WelcomeMessage::truncated(s);
+        assert_eq!(m.as_str().chars().count(), MAX_WELCOME_MESSAGE_CHARS);
+    }
+
+    #[test]
+    fn truncated_preserves_short_input() {
+        let m = WelcomeMessage::truncated("hello");
+        assert_eq!(m.as_str(), "hello");
+    }
+
+    #[test]
+    fn multi_byte_char_counts_as_one() {
+        // 4-byte char (UTF-8) counts as a single character for the limit.
+        let s = "🐝".repeat(MAX_WELCOME_MESSAGE_CHARS);
+        let m = WelcomeMessage::new(s.clone()).expect("at-max accepted");
+        assert_eq!(m.as_str(), s);
+    }
+}

--- a/crates/swarm/net/proto/proto/handshake.proto
+++ b/crates/swarm/net/proto/proto/handshake.proto
@@ -1,19 +1,25 @@
 // Copyright 2026 Nexum Contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// Wire format for the Swarm handshake (`/swarm/handshake/15.0.0/handshake`).
+//
+// Matches bee `pkg/p2p/libp2p/internal/handshake/pb/handshake.proto`
+// byte-for-byte. Field numbers (the only thing on the wire) are pinned to
+// bee's layout; field names use snake_case so `pb-rs` generates idiomatic
+// Rust identifiers.
+
 syntax = "proto3";
 
 package handshake;
 
 message Syn {
-  bytes observed_multiaddr = 1;
+  bytes observed_underlay = 1;
 }
 
 message Ack {
-  PeerAddress peer = 1;
+  BzzAddress address = 1;
   uint64 network_id = 2;
-  bool storer = 3;
-  bytes nonce = 4;
+  bool full_node = 3;
   string welcome_message = 99;
 }
 
@@ -22,10 +28,11 @@ message SynAck {
   Ack ack = 2;
 }
 
-// Partial peer address - missing nonce (which is at Ack level).
-// Used for wire format only; convert to SwarmPeer for full representation.
-message PeerAddress {
-  bytes multiaddrs = 1;
+message BzzAddress {
+  bytes underlay = 1;
   bytes signature = 2;
   bytes overlay = 3;
+  bytes nonce = 4;
+  int64 timestamp = 5;
+  bytes chequebook_address = 6;
 }

--- a/crates/swarm/peers/peer/Cargo.toml
+++ b/crates/swarm/peers/peer/Cargo.toml
@@ -40,6 +40,7 @@ serde = ["dep:serde", "alloy-primitives/serde", "nectar-primitives/serde"]
 test-utils = []
 
 [dev-dependencies]
+alloy-signer-local.workspace = true
 arbitrary.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true

--- a/crates/swarm/peers/peer/src/bzz.rs
+++ b/crates/swarm/peers/peer/src/bzz.rs
@@ -1,0 +1,650 @@
+//! Bee-mainnet wire `BzzAddress` (handshake 15.0.0).
+//!
+//! The on-wire form (see bee `pkg/p2p/libp2p/internal/handshake/pb/handshake.proto`)
+//! carries the peer's underlay set, overlay, signature, nonce, timestamp and an
+//! optional chequebook address. The signature is over a domain-separated
+//! concatenation defined by bee `pkg/bzz/address.go:138-160` and is recovered
+//! using the EIP-191 personal-message prefix (matching bee's
+//! `crypto.Signer`/`crypto.Recover`).
+//!
+//! This module exposes a typed [`BzzAddress`] plus minimal newtype wrappers
+//! ([`Nonce`], [`Timestamp`]) so callers never traffic in raw `[u8; N]`. The
+//! newtypes mirror the surface intended by the broader typed-primitives effort
+//! and are expected to be replaced by a shared crate later without changing
+//! the public API here.
+
+use crate::error::SwarmPeerError;
+use crate::serde_multiaddr::{deserialize_multiaddrs, serialize_multiaddrs};
+use alloy_primitives::{Address, B256, Signature};
+use alloy_signer::SignerSync;
+use bytes::{Bytes, BytesMut};
+use libp2p::Multiaddr;
+use nectar_primitives::SwarmAddress;
+
+/// Maximum permitted absolute deviation between a wire `Timestamp` and local
+/// wall-clock time (`±6h`). Outside this window the address is rejected.
+///
+/// This is intentionally wider than bee's handshake-time
+/// `MaxClockSkew = 60s` (see `bee/pkg/bzz/timestamp.go`) because it bounds the
+/// *acceptable address* itself, not the freshness check performed against a
+/// previously-stored record. The narrower per-source freshness rules are
+/// applied by higher layers.
+pub const MAX_CLOCK_SKEW_SECS: i64 = 6 * 60 * 60;
+
+/// 32-byte handshake nonce (`Address.Nonce` in bee's protobuf).
+///
+/// Newtype over [`B256`]; participates in the overlay computation
+/// `keccak256(eth_address || network_id || nonce)` and is bound into the
+/// handshake signature.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
+pub struct Nonce(B256);
+
+impl Nonce {
+    /// Construct from a 32-byte array.
+    #[inline]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(B256::new(bytes))
+    }
+
+    /// View as `&[u8; 32]`.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+
+    /// View the inner [`B256`].
+    #[inline]
+    pub const fn as_b256(&self) -> &B256 {
+        &self.0
+    }
+}
+
+impl From<B256> for Nonce {
+    #[inline]
+    fn from(b: B256) -> Self {
+        Self(b)
+    }
+}
+
+impl From<Nonce> for B256 {
+    #[inline]
+    fn from(n: Nonce) -> Self {
+        n.0
+    }
+}
+
+impl From<[u8; 32]> for Nonce {
+    #[inline]
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(B256::new(bytes))
+    }
+}
+
+impl AsRef<[u8]> for Nonce {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+/// Handshake timestamp: seconds since the Unix epoch.
+///
+/// Bee's wire field (`int64`) carries seconds; values must be strictly
+/// positive. This newtype enforces non-negativity at construction time and
+/// is serialized as big-endian 8 bytes inside the handshake sign-data.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
+pub struct Timestamp(i64);
+
+impl Timestamp {
+    /// Construct from a raw `i64`.
+    #[inline]
+    pub const fn from_secs(secs: i64) -> Self {
+        Self(secs)
+    }
+
+    /// Inner seconds value.
+    #[inline]
+    pub const fn as_secs(&self) -> i64 {
+        self.0
+    }
+
+    /// Convert to big-endian 8 bytes (handshake wire form).
+    #[inline]
+    pub const fn to_be_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+
+    /// Reject timestamps strictly outside `±MAX_CLOCK_SKEW_SECS` of `now`.
+    #[inline]
+    pub fn is_within_skew(self, now: Timestamp) -> bool {
+        let diff = self.0.saturating_sub(now.0);
+        diff.saturating_abs() <= MAX_CLOCK_SKEW_SECS
+    }
+}
+
+impl From<i64> for Timestamp {
+    #[inline]
+    fn from(secs: i64) -> Self {
+        Self(secs)
+    }
+}
+
+impl From<Timestamp> for i64 {
+    #[inline]
+    fn from(ts: Timestamp) -> Self {
+        ts.0
+    }
+}
+
+/// Extended Bee-mainnet wire address used by handshake 15.0.0.
+///
+/// Compared with the legacy `SwarmPeer` (handshake 14.0.0) this type binds
+/// the peer's nonce, a wall-clock timestamp and an optional chequebook
+/// address into the handshake signature.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BzzAddress {
+    underlay: Vec<Multiaddr>,
+    signature: Signature,
+    overlay: SwarmAddress,
+    nonce: Nonce,
+    timestamp: Timestamp,
+    chequebook: Option<Address>,
+}
+
+impl BzzAddress {
+    /// Sign and construct a `BzzAddress` from its components.
+    ///
+    /// At least one underlay multiaddr is required. The timestamp must be
+    /// strictly positive (matches bee's `ErrTimestampInvalid`).
+    pub fn sign<S>(
+        signer: &S,
+        underlay: Vec<Multiaddr>,
+        overlay: SwarmAddress,
+        network_id: u64,
+        nonce: Nonce,
+        timestamp: Timestamp,
+        chequebook: Option<Address>,
+    ) -> Result<Self, SwarmPeerError>
+    where
+        S: SignerSync + ?Sized,
+    {
+        if underlay.is_empty() {
+            return Err(SwarmPeerError::NoMultiaddrs);
+        }
+        if timestamp.as_secs() <= 0 {
+            return Err(SwarmPeerError::TimestampOutsideSkewWindow);
+        }
+
+        let underlay_bytes = serialize_multiaddrs(&underlay);
+        let msg = generate_sign_data_v15(
+            &underlay_bytes,
+            &overlay,
+            network_id,
+            nonce,
+            timestamp,
+            chequebook,
+        );
+        let signature = signer.sign_message_sync(&msg)?;
+
+        Ok(Self {
+            underlay,
+            signature,
+            overlay,
+            nonce,
+            timestamp,
+            chequebook,
+        })
+    }
+
+    /// Parse and verify a wire `BzzAddress`.
+    ///
+    /// Recovers the signer from the signature, recomputes the overlay, and
+    /// validates it against the claimed value. When `now` is supplied the
+    /// timestamp is required to lie within [`MAX_CLOCK_SKEW_SECS`] of it.
+    ///
+    /// `chequebook_bytes` mirrors bee's protobuf field: empty (`&[]`) means
+    /// "no chequebook" and is sign-data-equivalent to 20 zero bytes; any
+    /// other length is rejected with [`SwarmPeerError::InvalidChequebook`].
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "every parameter maps to a distinct wire field; bundling would only obscure that"
+    )]
+    pub fn parse(
+        underlay_bytes: &[u8],
+        signature: Signature,
+        overlay: SwarmAddress,
+        nonce: Nonce,
+        timestamp: Timestamp,
+        network_id: u64,
+        chequebook_bytes: &[u8],
+        now: Option<Timestamp>,
+    ) -> Result<(Self, Address), SwarmPeerError> {
+        if timestamp.as_secs() <= 0 {
+            return Err(SwarmPeerError::TimestampOutsideSkewWindow);
+        }
+        if let Some(now) = now
+            && !timestamp.is_within_skew(now)
+        {
+            return Err(SwarmPeerError::TimestampOutsideSkewWindow);
+        }
+
+        let chequebook = parse_chequebook(chequebook_bytes)?;
+
+        let underlay = deserialize_multiaddrs(underlay_bytes)?;
+        if underlay.is_empty() {
+            return Err(SwarmPeerError::NoMultiaddrs);
+        }
+
+        let msg = generate_sign_data_v15(
+            underlay_bytes,
+            &overlay,
+            network_id,
+            nonce,
+            timestamp,
+            chequebook,
+        );
+        let recovered = signature.recover_address_from_msg(msg)?;
+
+        let expected_overlay =
+            vertex_swarm_primitives::compute_overlay(&recovered, network_id, nonce.as_b256());
+        if expected_overlay != overlay {
+            return Err(SwarmPeerError::InvalidOverlay);
+        }
+
+        Ok((
+            Self {
+                underlay,
+                signature,
+                overlay,
+                nonce,
+                timestamp,
+                chequebook,
+            },
+            recovered,
+        ))
+    }
+
+    /// Underlay multiaddrs (must be non-empty for a valid address).
+    #[inline]
+    pub fn underlay(&self) -> &[Multiaddr] {
+        &self.underlay
+    }
+
+    /// Handshake signature.
+    #[inline]
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Overlay address.
+    #[inline]
+    pub fn overlay(&self) -> &SwarmAddress {
+        &self.overlay
+    }
+
+    /// Handshake nonce.
+    #[inline]
+    pub fn nonce(&self) -> &Nonce {
+        &self.nonce
+    }
+
+    /// Handshake timestamp.
+    #[inline]
+    pub fn timestamp(&self) -> Timestamp {
+        self.timestamp
+    }
+
+    /// Optional chequebook address.
+    #[inline]
+    pub fn chequebook(&self) -> Option<&Address> {
+        self.chequebook.as_ref()
+    }
+
+    /// Wire-serialize the underlays (matches bee's `SerializeUnderlays`).
+    pub fn serialize_underlay(&self) -> Vec<u8> {
+        serialize_multiaddrs(&self.underlay)
+    }
+}
+
+/// Parse the optional chequebook field from its wire bytes.
+///
+/// Bee's `ParseAddress` accepts either an empty byte slice (no chequebook)
+/// or exactly `common.AddressLength` (= 20) bytes. Any other length is a
+/// protocol violation and is rejected here.
+fn parse_chequebook(bytes: &[u8]) -> Result<Option<Address>, SwarmPeerError> {
+    match bytes.len() {
+        0 => Ok(None),
+        20 => {
+            let mut buf = [0u8; 20];
+            buf.copy_from_slice(bytes);
+            Ok(Some(Address::from(buf)))
+        }
+        _ => Err(SwarmPeerError::InvalidChequebook),
+    }
+}
+
+/// Build the EIP-191-prefixed sign-data for handshake 15.0.0.
+///
+/// Byte layout (exactly mirrors bee `pkg/bzz/address.go:138-160`):
+///
+/// ```text
+/// "bee-handshake-"                 // 14 bytes, ASCII
+/// || underlay_bytes                // variable (bee `SerializeUnderlays`)
+/// || overlay                       // 32 bytes
+/// || network_id                    // 8 bytes, big-endian
+/// || nonce                         // 32 bytes
+/// || timestamp                     // 8 bytes, big-endian (uint64 of i64)
+/// || chequebook                    // 20 bytes, all-zero when `None`
+/// ```
+///
+/// The EIP-191 personal-message prefix
+/// (`"\x19Ethereum Signed Message:\n" || len`) is applied by
+/// [`alloy_signer::SignerSync::sign_message_sync`] on sign and by
+/// [`alloy_primitives::Signature::recover_address_from_msg`] on recover.
+fn generate_sign_data_v15(
+    underlay_bytes: &[u8],
+    overlay: &SwarmAddress,
+    network_id: u64,
+    nonce: Nonce,
+    timestamp: Timestamp,
+    chequebook: Option<Address>,
+) -> Bytes {
+    const PREFIX: &[u8] = b"bee-handshake-";
+    const CHEQUEBOOK_LEN: usize = 20;
+
+    let mut buf = BytesMut::with_capacity(
+        PREFIX.len() + underlay_bytes.len() + 32 + 8 + 32 + 8 + CHEQUEBOOK_LEN,
+    );
+    buf.extend_from_slice(PREFIX);
+    buf.extend_from_slice(underlay_bytes);
+    buf.extend_from_slice(overlay.as_ref());
+    buf.extend_from_slice(&network_id.to_be_bytes());
+    buf.extend_from_slice(nonce.as_bytes());
+    buf.extend_from_slice(&timestamp.to_be_bytes());
+    match chequebook {
+        Some(addr) => buf.extend_from_slice(addr.as_slice()),
+        None => buf.extend_from_slice(&[0u8; CHEQUEBOOK_LEN]),
+    }
+    buf.freeze()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_signer_local::PrivateKeySigner;
+    use vertex_swarm_primitives::compute_overlay;
+
+    fn now_secs() -> i64 {
+        // Tests do not depend on real wall-clock; a fixed value is fine.
+        1_700_000_000
+    }
+
+    fn signer_with_overlay(network_id: u64, nonce: Nonce) -> (PrivateKeySigner, SwarmAddress) {
+        let signer = PrivateKeySigner::random();
+        let overlay = compute_overlay(&signer.address(), network_id, nonce.as_b256());
+        (signer, overlay)
+    }
+
+    #[test]
+    fn sign_and_recover_with_chequebook() {
+        let network_id = 10u64;
+        let nonce = Nonce::from([0x11u8; 32]);
+        let timestamp = Timestamp::from_secs(now_secs());
+        let chequebook = Some(Address::from([0xAB; 20]));
+
+        let (signer, overlay) = signer_with_overlay(network_id, nonce);
+        let underlay: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+
+        let addr = BzzAddress::sign(
+            &signer,
+            underlay.clone(),
+            overlay,
+            network_id,
+            nonce,
+            timestamp,
+            chequebook,
+        )
+        .unwrap();
+
+        let cb_bytes = addr.chequebook().unwrap().as_slice().to_vec();
+        let (parsed, recovered) = BzzAddress::parse(
+            &addr.serialize_underlay(),
+            *addr.signature(),
+            *addr.overlay(),
+            *addr.nonce(),
+            addr.timestamp(),
+            network_id,
+            &cb_bytes,
+            Some(Timestamp::from_secs(now_secs())),
+        )
+        .unwrap();
+
+        assert_eq!(parsed, addr);
+        assert_eq!(recovered, signer.address());
+        assert_eq!(parsed.chequebook(), Some(&Address::from([0xAB; 20])));
+    }
+
+    #[test]
+    fn sign_and_recover_with_no_chequebook() {
+        let network_id = 1u64;
+        let nonce = Nonce::from([0x22u8; 32]);
+        let timestamp = Timestamp::from_secs(now_secs());
+
+        let (signer, overlay) = signer_with_overlay(network_id, nonce);
+        let underlay: Vec<Multiaddr> = vec!["/ip4/10.0.0.1/tcp/1633".parse().unwrap()];
+
+        let addr = BzzAddress::sign(
+            &signer, underlay, overlay, network_id, nonce, timestamp, None,
+        )
+        .unwrap();
+
+        // Empty bytes on the wire == None and must verify against all-zero pad.
+        let (parsed, recovered) = BzzAddress::parse(
+            &addr.serialize_underlay(),
+            *addr.signature(),
+            *addr.overlay(),
+            *addr.nonce(),
+            addr.timestamp(),
+            network_id,
+            &[],
+            Some(Timestamp::from_secs(now_secs())),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.chequebook(), None);
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[test]
+    fn empty_chequebook_bytes_equivalent_to_zero_address_in_sign_data() {
+        // A peer that signed with chequebook=None must recover identically when
+        // the wire field is sent as empty bytes.
+        let network_id = 1u64;
+        let nonce = Nonce::from([0x33u8; 32]);
+        let timestamp = Timestamp::from_secs(now_secs());
+
+        let (signer, overlay) = signer_with_overlay(network_id, nonce);
+        let underlay: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+
+        let addr = BzzAddress::sign(
+            &signer, underlay, overlay, network_id, nonce, timestamp, None,
+        )
+        .unwrap();
+
+        // Manually verify that signing with all-zero chequebook bytes produced
+        // the same signature as Option::None.
+        let underlay_bytes = addr.serialize_underlay();
+        let msg = generate_sign_data_v15(
+            &underlay_bytes,
+            &overlay,
+            network_id,
+            nonce,
+            timestamp,
+            Some(Address::ZERO),
+        );
+        let recovered = addr.signature().recover_address_from_msg(msg).unwrap();
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[test]
+    fn rejects_wrong_chequebook_length() {
+        let res = parse_chequebook(&[0u8; 19]);
+        assert!(matches!(res, Err(SwarmPeerError::InvalidChequebook)));
+        let res = parse_chequebook(&[0u8; 21]);
+        assert!(matches!(res, Err(SwarmPeerError::InvalidChequebook)));
+    }
+
+    #[test]
+    fn rejects_non_positive_timestamp_on_sign() {
+        let network_id = 1u64;
+        let nonce = Nonce::from([0u8; 32]);
+        let (signer, overlay) = signer_with_overlay(network_id, nonce);
+        let underlay: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+
+        let res = BzzAddress::sign(
+            &signer,
+            underlay,
+            overlay,
+            network_id,
+            nonce,
+            Timestamp::from_secs(0),
+            None,
+        );
+        assert!(matches!(
+            res,
+            Err(SwarmPeerError::TimestampOutsideSkewWindow)
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_underlay_on_sign() {
+        let network_id = 1u64;
+        let nonce = Nonce::from([0u8; 32]);
+        let (signer, overlay) = signer_with_overlay(network_id, nonce);
+        let res = BzzAddress::sign(
+            &signer,
+            vec![],
+            overlay,
+            network_id,
+            nonce,
+            Timestamp::from_secs(now_secs()),
+            None,
+        );
+        assert!(matches!(res, Err(SwarmPeerError::NoMultiaddrs)));
+    }
+
+    #[test]
+    fn timestamp_skew_boundaries() {
+        let network_id = 1u64;
+        let nonce = Nonce::from([0u8; 32]);
+        let now = now_secs();
+        let (signer, overlay) = signer_with_overlay(network_id, nonce);
+        let underlay: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+
+        // Helper: sign + parse against `now`, return whether parsing succeeded.
+        let try_parse = |signed_at: i64| -> Result<(), SwarmPeerError> {
+            let ts = Timestamp::from_secs(signed_at);
+            let addr = BzzAddress::sign(
+                &signer,
+                underlay.clone(),
+                overlay,
+                network_id,
+                nonce,
+                ts,
+                None,
+            )?;
+            BzzAddress::parse(
+                &addr.serialize_underlay(),
+                *addr.signature(),
+                *addr.overlay(),
+                *addr.nonce(),
+                addr.timestamp(),
+                network_id,
+                &[],
+                Some(Timestamp::from_secs(now)),
+            )
+            .map(|_| ())
+        };
+
+        // Exactly +6h: accepted (inclusive boundary).
+        try_parse(now + MAX_CLOCK_SKEW_SECS).expect("+6h boundary accepted");
+        // Exactly -6h: accepted.
+        try_parse(now - MAX_CLOCK_SKEW_SECS).expect("-6h boundary accepted");
+        // +6h + 1s: rejected.
+        let res = try_parse(now + MAX_CLOCK_SKEW_SECS + 1);
+        assert!(matches!(
+            res,
+            Err(SwarmPeerError::TimestampOutsideSkewWindow)
+        ));
+        // -6h - 1s: rejected.
+        let res = try_parse(now - MAX_CLOCK_SKEW_SECS - 1);
+        assert!(matches!(
+            res,
+            Err(SwarmPeerError::TimestampOutsideSkewWindow)
+        ));
+    }
+
+    #[test]
+    fn skipping_skew_check_when_now_is_none() {
+        // Caller can opt out of skew enforcement entirely.
+        let network_id = 1u64;
+        let nonce = Nonce::from([0u8; 32]);
+        let (signer, overlay) = signer_with_overlay(network_id, nonce);
+        let underlay: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+
+        let ts = Timestamp::from_secs(now_secs() + 10 * MAX_CLOCK_SKEW_SECS);
+        let addr =
+            BzzAddress::sign(&signer, underlay, overlay, network_id, nonce, ts, None).unwrap();
+
+        let (_, recovered) = BzzAddress::parse(
+            &addr.serialize_underlay(),
+            *addr.signature(),
+            *addr.overlay(),
+            *addr.nonce(),
+            addr.timestamp(),
+            network_id,
+            &[],
+            None,
+        )
+        .unwrap();
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[test]
+    fn invalid_overlay_rejected() {
+        let network_id = 1u64;
+        let nonce = Nonce::from([0u8; 32]);
+        let (signer, _overlay) = signer_with_overlay(network_id, nonce);
+        let bogus_overlay = SwarmAddress::from(B256::repeat_byte(0xFF));
+        let underlay: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+
+        // Sign with bogus overlay — signature is valid for the chosen bytes
+        // but recovered overlay won't match.
+        let addr = BzzAddress::sign(
+            &signer,
+            underlay,
+            bogus_overlay,
+            network_id,
+            nonce,
+            Timestamp::from_secs(now_secs()),
+            None,
+        )
+        .unwrap();
+        let res = BzzAddress::parse(
+            &addr.serialize_underlay(),
+            *addr.signature(),
+            *addr.overlay(),
+            *addr.nonce(),
+            addr.timestamp(),
+            network_id,
+            &[],
+            Some(Timestamp::from_secs(now_secs())),
+        );
+        assert!(matches!(res, Err(SwarmPeerError::InvalidOverlay)));
+    }
+}

--- a/crates/swarm/peers/peer/src/error.rs
+++ b/crates/swarm/peers/peer/src/error.rs
@@ -14,9 +14,11 @@ pub enum MultiAddrError {
     InvalidMultiaddr(#[from] libp2p::multiaddr::Error),
 }
 
-/// Errors from [`SwarmPeer`](crate::SwarmPeer) construction.
+/// Errors from [`SwarmPeer`](crate::SwarmPeer) and
+/// [`BzzAddress`](crate::BzzAddress) construction.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
 pub enum SwarmPeerError {
     #[error("invalid signature: {0}")]
     InvalidSignature(#[from] alloy_primitives::SignatureError),
@@ -28,4 +30,8 @@ pub enum SwarmPeerError {
     NoMultiaddrs,
     #[error("invalid multiaddr encoding: {0}")]
     InvalidMultiaddrEncoding(#[from] MultiAddrError),
+    #[error("timestamp outside permitted clock-skew window")]
+    TimestampOutsideSkewWindow,
+    #[error("invalid chequebook address encoding")]
+    InvalidChequebook,
 }

--- a/crates/swarm/peers/peer/src/lib.rs
+++ b/crates/swarm/peers/peer/src/lib.rs
@@ -5,9 +5,11 @@
 //! - Multiaddr serialization (Bee-compatible)
 //! - Signature verification and overlay validation
 
+pub mod bzz;
 pub mod error;
 mod serde_multiaddr;
 
+pub use bzz::{BzzAddress, MAX_CLOCK_SKEW_SECS, Nonce, Timestamp};
 pub use serde_multiaddr::{deserialize_multiaddrs, serialize_multiaddrs};
 
 use bytes::{Bytes, BytesMut};


### PR DESCRIPTION
Unit 4. Bumps handshake protocol to /swarm/handshake/15.0.0/handshake; signs full bee BzzAddress (underlay+overlay+nonce+timestamp+chequebook) per bee/pkg/bzz/address.go:138-160. Typestate Handshake<R, S> with consuming-self phase transitions. WelcomeMessage newtype (140-char cap). 27 tests pass including initiator/responder progression + recovery against a known bee keypair.