### PR TITLE
feat(net-handshake): admission control trait + kademlia gate

### DIFF
--- a/crates/swarm/net/handshake/src/admission.rs
+++ b/crates/swarm/net/handshake/src/admission.rs
@@ -1,0 +1,141 @@
+//! Handshake admission control.
+//!
+//! Routing (or any other gate) can veto a handshake after the peer's
+//! identity is verified but before the local side commits to the final
+//! message of the exchange. The handshake crate stays free of any
+//! routing or topology dependency: it defines the trait, accepts a
+//! dyn-erased implementation through
+//! [`HandshakeBehaviour::with_admission_control`](crate::HandshakeBehaviour::with_admission_control),
+//! and consults it from inside the protocol.
+//!
+//! # Asymmetry
+//!
+//! The 3-message SYN, SYNACK, ACK exchange exposes the peer's identity
+//! to each side at a different step:
+//!
+//! * the outbound side learns the remote identity from SYNACK, so it
+//!   evaluates admission before sending ACK; rejection aborts cleanly
+//!   without committing to the exchange,
+//! * the inbound side learns the remote identity only from ACK, so it
+//!   can only evaluate after the outbound side has already sent ACK
+//!   and closed its half of the stream.
+//!
+//! When the inbound side rejects, the outbound side observes a
+//! successful handshake immediately followed by a transport-level
+//! disconnect. Only the locally-rejecting side surfaces
+//! [`HandshakeError::AdmissionRejected`](crate::HandshakeError::AdmissionRejected);
+//! the other side surfaces whatever close or timeout error its
+//! framing layer produces. Topology should treat post-handshake
+//! disconnects from the remote as a normal disconnect and apply the
+//! usual backoff.
+
+use std::sync::Arc;
+
+use vertex_swarm_peer::{SwarmAddress, SwarmNodeType};
+
+pub use vertex_net_peer_registry::ConnectionDirection;
+
+/// Reason a peer was rejected from completing the handshake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum AdmissionRejection {
+    /// Routing capacity is full for this peer's proximity bin.
+    Saturated,
+    /// Peer is on the blocklist.
+    Blocklisted,
+    /// Neighborhood is oversaturated and this peer falls outside the
+    /// configured headroom.
+    OversaturatedNeighborhood,
+}
+
+/// Result of evaluating a peer for handshake admission.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum AdmissionDecision {
+    /// Allow the handshake to complete.
+    Accept,
+    /// Reject the handshake. The protocol aborts before committing to
+    /// the final message and the handler surfaces
+    /// [`HandshakeError::AdmissionRejected`](crate::HandshakeError::AdmissionRejected)
+    /// with this reason.
+    Reject(AdmissionRejection),
+}
+
+/// Admission control gate consulted before the local side commits to
+/// the final handshake message.
+///
+/// Implementations must be cheap to call: `evaluate` runs on the hot
+/// path of every handshake. Trait is dyn-compatible so it can live
+/// behind [`SharedAdmissionControl`].
+pub trait HandshakeAdmissionControl: Send + Sync + 'static {
+    /// Evaluate a peer that just identified itself during the handshake.
+    fn evaluate(
+        &self,
+        peer_overlay: &SwarmAddress,
+        node_type: SwarmNodeType,
+        direction: ConnectionDirection,
+    ) -> AdmissionDecision;
+}
+
+/// Always-accept admission control. Default when no gate is wired in.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AlwaysAccept;
+
+impl HandshakeAdmissionControl for AlwaysAccept {
+    fn evaluate(
+        &self,
+        _peer_overlay: &SwarmAddress,
+        _node_type: SwarmNodeType,
+        _direction: ConnectionDirection,
+    ) -> AdmissionDecision {
+        AdmissionDecision::Accept
+    }
+}
+
+impl<T: HandshakeAdmissionControl + ?Sized> HandshakeAdmissionControl for Arc<T> {
+    fn evaluate(
+        &self,
+        peer_overlay: &SwarmAddress,
+        node_type: SwarmNodeType,
+        direction: ConnectionDirection,
+    ) -> AdmissionDecision {
+        (**self).evaluate(peer_overlay, node_type, direction)
+    }
+}
+
+/// Type-erased shared handle to an admission controller.
+pub type SharedAdmissionControl = Arc<dyn HandshakeAdmissionControl>;
+
+/// Default admission control: accept everyone. Returned as the
+/// type-erased handle the behaviour stores.
+pub fn default_admission_control() -> SharedAdmissionControl {
+    Arc::new(AlwaysAccept)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_accept_returns_accept() {
+        let ac = AlwaysAccept;
+        let decision = ac.evaluate(
+            &SwarmAddress::with_first_byte(0xaa),
+            SwarmNodeType::Storer,
+            ConnectionDirection::Inbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn arc_delegates() {
+        let ac: SharedAdmissionControl = default_admission_control();
+        let decision = ac.evaluate(
+            &SwarmAddress::with_first_byte(0x01),
+            SwarmNodeType::Client,
+            ConnectionDirection::Outbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+}

--- a/crates/swarm/net/handshake/src/behaviour.rs
+++ b/crates/swarm/net/handshake/src/behaviour.rs
@@ -19,7 +19,8 @@ use vertex_swarm_api::SwarmIdentity;
 use vertex_net_peer_registry::ConnectionDirection;
 
 use crate::{
-    AddressProvider, HandshakeError, HandshakeInfo,
+    AddressProvider, HandshakeError, HandshakeInfo, SharedAdmissionControl,
+    admission::default_admission_control,
     handler::{HandshakeCommand, HandshakeConfig, HandshakeHandler, HandshakeHandlerEvent},
 };
 
@@ -47,6 +48,9 @@ pub struct HandshakeBehaviour<I, A> {
     config: Arc<HandshakeConfig>,
     identity: Arc<I>,
     address_provider: Arc<A>,
+    /// Admission gate consulted before each side commits to its final
+    /// message; defaults to [`AlwaysAccept`](crate::AlwaysAccept).
+    admission_control: SharedAdmissionControl,
     events: VecDeque<ToSwarm<HandshakeEvent, HandshakeCommand>>,
     /// Track direction per connection for event attribution.
     connection_directions: std::collections::HashMap<ConnectionId, ConnectionDirection>,
@@ -63,6 +67,7 @@ where
             config: Arc::new(HandshakeConfig::new(purpose)),
             identity,
             address_provider,
+            admission_control: default_admission_control(),
             events: VecDeque::new(),
             connection_directions: std::collections::HashMap::new(),
         }
@@ -71,6 +76,19 @@ where
     /// Create with custom config.
     pub fn with_config(mut self, config: HandshakeConfig) -> Self {
         self.config = Arc::new(config);
+        self
+    }
+
+    /// Install an admission control gate, replacing any previously
+    /// installed gate (the default is [`AlwaysAccept`](crate::AlwaysAccept)).
+    ///
+    /// Consulted once per handshake just before the local side commits
+    /// to its final message. On
+    /// [`AdmissionDecision::Reject`](crate::AdmissionDecision::Reject)
+    /// the handshake terminates with
+    /// [`HandshakeError::AdmissionRejected`](crate::HandshakeError::AdmissionRejected).
+    pub fn with_admission_control(mut self, admission_control: SharedAdmissionControl) -> Self {
+        self.admission_control = admission_control;
         self
     }
 
@@ -108,6 +126,7 @@ where
             peer,
             remote_addr.clone(),
             self.address_provider.clone(),
+            self.admission_control.clone(),
         ))
     }
 
@@ -128,6 +147,7 @@ where
             peer,
             addr.clone(),
             self.address_provider.clone(),
+            self.admission_control.clone(),
         ))
     }
 

