### PR TITLE
feat(net-handshake): admission control trait + kademlia gate

### DIFF
--- a/crates/swarm/net/handshake/src/admission.rs
+++ b/crates/swarm/net/handshake/src/admission.rs
@@ -1,0 +1,144 @@
+//! Handshake admission control.
+//!
+//! Lets routing (or any other gate) veto a handshake after the peer's
+//! identity is known, but before the final Ack is sent. Mirrors bee's
+//! `p2p.Picker` (`bee/pkg/p2p/libp2p/internal/handshake/handshake.go:167`).
+//!
+//! The handshake crate stays free of any routing/topology dependency: it
+//! defines the trait and accepts a dyn-erased implementation via
+//! [`HandshakeBehaviour::with_admission_control`](crate::HandshakeBehaviour::with_admission_control).
+
+use std::sync::Arc;
+
+use libp2p::PeerId;
+use vertex_swarm_peer::{SwarmAddress, SwarmNodeType};
+
+pub use vertex_net_peer_registry::ConnectionDirection;
+
+/// Reason a peer was rejected from completing the handshake.
+///
+/// `#[non_exhaustive]` so adding new reasons is non-breaking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum AdmissionRejection {
+    /// Routing capacity is full for this peer's proximity bin.
+    Saturated,
+    /// Peer is on the blocklist (banned).
+    Blocklisted,
+    /// Neighborhood is oversaturated and this peer falls outside the
+    /// configured headroom.
+    OversaturatedNeighborhood,
+}
+
+/// Why an existing peer is being evicted to make room for an incoming one.
+///
+/// `#[non_exhaustive]` so new eviction reasons can be added without breaking
+/// downstream consumers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum EvictReason {
+    /// Incoming peer is closer (higher proximity order) than the evictee.
+    Oversaturated,
+}
+
+/// Result of evaluating a peer for handshake admission.
+///
+/// `#[non_exhaustive]` so adding new outcomes (e.g. defer/retry) is
+/// non-breaking.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum AdmissionDecision {
+    /// Allow the handshake to complete.
+    Accept,
+    /// Reject the handshake. The handshake will abort before the final Ack
+    /// and the handler reports [`HandshakeError::AdmissionRejected`](crate::HandshakeError::AdmissionRejected).
+    Reject(AdmissionRejection),
+    /// Accept the new peer but evict an existing one first.
+    ///
+    /// The handshake crate does not perform eviction; it just surfaces the
+    /// decision. Unit 8 wires the eviction path through the topology
+    /// behaviour.
+    AcceptEvict {
+        evict: PeerId,
+        reason: EvictReason,
+    },
+}
+
+/// Admission control gate consulted before the final handshake Ack.
+///
+/// Implementors must be cheap to call: it runs on every handshake completion.
+/// Trait is dyn-compatible so it can live behind `Arc<dyn ...>` in the
+/// handshake behaviour.
+pub trait HandshakeAdmissionControl: Send + Sync + 'static {
+    /// Evaluate a peer that just identified itself during the handshake.
+    fn evaluate(
+        &self,
+        peer_overlay: &SwarmAddress,
+        node_type: SwarmNodeType,
+        direction: ConnectionDirection,
+    ) -> AdmissionDecision;
+}
+
+/// Always-accept admission control. Used as the default when none is wired in.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AlwaysAccept;
+
+impl HandshakeAdmissionControl for AlwaysAccept {
+    fn evaluate(
+        &self,
+        _peer_overlay: &SwarmAddress,
+        _node_type: SwarmNodeType,
+        _direction: ConnectionDirection,
+    ) -> AdmissionDecision {
+        AdmissionDecision::Accept
+    }
+}
+
+impl<T: HandshakeAdmissionControl + ?Sized> HandshakeAdmissionControl for Arc<T> {
+    fn evaluate(
+        &self,
+        peer_overlay: &SwarmAddress,
+        node_type: SwarmNodeType,
+        direction: ConnectionDirection,
+    ) -> AdmissionDecision {
+        (**self).evaluate(peer_overlay, node_type, direction)
+    }
+}
+
+/// Type-erased shared handle to an admission controller.
+pub type SharedAdmissionControl = Arc<dyn HandshakeAdmissionControl>;
+
+/// Default admission control: accept everyone. Lives behind an `Arc` to match
+/// the handshake behaviour's slot.
+pub fn default_admission_control() -> SharedAdmissionControl {
+    Arc::new(AlwaysAccept)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_accept_returns_accept() {
+        let ac = AlwaysAccept;
+        let decision = ac.evaluate(
+            &SwarmAddress::with_first_byte(0xaa),
+            SwarmNodeType::Storer,
+            ConnectionDirection::Inbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn arc_delegates() {
+        let ac: SharedAdmissionControl = default_admission_control();
+        let decision = ac.evaluate(
+            &SwarmAddress::with_first_byte(0x01),
+            SwarmNodeType::Client,
+            ConnectionDirection::Outbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+}

--- a/crates/swarm/net/handshake/src/behaviour.rs
+++ b/crates/swarm/net/handshake/src/behaviour.rs
@@ -19,7 +19,8 @@ use vertex_swarm_api::SwarmIdentity;
 use vertex_net_peer_registry::ConnectionDirection;
 
 use crate::{
-    AddressProvider, HandshakeError, HandshakeInfo,
+    AddressProvider, HandshakeError, HandshakeInfo, SharedAdmissionControl,
+    admission::default_admission_control,
     handler::{HandshakeCommand, HandshakeConfig, HandshakeHandler, HandshakeHandlerEvent},
 };
 
@@ -47,6 +48,10 @@ pub struct HandshakeBehaviour<I, A> {
     config: Arc<HandshakeConfig>,
     identity: Arc<I>,
     address_provider: Arc<A>,
+    /// Admission gate consulted before the final Ack (see
+    /// [`HandshakeAdmissionControl`](crate::HandshakeAdmissionControl)).
+    /// Defaults to [`AlwaysAccept`](crate::AlwaysAccept).
+    admission_control: SharedAdmissionControl,
     events: VecDeque<ToSwarm<HandshakeEvent, HandshakeCommand>>,
     /// Track direction per connection for event attribution.
     connection_directions: std::collections::HashMap<ConnectionId, ConnectionDirection>,
@@ -63,6 +68,7 @@ where
             config: Arc::new(HandshakeConfig::new(purpose)),
             identity,
             address_provider,
+            admission_control: default_admission_control(),
             events: VecDeque::new(),
             connection_directions: std::collections::HashMap::new(),
         }
@@ -71,6 +77,19 @@ where
     /// Create with custom config.
     pub fn with_config(mut self, config: HandshakeConfig) -> Self {
         self.config = Arc::new(config);
+        self
+    }
+
+    /// Install an admission control gate. Replaces any previously installed
+    /// gate (default is [`AlwaysAccept`](crate::AlwaysAccept)).
+    ///
+    /// Consulted on every handshake just before the protocol commits to the
+    /// final Ack; on
+    /// [`AdmissionDecision::Reject`](crate::AdmissionDecision::Reject) the
+    /// handshake terminates with
+    /// [`HandshakeError::AdmissionRejected`](crate::HandshakeError::AdmissionRejected).
+    pub fn with_admission_control(mut self, admission_control: SharedAdmissionControl) -> Self {
+        self.admission_control = admission_control;
         self
     }
 
@@ -108,6 +127,7 @@ where
             peer,
             remote_addr.clone(),
             self.address_provider.clone(),
+            self.admission_control.clone(),
         ))
     }
 
@@ -128,6 +148,7 @@ where
             peer,
             addr.clone(),
             self.address_provider.clone(),
+            self.admission_control.clone(),
         ))
     }
 

