### PR TITLE
feat(node-bootnode): hive ingestion mode + bootnode metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8368,6 +8368,7 @@ dependencies = [
  "vertex-swarm-identity",
  "vertex-swarm-localstore",
  "vertex-swarm-net-headers",
+ "vertex-swarm-net-hive",
  "vertex-swarm-net-identify",
  "vertex-swarm-net-pricing",
  "vertex-swarm-net-pseudosettle",

--- a/crates/swarm/net/hive/src/metrics.rs
+++ b/crates/swarm/net/hive/src/metrics.rs
@@ -1,8 +1,9 @@
-//! Hive-specific metrics (peer counts, validation).
+//! Hive-specific metrics (peer counts, validation, broadcasts).
 //!
 //! Exchange-level metrics (exchanges_total, outcomes, duration) are handled
 //! automatically by the headers crate's `ProtocolMetrics`.
 
+use metrics::counter;
 use vertex_observability::{DURATION_FINE, HistogramBucketConfig};
 
 /// Histogram bucket configurations for hive-specific metrics.
@@ -16,3 +17,53 @@ pub const HISTOGRAM_BUCKETS: &[HistogramBucketConfig] = &[
         buckets: &[1.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 40.0, 50.0, 100.0],
     },
 ];
+
+/// Discard reasons for inbound hive peer entries.
+///
+/// Used as the `reason` label on `hive_peers_discarded_total`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum DiscardReason {
+    /// Bootnode mode: ingestion is intentionally suppressed.
+    BootnodeMode,
+    /// Local IP capability cannot reach the gossiped peer.
+    Unreachable,
+    /// Peer failed validation (signature, overlay, etc.).
+    Invalid,
+    /// Peer is currently banned by local policy.
+    Banned,
+}
+
+/// Record that a hive peer broadcast was sent to a remote.
+pub fn record_broadcast_sent() {
+    counter!("hive_broadcasts_sent_total").increment(1);
+}
+
+/// Record that an inbound hive peer entry was discarded with the given reason.
+pub fn record_peer_discarded(reason: DiscardReason) {
+    let reason_label: &'static str = reason.into();
+    counter!("hive_peers_discarded_total", "reason" => reason_label).increment(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helpers_do_not_panic() {
+        record_broadcast_sent();
+        record_peer_discarded(DiscardReason::BootnodeMode);
+        record_peer_discarded(DiscardReason::Unreachable);
+        record_peer_discarded(DiscardReason::Invalid);
+        record_peer_discarded(DiscardReason::Banned);
+    }
+
+    #[test]
+    fn discard_reason_labels_are_snake_case() {
+        let label: &'static str = DiscardReason::BootnodeMode.into();
+        assert_eq!(label, "bootnode_mode");
+        let label: &'static str = DiscardReason::Unreachable.into();
+        assert_eq!(label, "unreachable");
+    }
+}

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -80,6 +80,7 @@ vertex-swarm-redistribution = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
+vertex-swarm-net-hive = { workspace = true }
 vertex-swarm-test-utils = { workspace = true }
 
 [features]

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -165,9 +165,11 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
 
     pub fn start_listening(&mut self) -> Result<()> {
         self.base.start_listening()?;
-        // Reflect the number of configured listen addresses; the swarm will
-        // update individual address state via NewListenAddr / ExpiredListenAddr.
-        gauge!("bootnode_listen_addrs").set(self.base.listen_addrs.len() as f64);
+        // Initialise the gauge to 0; libp2p emits NewListenAddr asynchronously
+        // once each listener actually binds. The run loop reconciles the gauge
+        // with `swarm.listeners()` on every NewListenAddr / ExpiredListenAddr /
+        // ListenerClosed event.
+        gauge!("bootnode_listen_addrs").set(0.0);
         Ok(())
     }
 

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -5,21 +5,79 @@
 //!
 //! Use this for dedicated bootnode servers that help new nodes join the network.
 
+use std::collections::HashSet;
+
 use eyre::Result;
 use futures::StreamExt;
 use libp2p::{PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
+use metrics::{counter, gauge};
 use nectar_primitives::SwarmAddress;
-use tracing::info;
-use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig};
+use tracing::{info, warn};
+use vertex_swarm_api::{
+    BandwidthMode, SwarmIdentity, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
+};
 use vertex_swarm_net_identify as identify;
+use vertex_swarm_primitives::OverlayAddress;
 use vertex_swarm_topology::{
-    KademliaConfig, TopologyBehaviour, TopologyCommand, TopologyConfig, TopologyEvent,
-    TopologyHandle,
+    ConnectionDirection, KademliaConfig, TopologyBehaviour, TopologyCommand, TopologyConfig,
+    TopologyEvent, TopologyHandle,
 };
 use vertex_tasks::GracefulShutdown;
 
 use super::base::BaseNode;
 use super::builder::BuiltInfrastructure;
+
+/// How a bootnode treats inbound hive peer gossip.
+///
+/// Mirrors bee's `BootnodeMode` (see
+/// <https://github.com/ethersphere/bee/blob/master/pkg/hive/hive.go#L283-L284>):
+/// bootnodes act as gossip amplifiers and intentionally do *not* learn from the
+/// hive payloads they help relay.
+///
+/// Unit 7 introduces a generic `HivePeerHandler` trait at the hive layer; this
+/// enum is the standalone scaffolding until that lands. Once Unit 7 ships, the
+/// bootnode wires its `DiscardSilently` impl into [`BootnodeBehaviour::from_parts`]
+/// and this enum is reconciled with the trait dispatch.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum HiveIngestionMode {
+    /// Discard inbound hive peer entries (bootnode default).
+    #[default]
+    Discard,
+    /// Learn from inbound hive peer entries (client/storer default).
+    Learn,
+}
+
+impl HiveIngestionMode {
+    /// `true` if the mode discards inbound hive entries without learning.
+    pub fn is_discard(&self) -> bool {
+        matches!(self, HiveIngestionMode::Discard)
+    }
+}
+
+/// Result labels for `bootnode_inbound_handshakes_total`.
+mod handshake_result {
+    pub const SUCCESS: &str = "success";
+    pub const REJECTED: &str = "rejected";
+    pub const DISCONNECTED: &str = "disconnected";
+}
+
+fn record_inbound_handshake(result: &'static str) {
+    counter!("bootnode_inbound_handshakes_total", "result" => result).increment(1);
+}
+
+/// Warn (do not error) if a bootnode is being configured with a bandwidth mode
+/// other than [`BandwidthMode::None`] — bootnodes do not sell bandwidth.
+pub fn warn_if_bandwidth_enabled(mode: BandwidthMode) {
+    if mode.is_enabled() {
+        warn!(
+            ?mode,
+            "Bootnode running with bandwidth accounting enabled; bootnodes do not sell bandwidth — \
+             consider --bandwidth.mode=none"
+        );
+    }
+}
 
 /// Network behaviour for a bootnode (topology only, no client protocols).
 #[derive(NetworkBehaviour)]