--- a/crates/swarm/net/handshake/src/error.rs
+++ b/crates/swarm/net/handshake/src/error.rs
@@ -5,6 +5,8 @@ use std::convert::Infallible;
 use strum::IntoStaticStr;
 use vertex_swarm_peer::error::{MultiAddrError, SwarmPeerError};
 
+use crate::admission::AdmissionRejection;
+
 /// Handshake protocol errors.
 #[derive(Debug, thiserror::Error, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -70,6 +72,14 @@ pub enum HandshakeError {
     /// Stream upgrade failed at libp2p layer.
     #[error("upgrade error: {0}")]
     UpgradeError(String),
+
+    /// Admission control rejected the peer.
+    ///
+    /// Surfaces the structured reason from
+    /// [`HandshakeAdmissionControl`](crate::HandshakeAdmissionControl) so
+    /// the handler can report it without string-matching.
+    #[error("admission rejected: {0}")]
+    AdmissionRejected(AdmissionRejection),
 }
 
 impl From<Infallible> for HandshakeError {

--- a/crates/swarm/net/handshake/src/handler.rs
+++ b/crates/swarm/net/handshake/src/handler.rs
@@ -22,8 +22,8 @@ use tracing::{debug, warn};
 use vertex_swarm_api::SwarmIdentity;
 
 use crate::{
-    AddressProvider, HANDSHAKE_TIMEOUT, HandshakeError, HandshakeInfo, PROTOCOL,
-    protocol::HandshakeProtocol,
+    AddressProvider, ConnectionDirection, HANDSHAKE_TIMEOUT, HandshakeError, HandshakeInfo,
+    PROTOCOL, SharedAdmissionControl, protocol::HandshakeProtocol,
 };
 
 /// Configuration for handshake handler.
@@ -89,6 +89,8 @@ pub struct HandshakeHandler<I, A> {
     peer_id: PeerId,
     remote_addr: Multiaddr,
     address_provider: Arc<A>,
+    /// Admission gate forwarded into [`HandshakeProtocol`].
+    admission_control: SharedAdmissionControl,
     state: State,
     pending_event: Option<HandshakeHandlerEvent>,
     should_initiate: bool,
@@ -107,6 +109,7 @@ where
         peer_id: PeerId,
         remote_addr: Multiaddr,
         address_provider: Arc<A>,
+        admission_control: SharedAdmissionControl,
     ) -> Self {
         Self {
             config,
@@ -114,6 +117,7 @@ where
             peer_id,
             remote_addr,
             address_provider,
+            admission_control,
             state: State::Pending,
             pending_event: None,
             should_initiate: false,
@@ -128,6 +132,7 @@ where
         peer_id: PeerId,
         remote_addr: Multiaddr,
         address_provider: Arc<A>,
+        admission_control: SharedAdmissionControl,
     ) -> Self {
         Self {
             config,
@@ -135,6 +140,7 @@ where
             peer_id,
             remote_addr,
             address_provider,
+            admission_control,
             state: State::Pending,
             pending_event: None,
             should_initiate: true,
@@ -142,12 +148,14 @@ where
         }
     }
 
-    fn make_upgrade(&self) -> HandshakeUpgrade<I, A> {
+    fn make_upgrade(&self, direction: ConnectionDirection) -> HandshakeUpgrade<I, A> {
         HandshakeUpgrade {
             identity: self.identity.clone(),
             peer_id: self.peer_id,
             remote_addr: self.remote_addr.clone(),
             address_provider: self.address_provider.clone(),
+            admission_control: self.admission_control.clone(),
+            direction,
             purpose: self.config.purpose,
         }
     }
@@ -166,7 +174,8 @@ where
     type OutboundOpenInfo = ();
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
-        SubstreamProtocol::new(self.make_upgrade(), ()).with_timeout(self.config.timeout)
+        SubstreamProtocol::new(self.make_upgrade(ConnectionDirection::Inbound), ())
+            .with_timeout(self.config.timeout)
     }
 
     fn connection_keep_alive(&self) -> bool {
@@ -189,8 +198,11 @@ where
             self.state = State::InProgress;
             debug!(peer_id = %self.peer_id, "Initiating outbound handshake");
             return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
-                protocol: SubstreamProtocol::new(self.make_upgrade(), ())
-                    .with_timeout(self.config.timeout),
+                protocol: SubstreamProtocol::new(
+                    self.make_upgrade(ConnectionDirection::Outbound),
+                    (),
+                )
+                .with_timeout(self.config.timeout),
             });
         }
 
