### PR TITLE
feat(node-bootnode): compose ClientBehaviour for listen-only pricing

### DIFF
--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -1,9 +1,11 @@
-//! Bootnode - minimal Swarm node with topology protocols only.
+//! Bootnode - minimal Swarm node with topology protocols and a listen-only
+//! pricing handler.
 //!
-//! A [`BootNode`] participates in peer discovery via handshake, hive, and pingpong
-//! but does not run client protocols (pricing, retrieval, pushsync, settlement).
-//!
-//! Use this for dedicated bootnode servers that help new nodes join the network.
+//! A [`BootNode`] participates in peer discovery via handshake, hive, and
+//! pingpong and advertises the pricing protocol in listen-only mode so peers
+//! that disconnect on a failed pricing handshake stay connected. It does not
+//! initiate any pricing announcement of its own and does not run the other
+//! client protocols (retrieval, pushsync, pseudosettle).
 
 use eyre::Result;
 use futures::StreamExt;
@@ -14,6 +16,7 @@ use vertex_swarm_api::{
     SwarmIdentity, SwarmIdentityConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
 };
 use vertex_swarm_net_identify as identify;
+use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_topology::{
     KademliaConfig, TopologyBehaviour, TopologyCommand, TopologyConfig, TopologyEvent,
     TopologyHandle,
@@ -22,13 +25,21 @@ use vertex_tasks::GracefulShutdown;
 
 use super::base::BaseNode;
 use super::builder::BuiltInfrastructure;
+use crate::protocol::{BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, ClientEvent};
 
-/// Network behaviour for a bootnode (topology only, no client protocols).
+/// Network behaviour for a bootnode (topology + listen-only client behaviour).
+///
+/// The same client behaviour composed into [`ClientNode`](super::ClientNode) is
+/// used here with [`SwarmNodeType::Bootnode`], which narrows the advertised
+/// client protocol set to pricing only. The bootnode never issues client
+/// commands (`AnnouncePricing`, `RetrieveChunk`, ...), so only the inbound
+/// pricing path is ever exercised.
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "BootnodeEvent")]
-pub struct BootnodeBehaviour<I: SwarmIdentity + Clone> {
-    pub identify: identify::Behaviour,
-    pub topology: TopologyBehaviour<I>,
+pub(crate) struct BootnodeBehaviour<I: SwarmIdentity + Clone> {
+    pub(crate) identify: identify::Behaviour,
+    pub(crate) topology: TopologyBehaviour<I>,
+    pub(crate) client: ClientBehaviour,
 }
 
 impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
@@ -36,23 +47,36 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
     pub fn from_parts(local_public_key: PublicKey, topology: TopologyBehaviour<I>) -> Self {
         let agent_versions = topology.agent_versions();
         Self {
-            // Send listen addresses (even private IPs) so bee's peerstore has entries.
-            // waitPeerAddrs() returns immediately if len(addrs) > 0, regardless of
-            // whether addresses match or are reachable. The handshake protocol uses
-            // RemoteMultiaddr directly. Private IPs in gossip are harmless.
+            // Advertise listen addresses (even private IPs). Peers gate on
+            // "we have at least one addr" rather than reachability, and the
+            // handshake itself uses the libp2p-observed remote multiaddr, so
+            // private IPs in the identify payload are harmless.
             identify: identify::Behaviour::new(
                 identify::Config::new(local_public_key),
                 agent_versions,
             ),
             topology,
+            client: ClientBehaviour::new(ClientBehaviourConfig::for_role(SwarmNodeType::Bootnode)),
         }
+    }
+
+    /// Wire-protocol identifiers advertised by this behaviour above the
+    /// topology layer. Topology's protocols (handshake, hive, pingpong) are
+    /// owned by `topology` itself and are not enumerated here. Currently
+    /// only the test below consumes this; the `dead_code` allow keeps the
+    /// helper available for future diagnostics and operator-facing readouts.
+    #[allow(dead_code)]
+    pub fn supported_protocols() -> &'static [&'static str] {
+        &[vertex_swarm_net_pricing::PROTOCOL_NAME]
     }
 }
 
 /// Events from the bootnode behaviour.
+#[allow(clippy::large_enum_variant)]
 pub enum BootnodeEvent {
     Identify(Box<identify::Event>),
     Topology(()),
+    Client(ClientEvent),
 }
 
 impl From<identify::Event> for BootnodeEvent {
@@ -64,6 +88,12 @@ impl From<identify::Event> for BootnodeEvent {
 impl From<()> for BootnodeEvent {
     fn from(_: ()) -> Self {
         BootnodeEvent::Topology(())
+    }
+}
+
+impl From<ClientEvent> for BootnodeEvent {
+    fn from(event: ClientEvent) -> Self {
+        BootnodeEvent::Client(event)
     }
 }
 
@@ -160,6 +190,10 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
                 self.handle_identify_event(*boxed_event);
             }
             BootnodeEvent::Topology(_) => {}
+            BootnodeEvent::Client(event) => {
+                // Bootnodes only accept pricing-receive; observability only.
+                tracing::debug!(?event, "bootnode client event");
+            }
         }
     }
 
