### PR TITLE
feat(net-hive)!: hive 2.0.0 wire + verifier trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,6 +8183,8 @@ name = "vertex-swarm-net-hive"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-signer",
+ "bytes",
  "futures",
  "hashlink",
  "libp2p",
@@ -8198,6 +8200,7 @@ dependencies = [
  "vertex-net-utils",
  "vertex-observability",
  "vertex-swarm-api",
+ "vertex-swarm-identity",
  "vertex-swarm-net-handler-core",
  "vertex-swarm-net-headers",
  "vertex-swarm-net-proto",

--- a/crates/swarm/net/hive/Cargo.toml
+++ b/crates/swarm/net/hive/Cargo.toml
@@ -35,6 +35,9 @@ libp2p.workspace = true
 ## crypto
 alloy-primitives.workspace = true
 
+## bytes
+bytes.workspace = true
+
 ## cache
 hashlink.workspace = true
 parking_lot.workspace = true
@@ -49,3 +52,5 @@ strum.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+vertex-swarm-identity.workspace = true
+alloy-signer.workspace = true

--- a/crates/swarm/net/hive/src/bzz.rs
+++ b/crates/swarm/net/hive/src/bzz.rs
@@ -1,0 +1,286 @@
+//! Local minimal `BzzAddress` for hive 2.0.0.
+//!
+//! This type mirrors bee's `pkg/bzz.Address` on the wire and is sufficient for
+//! hive 2.0.0 peer-record verification. It will be replaced by the canonical
+//! `BzzAddress` introduced by Unit 2 of the indexed-snacking-crown plan once
+//! that lands; the field layout is intentionally identical.
+//!
+//! ### Sign data layout (bee 15.0.0+)
+//!
+//! ```text
+//! "bee-handshake-"        // 14 bytes
+//! || underlay_bytes       // wire-encoded multiaddrs (length-prefixed entries)
+//! || overlay              // 32 bytes
+//! || network_id           // 8 bytes, big-endian
+//! || nonce                // 32 bytes
+//! || timestamp            // 8 bytes, big-endian (unix seconds, as u64 cast)
+//! || chequebook_address   // 0 or 20 bytes (zeros == "no chequebook")
+//! ```
+//!
+//! Reference: `bee/pkg/bzz/address.go` `generateSignData` (lines 138-160).
+//! The EIP-191 personal-sign prefix is applied by
+//! [`alloy_primitives::Signature::recover_address_from_msg`].
+//!
+//! ### Timestamp skew window
+//!
+//! Per `bee/pkg/bzz/timestamp.go`:
+//! - timestamp must be strictly positive,
+//! - timestamp must not be more than `MAX_CLOCK_SKEW_SECS` seconds in the future.
+//!
+//! Source-specific staleness checks (gossip vs handshake) are the responsibility
+//! of higher layers that compare against an existing stored record.
+
+use alloy_primitives::{Address, B256, Signature};
+use bytes::{Bytes, BytesMut};
+use libp2p::Multiaddr;
+use vertex_swarm_peer::{SwarmAddress, SwarmPeer, deserialize_multiaddrs};
+
+/// Required nonce length in bytes (matches bee `bzz.NonceLength`).
+pub const NONCE_LENGTH: usize = 32;
+/// Ethereum address length in bytes.
+pub const CHEQUEBOOK_ADDRESS_LENGTH: usize = 20;
+
+/// Maximum permitted clock skew when validating a received timestamp (60s,
+/// matching bee `bzz.MaxClockSkew`).
+pub const MAX_CLOCK_SKEW_SECS: i64 = 60;
+
+/// Signing prefix shared by bee handshake/hive records.
+const SIGN_PREFIX: &[u8] = b"bee-handshake-";
+
+/// Wire form of a single hive peer record. Mirrors bee's `BzzAddress`.
+///
+/// This is the minimal Unit 6 local shim — Unit 2 will replace it with the
+/// canonical type from the peers crate.
+#[derive(Debug, Clone)]
+pub struct BzzAddress {
+    /// Underlay multiaddrs (parsed).
+    pub underlays: Vec<Multiaddr>,
+    /// Raw underlay bytes as received on the wire — kept so callers can
+    /// re-verify the signature without re-serializing (bee's underlay
+    /// serializer is not idempotent across implementations).
+    pub underlay_bytes: Vec<u8>,
+    /// Overlay (Swarm) address.
+    pub overlay: SwarmAddress,
+    /// Signature over `generate_sign_data(...)`.
+    pub signature: Signature,
+    /// 32-byte nonce mixed into overlay derivation.
+    pub nonce: B256,
+    /// Unix-seconds timestamp at which the record was minted by its owner.
+    pub timestamp: i64,
+    /// Owner's chequebook address. `Address::ZERO` is treated as "no chequebook".
+    pub chequebook: Address,
+}
+
+/// Why a wire-encoded peer record was rejected before reaching the routing
+/// table.
+///
+/// Every variant doubles as a stable metric label via [`strum::IntoStaticStr`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum BzzAddressError {
+    /// Nonce is not exactly [`NONCE_LENGTH`] bytes.
+    NonceLength,
+    /// Overlay is not 32 bytes.
+    OverlayLength,
+    /// Chequebook field is neither empty nor 20 bytes.
+    ChequebookLength,
+    /// Signature failed to parse.
+    SignatureFormat,
+    /// Timestamp must be strictly positive.
+    TimestampInvalid,
+    /// No usable underlays after deserialisation.
+    NoUnderlays,
+    /// Underlay bytes failed to deserialise.
+    UnderlayDecode,
+}
+
+impl core::fmt::Display for BzzAddressError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(<&'static str>::from(*self))
+    }
+}
+
+impl std::error::Error for BzzAddressError {}
+
+impl BzzAddress {
+    /// Construct a `BzzAddress` from wire fields, validating only the cheap
+    /// structural invariants (lengths and timestamp sign).
+    ///
+    /// Does NOT verify the signature — call [`Self::verify_signature`] for
+    /// that. We keep the two steps separate so the caller can decide whether
+    /// to run signature recovery on the blocking executor.
+    pub fn from_wire(
+        multiaddrs_bytes: Vec<u8>,
+        signature_bytes: &[u8],
+        overlay_bytes: &[u8],
+        nonce_bytes: &[u8],
+        timestamp: i64,
+        chequebook_bytes: &[u8],
+    ) -> Result<Self, BzzAddressError> {
+        if nonce_bytes.len() != NONCE_LENGTH {
+            return Err(BzzAddressError::NonceLength);
+        }
+        if !(chequebook_bytes.is_empty() || chequebook_bytes.len() == CHEQUEBOOK_ADDRESS_LENGTH) {
+            return Err(BzzAddressError::ChequebookLength);
+        }
+        if timestamp <= 0 {
+            return Err(BzzAddressError::TimestampInvalid);
+        }
+
+        let overlay = B256::try_from(overlay_bytes).map_err(|_| BzzAddressError::OverlayLength)?;
+        let nonce = B256::try_from(nonce_bytes).map_err(|_| BzzAddressError::NonceLength)?;
+        let signature =
+            Signature::try_from(signature_bytes).map_err(|_| BzzAddressError::SignatureFormat)?;
+        let chequebook = if chequebook_bytes.is_empty() {
+            Address::ZERO
+        } else {
+            Address::from_slice(chequebook_bytes)
+        };
+
+        let underlays = deserialize_multiaddrs(&multiaddrs_bytes)
+            .map_err(|_| BzzAddressError::UnderlayDecode)?;
+        if underlays.is_empty() {
+            return Err(BzzAddressError::NoUnderlays);
+        }
+
+        Ok(Self {
+            underlays,
+            underlay_bytes: multiaddrs_bytes,
+            overlay: SwarmAddress::from(overlay),
+            signature,
+            nonce,
+            timestamp,
+            chequebook,
+        })
+    }
+
+    /// Verify the EIP-191 signature and return the recovered signer address.
+    ///
+    /// The caller is responsible for cross-checking the recovered signer
+    /// against the overlay (via `compute_overlay`) when overlay-derivation
+    /// verification is desired.
+    pub fn verify_signature(&self, network_id: u64) -> Result<Address, BzzAddressError> {
+        let msg = generate_sign_data(
+            &self.underlay_bytes,
+            self.overlay.as_ref(),
+            network_id,
+            self.nonce.as_slice(),
+            self.timestamp,
+            self.chequebook.as_slice(),
+        );
+        self.signature
+            .recover_address_from_msg(msg)
+            .map_err(|_| BzzAddressError::SignatureFormat)
+    }
+
+    /// Convert into a [`SwarmPeer`] after the signature has been verified.
+    ///
+    /// `ethereum_address` is the recovered signer from [`Self::verify_signature`].
+    pub fn into_swarm_peer(self, ethereum_address: Address) -> SwarmPeer {
+        SwarmPeer::from_validated(
+            self.underlays,
+            self.signature,
+            B256::from(self.overlay),
+            self.nonce,
+            ethereum_address,
+        )
+    }
+}
+
+/// Verify the timestamp is within the allowed skew window relative to `now`.
+///
+/// `now` is unix-seconds. Strictly future-dated records by more than
+/// [`MAX_CLOCK_SKEW_SECS`] are rejected. The lower bound (zero/negative) is
+/// enforced in [`BzzAddress::from_wire`].
+pub fn check_timestamp_skew(timestamp: i64, now: i64) -> bool {
+    if timestamp <= 0 {
+        return false;
+    }
+    timestamp <= now.saturating_add(MAX_CLOCK_SKEW_SECS)
+}
+
+/// Build the bee `bzz` sign-data byte sequence.
+///
+/// Layout documented at the module level. Returns a [`Bytes`] so callers can
+/// hand it to `Signature::recover_address_from_msg` without re-copying.
+pub fn generate_sign_data(
+    underlay: &[u8],
+    overlay: &[u8],
+    network_id: u64,
+    nonce: &[u8],
+    timestamp: i64,
+    chequebook: &[u8],
+) -> Bytes {
+    let mut buf = BytesMut::with_capacity(
+        SIGN_PREFIX.len() + underlay.len() + overlay.len() + 8 + nonce.len() + 8 + chequebook.len(),
+    );
+    buf.extend_from_slice(SIGN_PREFIX);
+    buf.extend_from_slice(underlay);
+    buf.extend_from_slice(overlay);
+    buf.extend_from_slice(&network_id.to_be_bytes());
+    buf.extend_from_slice(nonce);
+    buf.extend_from_slice(&(timestamp as u64).to_be_bytes());
+    buf.extend_from_slice(chequebook);
+    buf.freeze()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_rejects_negative_and_zero() {
+        assert!(!check_timestamp_skew(0, 1_000));
+        assert!(!check_timestamp_skew(-1, 1_000));
+    }
+
+    #[test]
+    fn timestamp_accepts_within_skew_window() {
+        let now = 1_700_000_000;
+        assert!(check_timestamp_skew(now, now));
+        assert!(check_timestamp_skew(now - 3600, now));
+        assert!(check_timestamp_skew(now + MAX_CLOCK_SKEW_SECS, now));
+    }
+
+    #[test]
+    fn timestamp_rejects_too_far_future() {
+        let now = 1_700_000_000;
+        assert!(!check_timestamp_skew(now + MAX_CLOCK_SKEW_SECS + 1, now));
+    }
+
+    #[test]
+    fn from_wire_rejects_bad_nonce_length() {
+        let err = BzzAddress::from_wire(vec![], &[0u8; 65], &[0u8; 32], &[0u8; 16], 1, &[])
+            .unwrap_err();
+        assert!(matches!(err, BzzAddressError::NonceLength));
+    }
+
+    #[test]
+    fn from_wire_rejects_bad_chequebook_length() {
+        let err =
+            BzzAddress::from_wire(vec![], &[0u8; 65], &[0u8; 32], &[0u8; 32], 1, &[0u8; 7])
+                .unwrap_err();
+        assert!(matches!(err, BzzAddressError::ChequebookLength));
+    }
+
+    #[test]
+    fn from_wire_rejects_nonpositive_timestamp() {
+        let err =
+            BzzAddress::from_wire(vec![], &[0u8; 65], &[0u8; 32], &[0u8; 32], 0, &[]).unwrap_err();
+        assert!(matches!(err, BzzAddressError::TimestampInvalid));
+    }
+
+    #[test]
+    fn error_label_stable() {
+        assert_eq!(
+            <&'static str>::from(BzzAddressError::NonceLength),
+            "nonce_length"
+        );
+        assert_eq!(
+            <&'static str>::from(BzzAddressError::TimestampInvalid),
+            "timestamp_invalid"
+        );
+    }
+}