@@ -280,6 +292,12 @@ pub struct HandshakeUpgrade<I, A> {
     peer_id: PeerId,
     remote_addr: Multiaddr,
     address_provider: Arc<A>,
+    /// Forwarded into [`HandshakeProtocol`] so admission control can run
+    /// before the local side commits to the final exchange message.
+    admission_control: SharedAdmissionControl,
+    /// Direction this upgrade was created for; drives which arm of the
+    /// protocol runs and which side the admission gate sees.
+    direction: ConnectionDirection,
     purpose: &'static str,
 }
 
@@ -290,6 +308,8 @@ impl<I, A> Clone for HandshakeUpgrade<I, A> {
             peer_id: self.peer_id,
             remote_addr: self.remote_addr.clone(),
             address_provider: self.address_provider.clone(),
+            admission_control: self.admission_control.clone(),
+            direction: self.direction,
             purpose: self.purpose,
         }
     }
@@ -323,7 +343,8 @@ where
             self.remote_addr,
             additional_addrs,
             self.purpose,
-        );
+        )
+        .with_admission_control(self.admission_control, self.direction);
         if let Some(local_peer_id) = local_peer_id {
             protocol = protocol.with_local_peer_id(local_peer_id);
         }

--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -23,6 +23,12 @@ pub use metrics::HandshakeStage;
 mod address;
 pub use address::{AddressProvider, NoAddresses};
 