--- a/crates/swarm/net/handshake/src/error.rs
+++ b/crates/swarm/net/handshake/src/error.rs
@@ -5,6 +5,8 @@ use std::convert::Infallible;
 use strum::IntoStaticStr;
 use vertex_swarm_peer::error::{MultiAddrError, SwarmPeerError};
 
+use crate::admission::AdmissionRejection;
+
 /// Handshake protocol errors.
 #[derive(Debug, thiserror::Error, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -70,6 +72,14 @@ pub enum HandshakeError {
     /// Stream upgrade failed at libp2p layer.
     #[error("upgrade error: {0}")]
     UpgradeError(String),
+
+    /// Admission control rejected the peer before the final Ack.
+    ///
+    /// Surfaces the structured reason from
+    /// [`HandshakeAdmissionControl`](crate::HandshakeAdmissionControl) so
+    /// callers (e.g. topology, metrics) can react without string-matching.
+    #[error("admission rejected: {0}")]
+    AdmissionRejected(AdmissionRejection),
 }
 
 impl From<Infallible> for HandshakeError {

--- a/crates/swarm/net/handshake/src/handler.rs
+++ b/crates/swarm/net/handshake/src/handler.rs
@@ -22,8 +22,8 @@ use tracing::{debug, warn};
 use vertex_swarm_api::SwarmIdentity;
 
 use crate::{
-    AddressProvider, HANDSHAKE_TIMEOUT, HandshakeError, HandshakeInfo, PROTOCOL,
-    protocol::HandshakeProtocol,
+    AddressProvider, ConnectionDirection, HANDSHAKE_TIMEOUT, HandshakeError, HandshakeInfo,
+    PROTOCOL, SharedAdmissionControl, protocol::HandshakeProtocol,
 };
 
 /// Configuration for handshake handler.
@@ -89,6 +89,9 @@ pub struct HandshakeHandler<I, A> {
     peer_id: PeerId,
     remote_addr: Multiaddr,
     address_provider: Arc<A>,
+    /// Admission gate forwarded into [`HandshakeProtocol`] before the final
+    /// Ack is committed.
+    admission_control: SharedAdmissionControl,
     state: State,
     pending_event: Option<HandshakeHandlerEvent>,
     should_initiate: bool,
@@ -107,6 +110,7 @@ where
         peer_id: PeerId,
         remote_addr: Multiaddr,
         address_provider: Arc<A>,
+        admission_control: SharedAdmissionControl,
     ) -> Self {
         Self {
             config,
@@ -114,6 +118,7 @@ where
             peer_id,
             remote_addr,
             address_provider,
+            admission_control,
             state: State::Pending,
             pending_event: None,
             should_initiate: false,
@@ -128,6 +133,7 @@ where
         peer_id: PeerId,
         remote_addr: Multiaddr,
         address_provider: Arc<A>,
+        admission_control: SharedAdmissionControl,
     ) -> Self {
         Self {
             config,
@@ -135,6 +141,7 @@ where
             peer_id,
             remote_addr,
             address_provider,
+            admission_control,
             state: State::Pending,
             pending_event: None,
             should_initiate: true,
@@ -142,12 +149,14 @@ where
         }
     }
 
-    fn make_upgrade(&self) -> HandshakeUpgrade<I, A> {
+    fn make_upgrade(&self, direction: ConnectionDirection) -> HandshakeUpgrade<I, A> {
         HandshakeUpgrade {
             identity: self.identity.clone(),
             peer_id: self.peer_id,
             remote_addr: self.remote_addr.clone(),
             address_provider: self.address_provider.clone(),
+            admission_control: self.admission_control.clone(),
+            direction,
             purpose: self.config.purpose,
         }
     }
@@ -166,7 +175,8 @@ where
     type OutboundOpenInfo = ();
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        SubstreamProtocol::new(self.make_upgrade(), ()).with_timeout(self.config.timeout)
+        SubstreamProtocol::new(self.make_upgrade(ConnectionDirection::Inbound), ())
+            .with_timeout(self.config.timeout)
     }
 
     fn connection_keep_alive(&self) -> bool {
@@ -189,8 +199,11 @@ where
             self.state = State::InProgress;
             debug!(peer_id = %self.peer_id, "Initiating outbound handshake");
             return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                protocol: SubstreamProtocol::new(self.make_upgrade(), ())
-                    .with_timeout(self.config.timeout),
+                protocol: SubstreamProtocol::new(
+                    self.make_upgrade(ConnectionDirection::Outbound),
+                    (),
+                )
+                .with_timeout(self.config.timeout),
             });
         }
 
