### PR TITLE
fix(topology): correct neighborhood depth and converge aggressively

### DIFF
--- a/crates/swarm/api/src/spec.rs
+++ b/crates/swarm/api/src/spec.rs
@@ -7,6 +7,21 @@ use nectar_primitives::{ChunkTypeSet, NetworkId};
 use nectar_swarms::{NamedSwarm, Swarm};
 use vertex_swarm_forks::{ForkCondition, ForkDigest, SwarmHardfork, SwarmHardforks};
 
+/// Default per-bin saturation target driving the neighborhood-depth frontier.
+///
+/// A bin with fewer than this many connected peers marks the shallowest
+/// unsaturated frontier in [`recompute_neighborhood_depth`]. Matches the live
+/// reference network so depth tracks node-for-node.
+///
+/// [`recompute_neighborhood_depth`]: nectar_primitives::recompute_neighborhood_depth
+pub const DEFAULT_SATURATION_PEERS: u8 = 8;
+
+/// Default cumulative count of peers in the deepest bins anchoring the
+/// neighborhood in [`recompute_neighborhood_depth`].
+///
+/// [`recompute_neighborhood_depth`]: nectar_primitives::recompute_neighborhood_depth
+pub const DEFAULT_NEIGHBORHOOD_LOW_WATERMARK: u8 = 3;
+
 /// Parser for Swarm network specifications.
 ///
 /// Handles both preset names ("mainnet", "testnet") and file paths via a single
@@ -143,6 +158,24 @@ pub trait SwarmSpec: Send + Sync + 'static {
     /// Returns the maximum proximity order for addresses in this network.
     fn max_po(&self) -> u8 {
         nectar_primitives::MAX_PO
+    }
+
+    /// Per-bin saturation target driving the neighborhood-depth frontier.
+    ///
+    /// Passed as the `saturation` argument to
+    /// [`nectar_primitives::recompute_neighborhood_depth`]: the shallowest bin
+    /// holding fewer than this many connected peers caps the depth.
+    fn saturation_peers(&self) -> u8 {
+        DEFAULT_SATURATION_PEERS
+    }
+
+    /// Minimum cumulative count of peers in the deepest bins that anchors the
+    /// neighborhood.
+    ///
+    /// Passed as the `low_watermark` argument to
+    /// [`nectar_primitives::recompute_neighborhood_depth`].
+    fn neighborhood_low_watermark(&self) -> u8 {
+        DEFAULT_NEIGHBORHOOD_LOW_WATERMARK
     }
 
     /// Returns whether this is a development network.