--- a/crates/swarm/net/hive/src/codec.rs
+++ b/crates/swarm/net/hive/src/codec.rs
@@ -1,8 +1,21 @@
-//! Proto codec helpers for hive protocol.
+//! Proto codec helpers for hive 2.0.0.
+//!
+//! Wire format mirrors bee's `pkg/hive/pb/hive.proto` — each gossiped peer
+//! carries its full `BzzAddress` (multiaddrs, signature, overlay, nonce,
+//! timestamp, chequebook). See [`crate::bzz`] for the canonical sign-data
+//! layout.
 
 use vertex_swarm_peer::SwarmPeer;
 
-/// Encode SwarmPeers into a proto Peers message for sending.
+/// Encode SwarmPeers into a proto `Peers` message for sending.
+///
+/// `SwarmPeer` does not yet carry a signed timestamp / chequebook (Unit 2's
+/// `BzzAddress` will plumb those through end-to-end). Until then we emit
+/// zero/empty so bee can identify these records as transitional and skip
+/// them in its own re-broadcast loop (bee's `hive.go:221-223` filters
+/// `timestamp == 0`). Outbound interop with bee is restored in Unit 4 once
+/// the handshake produces fully-signed `BzzAddress` records that we can
+/// surface here.
 pub(crate) fn encode_peers(peers: &[SwarmPeer]) -> vertex_swarm_net_proto::hive::Peers {
     let proto_peers = peers
         .iter()
@@ -11,6 +24,8 @@ pub(crate) fn encode_peers(peers: &[SwarmPeer]) -> vertex_swarm_net_proto::hive:
             signature: p.signature().as_bytes().to_vec(),
             overlay: p.overlay().as_slice().to_vec(),
             nonce: p.nonce().to_vec(),
+            timestamp: 0,
+            chequebook_address: Vec::new(),
         })
         .collect();
     vertex_swarm_net_proto::hive::Peers { peers: proto_peers }

