### PR TITLE
docs(topology): strip "Unit N" plan references from rustdoc

### DIFF
--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -417,20 +417,14 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         self.nat_discovery.on_autonat_event(event);
     }
 
-    /// Notify the reachability tracker that the stabilization detector
-    /// (Unit 9) has classified `peer` with `stable`. See
-    /// [`crate::ReachabilityTracker::update_from_stabilization`].
+    /// Forward a stabilization-detector verdict to the reachability tracker.
     pub fn on_stabilization(&self, peer: PeerId, stable: bool) {
         self.nat_discovery
             .reachability()
             .update_from_stabilization(peer, stable);
     }
 
-    /// Shared per-peer reachability tracker.
-    ///
-    /// Cheap to clone (Arc inside). Exposed so the routing layer (Unit 8) can
-    /// consult per-peer reachability without taking a hard dependency on the
-    /// topology behaviour internals.
+    /// Shared per-peer reachability tracker; cheap to clone.
     pub fn reachability(&self) -> crate::ReachabilityTracker {
         self.nat_discovery.reachability()
     }

--- a/crates/swarm/topology/src/reachability.rs
+++ b/crates/swarm/topology/src/reachability.rs
@@ -69,8 +69,8 @@ impl PeerReachability {
         matches!(self, Self::Private)
     }
 
-    /// Total order used by Unit 8's eviction policy: `Public` survives,
-    /// `Unknown` is neutral, `Private` is evicted first. Higher value = better.
+    /// Eviction ordering: higher rank survives. `Public` > `Unknown` >
+    /// `Private`.
     pub fn rank(&self) -> u8 {
         match self {
             Self::Public => 2,
@@ -316,21 +316,16 @@ impl ReachabilityTracker {
         }
     }
 
-    // ---------------------------------------------------------------------
-    // Consumer surface for Unit 8 (Kademlia eviction / saturation accounting)
-    // ---------------------------------------------------------------------
+    // Routing-layer consumer surface (eviction / saturation accounting).
 
-    /// Predicate used by the kademlia routing layer to exclude private peers
-    /// from saturation counts in non-neighborhood bins. Returns `true` if
-    /// `peer` should count toward bin capacity.
+    /// `true` if `peer` should count toward bin capacity; private peers are
+    /// excluded from saturation counts in non-neighborhood bins.
     pub fn counts_toward_saturation(&self, peer: &PeerId) -> bool {
         !self.status(peer).is_private()
     }
 
-    /// Comparator used by Unit 8's eviction policy: returns the **survivor**
-    /// of two peers, preferring [`PeerReachability::Public`]. Ties fall back
-    /// to the first argument; the caller can break further ties on score or
-    /// `last_seen`.
+    /// Pick the survivor of `a` and `b` by reachability rank. Ties prefer
+    /// `a`; the caller breaks further ties on score or `last_seen`.
     pub fn prefer_survivor<'a>(&self, a: &'a PeerId, b: &'a PeerId) -> &'a PeerId {
         let rank_a = self.status(a).rank();
         let rank_b = self.status(b).rank();


### PR DESCRIPTION
## Summary

- Replace `Unit 8` / `Unit 9` references in `crates/swarm/topology/src/{behaviour.rs,reachability.rs}` with descriptions of the consumer in vertex's own terms (the kademlia routing layer, the stabilization detector).
- The "Unit N" labels were coordination metadata from the multi-PR bee-bootnode work plan; they are not architectural documentation and rot as the plan evolves.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --lib --all-features -- -D warnings`
- [x] `cargo test -p vertex-swarm-topology --all-features --no-fail-fast` (115 pass)
- [x] grep confirms no remaining `Unit [0-9]` references in `crates/`