@@ -326,6 +360,17 @@ mod tests {
         fn routing(&self) -> &Self::Routing {
             &self.routing
         }
+    }
+
+    /// The bootnode advertises the pricing protocol so peers that disconnect
+    /// on a failed pricing handshake stay connected.
+    #[test]
+    fn bootnode_advertises_pricing_in_supported_protocols() {
+        let protocols = BootnodeBehaviour::<Arc<Identity>>::supported_protocols();
+        assert!(
+            protocols.contains(&vertex_swarm_net_pricing::PROTOCOL_NAME),
+            "bootnode must advertise pricing protocol; got {protocols:?}"
+        );
     }
 
     /// An ephemeral bootnode must be rejected at build time. The well-known

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -46,6 +46,17 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    /// Build a config for the given local node role. The handler's inbound
+    /// protocol set is narrowed by role: bootnodes advertise pricing only,
+    /// clients and storers advertise the full client protocol set.
+    pub(crate) fn for_role(local_role: vertex_swarm_primitives::SwarmNodeType) -> Self {
+        let mut cfg = Self::default();
+        cfg.handler.local_role = local_role;
+        cfg
+    }
+}
+
 /// The ClientBehaviour manages client-side protocols.
 ///
 /// It creates handlers in dormant state for each connection, and activates

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -63,6 +63,11 @@ pub(crate) struct Config {
     pub(crate) max_pending_commands: usize,
     /// Maximum pending events before dropping new ones.
     pub(crate) max_pending_events: usize,
+    /// Local node's role. Controls which protocols are advertised on
+    /// inbound substream upgrades and which outbound commands are honoured.
+    /// Bootnodes only speak pricing (listen-only) so the rest of the
+    /// client surface is inert.
+    pub(crate) local_role: SwarmNodeType,
 }
 
 impl Default for Config {
@@ -71,6 +76,7 @@ impl Default for Config {
             timeout: Duration::from_secs(30),
             max_pending_commands: DEFAULT_MAX_PENDING_COMMANDS,
             max_pending_events: DEFAULT_MAX_PENDING_EVENTS,
+            local_role: SwarmNodeType::Client,
         }
     }
 }