--- a/crates/swarm/topology/src/kademlia/admission.rs
+++ b/crates/swarm/topology/src/kademlia/admission.rs
@@ -100,7 +100,8 @@ mod tests {
         let base = SwarmAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
-            .with_inbound_headroom(0);
+            .with_inbound_headroom(0)
+            .with_bootstrap_target(1);
         let routing = make_routing(base, config);
 
         let ac = KademliaAdmissionControl::new(routing);
@@ -117,7 +118,8 @@ mod tests {
         let base = SwarmAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
-            .with_inbound_headroom(0);
+            .with_inbound_headroom(0)
+            .with_bootstrap_target(1);
         let routing = make_routing(base, config);
 
         let occupied = SwarmAddress::with_first_byte(0xc0);
@@ -140,7 +142,8 @@ mod tests {
         let base = SwarmAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
-            .with_inbound_headroom(0);
+            .with_inbound_headroom(0)
+            .with_bootstrap_target(1);
         let routing = make_routing(base, config);
 
         let peer = SwarmAddress::with_first_byte(0x80);
@@ -164,7 +167,8 @@ mod tests {
         let base = SwarmAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
-            .with_inbound_headroom(0);
+            .with_inbound_headroom(0)
+            .with_bootstrap_target(1);
         let routing = make_routing(base, config);
 
         let peer1 = SwarmAddress::with_first_byte(0x80);

--- a/crates/swarm/topology/src/kademlia/config.rs
+++ b/crates/swarm/topology/src/kademlia/config.rs
@@ -55,6 +55,12 @@ impl KademliaConfig {
             ..Default::default()
         }
     }
+
+    /// Set the per-bin bootstrap fill target used while `depth == 0`.
+    pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
+        self.limits = self.limits.with_bootstrap_target(target);
+        self
+    }
 }
 
 #[cfg(test)]

--- a/crates/swarm/topology/src/kademlia/limits.rs
+++ b/crates/swarm/topology/src/kademlia/limits.rs
@@ -12,6 +12,16 @@ const DEFAULT_TOTAL_TARGET: usize = 160;
 /// Default ceiling for inbound connections above target.
 pub(crate) const DEFAULT_INBOUND_HEADROOM: usize = 4;
 
+/// Default per-bin fill target during bootstrap (`depth == 0`).
+///
+/// Before a neighborhood is established every bin is filled aggressively toward
+/// this bound so bins reach the saturation frontier quickly and depth can climb.
+/// Must be `>= SwarmSpec::saturation_peers()` or depth can never advance past 0.
+/// Bounded (not `usize::MAX`) so a node that has not yet established a
+/// neighborhood cannot be flooded by inbound connections. Matches the reference
+/// network's oversaturation level.
+pub(crate) const DEFAULT_BOOTSTRAP_TARGET: usize = 18;
+
 /// Depth-aware peer allocation with linear tapering across Kademlia bins.
 ///
 /// Stateless: callers provide depth explicitly to avoid dual-source-of-truth bugs.
@@ -21,6 +31,8 @@ pub(crate) struct DepthAwareLimits {
     /// Minimum peers per bin.
     nominal: usize,
     inbound_headroom: usize,
+    /// Per-bin fill target during bootstrap (`depth == 0`).
+    bootstrap_target: usize,
 }
 
 impl Default for DepthAwareLimits {
@@ -36,6 +48,7 @@ impl DepthAwareLimits {
             total_target,
             nominal,
             inbound_headroom: DEFAULT_INBOUND_HEADROOM,
+            bootstrap_target: DEFAULT_BOOTSTRAP_TARGET,
         }
     }
 
@@ -58,8 +71,11 @@ impl DepthAwareLimits {
     /// Target for bin at depth. Returns `usize::MAX` for neighborhood bins (>= depth).
     pub(crate) fn target(&self, bin: u8, depth: u8) -> usize {
         if depth == 0 {
-            // No depth yet - use nominal for all bins
-            return self.nominal;
+            // Bootstrap: no neighborhood established yet. Fill every bin
+            // aggressively toward `bootstrap_target` so bins reach the
+            // saturation frontier quickly and depth can climb. Bounded so a
+            // not-yet-established node cannot be flooded by inbound.
+            return self.bootstrap_target;
         }
 
         if bin >= depth {
@@ -148,6 +164,12 @@ impl DepthAwareLimits {
 
 #[cfg(test)]
 impl DepthAwareLimits {
+    /// Set the per-bin bootstrap fill target used while `depth == 0`.
+    pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
+        self.bootstrap_target = target;
+        self
+    }
+
     /// Expected available peers in bin (exponential estimate from uniform distribution).
     pub(crate) fn expected_available(&self, bin: u8, depth: u8) -> usize {
         if depth == 0 || bin >= depth {
@@ -361,10 +383,11 @@ mod tests {
     fn test_zero_depth() {
         let limits = DepthAwareLimits::new(160, 3);
 
-        // All bins return nominal when depth is 0
-        assert_eq!(limits.target(0, 0), 3);
-        assert_eq!(limits.target(7, 0), 3);
-        assert_eq!(limits.target(31, 0), 3);
+        // All bins fill toward bootstrap_target when depth is 0 (aggressive
+        // bootstrap so bins reach the saturation frontier and depth can climb).
+        assert_eq!(limits.target(0, 0), DEFAULT_BOOTSTRAP_TARGET);
+        assert_eq!(limits.target(7, 0), DEFAULT_BOOTSTRAP_TARGET);
+        assert_eq!(limits.target(31, 0), DEFAULT_BOOTSTRAP_TARGET);
     }
 
     #[test]
@@ -428,9 +451,13 @@ mod tests {
     fn test_target_effective() {
         let limits = DepthAwareLimits::new(160, 3);
 
-        // With no known peers and connected depth 0, target_effective returns nominal
+        // With no known peers and connected depth 0, target_effective falls
+        // back to the depth-0 bootstrap target.
         let empty: Vec<usize> = vec![0; 32];
-        assert_eq!(limits.target_effective(5, 0, &empty), 3);
+        assert_eq!(
+            limits.target_effective(5, 0, &empty),
+            DEFAULT_BOOTSTRAP_TARGET
+        );
 
         // With known peers estimating depth 5, get proper allocation
         let mut known = vec![0; 32];
@@ -497,12 +524,13 @@ mod tests {
     #[test]
     fn test_surplus_at_depth_zero() {
         let limits = DepthAwareLimits::new(160, 3);
-        // depth = 0: all bins use nominal (3) as target
+        // depth = 0: all bins fill toward bootstrap_target (18); no surplus
+        // below it. (Eviction never runs at depth 0 anyway - it scans 0..depth.)
 
         assert_eq!(limits.surplus(0, 0, 2), 0);
-        assert_eq!(limits.surplus(0, 0, 3), 0);
-        assert_eq!(limits.surplus(0, 0, 5), 2);
-        assert_eq!(limits.surplus(7, 0, 10), 7);
+        assert_eq!(limits.surplus(0, 0, 18), 0);
+        assert_eq!(limits.surplus(0, 0, 20), 2);
+        assert_eq!(limits.surplus(7, 0, 25), 7);
     }
 
     #[test]

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -14,7 +14,7 @@ use super::{
     select_neighborhood_candidates,
 };
 use crate::metrics::{phase, record_phase_transition};
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, recompute_neighborhood_depth};
 use parking_lot::RwLock;
 use tracing::{debug, info, trace};
 use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
@@ -176,13 +176,28 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         }
     }
 
+    /// Recompute neighborhood depth from the connected-peer bin distribution.
+    ///
+    /// Delegates to [`recompute_neighborhood_depth`], the canonical port that
+    /// walks shallow to deep to find the unsaturated frontier and then anchors
+    /// the neighborhood by the low watermark. Crucially this caps depth at the
+    /// shallowest empty or unsaturated bin, so a gap below the deepest populated
+    /// bin pulls depth shallower rather than reporting a too-deep neighborhood.
     fn recalc_depth(&self) -> u8 {
-        for po in (0..=self.max_po).rev() {
-            if self.connected_peers.bin_size(po) >= self.config.limits.nominal() {
-                return po;
-            }
+        let spec = self.identity.spec();
+        let sizes = self.connected_peers.bin_sizes();
+        let mut counts = [0u8; 32];
+        for (slot, size) in counts.iter_mut().zip(sizes) {
+            *slot = u8::try_from(size).unwrap_or(u8::MAX);
         }
-        0
+
+        recompute_neighborhood_depth(
+            &counts,
+            spec.saturation_peers(),
+            spec.neighborhood_low_watermark(),
+        )
+        .get()
+        .min(self.max_po)
     }
 
     /// Log the current routing status showing bin populations.
@@ -684,15 +699,18 @@ mod tests {
     #[test]
     fn test_capacity_reserve_and_release() {
         let base = SwarmAddress::with_first_byte(0x00);
-        // With depth 0, all bins use nominal (3) as target
-        let config = KademliaConfig::default().with_nominal(2);
+        // Pin the depth-0 bootstrap target to 2 so the capacity mechanism is
+        // exercised with small numbers (default bootstrap fill is generous).
+        let config = KademliaConfig::default()
+            .with_nominal(2)
+            .with_bootstrap_target(2);
         let (routing, _pm) = make_routing(base, config);
 
         let peer1 = SwarmAddress::with_first_byte(0x80); // po=0
         let peer2 = SwarmAddress::with_first_byte(0xc0); // po=0
         let peer3 = SwarmAddress::with_first_byte(0xa0); // po=0
 
-        // First reserve succeeds (effective=0 < nominal=2)
+        // First reserve succeeds (effective=0 < target=2)
         assert!(routing.try_reserve_dial(&peer1, SwarmNodeType::Storer));
 
         // Second reserve succeeds (effective=1 < nominal=2)
@@ -756,26 +774,67 @@ mod tests {
         assert!(pm.index().exists(&peer));
     }
 
+    /// Build an overlay at exactly proximity order `bin` to base `0x00`,
+    /// disambiguated by `idx` in a deep byte (does not affect proximity order).
+    fn addr_in_bin(bin: u8, idx: u8) -> OverlayAddress {
+        let mut b = [0u8; 32];
+        b[(bin / 8) as usize] = 0x80 >> (bin % 8);
+        b[31] = idx;
+        OverlayAddress::from(b)
+    }
+
     #[test]
-    fn test_depth_calculation() {
+    fn test_depth_stays_zero_below_saturation() {
+        // A handful of peers in one mid bin, everything shallower empty. The
+        // depth frontier is the shallowest unsaturated bin (0), so depth stays
+        // 0 - the corrected algorithm does not jump to the deepest populated
+        // bin the way the old deepest-bin scan did.
         let base = SwarmAddress::with_first_byte(0x00);
-        let config = KademliaConfig::default().with_nominal(2);
-        let (routing, _pm) = make_routing(base, config);
+        let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
         assert_eq!(routing.depth(), 0);
+        for idx in 0..2 {
+            SwarmRouting::connected(&*routing, addr_in_bin(5, idx));
+        }
+        assert_eq!(routing.depth(), 0);
+    }
 
-        let mut peer_bytes1 = [0x00u8; 32];
-        peer_bytes1[0] = 0x04;
-        let peer1 = OverlayAddress::from(peer_bytes1);
+    #[test]
+    fn test_depth_caps_at_gap() {
+        // Regression for the deepest-bin bug: bin 0 is saturated, bins 1..8 are
+        // empty, and bin 8 holds several peers. The old scan reported depth 8;
+        // the corrected algorithm caps depth at the shallowest unsaturated bin
+        // (bin 1, just past the saturated frontier at bin 0).
+        let base = SwarmAddress::with_first_byte(0x00);
+        let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
-        let mut peer_bytes2 = [0x00u8; 32];
-        peer_bytes2[0] = 0x05;
-        let peer2 = OverlayAddress::from(peer_bytes2);
+        for idx in 0..8 {
+            SwarmRouting::connected(&*routing, addr_in_bin(0, idx));
+        }
+        for idx in 0..5 {
+            SwarmRouting::connected(&*routing, addr_in_bin(8, idx));
+        }
 
-        SwarmRouting::connected(&*routing, peer1);
-        SwarmRouting::connected(&*routing, peer2);
+        assert_eq!(routing.depth(), 1, "gap below the deep bin must cap depth");
+    }
 
-        assert_eq!(routing.depth(), 5);
+    #[test]
+    fn test_depth_climbs_with_saturated_bins() {
+        // Bins 0,1,2 saturated (>= 8) with bin 3 holding the low-watermark (3)
+        // anchors the neighborhood at bin 3.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let (routing, _pm) = make_routing(base, KademliaConfig::default());
+
+        for bin in 0..3 {
+            for idx in 0..8 {
+                SwarmRouting::connected(&*routing, addr_in_bin(bin, idx));
+            }
+        }
+        for idx in 0..3 {
+            SwarmRouting::connected(&*routing, addr_in_bin(3, idx));
+        }
+
+        assert_eq!(routing.depth(), 3);
     }
 
     #[test]
@@ -830,10 +889,11 @@ mod tests {
     #[test]
     fn test_inbound_capacity() {
         let base = SwarmAddress::with_first_byte(0x00);
-        // With nominal=2 and headroom=0, inbound ceiling = 2
+        // With bootstrap target 2 and headroom 0, depth-0 inbound ceiling = 2
         let config = KademliaConfig::default()
             .with_nominal(2)
-            .with_inbound_headroom(0);
+            .with_inbound_headroom(0)
+            .with_bootstrap_target(2);
         let (routing, _pm) = make_routing(base, config);
 
         let peer1 = SwarmAddress::with_first_byte(0x80);
@@ -870,9 +930,9 @@ mod tests {
         let config = KademliaConfig::default();
         let (routing, _pm) = make_routing(base, config);
 
-        // Initially depth=0, all bins should use nominal
-        assert_eq!(routing.config.limits.target(0, 0), 3);
-        assert_eq!(routing.config.limits.target(7, 0), 3);
+        // Initially depth=0, all bins fill toward the bootstrap target
+        assert_eq!(routing.config.limits.target(0, 0), 18);
+        assert_eq!(routing.config.limits.target(7, 0), 18);
 
         // At depth 8, targets should vary by bin
         // Bin 7: 160 × 8 / 36 = 35
@@ -995,38 +1055,35 @@ mod tests {
     #[test]
     fn test_eviction_candidates_neighborhood_never_evicted() {
         let base = SwarmAddress::with_first_byte(0x00);
-        let config = KademliaConfig::default().with_nominal(1);
+        // Small total target so below-depth bins overflow their tapered target
+        // and actually yield eviction candidates.
+        let config = KademliaConfig::default().with_total_target(8);
         let (routing, _pm) = make_routing(base, config);
 
-        // Create peers in bin 5 (which will become neighborhood bin)
-        let peer1 = {
-            let mut bytes = [0x00u8; 32];
-            bytes[0] = 0x04;
-            OverlayAddress::from(bytes)
-        };
-        let peer2 = {
-            let mut bytes = [0x00u8; 32];
-            bytes[0] = 0x05;
-            OverlayAddress::from(bytes)
-        };
-        let peer3 = {
-            let mut bytes = [0x00u8; 32];
-            bytes[0] = 0x06;
-            OverlayAddress::from(bytes)
-        };
-
-        for peer in [peer1, peer2, peer3] {
+        let connect = |peer: OverlayAddress| {
             routing.try_reserve_dial(&peer, SwarmNodeType::Storer);
             routing.dial_connected(&peer);
             routing.handshake_completed(&peer);
             SwarmRouting::connected(&*routing, peer);
+        };
+
+        // Saturate bins 0 and 1 (>= saturation) and anchor bin 2 with the low
+        // watermark so depth climbs to 2; bin 2 is then a neighborhood bin.
+        for bin in 0..2 {
+            for idx in 0..8 {
+                connect(addr_in_bin(bin, idx));
+            }
+        }
+        for idx in 0..6 {
+            connect(addr_in_bin(2, idx));
         }
 
-        // With nominal=1 and 3 peers in bin 5, depth should be 5
-        // Bin 5 is neighborhood (>= depth), so no eviction
-        assert!(routing.depth() >= 5);
+        assert_eq!(routing.depth(), 2);
+
         let candidates = routing.eviction_candidates();
-        // Only bins < depth produce candidates; bins >= depth are neighborhood
+        // Below-depth bins (0, 1) overflow their small target; the neighborhood
+        // bin (2) never produces candidates regardless of its population.
+        assert!(!candidates.is_empty());
         for c in &candidates {
             assert!(
                 c.bin < routing.depth(),


### PR DESCRIPTION
## What

Audit of the Kademlia topology against the reference and the Book of Swarm (ch 2.1.3, 2.1.4, 2.2.4, 3.3.4) found the neighborhood-depth computation diverged from the spec, with knock-on effects on hive gossip and (future) storage responsibility. This corrects it and makes bootstrap converge aggressively.

## The bug

`KademliaRouting::recalc_depth` returned the *deepest* bin with `>= nominal` connected peers. It never inspected shallower bins, so a populated deep bin reported a too-deep depth even when shallower bins were empty or unsaturated. That violates the "no empty bin below depth" invariant that thin-table routability depends on, and a wrong depth feeds hive gossip neighbour classification (`proximity >= depth`) and the neighbourhood-vs-balanced split.

## The fix

- Delegate depth to `nectar_primitives::recompute_neighborhood_depth` (the canonical shallowest-unsaturated-frontier + low-watermark-anchor algorithm). The empty-bin clause now falls out for free: an empty bin is unsaturated, so it caps the frontier.
- Drive `saturation` and `low_watermark` from `SwarmSpec` (`saturation_peers` = 8, `neighborhood_low_watermark` = 3 by default), so they are fork/spec-selectable.
- Replace the `depth == 0 ⇒ nominal` allocation cap with a bounded aggressive bootstrap fill toward `bootstrap_target` (18). Using saturation 8 with the old cap deadlocked: no bin could exceed `nominal` while depth was 0, so no bin could reach 8 and depth was pinned at 0 forever. The bounded fill lets bins reach the frontier fast and depth climb in real steps, without exposing a not-yet-established node to unbounded inbound.
- Add a periodic oversaturation prune. Depth-increase events already trim eagerly; this reclaims surplus that accrues in below-depth bins while depth is stable (e.g. from inbound connections), matching the reference network's timer-driven prune.

## Tests

- `test_depth_caps_at_gap`: bin 0 saturated, bins 1..8 empty, bin 8 populated -> depth caps at 1 (old scan reported 8).
- `test_depth_climbs_with_saturated_bins`: bins 0..2 saturated + bin 3 at the watermark -> depth 3.
- `test_depth_stays_zero_below_saturation`: a few peers in one mid bin -> depth stays 0.
- Existing capacity/eviction tests updated for the new depth-0 regime; `bootnode_cluster` convergence test still green.

## Scope notes

- Resolves the periodic-prune gap (audit Finding 2).
- Advances #134 by delegating the depth math to nectar; the remaining typed-surface rekey (`ProximityIndex` keyed by `Bin`, `NeighborhoodDepth` newtype, typed `ProximityOrder`) is a mechanical follow-up tracked separately.