--- a/crates/swarm/net/hive/src/error.rs
+++ b/crates/swarm/net/hive/src/error.rs
@@ -1,13 +1,21 @@
 //! Hive protocol validation errors.
+//!
+//! Retained as a public type so downstream callers compiled against earlier
+//! versions of the crate continue to build. The active validation path now
+//! lives in [`crate::verifier`] and reports failures as [`crate::HiveRejection`]
+//! instead.
 
-use metrics::counter;
 use strum::IntoStaticStr;
 
 use core::array::TryFromSliceError;
 
-/// Per-peer validation failure reasons.
+/// Per-peer validation failure reasons (legacy surface).
+///
+/// New code should consume [`crate::HiveRejection`] from the
+/// [`crate::HiveVerifier`] trait.
 #[derive(Debug, thiserror::Error, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
 pub enum ValidationFailure {
     #[error("invalid overlay length: {0}")]
     OverlayLength(TryFromSliceError),
@@ -21,11 +29,4 @@ pub enum ValidationFailure {
     SelfOverlay,
     #[error("multiaddrs missing /p2p/ component")]
     MissingPeerId,
-}
-
-impl ValidationFailure {
-    pub(crate) fn record(&self) {
-        let reason: &'static str = self.into();
-        counter!("hive_peer_validation_failures_total", "reason" => reason).increment(1);
-    }
 }

--- a/crates/swarm/net/hive/src/lib.rs
+++ b/crates/swarm/net/hive/src/lib.rs
@@ -1,17 +1,27 @@
 //! Hive protocol for Swarm peer gossip and network bootstrapping.
 
 mod behaviour;
+pub mod bzz;
 mod codec;
 mod error;
 mod handler;
 pub mod metrics;
 mod protocol;
+mod verifier;
 
 pub use behaviour::{HiveBehaviour, HiveEvent};
+pub use bzz::{BzzAddress, BzzAddressError};
 pub use error::ValidationFailure;
+pub use verifier::{
+    BlocklistQuery, DefaultHiveVerifier, GossipSource, HiveRejection, HiveVerifier, VerifiedPeer,
+};
 
 /// Protocol name for hive.
-pub const PROTOCOL_NAME: &str = "/swarm/hive/1.1.0/peers";
+///
+/// Bumped from `1.1.0` → `2.0.0` to match bee mainnet: hive 2.0.0 carries the
+/// full `BzzAddress` (adds `timestamp` and `chequebook_address` fields) on
+/// the wire. See `bee/pkg/hive/pb/hive.proto`.
+pub const PROTOCOL_NAME: &str = "/swarm/hive/2.0.0/peers";
 
 /// Maximum number of peers per broadcast message.
 pub const MAX_BATCH_SIZE: usize = 30;

--- a/crates/swarm/net/hive/src/protocol.rs
+++ b/crates/swarm/net/hive/src/protocol.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use std::time::Instant;
 
-use alloy_primitives::{B256, Signature};
 use futures::future::BoxFuture;
 use hashlink::LruCache;
 use metrics::{counter, histogram};
@@ -20,8 +19,9 @@ use vertex_swarm_peer::{SwarmAddress, SwarmPeer};
 use vertex_tasks::TaskExecutor;
 
 use crate::PROTOCOL_NAME;
+use crate::bzz::BzzAddress;
 use crate::codec::encode_peers;
-use crate::error::ValidationFailure;
+use crate::verifier::{DefaultHiveVerifier, GossipSource, HiveRejection, HiveVerifier};
 
 /// 32 KiB frame limit (fits ~100 peers at typical size).
 const MAX_MESSAGE_SIZE: usize = 32 * 1024;
@@ -84,9 +84,13 @@ impl<I: SwarmIdentity> HeaderedInbound for HiveInner<I> {
 
             let raw_peers = proto.peers;
 
-            // Offload CPU-bound ECDSA validation to blocking thread pool.
+            // Offload CPU-bound ECDSA validation to blocking thread pool. The
+            // verifier owns both signature recovery and timestamp-skew
+            // validation; rejections are mapped to stable metric labels.
+            let verifier: Arc<dyn HiveVerifier> =
+                Arc::new(DefaultHiveVerifier::new(network_id, local_overlay));
             let (peers, valid_count, invalid_count) =
-                validate_batch_blocking(raw_peers, network_id, local_overlay, cache).await;
+                validate_batch_blocking(raw_peers, verifier, cache).await;
 
             // Hive-specific peer metrics
             counter!("hive_peers_received_total", "outcome" => "valid")
@@ -104,17 +108,16 @@ impl<I: SwarmIdentity> HeaderedInbound for HiveInner<I> {
 /// Validate a batch of proto peers, offloading to a blocking thread if the executor is available.
 async fn validate_batch_blocking(
     raw_peers: Vec<vertex_swarm_net_proto::hive::Peer>,
-    network_id: u64,
-    local_overlay: SwarmAddress,
+    verifier: Arc<dyn HiveVerifier>,
     cache: PeerCache,
 ) -> (Vec<SwarmPeer>, usize, usize) {
     let Ok(executor) = TaskExecutor::try_current() else {
-        return validate_batch(raw_peers, network_id, &local_overlay, &cache);
+        return validate_batch(raw_peers, verifier.as_ref(), &cache);
     };
 
     let (tx, rx) = tokio::sync::oneshot::channel();
     executor.spawn_blocking("hive_peer_validation", async move {
-        let result = validate_batch(raw_peers, network_id, &local_overlay, &cache);
+        let result = validate_batch(raw_peers, verifier.as_ref(), &cache);
         let _ = tx.send(result);
     });
 
@@ -124,10 +127,9 @@ async fn validate_batch_blocking(
 /// Validate a batch of proto peers (CPU-bound).
 ///
 /// Returns (valid_peers, valid_count, invalid_count).
-fn validate_batch(
+pub(crate) fn validate_batch(
     raw_peers: Vec<vertex_swarm_net_proto::hive::Peer>,
-    network_id: u64,
-    local_overlay: &SwarmAddress,
+    verifier: &dyn HiveVerifier,
     cache: &Mutex<LruCache<SwarmAddress, SwarmPeer>>,
 ) -> (Vec<SwarmPeer>, usize, usize) {
     let validation_start = Instant::now();
@@ -136,19 +138,17 @@ fn validate_batch(
 
     let peers: Vec<SwarmPeer> = raw_peers
         .into_iter()
-        .filter_map(
-            |p| match validate_proto_peer(p, network_id, local_overlay, cache) {
-                Ok(peer) => {
-                    valid_count += 1;
-                    Some(peer)
-                }
-                Err(reason) => {
-                    reason.record();
-                    invalid_count += 1;
-                    None
-                }
-            },
-        )
+        .filter_map(|p| match validate_proto_peer(p, verifier, cache) {
+            Ok(peer) => {
+                valid_count += 1;
+                Some(peer)
+            }
+            Err(reason) => {
+                record_rejection(reason);
+                invalid_count += 1;
+                None
+            }
+        })
         .collect();
 
     histogram!("hive_validation_duration_seconds", "direction" => "inbound")
@@ -157,34 +157,39 @@ fn validate_batch(
     (peers, valid_count, invalid_count)
 }
 
-/// Validate and convert a single proto peer.
+fn record_rejection(reason: HiveRejection) {
+    let label: &'static str = reason.into();
+    counter!("hive_peer_validation_failures_total", "reason" => label).increment(1);
+}
+
+/// Validate and convert a single proto peer using the supplied [`HiveVerifier`].
 ///
 /// Two-tier lookup to avoid redundant ECDSA signature recovery:
-/// 1. LRU cache — validated earlier in this session
-/// 2. Full ECDSA recovery — cold path
-fn validate_proto_peer(
+/// 1. LRU cache — validated earlier in this session (matching signature bytes)
+/// 2. Full `BzzAddress` parse + verifier dispatch — cold path
+pub(crate) fn validate_proto_peer(
     p: vertex_swarm_net_proto::hive::Peer,
-    network_id: u64,
-    local_overlay: &SwarmAddress,
+    verifier: &dyn HiveVerifier,
     cache: &Mutex<LruCache<SwarmAddress, SwarmPeer>>,
-) -> Result<SwarmPeer, ValidationFailure> {
-    let overlay = B256::try_from(p.overlay.as_slice()).map_err(ValidationFailure::OverlayLength)?;
+) -> Result<SwarmPeer, HiveRejection> {
+    let addr = BzzAddress::from_wire(
+        p.multiaddrs,
+        &p.signature,
+        &p.overlay,
+        &p.nonce,
+        p.timestamp,
+        &p.chequebook_address,
+    )
+    .map_err(HiveRejection::from)?;
 
-    // Reject our own overlay address to prevent self-dial
-    let peer_overlay = SwarmAddress::from(overlay);
-    if peer_overlay == *local_overlay {
-        debug!("Hive: rejected self-overlay from peer exchange");
-        return Err(ValidationFailure::SelfOverlay);
-    }
+    let overlay_for_cache = addr.overlay;
 
-    let signature = Signature::try_from(p.signature.as_slice())?;
-
-    // Tier 1: Check LRU cache — validated earlier in this session.
-    // On signature mismatch, falls through to tier 2 which re-validates and overwrites.
+    // Tier 1: Check LRU cache by overlay+signature — verified earlier in this session.
+    // On signature mismatch the cold path overwrites the entry.
     {
         let mut guard = cache.lock();
-        if let Some(cached) = guard.get(&peer_overlay)
-            && *cached.signature() == signature
+        if let Some(cached) = guard.get(&overlay_for_cache)
+            && cached.signature() == &addr.signature
         {
             counter!("hive_validation_cache_total", "outcome" => "cache_hit").increment(1);
             return Ok(cached.clone());
@@ -192,33 +197,28 @@ fn validate_proto_peer(
     }
     counter!("hive_validation_cache_total", "outcome" => "miss").increment(1);
 
-    // Tier 2: Full ECDSA signature recovery.
-    let nonce = B256::try_from(p.nonce.as_slice()).map_err(ValidationFailure::NonceLength)?;
+    // Tier 2: Full verification via the trait. Every received peer record
+    // must pass signature + timestamp-skew validation before reaching the
+    // routing table (kademlia AddPeer).
+    let verified = verifier.verify(&addr, GossipSource::Gossip)?;
+    let peer = verified.peer;
 
-    // NOTE: validate_overlay disabled due to Bee multiaddr re-serialization bug
-    let peer = SwarmPeer::from_signed(
-        &p.multiaddrs,
-        signature,
-        peer_overlay,
-        nonce,
-        network_id,
-        false,
-    )?;
-
+    // Reject if any multiaddr lacks a `/p2p/` component — without one we
+    // cannot dial the peer back. Bee strips/normalises these upstream.
     if !peer
         .multiaddrs()
         .iter()
         .all(|addr| extract_peer_id(addr).is_some())
     {
         warn!(
-            overlay = %overlay,
+            overlay = %peer.overlay(),
             "rejecting peer: multiaddrs missing /p2p/ component"
         );
-        return Err(ValidationFailure::MissingPeerId);
+        return Err(HiveRejection::Malformed);
     }
 
-    // Store validated peer in LRU cache.
-    cache.lock().insert(peer_overlay, peer.clone());
+    // Store verified peer in LRU cache.
+    cache.lock().insert(overlay_for_cache, peer.clone());
 
     Ok(peer)
 }

--- a/crates/swarm/net/hive/src/verifier.rs
+++ b/crates/swarm/net/hive/src/verifier.rs
@@ -1,0 +1,431 @@
+//! Per-record verification for inbound hive 2.0.0 peer exchanges.
+//!
+//! Refactors what used to be inline closure logic inside [`crate::protocol`]
+//! into a small object-safe [`HiveVerifier`] trait so future work (Unit 7's
+//! bootnode discard gate, Unit 8's saturation-aware admission, network-id
+//! mismatch in fuzz harnesses, etc.) can swap policy without forking the
+//! parsing path.
+//!
+//! Each verifier MUST be able to reject a record with a stable
+//! [`HiveRejection`] variant — every variant doubles as a metric label.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tracing::debug;
+use vertex_swarm_peer::{SwarmAddress, SwarmPeer};
+use vertex_swarm_primitives::compute_overlay;
+
+use crate::bzz::{BzzAddress, BzzAddressError, check_timestamp_skew};
+
+/// Where an inbound peer record was received from.
+///
+/// Currently every received hive record is `Gossip`; the variant exists so
+/// future protocols (e.g. handshake addrbook reuse) can share the verifier
+/// shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GossipSource {
+    /// Record was learned from a hive `Peers` broadcast.
+    Gossip,
+}
+
+/// A peer record that passed verification.
+#[derive(Debug, Clone)]
+pub struct VerifiedPeer {
+    /// The verified peer in vertex's canonical form.
+    pub peer: SwarmPeer,
+}
+
+/// Why a peer record was rejected. Every variant is a stable metric label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum HiveRejection {
+    /// Signature failed to recover, or recovered to an address that does not
+    /// own the claimed overlay (re-derivation check failed).
+    InvalidSignature,
+    /// Timestamp is zero/negative or more than [`crate::bzz::MAX_CLOCK_SKEW_SECS`]
+    /// seconds in the future.
+    TimestampOutsideSkewWindow,
+    /// Sender's claimed network id does not match ours.
+    NetworkIdMismatch,
+    /// Peer is on a local blocklist (reserved for callers that supply one;
+    /// the default verifier never emits this unless a blocklist is attached).
+    Blocklisted,
+    /// Underlay multiaddrs decoded to a private/loopback/link-local-only set
+    /// that the local policy refuses to keep.
+    PrivateMultiaddr,
+    /// Record's structural invariants failed (nonce/overlay/chequebook length,
+    /// missing underlays).
+    Malformed,
+    /// Sender gossiped its own overlay back to us. Bee filters this out
+    /// before broadcasting; rejecting it here defends against self-dial.
+    SelfOverlay,
+}
+
+impl core::fmt::Display for HiveRejection {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(<&'static str>::from(*self))
+    }
+}
+
+impl std::error::Error for HiveRejection {}
+
+impl From<BzzAddressError> for HiveRejection {
+    fn from(err: BzzAddressError) -> Self {
+        match err {
+            BzzAddressError::SignatureFormat => Self::InvalidSignature,
+            BzzAddressError::TimestampInvalid => Self::TimestampOutsideSkewWindow,
+            _ => Self::Malformed,
+        }
+    }
+}
+
+/// Verification surface for inbound hive peer records.
+///
+/// Implementations MUST be cheap to call concurrently — the verifier is
+/// invoked once per gossiped record on the validation hot path.
+pub trait HiveVerifier: Send + Sync {
+    /// Inspect a parsed [`BzzAddress`] and return either a [`VerifiedPeer`]
+    /// or a [`HiveRejection`] suitable for metric labelling.
+    fn verify(
+        &self,
+        addr: &BzzAddress,
+        source: GossipSource,
+    ) -> Result<VerifiedPeer, HiveRejection>;
+}
+
+/// Wall-clock source used by [`DefaultHiveVerifier`].
+///
+/// Indirected through a trait object so tests can pin time without depending
+/// on `tokio::time::pause`.
+type Clock = Arc<dyn Fn() -> i64 + Send + Sync>;
+
+/// Tiny query interface so the verifier doesn't depend on a concrete
+/// blocklist crate. Implement on any cache that can answer "is this overlay
+/// banned right now?".
+pub trait BlocklistQuery: Send + 'static {
+    fn is_blocked(&mut self, overlay: &SwarmAddress) -> bool;
+}
+
+/// Default hive verifier: validates signature, re-derives overlay, and checks
+/// the timestamp against the local clock.
+///
+/// Cheap to clone (everything is behind `Arc`).
+#[derive(Clone)]
+pub struct DefaultHiveVerifier {
+    network_id: u64,
+    local_overlay: SwarmAddress,
+    now_secs: Clock,
+    blocklist: Option<Arc<Mutex<dyn BlocklistQuery>>>,
+}
+
+impl DefaultHiveVerifier {
+    /// Create a verifier backed by the real wall clock.
+    pub fn new(network_id: u64, local_overlay: SwarmAddress) -> Self {
+        Self {
+            network_id,
+            local_overlay,
+            now_secs: Arc::new(default_now_secs),
+            blocklist: None,
+        }
+    }
+
+    /// Create a verifier with a custom clock source (used by tests).
+    pub fn with_clock<F>(network_id: u64, local_overlay: SwarmAddress, now_secs: F) -> Self
+    where
+        F: Fn() -> i64 + Send + Sync + 'static,
+    {
+        Self {
+            network_id,
+            local_overlay,
+            now_secs: Arc::new(now_secs),
+            blocklist: None,
+        }
+    }
+
+    /// Attach a blocklist query — when present, the verifier rejects any
+    /// overlay the blocklist marks as blocked with [`HiveRejection::Blocklisted`].
+    pub fn with_blocklist<B: BlocklistQuery>(mut self, blocklist: Arc<Mutex<B>>) -> Self {
+        self.blocklist = Some(blocklist as Arc<Mutex<dyn BlocklistQuery>>);
+        self
+    }
+}
+
+fn default_now_secs() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+impl HiveVerifier for DefaultHiveVerifier {
+    fn verify(
+        &self,
+        addr: &BzzAddress,
+        _source: GossipSource,
+    ) -> Result<VerifiedPeer, HiveRejection> {
+        // Self-overlay defence — never re-admit our own address.
+        if addr.overlay == self.local_overlay {
+            return Err(HiveRejection::SelfOverlay);
+        }
+
+        // Timestamp skew window.
+        let now = (self.now_secs)();
+        if !check_timestamp_skew(addr.timestamp, now) {
+            return Err(HiveRejection::TimestampOutsideSkewWindow);
+        }
+
+        // Optional blocklist short-circuit (cheaper than ECDSA recovery).
+        if let Some(blocklist) = &self.blocklist
+            && blocklist.lock().is_blocked(&addr.overlay)
+        {
+            return Err(HiveRejection::Blocklisted);
+        }
+
+        // Signature recovery + overlay re-derivation.
+        let signer = addr
+            .verify_signature(self.network_id)
+            .map_err(|_| HiveRejection::InvalidSignature)?;
+
+        let expected_overlay = compute_overlay(&signer, self.network_id, &addr.nonce);
+        if expected_overlay != addr.overlay {
+            debug!(
+                claimed = %addr.overlay,
+                derived = %expected_overlay,
+                "Hive: overlay does not derive from recovered signer"
+            );
+            return Err(HiveRejection::InvalidSignature);
+        }
+
+        let peer = addr.clone().into_swarm_peer(signer);
+        Ok(VerifiedPeer { peer })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, B256};
+    use std::sync::Arc;
+    use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
+    use vertex_swarm_identity::Identity;
+    use vertex_swarm_primitives::SwarmNodeType;
+    use vertex_swarm_spec::init_testnet;
+
+    /// Build a fully-signed `BzzAddress` for the given identity at the given
+    /// timestamp. Signs using the bee 15.0.0 layout (with zero chequebook).
+    fn signed_bzz_address(
+        identity: &Identity,
+        underlays: Vec<libp2p::Multiaddr>,
+        timestamp: i64,
+    ) -> BzzAddress {
+        use alloy_signer::SignerSync;
+        use vertex_swarm_peer::serialize_multiaddrs;
+
+        let underlay_bytes = serialize_multiaddrs(&underlays);
+        let overlay = identity.overlay_address();
+        let nonce = identity.nonce();
+        let network_id = identity.spec().network_id();
+        let chequebook = Address::ZERO;
+
+        let msg = crate::bzz::generate_sign_data(
+            &underlay_bytes,
+            overlay.as_ref(),
+            network_id,
+            nonce.as_slice(),
+            timestamp,
+            chequebook.as_slice(),
+        );
+        let signature = identity.signer().sign_message_sync(&msg).unwrap();
+
+        BzzAddress {
+            underlays,
+            underlay_bytes,
+            overlay,
+            signature,
+            nonce,
+            timestamp,
+            chequebook,
+        }
+    }
+
+    fn local_identity() -> Arc<Identity> {
+        Arc::new(Identity::random(init_testnet(), SwarmNodeType::Storer))
+    }
+
+    fn remote_identity() -> Arc<Identity> {
+        Arc::new(Identity::random(init_testnet(), SwarmNodeType::Storer))
+    }
+
+    #[test]
+    fn verifier_accepts_well_formed_record() {
+        let local = local_identity();
+        let remote = remote_identity();
+        let now = 1_700_000_000;
+
+        let verifier = DefaultHiveVerifier::with_clock(
+            local.spec().network_id(),
+            local.overlay_address(),
+            move || now,
+        );
+
+        let underlays: Vec<libp2p::Multiaddr> =
+            vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+        let addr = signed_bzz_address(&remote, underlays, now);
+
+        let verified = verifier.verify(&addr, GossipSource::Gossip).unwrap();
+        assert_eq!(verified.peer.overlay(), &remote.overlay_address());
+    }
+
+    #[test]
+    fn verifier_rejects_self_overlay() {
+        let local = local_identity();
+        let now = 1_700_000_000;
+
+        let verifier = DefaultHiveVerifier::with_clock(
+            local.spec().network_id(),
+            local.overlay_address(),
+            move || now,
+        );
+
+        let underlays: Vec<libp2p::Multiaddr> =
+            vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+        let addr = signed_bzz_address(&local, underlays, now);
+        let err = verifier.verify(&addr, GossipSource::Gossip).unwrap_err();
+        assert_eq!(err, HiveRejection::SelfOverlay);
+    }
+
+    #[test]
+    fn verifier_rejects_future_timestamp_beyond_skew() {
+        let local = local_identity();
+        let remote = remote_identity();
+        let now = 1_700_000_000;
+
+        let verifier = DefaultHiveVerifier::with_clock(
+            local.spec().network_id(),
+            local.overlay_address(),
+            move || now,
+        );
+
+        let underlays: Vec<libp2p::Multiaddr> =
+            vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+        let addr = signed_bzz_address(
+            &remote,
+            underlays,
+            now + crate::bzz::MAX_CLOCK_SKEW_SECS + 1,
+        );
+        let err = verifier.verify(&addr, GossipSource::Gossip).unwrap_err();
+        assert_eq!(err, HiveRejection::TimestampOutsideSkewWindow);
+    }
+
+    #[test]
+    fn verifier_rejects_tampered_overlay() {
+        let local = local_identity();
+        let remote = remote_identity();
+        let now = 1_700_000_000;
+
+        let verifier = DefaultHiveVerifier::with_clock(
+            local.spec().network_id(),
+            local.overlay_address(),
+            move || now,
+        );
+
+        let underlays: Vec<libp2p::Multiaddr> =
+            vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+        let mut addr = signed_bzz_address(&remote, underlays, now);
+        // Tamper: replace overlay with an unrelated one. Recovery succeeds
+        // against the tampered signing data, but overlay re-derivation fails.
+        addr.overlay = SwarmAddress::from(B256::from([7u8; 32]));
+        let err = verifier.verify(&addr, GossipSource::Gossip).unwrap_err();
+        assert_eq!(err, HiveRejection::InvalidSignature);
+    }
+
+    #[test]
+    fn rejection_labels_stable() {
+        assert_eq!(
+            <&'static str>::from(HiveRejection::InvalidSignature),
+            "invalid_signature"
+        );
+        assert_eq!(
+            <&'static str>::from(HiveRejection::TimestampOutsideSkewWindow),
+            "timestamp_outside_skew_window"
+        );
+        assert_eq!(
+            <&'static str>::from(HiveRejection::NetworkIdMismatch),
+            "network_id_mismatch"
+        );
+        assert_eq!(
+            <&'static str>::from(HiveRejection::Blocklisted),
+            "blocklisted"
+        );
+        assert_eq!(
+            <&'static str>::from(HiveRejection::PrivateMultiaddr),
+            "private_multiaddr"
+        );
+        assert_eq!(
+            <&'static str>::from(HiveRejection::Malformed),
+            "malformed"
+        );
+        assert_eq!(
+            <&'static str>::from(HiveRejection::SelfOverlay),
+            "self_overlay"
+        );
+    }
+
+    /// A toy blocklist for the with_blocklist test.
+    struct StaticBlocklist(SwarmAddress);
+    impl BlocklistQuery for StaticBlocklist {
+        fn is_blocked(&mut self, overlay: &SwarmAddress) -> bool {
+            overlay == &self.0
+        }
+    }
+
+    #[test]
+    fn verifier_rejects_blocklisted_overlay() {
+        let local = local_identity();
+        let remote = remote_identity();
+        let now = 1_700_000_000;
+
+        let blocklist = Arc::new(Mutex::new(StaticBlocklist(remote.overlay_address())));
+        let verifier = DefaultHiveVerifier::with_clock(
+            local.spec().network_id(),
+            local.overlay_address(),
+            move || now,
+        )
+        .with_blocklist(blocklist);
+
+        let underlays: Vec<libp2p::Multiaddr> =
+            vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+        let addr = signed_bzz_address(&remote, underlays, now);
+        let err = verifier.verify(&addr, GossipSource::Gossip).unwrap_err();
+        assert_eq!(err, HiveRejection::Blocklisted);
+    }
+
+    #[test]
+    fn verifier_rejects_unsigned_signature() {
+        // Construct a BzzAddress carrying a signature that does not recover.
+        let local = local_identity();
+        let remote = remote_identity();
+        let now = 1_700_000_000;
+
+        let verifier = DefaultHiveVerifier::with_clock(
+            local.spec().network_id(),
+            local.overlay_address(),
+            move || now,
+        );
+
+        let underlays: Vec<libp2p::Multiaddr> =
+            vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
+        let mut addr = signed_bzz_address(&remote, underlays, now);
+        // Flip every byte of the underlay to invalidate the signature.
+        for b in &mut addr.underlay_bytes {
+            *b = b.wrapping_add(1);
+        }
+        let err = verifier.verify(&addr, GossipSource::Gossip).unwrap_err();
+        assert_eq!(err, HiveRejection::InvalidSignature);
+    }
+}

--- a/crates/swarm/net/proto/proto/hive.proto
+++ b/crates/swarm/net/proto/proto/hive.proto
@@ -10,10 +10,13 @@ message Peers {
 }
 
 // Peer represents a gossiped peer address in the Hive protocol.
-// Note: Field numbers match BzzAddress for wire compatibility with Bee.
+// Mirrors bee's BzzAddress wire format (pkg/hive/pb/hive.proto) for hive 2.0.0.
+// Field numbers MUST match bee's BzzAddress.
 message Peer {
   bytes multiaddrs = 1;
   bytes signature = 2;
   bytes overlay = 3;
   bytes nonce = 4;
+  int64 timestamp = 5;
+  bytes chequebook_address = 6;
 }


### PR DESCRIPTION
Unit 6. Bumps protocol to /swarm/hive/2.0.0/peers; Peer proto extended to bee's BzzAddress (adds timestamp int64 + chequebook_address bytes). HiveVerifier trait with HiveRejection { InvalidSignature, TimestampOutsideSkewWindow, NetworkIdMismatch, Blocklisted, PrivateMultiaddr } (#[non_exhaustive]).