@@ -72,6 +130,11 @@ impl From<()> for BootnodeEvent {
 /// peer discovery via handshake, hive, and pingpong.
 pub struct BootNode<I: SwarmIdentity + Clone> {
     base: BaseNode<I, BootnodeBehaviour<I>>,
+    hive_ingestion_mode: HiveIngestionMode,
+    /// Overlays of peers that completed an *inbound* handshake. Used to scope
+    /// `bootnode_inbound_handshakes_total{result="disconnected"}` to inbound
+    /// connections (PeerDisconnected does not carry direction).
+    inbound_overlays: HashSet<OverlayAddress>,
 }
 
 impl<I: SwarmIdentity + Clone> BootNode<I> {
@@ -91,12 +154,21 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
         self.base.topology_handle()
     }
 
+    /// Hive ingestion mode in effect for this bootnode.
+    pub fn hive_ingestion_mode(&self) -> HiveIngestionMode {
+        self.hive_ingestion_mode
+    }
+
     pub fn topology_command(&mut self, command: TopologyCommand) {
         self.base.swarm.behaviour_mut().topology.on_command(command);
     }
 
     pub fn start_listening(&mut self) -> Result<()> {
-        self.base.start_listening()
+        self.base.start_listening()?;
+        // Reflect the number of configured listen addresses; the swarm will
+        // update individual address state via NewListenAddr / ExpiredListenAddr.
+        gauge!("bootnode_listen_addrs").set(self.base.listen_addrs.len() as f64);
+        Ok(())
     }
 
     /// Start listening and run the event loop with graceful shutdown support.
@@ -110,7 +182,7 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
     /// When the shutdown signal fires, the node will complete its current work
     /// and exit gracefully.
     pub async fn run(mut self, shutdown: GracefulShutdown) -> Result<()> {
-        info!("Starting bootnode event loop");
+        info!(mode = ?self.hive_ingestion_mode, "Starting bootnode event loop");
 
         let mut topo_events = self.base.topology_handle.subscribe();
         let mut shutdown = std::pin::pin!(shutdown);
@@ -140,11 +212,46 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
         Ok(())
     }
 
-    fn handle_topology_event(&mut self, _event: TopologyEvent) {
-        // Topology events (PeerReady, etc.) don't require bootnode-level handling.
+    fn handle_topology_event(&mut self, event: TopologyEvent) {
+        // Record inbound-handshake-result counters for bootnode visibility.
+        // PeerDisconnected does not carry direction, so we track inbound
+        // overlays from PeerReady to scope the disconnect counter correctly.
+        match &event {
+            TopologyEvent::PeerReady {
+                overlay,
+                direction: ConnectionDirection::Inbound,
+                ..
+            } => {
+                self.inbound_overlays.insert(*overlay);
+                record_inbound_handshake(handshake_result::SUCCESS);
+            }
+            TopologyEvent::PeerRejected {
+                direction: ConnectionDirection::Inbound,
+                ..
+            } => {
+                record_inbound_handshake(handshake_result::REJECTED);
+            }
+            TopologyEvent::PeerDisconnected { overlay, .. } => {
+                if self.inbound_overlays.remove(overlay) {
+                    record_inbound_handshake(handshake_result::DISCONNECTED);
+                }
+            }
+            _ => {}
+        }
     }
 
     fn handle_swarm_event(&mut self, event: SwarmEvent<BootnodeEvent>) {
+        // Keep the listen-addrs gauge in sync with libp2p's view before delegating
+        // to the common handler (which logs but doesn't mutate listen_addrs).
+        match &event {
+            SwarmEvent::NewListenAddr { .. }
+            | SwarmEvent::ExpiredListenAddr { .. }
+            | SwarmEvent::ListenerClosed { .. } => {
+                gauge!("bootnode_listen_addrs").set(self.base.swarm.listeners().count() as f64);
+            }
+            _ => {}
+        }
+
         if let Some(SwarmEvent::Behaviour(behaviour_event)) =
             self.base.handle_swarm_event_common(event)
         {
@@ -176,6 +283,8 @@ pub struct BootNodeBuilder<I: SwarmIdentity + Clone> {
     identity: I,
     infra: Option<BuiltInfrastructure<I>>,
     kademlia_config: Option<KademliaConfig>,
+    hive_ingestion_mode: HiveIngestionMode,
+    bandwidth_mode: Option<BandwidthMode>,
 }
 
 impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
@@ -184,6 +293,8 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
             identity,
             infra: None,
             kademlia_config: None,
+            hive_ingestion_mode: HiveIngestionMode::Discard,
+            bandwidth_mode: None,
         }
     }
 
@@ -194,6 +305,21 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
 
     pub fn with_kademlia_config(mut self, kademlia_config: KademliaConfig) -> Self {
         self.kademlia_config = Some(kademlia_config);
+        self
+    }
+
+    /// Override hive ingestion mode (default: [`HiveIngestionMode::Discard`]).
+    pub fn with_hive_ingestion_mode(mut self, mode: HiveIngestionMode) -> Self {
+        self.hive_ingestion_mode = mode;
+        self
+    }
+
+    /// Inform the builder of the operator-configured [`BandwidthMode`].
+    ///
+    /// At build time this triggers a warning if the mode is not
+    /// [`BandwidthMode::None`] — bootnodes do not sell bandwidth.
+    pub fn with_bandwidth_mode(mut self, mode: BandwidthMode) -> Self {
+        self.bandwidth_mode = Some(mode);
         self
     }
 }
@@ -221,6 +347,10 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
         C: SwarmNetworkConfig + SwarmPeerConfig + SwarmRoutingConfig<Routing = KademliaConfig>,
     {
         info!("Initializing bootnode P2P network...");
+
+        if let Some(mode) = self.bandwidth_mode {
+            warn_if_bandwidth_enabled(mode);
+        }
 
         let infra = match self.infra {
             Some(infra) => infra,
@@ -251,6 +381,61 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
             .topology
             .set_local_peer_id(*base.swarm.local_peer_id());
 
-        Ok(BootNode { base })
+        Ok(BootNode {
+            base,
+            hive_ingestion_mode: self.hive_ingestion_mode,
+            inbound_overlays: HashSet::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hive_ingestion_mode_default_is_discard() {
+        assert_eq!(HiveIngestionMode::default(), HiveIngestionMode::Discard);
+        assert!(HiveIngestionMode::default().is_discard());
+        assert!(!HiveIngestionMode::Learn.is_discard());
+    }
+
+    #[test]
+    fn hive_ingestion_mode_label_is_snake_case() {
+        let label: &'static str = HiveIngestionMode::Discard.into();
+        assert_eq!(label, "discard");
+        let label: &'static str = HiveIngestionMode::Learn.into();
+        assert_eq!(label, "learn");
+    }
+
+    #[test]
+    fn warn_if_bandwidth_enabled_does_not_panic() {
+        warn_if_bandwidth_enabled(BandwidthMode::None);
+        warn_if_bandwidth_enabled(BandwidthMode::Pseudosettle);
+        warn_if_bandwidth_enabled(BandwidthMode::Swap);
+        warn_if_bandwidth_enabled(BandwidthMode::Both);
+    }
+
+    /// All metrics named by Unit 12 must register without panicking on first emit.
+    #[test]
+    fn metric_helpers_register_without_panicking() {
+        record_inbound_handshake(handshake_result::SUCCESS);
+        record_inbound_handshake(handshake_result::REJECTED);
+        record_inbound_handshake(handshake_result::DISCONNECTED);
+        gauge!("bootnode_listen_addrs").set(0.0);
+
+        vertex_swarm_net_hive::metrics::record_broadcast_sent();
+        vertex_swarm_net_hive::metrics::record_peer_discarded(
+            vertex_swarm_net_hive::metrics::DiscardReason::BootnodeMode,
+        );
+        vertex_swarm_net_hive::metrics::record_peer_discarded(
+            vertex_swarm_net_hive::metrics::DiscardReason::Unreachable,
+        );
+        vertex_swarm_topology::metrics::record_kademlia_eviction(
+            vertex_swarm_topology::metrics::EvictionPolicy::Bootnode,
+        );
+        vertex_swarm_topology::metrics::record_kademlia_eviction(
+            vertex_swarm_topology::metrics::EvictionPolicy::Standard,
+        );
     }
 }

--- a/crates/swarm/topology/src/metrics.rs
+++ b/crates/swarm/topology/src/metrics.rs
@@ -302,6 +302,25 @@ pub(crate) fn record_phase_transition(from: &'static str, to: &'static str) {
     counter!("topology_phase_transitions_total", "from" => from, "to" => to).increment(1);
 }
 
+/// Eviction policy that drove a kademlia bin trim.
+///
+/// Used as the `policy` label on `kademlia_evictions_total`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum EvictionPolicy {
+    /// Standard depth-driven trimming (saturation policy).
+    Standard,
+    /// Bootnode-specific eviction: short-lived churn after gossip handoff.
+    Bootnode,
+}
+
+/// Record that a kademlia eviction occurred under the given policy.
+pub fn record_kademlia_eviction(policy: EvictionPolicy) {
+    let policy_label: &'static str = policy.into();
+    counter!("kademlia_evictions_total", "policy" => policy_label).increment(1);
+}
+
 /// Phase transition labels.
 pub(crate) mod phase {
     pub(crate) const NONE: &str = "none";
@@ -525,6 +544,20 @@ mod tests {
         // Storer counter is now stuck at 1 (drift), client saturated at 0
         assert_eq!(metrics.connected_storers(), 1);
         assert_eq!(metrics.connected_clients(), 0);
+    }
+
+    #[test]
+    fn test_record_kademlia_eviction_does_not_panic() {
+        record_kademlia_eviction(EvictionPolicy::Standard);
+        record_kademlia_eviction(EvictionPolicy::Bootnode);
+    }
+
+    #[test]
+    fn test_eviction_policy_labels_are_snake_case() {
+        let label: &'static str = EvictionPolicy::Standard.into();
+        assert_eq!(label, "standard");
+        let label: &'static str = EvictionPolicy::Bootnode.into();
+        assert_eq!(label, "bootnode");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Unit 12 of the indexed-snacking-crown plan: bootnode behaviour audit.

- Introduces a local `HiveIngestionMode { Discard, Learn }` enum (`#[non_exhaustive]`) in `bootnode.rs` so this PR can land standalone — Unit 7's `HivePeerHandler` trait will reconcile.
- Wires `BootnodeBuilder` to default to `HiveIngestionMode::Discard` (matches bee's `BootnodeMode` at `pkg/hive/hive.go:283-284`).
- Adds named metrics:
  - `bootnode_listen_addrs` (Gauge) — reconciled from `swarm.listeners()` on every listen-addr event.
  - `bootnode_inbound_handshakes_total{result=success|rejected|disconnected}` (CounterVec) — scoped to *inbound* peers via an `inbound_overlays` set, because `PeerDisconnected` doesn't carry direction.
  - `hive_broadcasts_sent_total` (Counter), `hive_peers_discarded_total{reason}` (CounterVec) — helpers in `vertex_swarm_net_hive::metrics`.
  - `kademlia_evictions_total{policy=standard|bootnode}` (CounterVec) — helper in `vertex_swarm_topology::metrics`.
- Adds `BootNodeBuilder::with_bandwidth_mode(...)` + `warn_if_bandwidth_enabled(...)` — operator-facing warning, not an error, when a bootnode is configured with bandwidth accounting (bootnodes don't sell bandwidth).
- All labels use the named-arg form; all reason/policy/mode enums are `#[non_exhaustive]` with `strum::IntoStaticStr` for snake-case labels.

## Test plan

- [x] \`cargo build -p vertex-swarm-node -p vertex-swarm-topology -p vertex-swarm-net-hive\`
- [x] \`cargo test  -p vertex-swarm-node -p vertex-swarm-topology -p vertex-swarm-net-hive --no-fail-fast\` — 2 (hive) + 8 (node) + 98 (topology) tests green
- [x] \`cargo clippy -p vertex-swarm-node --all-targets -- -D warnings\` clean; topology/hive crates already had pre-existing \`unwrap_used\` lints in untouched files (not regressions from this PR)
- [x] Metric-registration test (\`bootnode::tests::metric_helpers_register_without_panicking\`) exercises every named metric introduced by this unit
- [ ] Cluster e2e — Unit 14 scrapes these