@@ -280,6 +293,12 @@ pub struct HandshakeUpgrade<I, A> {
     peer_id: PeerId,
     remote_addr: Multiaddr,
     address_provider: Arc<A>,
+    /// Forwarded into [`HandshakeProtocol`] so admission control can be
+    /// consulted before the final Ack is sent.
+    admission_control: SharedAdmissionControl,
+    /// Direction this upgrade was created for — drives which protocol arm
+    /// runs and which side the admission gate sees.
+    direction: ConnectionDirection,
     purpose: &'static str,
 }
 
@@ -290,6 +309,8 @@ impl<I, A> Clone for HandshakeUpgrade<I, A> {
             peer_id: self.peer_id,
             remote_addr: self.remote_addr.clone(),
             address_provider: self.address_provider.clone(),
+            admission_control: self.admission_control.clone(),
+            direction: self.direction,
             purpose: self.purpose,
         }
     }
@@ -323,7 +344,8 @@ where
             self.remote_addr,
             additional_addrs,
             self.purpose,
-        );
+        )
+        .with_admission_control(self.admission_control, self.direction);
         if let Some(local_peer_id) = local_peer_id {
             protocol = protocol.with_local_peer_id(local_peer_id);
         }

--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -23,6 +23,12 @@ pub use metrics::HandshakeStage;
 mod address;
 pub use address::{AddressProvider, NoAddresses};
 