+mod admission;
+pub use admission::{
+    AdmissionDecision, AdmissionRejection, AlwaysAccept, ConnectionDirection,
+    HandshakeAdmissionControl, SharedAdmissionControl, default_admission_control,
+};
+
 /// Protocol name for handshake.
 pub const PROTOCOL: &str = "/swarm/handshake/15.0.0/handshake";
 

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -7,9 +7,10 @@ use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_peer::{SwarmPeer, Timestamp};
 use vertex_swarm_spec::SwarmSpec;
 
+use crate::admission::{AdmissionDecision, ConnectionDirection};
 use crate::codec::{decode_ack, decode_syn, decode_synack, encode_ack, encode_syn, encode_synack};
 use crate::metrics::HandshakeMetrics;
-use crate::{HandshakeError, HandshakeInfo};
+use crate::{HandshakeError, HandshakeInfo, SharedAdmissionControl};
 
 /// Maximum size for handshake message buffers.
 const MAX_HANDSHAKE_BUFFER_SIZE: usize = 1024;
@@ -67,14 +68,19 @@ fn prepare_local_peer<I: SwarmIdentity>(
 
 /// Handshake protocol for Swarm peer authentication.
 ///
-/// Implements the SYN-SYNACK-ACK exchange for mutual peer identity verification.
-/// Used internally by `HandshakeUpgrade` — not a libp2p upgrade on its own.
+/// Implements the SYN, SYNACK, ACK exchange for mutual peer identity
+/// verification. Used internally by `HandshakeUpgrade`; not a libp2p
+/// upgrade on its own.
 pub(crate) struct HandshakeProtocol<I: SwarmIdentity> {
     identity: I,
     peer_id: PeerId,
     local_peer_id: Option<PeerId>,
     remote_addr: Multiaddr,
     additional_addrs: Vec<Multiaddr>,
+    /// Optional admission gate. When set, the protocol consults it as
+    /// soon as the remote peer's identity is verified and aborts with
+    /// [`HandshakeError::AdmissionRejected`] on a `Reject` decision.
+    admission_control: Option<(SharedAdmissionControl, ConnectionDirection)>,
     purpose: &'static str,
 }
 
@@ -92,6 +98,7 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             local_peer_id: None,
             remote_addr,
             additional_addrs,
+            admission_control: None,
             purpose,
         }
     }
@@ -100,6 +107,31 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
     pub(crate) fn with_local_peer_id(mut self, local_peer_id: PeerId) -> Self {
         self.local_peer_id = Some(local_peer_id);
         self
+    }
+
+    /// Install the admission gate for this exchange.
+    ///
+    /// `direction` is which side this end of the connection plays
+    /// (`Inbound` received SYN, `Outbound` sent SYN). Routing uses it to
+    /// decide whether the in-flight peer is already counted in capacity.
+    pub(crate) fn with_admission_control(
+        mut self,
+        admission_control: SharedAdmissionControl,
+        direction: ConnectionDirection,
+    ) -> Self {
+        self.admission_control = Some((admission_control, direction));
+        self
+    }
+
+    /// Evaluate admission control if installed.
+    fn evaluate_admission(&self, info: &HandshakeInfo) -> Result<(), HandshakeError> {
+        let Some((ref ac, direction)) = self.admission_control else {
+            return Ok(());
+        };
+        match ac.evaluate(info.swarm_peer.overlay(), info.node_type, direction) {
+            AdmissionDecision::Accept => Ok(()),
+            AdmissionDecision::Reject(reason) => Err(HandshakeError::AdmissionRejected(reason)),
+        }
     }
 
     #[instrument(
@@ -183,15 +215,26 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             .await?;
         let (swarm_peer, node_type, welcome_message) = decode_ack(ack, network_id)?;
 
-        futures::AsyncWriteExt::close(&mut stream).await?;
-
-        Ok(HandshakeInfo {
+        let info = HandshakeInfo {
             peer_id: self.peer_id,
             swarm_peer,
             node_type,
             welcome_message,
             observed_multiaddr,
-        })
+        };
+
+        // Consult admission control now that the peer's identity is
+        // verified. Note the protocol asymmetry: the outbound side has
+        // already sent its ACK and closed its half of the stream by the
+        // time we reach this point, so a reject here surfaces as
+        // `AdmissionRejected` locally and a transport-level disconnect
+        // on the remote (see the module docs on
+        // [`crate::admission`]).
+        self.evaluate_admission(&info)?;
+
+        futures::AsyncWriteExt::close(&mut stream).await?;
+
+        Ok(info)
     }
 
     #[instrument(