@@ -510,7 +516,7 @@ impl ConnectionHandler for ClientHandler {
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         let upgrade = match &self.state {
-            State::Active { .. } => ClientInboundUpgrade::active(),
+            State::Active { .. } => ClientInboundUpgrade::active_for(self.config.local_role),
             State::Dormant => ClientInboundUpgrade::new(),
         };
         SubstreamProtocol::new(upgrade, ()).with_timeout(self.config.timeout)

--- a/crates/swarm/node/src/protocol/upgrade.rs
+++ b/crates/swarm/node/src/protocol/upgrade.rs
@@ -97,30 +97,52 @@ impl std::fmt::Debug for ClientInboundOutput {
 
 /// Combined inbound upgrade for client protocols.
 ///
-/// Advertises pricing, retrieval, and pushsync protocols and dispatches
-/// to the appropriate handler based on the negotiated protocol.
+/// Advertises pricing, retrieval, pushsync, and pseudosettle based on the
+/// handler's state and the local node's role; dispatches to the appropriate
+/// per-protocol upgrade after libp2p negotiates a protocol id.
 ///
-/// # Dormant State
+/// # State
 ///
-/// When `is_active` is false, no protocols are advertised. This prevents
-/// remote peers from initiating client protocols before the handshake is
-/// complete. Once the handler is activated (after handshake), protocols
-/// are advertised on subsequent inbound substream requests.
+/// - [`Self::new`] (dormant): no protocols advertised. Used before the
+///   topology handshake completes; prevents a remote peer from initiating
+///   any client protocol before we have verified them.
+/// - [`Self::active_for`] (active): advertises a protocol set picked by the
+///   local node's [`SwarmNodeType`]. Bootnodes advertise pricing only
+///   (listen-only); clients and storers advertise the full set.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ClientInboundUpgrade {
-    /// Whether the handler is active (post-handshake).
-    is_active: bool,
+    advertised: ProtocolSet,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ProtocolSet {
+    /// Dormant: no protocols advertised.
+    #[default]
+    None,
+    /// Bootnode-active: pricing only.
+    PricingOnly,
+    /// Client/storer-active: pricing + retrieval + pushsync + pseudosettle.
+    Full,
 }
 
 impl ClientInboundUpgrade {
-    /// Create a new client inbound upgrade in dormant state (no protocols advertised).
+    /// Create a new client inbound upgrade in dormant state.
     pub(crate) fn new() -> Self {
-        Self { is_active: false }
+        Self {
+            advertised: ProtocolSet::None,
+        }
     }
 
-    /// Create a new client inbound upgrade in active state (all protocols advertised).
-    pub(crate) fn active() -> Self {
-        Self { is_active: true }
+    /// Create a new client inbound upgrade in active state for `local_role`.
+    /// Bootnodes only advertise pricing; clients and storers advertise the
+    /// full client protocol set.
+    pub(crate) fn active_for(local_role: vertex_swarm_primitives::SwarmNodeType) -> Self {
+        let advertised = match local_role {
+            vertex_swarm_primitives::SwarmNodeType::Bootnode => ProtocolSet::PricingOnly,
+            vertex_swarm_primitives::SwarmNodeType::Client
+            | vertex_swarm_primitives::SwarmNodeType::Storer => ProtocolSet::Full,
+        };
+        Self { advertised }
     }
 }
 
@@ -129,18 +151,16 @@ impl UpgradeInfo for ClientInboundUpgrade {
     type InfoIter = std::vec::IntoIter<Self::Info>;
 
     fn protocol_info(&self) -> Self::InfoIter {
-        if self.is_active {
-            vec![
+        match self.advertised {
+            ProtocolSet::None => Vec::new().into_iter(),
+            ProtocolSet::PricingOnly => vec![PRICING_PROTOCOL].into_iter(),
+            ProtocolSet::Full => vec![
                 PRICING_PROTOCOL,
                 RETRIEVAL_PROTOCOL,
                 PUSHSYNC_PROTOCOL,
                 PSEUDOSETTLE_PROTOCOL,
             ]
-            .into_iter()
-        } else {
-            // In dormant state, don't advertise any client protocols.
-            // This prevents remote peers from initiating protocols before handshake.
-            vec![].into_iter()
+            .into_iter(),
         }
     }
 }
@@ -333,4 +353,54 @@ pub(crate) enum ClientOutboundInfo {
     Pushsync { address: ChunkAddress },
     /// Pseudosettle payment with amount.
     Pseudosettle { amount: U256 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vertex_swarm_primitives::SwarmNodeType;
+
+    #[test]
+    fn dormant_advertises_nothing() {
+        let upgrade = ClientInboundUpgrade::new();
+        let protocols: Vec<_> = upgrade.protocol_info().collect();
+        assert!(protocols.is_empty(), "dormant must advertise no protocols");
+    }
+
+    #[test]
+    fn bootnode_role_advertises_pricing_only() {
+        let upgrade = ClientInboundUpgrade::active_for(SwarmNodeType::Bootnode);
+        let protocols: Vec<_> = upgrade.protocol_info().collect();
+        assert_eq!(protocols, vec![PRICING_PROTOCOL]);
+    }
+
+    #[test]
+    fn client_role_advertises_full_set() {
+        let upgrade = ClientInboundUpgrade::active_for(SwarmNodeType::Client);
+        let protocols: Vec<_> = upgrade.protocol_info().collect();
+        assert_eq!(
+            protocols,
+            vec![
+                PRICING_PROTOCOL,
+                RETRIEVAL_PROTOCOL,
+                PUSHSYNC_PROTOCOL,
+                PSEUDOSETTLE_PROTOCOL,
+            ]
+        );
+    }
+
+    #[test]
+    fn storer_role_advertises_full_set() {
+        let upgrade = ClientInboundUpgrade::active_for(SwarmNodeType::Storer);
+        let protocols: Vec<_> = upgrade.protocol_info().collect();
+        assert_eq!(
+            protocols,
+            vec![
+                PRICING_PROTOCOL,
+                RETRIEVAL_PROTOCOL,
+                PUSHSYNC_PROTOCOL,
+                PSEUDOSETTLE_PROTOCOL,
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

\`BootnodeBehaviour\` now composes \`identify + topology + client\` where \`client\` is the same \`ClientBehaviour\` already used by \`ClientNode\`, configured with \`SwarmNodeType::Bootnode\`. The handler's inbound upgrade narrows the advertised client protocol set by local role:

- Bootnode: pricing only (listen-only).
- Client and Storer: pricing + retrieval + pushsync + pseudosettle (existing behaviour).

The single source of truth for "which client protocols does this node speak" lives in \`ClientInboundUpgrade::active_for(local_role)\` in \`crates/swarm/node/src/protocol/upgrade.rs\`. A bootnode never issues client commands (\`AnnouncePricing\`, \`RetrieveChunk\`, etc.) from its own poll loop, so only the inbound pricing path is ever exercised; the match arm on \`BootnodeEvent::Client\` is purely observability.

Supersedes the closed PR #108, which mistakenly added a separate \`PricingBehaviour\` to bootnode at the node level rather than going through the existing client behaviour.

Closes #138.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --lib --all-features -- -D warnings\`
- [x] \`cargo clippy --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::indexing_slicing\`
- [x] \`cargo test --workspace --all-features --no-fail-fast\` (640 passed; +5 vs main: 4 new role-set tests in \`protocol/upgrade.rs\` + 1 \`bootnode_advertises_pricing_in_supported_protocols\`)
- [x] Cluster harness (\`tests/bootnode_cluster.rs\`) still converges.