+mod admission;
+pub use admission::{
+    AdmissionDecision, AdmissionRejection, AlwaysAccept, ConnectionDirection, EvictReason,
+    HandshakeAdmissionControl, SharedAdmissionControl, default_admission_control,
+};
+
 /// Protocol name for handshake.
 pub const PROTOCOL: &str = "/swarm/handshake/14.0.0/handshake";
 

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -7,9 +7,10 @@ use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_spec::SwarmSpec;
 
+use crate::admission::{AdmissionDecision, ConnectionDirection};
 use crate::codec::{decode_ack, decode_syn, decode_synack, encode_ack, encode_syn, encode_synack};
 use crate::metrics::HandshakeMetrics;
-use crate::{HandshakeError, HandshakeInfo};
+use crate::{HandshakeError, HandshakeInfo, SharedAdmissionControl};
 
 /// Maximum size for handshake message buffers.
 const MAX_HANDSHAKE_BUFFER_SIZE: usize = 1024;
@@ -64,6 +65,9 @@ pub(crate) struct HandshakeProtocol<I: SwarmIdentity> {
     local_peer_id: Option<PeerId>,
     remote_addr: Multiaddr,
     additional_addrs: Vec<Multiaddr>,
+    /// Optional admission gate. When set, the protocol consults it after the
+    /// remote's identity is verified but before the final Ack is sent.
+    admission_control: Option<(SharedAdmissionControl, ConnectionDirection)>,
     purpose: &'static str,
 }
 
@@ -81,6 +85,7 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             local_peer_id: None,
             remote_addr,
             additional_addrs,
+            admission_control: None,
             purpose,
         }
     }
@@ -89,6 +94,31 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
     pub(crate) fn with_local_peer_id(mut self, local_peer_id: PeerId) -> Self {
         self.local_peer_id = Some(local_peer_id);
         self
+    }
+
+    /// Install the admission gate for this exchange.
+    ///
+    /// `direction` is the side this end of the connection plays (inbound =
+    /// received SYN, outbound = sent SYN).
+    pub(crate) fn with_admission_control(
+        mut self,
+        admission_control: SharedAdmissionControl,
+        direction: ConnectionDirection,
+    ) -> Self {
+        self.admission_control = Some((admission_control, direction));
+        self
+    }
+
+    /// Evaluate admission control if installed. Returns
+    /// [`HandshakeError::AdmissionRejected`] if the peer is denied.
+    fn evaluate_admission(&self, info: &HandshakeInfo) -> Result<(), HandshakeError> {
+        let Some((ref ac, direction)) = self.admission_control else {
+            return Ok(());
+        };
+        match ac.evaluate(info.swarm_peer.overlay(), info.node_type, direction) {
+            AdmissionDecision::Accept | AdmissionDecision::AcceptEvict { .. } => Ok(()),
+            AdmissionDecision::Reject(reason) => Err(HandshakeError::AdmissionRejected(reason)),
+        }
     }
 
     #[instrument(
@@ -161,15 +191,23 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             .await?;
         let (swarm_peer, node_type, welcome_message) = decode_ack(ack, network_id)?;
 
-        futures::AsyncWriteExt::close(&mut stream).await?;
-
-        Ok(HandshakeInfo {
+        let info = HandshakeInfo {
             peer_id: self.peer_id,
             swarm_peer,
             node_type,
             welcome_message,
             observed_multiaddr,
-        })
+        };
+
+        // Consult admission control now that the peer's identity is verified.
+        // On reject, abort before closing successfully so the handler reports
+        // `HandshakeError::AdmissionRejected` and routing never sees the peer
+        // as completed.
+        self.evaluate_admission(&info)?;
+
+        futures::AsyncWriteExt::close(&mut stream).await?;
+
+        Ok(info)
     }
 
     #[instrument(