@@ -260,6 +303,17 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
         let local_peer =
             prepare_local_peer(&self.identity, &self.additional_addrs, &observed_multiaddr)?;
 
+        // Consult admission control before sending ACK so a reject
+        // aborts cleanly without committing to the exchange.
+        let info = HandshakeInfo {
+            peer_id: self.peer_id,
+            swarm_peer,
+            node_type,
+            welcome_message,
+            observed_multiaddr,
+        };
+        self.evaluate_admission(&info)?;
+
         // Send ACK: our identity.
         let ack = encode_ack(
             &local_peer,
@@ -273,12 +327,6 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
 
         futures::AsyncWriteExt::close(&mut stream).await?;
 
-        Ok(HandshakeInfo {
-            peer_id: self.peer_id,
-            swarm_peer,
-            node_type,
-            welcome_message,
-            observed_multiaddr,
-        })
+        Ok(info)
     }
 }

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -48,7 +48,10 @@ use crate::events::TopologyEvent;
 use crate::extract_peer_id;
 use crate::gossip::{GossipHandle, spawn_gossip_task};
 use crate::handle::TopologyHandle;
-use crate::kademlia::{KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting};
+use crate::kademlia::{
+    KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting,
+    kademlia_admission_control,
+};
 use crate::metrics::{TopologyMetrics, po_label};
 use crate::nat_discovery::LocalAddressManager;
 
@@ -305,8 +308,14 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
         let identity = Arc::new(identity);
 
+        // Wire kademlia routing as the handshake admission gate so the
+        // routing layer can veto a peer before the local side commits
+        // to its final exchange message.
+        let admission_control = kademlia_admission_control(routing.clone());
+
         // Create composed protocol behaviours
-        let protocols = ProtocolBehaviours::new(identity.clone(), nat_discovery.clone());
+        let protocols =
+            ProtocolBehaviours::new(identity.clone(), nat_discovery.clone(), admission_control);
 
         let metrics = Arc::new(TopologyMetrics::new());
 

--- a/crates/swarm/topology/src/composed.rs
+++ b/crates/swarm/topology/src/composed.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use libp2p::swarm::NetworkBehaviour;
 use vertex_swarm_api::SwarmIdentity;
-use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent};
+use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent, SharedAdmissionControl};
 use vertex_swarm_net_hive::{
     DiscardSilently, HiveBehaviour, HiveEvent, HivePeerHandler, LearnAndDial,
 };
@@ -108,14 +108,24 @@ where
     /// The hive [`HivePeerHandler`] is picked from the local node type:
     /// bootnodes drop inbound peer gossip without ingesting it, every other
     /// role learns and may dial. Outbound broadcasting runs in either case.
-    pub(crate) fn new(identity: Arc<I>, address_provider: Arc<LocalAddressManager>) -> Self {
+    ///
+    /// `admission_control` is installed on the handshake behaviour so
+    /// the routing layer can veto a peer before the local side commits
+    /// to the final exchange message (see
+    /// [`HandshakeBehaviour::with_admission_control`]).
+    pub(crate) fn new(
+        identity: Arc<I>,
+        address_provider: Arc<LocalAddressManager>,
+        admission_control: SharedAdmissionControl,
+    ) -> Self {
         let peer_handler: Arc<dyn HivePeerHandler> = match identity.node_type() {
             SwarmNodeType::Bootnode => Arc::new(DiscardSilently),
             SwarmNodeType::Client | SwarmNodeType::Storer => Arc::new(LearnAndDial),
         };
 
         Self {
-            handshake: HandshakeBehaviour::new(identity.clone(), address_provider, "topology"),
+            handshake: HandshakeBehaviour::new(identity.clone(), address_provider, "topology")
+                .with_admission_control(admission_control),
             hive: HiveBehaviour::with_peer_handler(identity, peer_handler),
             pingpong: PingpongBehaviour::new(),
         }

--- a/crates/swarm/topology/src/kademlia/admission.rs
+++ b/crates/swarm/topology/src/kademlia/admission.rs
@@ -1,0 +1,226 @@
+//! Kademlia-backed [`HandshakeAdmissionControl`].
+//!
+//! Delegates to [`KademliaRouting::admission_within_capacity`] with a
+//! direction-aware `extra` count so the in-flight peer is modelled
+//! correctly on both sides of the handshake. Plugs into the handshake
+//! behaviour through
+//! [`HandshakeBehaviour::with_admission_control`](vertex_swarm_net_handshake::HandshakeBehaviour::with_admission_control).
+
+use std::sync::Arc;
+
+use vertex_swarm_api::SwarmIdentity;
+use vertex_swarm_net_handshake::{
+    AdmissionDecision, AdmissionRejection, ConnectionDirection, HandshakeAdmissionControl,
+    SharedAdmissionControl,
+};
+use vertex_swarm_peer::{SwarmAddress, SwarmNodeType};
+
+use super::KademliaRouting;
+
+/// Admission gate backed by the kademlia routing table.
+///
+/// Holds an `Arc` to the routing so the handshake behaviour shares the
+/// same source of truth for capacity decisions as the dial planner.
+pub(crate) struct KademliaAdmissionControl<I: SwarmIdentity> {
+    routing: Arc<KademliaRouting<I>>,
+}
+
+impl<I: SwarmIdentity> KademliaAdmissionControl<I> {
+    pub(crate) fn new(routing: Arc<KademliaRouting<I>>) -> Self {
+        Self { routing }
+    }
+}
+
+impl<I: SwarmIdentity> HandshakeAdmissionControl for KademliaAdmissionControl<I> {
+    fn evaluate(
+        &self,
+        peer_overlay: &SwarmAddress,
+        _node_type: SwarmNodeType,
+        direction: ConnectionDirection,
+    ) -> AdmissionDecision {
+        // Inbound is not yet reserved at gate time; outbound was
+        // reserved at dial planning. See
+        // `KademliaRouting::admission_within_capacity` for the full
+        // accounting argument.
+        let extra = match direction {
+            ConnectionDirection::Inbound => 1,
+            ConnectionDirection::Outbound => 0,
+        };
+        if self.routing.admission_within_capacity(peer_overlay, extra) {
+            AdmissionDecision::Accept
+        } else {
+            AdmissionDecision::Reject(AdmissionRejection::Saturated)
+        }
+    }
+}
+
+/// Convenience constructor returning the type-erased handle expected by
+/// [`HandshakeBehaviour::with_admission_control`](vertex_swarm_net_handshake::HandshakeBehaviour::with_admission_control).
+pub(crate) fn kademlia_admission_control<I: SwarmIdentity>(
+    routing: Arc<KademliaRouting<I>>,
+) -> SharedAdmissionControl {
+    Arc::new(KademliaAdmissionControl::new(routing))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::kademlia::{KademliaConfig, RoutingCapacity};
+    use vertex_swarm_peer_manager::PeerManager;
+    use vertex_swarm_test_utils::MockIdentity;
+
+    fn make_routing(
+        base: SwarmAddress,
+        config: KademliaConfig,
+    ) -> Arc<KademliaRouting<MockIdentity>> {
+        let identity = MockIdentity::with_overlay(base);
+        let peer_manager = PeerManager::new(&identity);
+        KademliaRouting::new(identity, config, peer_manager)
+    }
+
+    #[test]
+    fn accepts_when_routing_has_capacity() {
+        let base = SwarmAddress::with_first_byte(0x00);
+        let routing = make_routing(base, KademliaConfig::default());
+        let ac = KademliaAdmissionControl::new(routing);
+
+        let decision = ac.evaluate(
+            &SwarmAddress::with_first_byte(0x80),
+            SwarmNodeType::Storer,
+            ConnectionDirection::Inbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn inbound_accepts_at_ceiling_minus_one() {
+        // Capacity 1 (nominal=1, headroom=0). With zero peers reserved
+        // the in-flight inbound peer fills the only slot exactly.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default()
+            .with_nominal(1)
+            .with_inbound_headroom(0);
+        let routing = make_routing(base, config);
+
+        let ac = KademliaAdmissionControl::new(routing);
+        let peer = SwarmAddress::with_first_byte(0x80);
+        let decision = ac.evaluate(&peer, SwarmNodeType::Storer, ConnectionDirection::Inbound);
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn inbound_rejects_when_bin_already_full() {
+        // Capacity 1 and one peer already reserved into po=0. The
+        // in-flight inbound peer (also po=0) would push the bin over
+        // ceiling.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default()
+            .with_nominal(1)
+            .with_inbound_headroom(0);
+        let routing = make_routing(base, config);
+
+        let occupied = SwarmAddress::with_first_byte(0xc0);
+        RoutingCapacity::reserve_inbound(&*routing, &occupied);
+
+        let ac = KademliaAdmissionControl::new(routing);
+        let peer = SwarmAddress::with_first_byte(0x80);
+        let decision = ac.evaluate(&peer, SwarmNodeType::Storer, ConnectionDirection::Inbound);
+        assert!(matches!(
+            decision,
+            AdmissionDecision::Reject(AdmissionRejection::Saturated)
+        ));
+    }
+
+    #[test]
+    fn outbound_accepts_at_ceiling_after_dial_reserve() {
+        // Capacity 1. The outbound peer reserved its slot via
+        // `try_reserve_dial`, so `effective_count` already includes it.
+        // Admission must accept because the slot it occupies is its own.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default()
+            .with_nominal(1)
+            .with_inbound_headroom(0);
+        let routing = make_routing(base, config);
+
+        let peer = SwarmAddress::with_first_byte(0x80);
+        assert!(RoutingCapacity::try_reserve_dial(
+            &*routing,
+            &peer,
+            SwarmNodeType::Storer,
+        ));
+
+        let ac = KademliaAdmissionControl::new(routing);
+        let decision = ac.evaluate(&peer, SwarmNodeType::Storer, ConnectionDirection::Outbound);
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn outbound_rejects_when_bin_oversaturated() {
+        // Two outbound dials reserved into the same bin while
+        // ceiling=1. The second peer should have been rejected by
+        // `try_reserve_dial` already, but if a stale caller passes it
+        // to the gate we still want a clean reject.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default()
+            .with_nominal(1)
+            .with_inbound_headroom(0);
+        let routing = make_routing(base, config);
+
+        let peer1 = SwarmAddress::with_first_byte(0x80);
+        let peer2 = SwarmAddress::with_first_byte(0xc0);
+        assert!(RoutingCapacity::try_reserve_dial(
+            &*routing,
+            &peer1,
+            SwarmNodeType::Storer,
+        ));
+        // Force-reserve peer2 even though try_reserve_dial would refuse,
+        // to reach the oversaturated state.
+        RoutingCapacity::reserve_inbound(&*routing, &peer2);
+
+        let ac = KademliaAdmissionControl::new(routing);
+        let decision = ac.evaluate(&peer1, SwarmNodeType::Storer, ConnectionDirection::Outbound);
+        assert!(matches!(
+            decision,
+            AdmissionDecision::Reject(AdmissionRejection::Saturated)
+        ));
+    }
+
+    #[test]
+    fn neighborhood_bin_always_accepts() {
+        // Bins inside the neighborhood (ceiling = usize::MAX) accept
+        // unconditionally; oversaturation there is a separate concern.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default().with_nominal(1);
+        let routing = make_routing(base, config);
+
+        for i in 0..3 {
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0x01 + i;
+            RoutingCapacity::reserve_inbound(&*routing, &SwarmAddress::from(bytes));
+        }
+
+        let ac = KademliaAdmissionControl::new(routing);
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x01;
+        let decision = ac.evaluate(
+            &SwarmAddress::from(bytes),
+            SwarmNodeType::Storer,
+            ConnectionDirection::Inbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+
+    #[test]
+    fn shared_handle_dispatches() {
+        let base = SwarmAddress::with_first_byte(0x00);
+        let routing = make_routing(base, KademliaConfig::default());
+        let handle = kademlia_admission_control(routing);
+        let decision = handle.evaluate(
+            &SwarmAddress::with_first_byte(0x42),
+            SwarmNodeType::Client,
+            ConnectionDirection::Outbound,
+        );
+        assert!(matches!(decision, AdmissionDecision::Accept));
+    }
+}

--- a/crates/swarm/topology/src/kademlia/mod.rs
+++ b/crates/swarm/topology/src/kademlia/mod.rs
@@ -1,5 +1,6 @@
 //! Kademlia-based peer routing for Swarm overlay network.
 
+mod admission;
 mod args;
 mod candidate_queues;
 mod candidates;
@@ -9,6 +10,7 @@ pub(crate) mod peer_selection;
 mod routing;
 mod task;
 
+pub(crate) use admission::kademlia_admission_control;
 pub use args::RoutingArgs;
 pub(crate) use candidates::{
     CandidateSelector, CandidateSnapshot, select_balanced_candidates,

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -111,6 +111,38 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         &self.config.limits
     }
 
+    /// Admission decision for a peer whose handshake is currently in
+    /// progress.
+    ///
+    /// `extra` is the number of slots the in-flight peer occupies in the
+    /// caller's accounting but is *not* yet counted in
+    /// [`Self::effective_count`]:
+    ///
+    /// * outbound: `0`. The dial planner reserved a `Dialing` slot via
+    ///   [`RoutingCapacity::try_reserve_dial`] (transitioned to
+    ///   `Handshaking` by [`RoutingCapacity::dial_connected`]) before
+    ///   the handshake started, so `effective_count` already includes
+    ///   the in-flight peer.
+    /// * inbound: `1`. No slot is reserved until topology processes the
+    ///   `HandshakeEvent::Completed`, which happens *after* the
+    ///   admission gate runs. The check must add one to model the slot
+    ///   that will be reserved on success.
+    ///
+    /// Returns `true` when the bin would still be within `ceiling`
+    /// (target plus headroom) after counting the in-flight peer. Bins
+    /// inside the neighborhood (where `ceiling == usize::MAX`) always
+    /// return `true`; eviction in oversaturated neighborhoods is a
+    /// separate concern handled by a future `AcceptEvict` decision.
+    pub(crate) fn admission_within_capacity(&self, overlay: &OverlayAddress, extra: usize) -> bool {
+        let po = self.proximity(overlay);
+        let depth = self.depth();
+        let ceiling = self.config.limits.ceiling(po, depth);
+        if ceiling == usize::MAX {
+            return true;
+        }
+        self.effective_count(po).saturating_add(extra) <= ceiling
+    }
+
     fn effective_count(&self, po: u8) -> usize {
         atomic_load(&self.dialing_counts, po)
             + atomic_load(&self.handshaking_counts, po)


### PR DESCRIPTION
Introduce a `HandshakeAdmissionControl` trait so routing (or any other gate) can veto a peer after its identity is verified but before the local side commits to the final exchange message. Wire kademlia routing as the default gate in topology.

## What it adds

* `HandshakeAdmissionControl` trait + `AdmissionDecision { Accept, Reject(AdmissionRejection) }` (both `#[non_exhaustive]` so future variants land additively).
* `AdmissionRejection { Saturated, Blocklisted, OversaturatedNeighborhood }` carries a structured reason through a new `HandshakeError::AdmissionRejected(reason)`. No string-matching needed downstream.
* `KademliaAdmissionControl` plugs the routing layer into `HandshakeBehaviour::with_admission_control(...)`. Delegates to a new `KademliaRouting::admission_within_capacity(overlay, extra)` that takes a direction-aware `extra` count.
* `AlwaysAccept` default keeps the surface non-breaking for callers that don't wire a gate.

## Direction-aware accounting (off-by-one fix vs original PR #110)

The inbound peer is *not* reserved into `effective_count` at gate time. Topology only calls `reserve_inbound` after it processes `HandshakeEvent::Completed`. Without `extra = 1` on inbound, the gate at ceiling would accept, the post-completion `should_accept_inbound` check would then silently drop the connection, and the remote would never see `AdmissionRejected`.

Outbound passes `extra = 0` because `try_reserve_dial` already reserved its slot at dial planning. `KademliaAdmissionControl::evaluate` does the dispatch.

## Protocol asymmetry

The 3-message SYN, SYNACK, ACK exchange exposes the peer identity to each side at different steps. Outbound learns from SYNACK and gates cleanly before sending ACK. Inbound learns from ACK and necessarily gates after the outbound side has finished `send_ack + close`. When inbound rejects, the rejecting side surfaces `AdmissionRejected`; the remote sees a transport-level disconnect, which topology already handles as a normal close. This is inherent to the protocol shape unless we add a fourth message; it is documented in the module docs on `admission`.

## Test plan

- [x] `cargo test -p vertex-swarm-net-handshake -p vertex-swarm-topology` — 13 + 122 passing locally.
- [x] `cargo test --workspace --no-fail-fast` — 649 passed, 0 failed across 104 suites.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p vertex-swarm-net-handshake -p vertex-swarm-topology --all-features --all-targets -- -D warnings` clean.
- [ ] CI passes (fmt, clippy, test, doc, audit, cargo-deny).

## Supersedes

Closes #110. The original PR shipped an off-by-one (inbound accounting), a test that pre-reserved the in-flight peer (modelling a state production never reaches), and an `AcceptEvict { evict: PeerId, .. }` variant whose `evict` field was silently dropped because the protocol gate collapsed `Accept | AcceptEvict { .. } => Ok(())`. This PR fixes the accounting, fixes the test, and drops `AcceptEvict` so the trait surface does not fail silently. `#[non_exhaustive]` means a future PR can add it once the eviction path is wired end-to-end.