@@ -238,6 +276,18 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
         let local_peer =
             prepare_local_peer(&self.identity, &self.additional_addrs, &observed_multiaddr)?;
 
+        // Consult admission control BEFORE sending the final Ack so a Reject
+        // aborts the handshake without ever committing to the peer (matches
+        // bee's Picker semantics in handshake.go:457).
+        let info = HandshakeInfo {
+            peer_id: self.peer_id,
+            swarm_peer,
+            node_type,
+            welcome_message,
+            observed_multiaddr,
+        };
+        self.evaluate_admission(&info)?;
+
         // Send ACK: our identity.
         let ack = encode_ack(
             &local_peer,
@@ -251,12 +301,6 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
 
         futures::AsyncWriteExt::close(&mut stream).await?;
 
-        Ok(HandshakeInfo {
-            peer_id: self.peer_id,
-            swarm_peer,
-            node_type,
-            welcome_message,
-            observed_multiaddr,
-        })
+        Ok(info)
     }
 }

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -48,7 +48,10 @@ use crate::events::TopologyEvent;
 use crate::extract_peer_id;
 use crate::gossip::{GossipHandle, spawn_gossip_task};
 use crate::handle::TopologyHandle;
-use crate::kademlia::{KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting};
+use crate::kademlia::{
+    KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting,
+    kademlia_admission_control,
+};
 use crate::metrics::{TopologyMetrics, po_label};
 use crate::nat_discovery::LocalAddressManager;
 
@@ -298,8 +301,13 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
         let identity = Arc::new(identity);
 
+        // Wire kademlia routing as the handshake admission gate so routing
+        // can veto a peer before the final Ack (mirrors bee's Picker).
+        let admission_control = kademlia_admission_control(routing.clone());
+
         // Create composed protocol behaviours
-        let protocols = ProtocolBehaviours::new(identity.clone(), nat_discovery.clone());
+        let protocols =
+            ProtocolBehaviours::new(identity.clone(), nat_discovery.clone(), admission_control);
 
         let metrics = Arc::new(TopologyMetrics::new());
 

--- a/crates/swarm/topology/src/composed.rs
+++ b/crates/swarm/topology/src/composed.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use libp2p::swarm::NetworkBehaviour;
 use vertex_swarm_api::SwarmIdentity;
-use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent};
+use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent, SharedAdmissionControl};
 use vertex_swarm_net_hive::{HiveBehaviour, HiveEvent};
 use vertex_swarm_net_pingpong::{PingpongBehaviour, PingpongEvent};
 
@@ -101,9 +101,18 @@ where
     I: SwarmIdentity + Clone + 'static,
 {
     /// Create new composed protocol behaviours.
-    pub(crate) fn new(identity: Arc<I>, address_provider: Arc<LocalAddressManager>) -> Self {
+    ///
+    /// `admission_control` is installed on the handshake behaviour so routing
+    /// can veto a handshake before the final Ack (see
+    /// [`HandshakeBehaviour::with_admission_control`]).
+    pub(crate) fn new(
+        identity: Arc<I>,
+        address_provider: Arc<LocalAddressManager>,
+        admission_control: SharedAdmissionControl,
+    ) -> Self {
         Self {
-            handshake: HandshakeBehaviour::new(identity.clone(), address_provider, "topology"),
+            handshake: HandshakeBehaviour::new(identity.clone(), address_provider, "topology")
+                .with_admission_control(admission_control),
             hive: HiveBehaviour::new(identity),
             pingpong: PingpongBehaviour::new(),
         }

--- a/crates/swarm/topology/src/kademlia/admission.rs
+++ b/crates/swarm/topology/src/kademlia/admission.rs
@@ -1,0 +1,183 @@
+//! Kademlia-based [`HandshakeAdmissionControl`] implementation.
+//!
+//! Delegates to [`KademliaRouting::admission_within_capacity`], which
+//! evaluates the existing depth-aware saturation math against the in-flight
+//! peer's bin. Plugs into the handshake behaviour via
+//! [`HandshakeBehaviour::with_admission_control`].
+//!
+//! Unit 8 will extend the decision surface to return
+//! [`AdmissionDecision::AcceptEvict`] for oversaturated neighborhoods; this
+//! file only wires the saturation check.
+
+use std::sync::Arc;
+
+use vertex_swarm_api::SwarmIdentity;
+use vertex_swarm_net_handshake::{
+    AdmissionDecision, AdmissionRejection, ConnectionDirection, HandshakeAdmissionControl,
+    SharedAdmissionControl,
+};
+use vertex_swarm_peer::{SwarmAddress, SwarmNodeType};
+
+use super::KademliaRouting;
+
+/// Admission gate backed by the kademlia routing table.
+///
+/// Holds an `Arc` to the routing so the handshake behaviour can share the
+/// same source of truth for capacity decisions as the dial planner.
+pub(crate) struct KademliaAdmissionControl<I: SwarmIdentity> {
+    routing: Arc<KademliaRouting<I>>,
+}
+
+impl<I: SwarmIdentity> KademliaAdmissionControl<I> {
+    pub(crate) fn new(routing: Arc<KademliaRouting<I>>) -> Self {
+        Self { routing }
+    }
+}
+
+impl<I: SwarmIdentity> HandshakeAdmissionControl for KademliaAdmissionControl<I> {
+    fn evaluate(
+        &self,
+        peer_overlay: &SwarmAddress,
+        _node_type: SwarmNodeType,
+        _direction: ConnectionDirection,
+    ) -> AdmissionDecision {
+        // Use the existing depth-aware saturation math. The in-flight peer
+        // is already counted in routing's `effective_count` (outbound via
+        // `try_reserve_dial`, inbound via `reserve_inbound` after handshake
+        // completes), so we ask `admission_within_capacity` rather than
+        // `should_accept_inbound` — the latter rejects any peer present in
+        // the phases map.
+        //
+        // Direction is intentionally ignored for now: bee's Picker also
+        // applies the saturation check symmetrically. Unit 8 will extend
+        // this with neighborhood eviction (AcceptEvict).
+        if self.routing.admission_within_capacity(peer_overlay) {
+            AdmissionDecision::Accept
+        } else {
+            AdmissionDecision::Reject(AdmissionRejection::Saturated)
+        }
+    }
+}
+
+/// Convenience constructor returning the type-erased handle expected by
+/// [`HandshakeBehaviour::with_admission_control`].
+pub(crate) fn kademlia_admission_control<I: SwarmIdentity>(
+    routing: Arc<KademliaRouting<I>>,
+) -> SharedAdmissionControl {
+    Arc::new(KademliaAdmissionControl::new(routing))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kademlia::{KademliaConfig, RoutingCapacity};
+    use vertex_swarm_peer_manager::PeerManager;
+    use vertex_swarm_test_utils::MockIdentity;
+
+    fn make_routing(
+        base: SwarmAddress,
+        config: KademliaConfig,
+    ) -> Arc<KademliaRouting<MockIdentity>> {
+        let identity = MockIdentity::with_overlay(base);
+        let peer_manager = PeerManager::new(&identity);
+        KademliaRouting::new(identity, config, peer_manager)
+    }
+
+    #[test]
+    fn accepts_when_routing_has_capacity() {
+        let base = SwarmAddress::with_first_byte(0x00);
+        let routing = make_routing(base, KademliaConfig::default());
+        let ac = KademliaAdmissionControl::new(routing);
+
+        let decision = ac.evaluate(
+            &SwarmAddress::with_first_byte(0x80),
+            SwarmNodeType::Storer,
+            ConnectionDirection::Inbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn accepts_when_bin_at_ceiling() {
+        // At the ceiling exactly (counting our in-flight slot) is still
+        // accepted; we only reject when strictly above.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default()
+            .with_nominal(1)
+            .with_inbound_headroom(0);
+        let routing = make_routing(base, config);
+
+        // Reserve one slot in bin 0 (po=0) representing the in-flight peer.
+        let peer = SwarmAddress::with_first_byte(0x80);
+        RoutingCapacity::reserve_inbound(&*routing, &peer);
+
+        let ac = KademliaAdmissionControl::new(routing);
+        let decision = ac.evaluate(&peer, SwarmNodeType::Storer, ConnectionDirection::Inbound);
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn rejects_when_bin_oversaturated() {
+        // Pile two in-flight peers into the same bin while the ceiling is 1
+        // (nominal=1, headroom=0). The bin is strictly over capacity →
+        // Reject.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default()
+            .with_nominal(1)
+            .with_inbound_headroom(0);
+        let routing = make_routing(base, config);
+
+        let peer1 = SwarmAddress::with_first_byte(0x80);
+        let peer2 = SwarmAddress::with_first_byte(0xc0);
+        RoutingCapacity::reserve_inbound(&*routing, &peer1);
+        RoutingCapacity::reserve_inbound(&*routing, &peer2);
+
+        let ac = KademliaAdmissionControl::new(routing);
+        // Either in-flight peer should be rejected: both are in bin 0,
+        // effective_count(0) = 2 > ceiling(0) = 1.
+        let decision = ac.evaluate(&peer1, SwarmNodeType::Storer, ConnectionDirection::Inbound);
+        assert!(matches!(
+            decision,
+            AdmissionDecision::Reject(AdmissionRejection::Saturated)
+        ));
+    }
+
+    #[test]
+    fn neighborhood_bin_always_accepts() {
+        // Bins >= depth use ceiling = usize::MAX. Even with many entries the
+        // saturation check must Accept; eviction is Unit 8's job.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default().with_nominal(1);
+        let routing = make_routing(base, config);
+
+        // Force depth to 0 so every bin is in neighborhood. (Default depth
+        // is 0 anyway.) Add several peers in bin 7.
+        for i in 0..3 {
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0x01 + i; // po >= 6
+            RoutingCapacity::reserve_inbound(&*routing, &SwarmAddress::from(bytes));
+        }
+        let ac = KademliaAdmissionControl::new(routing);
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x01;
+        let decision = ac.evaluate(
+            &SwarmAddress::from(bytes),
+            SwarmNodeType::Storer,
+            ConnectionDirection::Inbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn shared_handle_dispatches() {
+        let base = SwarmAddress::with_first_byte(0x00);
+        let routing = make_routing(base, KademliaConfig::default());
+        let handle = kademlia_admission_control(routing);
+        let decision = handle.evaluate(
+            &SwarmAddress::with_first_byte(0x42),
+            SwarmNodeType::Client,
+            ConnectionDirection::Outbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+}

--- a/crates/swarm/topology/src/kademlia/mod.rs
+++ b/crates/swarm/topology/src/kademlia/mod.rs
@@ -1,5 +1,6 @@
 //! Kademlia-based peer routing for Swarm overlay network.
 
+mod admission;
 mod args;
 mod candidate_queues;
 mod candidates;
@@ -9,6 +10,7 @@ pub(crate) mod peer_selection;
 mod routing;
 mod task;
 
+pub(crate) use admission::kademlia_admission_control;
 pub use args::RoutingArgs;
 pub(crate) use candidates::{
     CandidateSelector, CandidateSnapshot, select_balanced_candidates,

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -111,6 +111,27 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         &self.config.limits
     }
 
+    /// Admission decision for a peer whose handshake is currently in
+    /// progress — i.e. the peer is already counted in [`Self::effective_count`]
+    /// via a prior `try_reserve_dial` (outbound) or `reserve_inbound`
+    /// (inbound, post-handshake). Returns `true` if the bin is still within
+    /// `ceiling` (target + headroom); `false` if oversaturated.
+    ///
+    /// Distinct from [`Self::should_accept_inbound`], which gates *new* peers
+    /// not yet present in the phases map. This method assumes the peer's slot
+    /// is already reserved.
+    pub(crate) fn admission_within_capacity(&self, overlay: &OverlayAddress) -> bool {
+        let po = self.proximity(overlay);
+        let depth = self.depth();
+        let ceiling = self.config.limits.ceiling(po, depth);
+        if ceiling == usize::MAX {
+            // Neighborhood bin: always within capacity (eviction handled in
+            // Unit 8 via `AcceptEvict`, not Reject).
+            return true;
+        }
+        self.effective_count(po) <= ceiling
+    }
+
     fn effective_count(&self, po: u8) -> usize {
         atomic_load(&self.dialing_counts, po)
             + atomic_load(&self.handshaking_counts, po)


### PR DESCRIPTION
Unit 5. HandshakeAdmissionControl trait so kademlia can veto a peer pre-Ack (mirrors bee Picker). AdmissionDecision { Accept, Reject(reason), AcceptEvict } (#[non_exhaustive]). KademliaAdmissionControl impl using new admission_within_capacity(overlay) — neighborhood bins always accept; eviction is Unit 8. 117 tests pass.