### PR TITLE
refactor(topology): distinguish ProximityOrder, Bin, NeighborhoodDepth (closes #134)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8718,6 +8718,7 @@ dependencies = [
  "tonic 0.12.3",
  "tonic-build",
  "vertex-swarm-api",
+ "vertex-swarm-primitives",
 ]
 
 [[package]]

--- a/crates/swarm/AGENTS.md
+++ b/crates/swarm/AGENTS.md
@@ -44,6 +44,7 @@ Primitives and layer-2 constructs (chunks, addresses, BMT, manifests, feeds, pos
 
 - Treat `vertex-swarm-api` as the trait surface. New domain capabilities go in an api trait first, then in a concrete implementation crate.
 - Use `nectar-primitives` re-exports (`OverlayAddress`, `Bin`, `ProximityOrder`, `Nonce`, `Timestamp`) so the canonical types stay consistent across the workspace.
+- Keep the three proximity types distinct; do not collapse them to `u8` (the bee `po: u8` habit). `ProximityOrder` is the metric between two addresses (rank by closeness to a target); `Bin` is a peer's slot index in the local table (keys per-bin storage/iteration); `NeighborhoodDepth` is the boundary bin. Bridges: `Bin::from(po)` is the only `ProximityOrder -> Bin` conversion; `NeighborhoodDepth::{new, bin, contains}` are the only ways in/out of a depth. `NeighborhoodDepth` is intentionally NOT comparable with `Bin` - write `depth.contains(bin)`, never `bin >= depth`. Enumerate bins only via `all_bins`/`balanced_bins(depth)`/`neighborhood_bins(depth, max)`; extract `.get()` only at edges (logs, metrics, wire). Full rationale: `vertex-swarm-primitives` crate docs.
 - When `vertex-swarm-primitives` would host a new type that has no node dependency, push it upstream to `nectar` instead and re-export it here.
 - Error types are `thiserror` enums with `strum::IntoStaticStr` so they emit a `reason` label cleanly.
 - Use accounting units (AU) in bandwidth code. Never mix bytes, BZZ, and AU in the same struct field.

--- a/crates/swarm/api/src/components/topology.rs
+++ b/crates/swarm/api/src/components/topology.rs
@@ -4,7 +4,7 @@ use nectar_primitives::ChunkAddress;
 use std::vec::Vec;
 
 use crate::SwarmIdentity;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
 
 /// Bin sizes for topology routing (one per proximity order).
 #[auto_impl::auto_impl(&, Arc)]
@@ -25,7 +25,7 @@ pub trait SwarmTopologyState: Send + Sync {
     fn identity(&self) -> &Self::Identity;
 
     /// Get the current neighborhood depth.
-    fn depth(&self) -> u8;
+    fn depth(&self) -> NeighborhoodDepth;
 
     /// Get the node's overlay address.
     fn overlay_address(&self) -> OverlayAddress {
@@ -40,21 +40,21 @@ pub trait SwarmTopologyRouting: Send + Sync {
     fn closest_to(&self, address: &ChunkAddress, count: usize) -> Vec<OverlayAddress>;
 
     /// Get peers within our neighborhood at the given depth.
-    fn neighbors(&self, depth: u8) -> Vec<OverlayAddress>;
+    fn neighbors(&self, depth: NeighborhoodDepth) -> Vec<OverlayAddress>;
 }
 
 /// Connected peer inspection per bin.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait SwarmTopologyPeers: SwarmTopologyBins {
     /// Get connected peer overlay addresses in a specific bin.
-    fn connected_peers_in_bin(&self, po: u8) -> Vec<OverlayAddress>;
+    fn connected_peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress>;
 
     /// Get connected peer details in a specific bin.
     ///
     /// Returns `(overlay, multiaddrs)` for each connected peer in the bin.
     fn connected_peer_details_in_bin(
         &self,
-        po: u8,
+        bin: Bin,
     ) -> Vec<(OverlayAddress, Vec<libp2p::Multiaddr>)>;
 }
 

--- a/crates/swarm/node/src/node/stats.rs
+++ b/crates/swarm/node/src/node/stats.rs
@@ -39,15 +39,15 @@ pub(crate) fn log_stats<T: SwarmTopologyState + SwarmTopologyStats>(topology: &T
 
     let bin_sizes = topology.bin_sizes();
     let mut bin_summary = String::new();
-    for (po, (conn, known_in_bin)) in bin_sizes.iter().enumerate() {
+    for (bin, (conn, known_in_bin)) in bin_sizes.iter().enumerate() {
         if *conn > 0 || *known_in_bin > 0 {
             if !bin_summary.is_empty() {
                 bin_summary.push(' ');
             }
-            if po as u8 == depth {
-                bin_summary.push_str(&format!("[{po}:{conn}/{known_in_bin}]"));
+            if bin as u8 == depth.get() {
+                bin_summary.push_str(&format!("[{bin}:{conn}/{known_in_bin}]"));
             } else {
-                bin_summary.push_str(&format!("{po}:{conn}/{known_in_bin}"));
+                bin_summary.push_str(&format!("{bin}:{conn}/{known_in_bin}"));
             }
         }
     }
@@ -60,7 +60,7 @@ pub(crate) fn log_stats<T: SwarmTopologyState + SwarmTopologyStats>(topology: &T
         connected,
         routing,
         stored,
-        depth,
+        depth = depth.get(),
         pending,
         bins = %bin_summary,
         "swarm status"

--- a/crates/swarm/node/src/swarm_client.rs
+++ b/crates/swarm/node/src/swarm_client.rs
@@ -128,7 +128,9 @@ mod tests {
         let handle = create_test_handle();
 
         let client = Client::bootnode(topology, handle);
-        let _ = client.topology().neighbors(0);
+        let _ = client
+            .topology()
+            .neighbors(vertex_swarm_primitives::NeighborhoodDepth::ZERO);
     }
 
     #[test]

--- a/crates/swarm/node/tests/bootnode_cluster.rs
+++ b/crates/swarm/node/tests/bootnode_cluster.rs
@@ -21,6 +21,7 @@ use eyre::Result;
 use libp2p::PeerId;
 use tokio::time::timeout;
 use vertex_swarm_api::{SwarmTopologyPeers as _, SwarmTopologyState as _, SwarmTopologyStats as _};
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, all_bins};
 use vertex_swarm_test_utils::cluster::{ClusterBuilder, NodeRole};
 use vertex_swarm_topology::TopologyEvent;
 
@@ -130,7 +131,7 @@ async fn three_node_convergence() -> Result<()> {
     // progress.
     // ──────────────────────────────────────────────────────────────────
     for (idx, client) in clients.iter().enumerate() {
-        let knows_bootnode = (0u8..=31)
+        let knows_bootnode = all_bins(Bin::MAX)
             .flat_map(|po| client.topology.connected_peers_in_bin(po))
             .any(|peer| peer == bootnode_overlay);
         assert!(
@@ -151,20 +152,18 @@ async fn three_node_convergence() -> Result<()> {
     // With N=2 random overlays plus the bootnode's, all three nodes sit in
     // small proximity orders (random bits = bin 0/1 with overwhelming
     // probability). The recompute formula treats every connected peer at
-    // small PO as outside the neighborhood, so depth pins at 0.
-    //
-    // Once a typed `NeighborhoodDepth` newtype lands in vertex's routing
-    // layer (see issue #134), this should become
-    // `assert_eq!(depth, NeighborhoodDepth::from_raw(0))`.
+    // small PO as outside the neighborhood, so depth pins at the zero bin.
     let bootnode_depth = bootnode_topo.depth();
     assert_eq!(
-        bootnode_depth, 0,
+        bootnode_depth,
+        NeighborhoodDepth::ZERO,
         "bootnode kademlia depth should be 0 with two small-PO peers, got {bootnode_depth}"
     );
     for (idx, client) in clients.iter().enumerate() {
         let depth = client.topology.depth();
         assert_eq!(
-            depth, 0,
+            depth,
+            NeighborhoodDepth::ZERO,
             "client {idx} kademlia depth should be 0 (small-PO peers only), got {depth}"
         );
     }

--- a/crates/swarm/peers/peer-manager/src/maintenance.rs
+++ b/crates/swarm/peers/peer-manager/src/maintenance.rs
@@ -129,9 +129,9 @@ impl<I: SwarmIdentity> PeerManager<I> {
         let max_po = self.index.max_po() as usize;
         let mut remaining = vec![0usize; max_po + 1];
         let mut any_depleted = false;
-        for (po, &size) in bin_sizes.iter().enumerate() {
+        for (bin, &size) in bin_sizes.iter().enumerate() {
             if size < low_water {
-                remaining[po] = max_per_bin.saturating_sub(size);
+                remaining[bin] = max_per_bin.saturating_sub(size);
                 any_depleted = true;
             }
         }
@@ -153,10 +153,10 @@ impl<I: SwarmIdentity> PeerManager<I> {
             if self.index.exists(overlay) {
                 continue;
             }
-            let po = self.index.bin_for(overlay) as usize;
-            if remaining[po] > 0 && self.index.add(*overlay).is_ok() {
+            let bin = self.index.bin_for(overlay).as_index();
+            if remaining[bin] > 0 && self.index.add(*overlay).is_ok() {
                 added += 1;
-                remaining[po] -= 1;
+                remaining[bin] -= 1;
             }
         }
 

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -18,7 +18,7 @@ use vertex_net_peer_store::error::StoreError;
 use vertex_swarm_api::{SwarmIdentity, SwarmPeerResolver, SwarmScoreStore, SwarmSpec};
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_score::{PeerScore, ScoreCallbacks, SwarmScoringConfig};
-use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
+use vertex_swarm_primitives::{Bin, OverlayAddress, SwarmNodeType};
 
 use crate::entry::{
     HealthState, PeerEntry, StoredPeer, on_health_added, on_health_changed, on_health_removed,
@@ -255,11 +255,11 @@ impl<I: SwarmIdentity> PeerManager<I> {
 
     /// Get known storer overlays in a specific proximity bin (not banned).
     #[must_use]
-    pub fn storer_overlays_in_bin(&self, po: u8, count: usize) -> Vec<OverlayAddress> {
+    pub fn storer_overlays_in_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
         let mut result = Vec::new();
         let mut cold_candidates = Vec::new();
 
-        self.index.filter_bin(po, count + count, |overlay| {
+        self.index.filter_bin(bin, count + count, |overlay| {
             if self.banned_set.contains(overlay) {
                 return false;
             }
@@ -318,11 +318,11 @@ impl<I: SwarmIdentity> PeerManager<I> {
     }
 
     /// Get dialable overlay addresses from a specific bin (not banned, not in backoff).
-    pub fn dialable_overlays_in_bin(&self, po: u8, count: usize) -> Vec<OverlayAddress> {
+    pub fn dialable_overlays_in_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
         let mut result = Vec::new();
         let mut cold_candidates = Vec::new();
 
-        self.index.filter_bin(po, count + count, |overlay| {
+        self.index.filter_bin(bin, count + count, |overlay| {
             if self.banned_set.contains(overlay) {
                 return false;
             }
@@ -352,8 +352,8 @@ impl<I: SwarmIdentity> PeerManager<I> {
     }
 
     /// Get dialable peers from a specific bin (not banned, not in backoff).
-    pub fn dialable_in_bin(&self, po: u8, count: usize) -> Vec<SwarmPeer> {
-        let overlays = self.dialable_overlays_in_bin(po, count);
+    pub fn dialable_in_bin(&self, bin: Bin, count: usize) -> Vec<SwarmPeer> {
+        let overlays = self.dialable_overlays_in_bin(bin, count);
         self.get_swarm_peers(&overlays)
     }
 
@@ -861,7 +861,7 @@ mod tests {
 
         pm.ban(&p1, None);
 
-        let dialable = pm.dialable_in_bin(0, 2);
+        let dialable = pm.dialable_in_bin(Bin::new(0).unwrap(), 2);
         assert_eq!(dialable.len(), 2);
     }
 

--- a/crates/swarm/peers/peer-manager/src/proximity_index.rs
+++ b/crates/swarm/peers/peer-manager/src/proximity_index.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use hashlink::LinkedHashSet;
 use metrics::gauge;
 use parking_lot::RwLock;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Bin, OverlayAddress};
 
 /// Error returned when adding a peer to the index fails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error, strum::IntoStaticStr)]
@@ -38,7 +38,7 @@ pub struct ProximityIndex {
 /// Cached sorted list with generation stamp.
 struct CachedList {
     generation: Option<u64>,
-    items: Arc<Vec<(u8, OverlayAddress)>>,
+    items: Arc<Vec<(Bin, OverlayAddress)>>,
 }
 
 impl Default for CachedList {
@@ -84,9 +84,9 @@ impl ProximityIndex {
     }
 
     #[must_use]
-    pub fn bin_size(&self, po: u8) -> usize {
+    pub fn bin_size(&self, bin: Bin) -> usize {
         self.bin_counts
-            .get(po as usize)
+            .get(bin.as_index())
             .map_or(0, |c| c.load(Ordering::Relaxed))
     }
 
@@ -114,22 +114,22 @@ impl ProximityIndex {
     /// address is already in the index. Returns `Err(BinFull)` if the bin is
     /// at capacity (peer should be saved to DB only).
     pub fn add(&self, addr: OverlayAddress) -> Result<(), AddError> {
-        let po = self.bin_for(&addr);
-        let mut bin = self.bins[po as usize].write();
+        let bin = self.bin_for(&addr);
+        let mut bucket = self.bins[bin.as_index()].write();
 
         // Check duplicate first (before capacity check)
-        if bin.contains(&addr) {
+        if bucket.contains(&addr) {
             return Err(AddError::AlreadyPresent);
         }
 
         // Enforce capacity limit
-        if self.max_per_bin > 0 && bin.len() >= self.max_per_bin {
+        if self.max_per_bin > 0 && bucket.len() >= self.max_per_bin {
             return Err(AddError::BinFull);
         }
 
-        bin.insert(addr);
+        bucket.insert(addr);
 
-        self.bin_counts[po as usize].fetch_add(1, Ordering::Relaxed);
+        self.bin_counts[bin.as_index()].fetch_add(1, Ordering::Relaxed);
         self.total_count.fetch_add(1, Ordering::Relaxed);
         let generation = self.generation.fetch_add(1, Ordering::Release) + 1;
         gauge!("topology_proximity_generation").set(generation as f64);
@@ -138,14 +138,14 @@ impl ProximityIndex {
 
     /// Remove an address. Returns true if it existed.
     pub fn remove(&self, addr: &OverlayAddress) -> bool {
-        let po = self.bin_for(addr);
-        let mut bin = self.bins[po as usize].write();
+        let bin = self.bin_for(addr);
+        let mut bucket = self.bins[bin.as_index()].write();
 
-        if !bin.remove(addr) {
+        if !bucket.remove(addr) {
             return false;
         }
 
-        self.bin_counts[po as usize].fetch_sub(1, Ordering::Relaxed);
+        self.bin_counts[bin.as_index()].fetch_sub(1, Ordering::Relaxed);
         self.total_count.fetch_sub(1, Ordering::Relaxed);
         let generation = self.generation.fetch_add(1, Ordering::Release) + 1;
         gauge!("topology_proximity_generation").set(generation as f64);
@@ -156,23 +156,23 @@ impl ProximityIndex {
     ///
     /// Returns true if the address existed and was moved.
     pub fn touch(&self, addr: &OverlayAddress) -> bool {
-        let po = self.bin_for(addr);
-        let mut bin = self.bins[po as usize].write();
-        bin.to_back(addr)
+        let bin = self.bin_for(addr);
+        let mut bucket = self.bins[bin.as_index()].write();
+        bucket.to_back(addr)
     }
 
     /// Check if an address exists.
     #[must_use]
     pub fn exists(&self, addr: &OverlayAddress) -> bool {
-        let po = self.bin_for(addr);
-        self.bins[po as usize].read().contains(addr)
+        let bin = self.bin_for(addr);
+        self.bins[bin.as_index()].read().contains(addr)
     }
 
     /// Get all addresses in a specific bin (LRU to MRU order).
-    pub fn peers_in_bin(&self, po: u8) -> Vec<OverlayAddress> {
+    pub fn peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress> {
         self.bins
-            .get(po as usize)
-            .map_or_else(Vec::new, |bin| bin.read().iter().copied().collect())
+            .get(bin.as_index())
+            .map_or_else(Vec::new, |bucket| bucket.read().iter().copied().collect())
     }
 
     /// Get up to `count` addresses from a bin that match `predicate` (LRU first).
@@ -181,16 +181,16 @@ impl ProximityIndex {
     /// avoiding materializing the entire bin into a Vec.
     pub fn filter_bin(
         &self,
-        po: u8,
+        bin: Bin,
         count: usize,
         mut predicate: impl FnMut(&OverlayAddress) -> bool,
     ) -> Vec<OverlayAddress> {
-        let Some(bin) = self.bins.get(po as usize) else {
+        let Some(bucket) = self.bins.get(bin.as_index()) else {
             return Vec::new();
         };
-        let bin = bin.read();
-        let mut result = Vec::with_capacity(count.min(bin.len()));
-        for addr in bin.iter() {
+        let bucket = bucket.read();
+        let mut result = Vec::with_capacity(count.min(bucket.len()));
+        for addr in bucket.iter() {
             if result.len() >= count {
                 break;
             }
@@ -202,19 +202,21 @@ impl ProximityIndex {
     }
 
     /// Get up to `count` addresses from a bin (LRU first).
-    pub fn take_lru_from_bin(&self, po: u8, count: usize) -> Vec<OverlayAddress> {
-        self.bins.get(po as usize).map_or_else(Vec::new, |bin| {
-            bin.read().iter().take(count).copied().collect()
-        })
+    pub fn take_lru_from_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
+        self.bins
+            .get(bin.as_index())
+            .map_or_else(Vec::new, |bucket| {
+                bucket.read().iter().take(count).copied().collect()
+            })
     }
 
     /// Iterate from shallowest to deepest proximity order (ascending PO).
-    pub fn iter_by_proximity(&self) -> impl ExactSizeIterator<Item = (u8, OverlayAddress)> {
+    pub fn iter_by_proximity(&self) -> impl ExactSizeIterator<Item = (Bin, OverlayAddress)> {
         ArcIter::new(self.get_sorted())
     }
 
     /// Iterate from deepest to shallowest proximity order (descending PO).
-    pub fn iter_by_proximity_desc(&self) -> impl ExactSizeIterator<Item = (u8, OverlayAddress)> {
+    pub fn iter_by_proximity_desc(&self) -> impl ExactSizeIterator<Item = (Bin, OverlayAddress)> {
         ArcIterRev::new(self.get_sorted())
     }
 
@@ -227,10 +229,13 @@ impl ProximityIndex {
         result
     }
 
-    /// Compute bin (proximity order) for an address, capped at max_po.
+    /// Compute the [`Bin`] for an address, capped at `max_po`.
     #[must_use]
-    pub fn bin_for(&self, addr: &OverlayAddress) -> u8 {
-        self.local_overlay.proximity(addr).get().min(self.max_po)
+    pub fn bin_for(&self, addr: &OverlayAddress) -> Bin {
+        // proximity is range-validated (<= MAX_PO) and we cap at max_po, so the
+        // value is always a valid Bin.
+        let po = self.local_overlay.proximity(addr).get().min(self.max_po);
+        Bin::new(po).unwrap_or(Bin::MAX)
     }
 
     /// Build sorted list, using a generation-stamped cache to avoid rebuilds.
@@ -238,7 +243,7 @@ impl ProximityIndex {
     /// Items are collected from bins *before* acquiring the cache write lock
     /// to avoid holding the cache lock while reading bins (which would block
     /// concurrent add/remove/touch operations).
-    fn get_sorted(&self) -> Arc<Vec<(u8, OverlayAddress)>> {
+    fn get_sorted(&self) -> Arc<Vec<(Bin, OverlayAddress)>> {
         let current_gen = self.generation.load(Ordering::Acquire);
 
         // Fast path: cache is valid
@@ -252,9 +257,10 @@ impl ProximityIndex {
         // Collect items WITHOUT holding the cache lock, so concurrent
         // add/remove/touch can proceed on bins without blocking.
         let mut items = Vec::with_capacity(self.len());
-        for (po, bin) in self.bins.iter().enumerate() {
-            for &addr in bin.read().iter() {
-                items.push((po as u8, addr));
+        for (idx, bucket) in self.bins.iter().enumerate() {
+            let bin = Bin::new(idx as u8).unwrap_or(Bin::MAX);
+            for &addr in bucket.read().iter() {
+                items.push((bin, addr));
             }
         }
 
@@ -353,6 +359,10 @@ impl<T: Copy> ExactSizeIterator for ArcIterRev<T> {
 mod tests {
     use super::*;
 
+    fn b(n: u8) -> Bin {
+        Bin::new(n).expect("valid bin")
+    }
+
     fn local_overlay() -> OverlayAddress {
         OverlayAddress::from([0x00; 32])
     }
@@ -399,9 +409,9 @@ mod tests {
         index.add(addr1).unwrap();
         index.add(addr2).unwrap();
 
-        assert_eq!(index.bin_size(0), 1);
-        assert_eq!(index.bin_size(1), 1);
-        assert_eq!(index.bin_size(2), 1);
+        assert_eq!(index.bin_size(b(0)), 1);
+        assert_eq!(index.bin_size(b(1)), 1);
+        assert_eq!(index.bin_size(b(2)), 1);
         assert_eq!(index.len(), 3);
     }
 
@@ -416,11 +426,11 @@ mod tests {
 
         assert!(index.add(addr1).is_ok());
         assert!(index.add(addr2).is_ok());
-        assert_eq!(index.bin_size(0), 2);
+        assert_eq!(index.bin_size(b(0)), 2);
 
         // Third should fail (at capacity)
         assert_eq!(index.add(addr3), Err(AddError::BinFull));
-        assert_eq!(index.bin_size(0), 2);
+        assert_eq!(index.bin_size(b(0)), 2);
         assert!(!index.exists(&addr3));
     }
 
@@ -438,9 +448,9 @@ mod tests {
 
         let collected: Vec<_> = index.iter_by_proximity().collect();
         assert_eq!(collected.len(), 3);
-        assert_eq!(collected[0].0, 0);
-        assert_eq!(collected[1].0, 1);
-        assert_eq!(collected[2].0, 2);
+        assert_eq!(collected[0].0.get(), 0);
+        assert_eq!(collected[1].0.get(), 1);
+        assert_eq!(collected[2].0.get(), 2);
     }
 
     #[test]
@@ -457,9 +467,9 @@ mod tests {
 
         let collected: Vec<_> = index.iter_by_proximity_desc().collect();
         assert_eq!(collected.len(), 3);
-        assert_eq!(collected[0].0, 2);
-        assert_eq!(collected[1].0, 1);
-        assert_eq!(collected[2].0, 0);
+        assert_eq!(collected[0].0.get(), 2);
+        assert_eq!(collected[1].0.get(), 1);
+        assert_eq!(collected[2].0.get(), 0);
     }
 
     #[test]
@@ -503,12 +513,12 @@ mod tests {
         index.add(addr2).unwrap();
         index.add(addr3).unwrap();
 
-        let bin0 = index.peers_in_bin(0);
+        let bin0 = index.peers_in_bin(b(0));
         assert_eq!(bin0.len(), 2);
         assert!(bin0.contains(&addr1));
         assert!(bin0.contains(&addr2));
 
-        let bin1 = index.peers_in_bin(1);
+        let bin1 = index.peers_in_bin(b(1));
         assert_eq!(bin1.len(), 1);
         assert!(bin1.contains(&addr3));
     }
@@ -525,7 +535,7 @@ mod tests {
             assert!(index.add(addr).is_ok());
         }
 
-        assert_eq!(index.bin_size(0), 100);
+        assert_eq!(index.bin_size(b(0)), 100);
     }
 
     #[test]
@@ -541,7 +551,7 @@ mod tests {
         index.add(addr2).unwrap();
         index.add(addr3).unwrap();
 
-        let peers = index.peers_in_bin(0);
+        let peers = index.peers_in_bin(b(0));
         assert_eq!(peers.len(), 3);
         assert_eq!(peers[0], addr1); // First added = LRU
         assert_eq!(peers[1], addr2);
@@ -563,7 +573,7 @@ mod tests {
         // Touch addr1 (move from front to back)
         assert!(index.touch(&addr1));
 
-        let peers = index.peers_in_bin(0);
+        let peers = index.peers_in_bin(b(0));
         assert_eq!(peers[0], addr2); // Now LRU
         assert_eq!(peers[1], addr3);
         assert_eq!(peers[2], addr1); // Now MRU
@@ -590,17 +600,17 @@ mod tests {
         index.add(addr3).unwrap();
 
         // Take 2 LRU peers
-        let taken = index.take_lru_from_bin(0, 2);
+        let taken = index.take_lru_from_bin(b(0), 2);
         assert_eq!(taken.len(), 2);
         assert_eq!(taken[0], addr1);
         assert_eq!(taken[1], addr2);
 
         // Take more than available
-        let taken_all = index.take_lru_from_bin(0, 10);
+        let taken_all = index.take_lru_from_bin(b(0), 10);
         assert_eq!(taken_all.len(), 3);
 
         // Take 0
-        let taken_none = index.take_lru_from_bin(0, 0);
+        let taken_none = index.take_lru_from_bin(b(0), 0);
         assert!(taken_none.is_empty());
     }
 
@@ -657,24 +667,20 @@ mod tests {
         index.add(addr4).unwrap();
 
         // Filter with predicate that rejects addr2
-        let result = index.filter_bin(0, 3, |a| *a != addr2);
+        let result = index.filter_bin(b(0), 3, |a| *a != addr2);
         assert_eq!(result.len(), 3);
         assert!(!result.contains(&addr2));
 
         // Filter with count limit (early exit)
-        let result = index.filter_bin(0, 1, |_| true);
+        let result = index.filter_bin(b(0), 1, |_| true);
         assert_eq!(result.len(), 1);
 
         // Filter with no matches
-        let result = index.filter_bin(0, 10, |_| false);
+        let result = index.filter_bin(b(0), 10, |_| false);
         assert!(result.is_empty());
 
         // Filter on empty bin
-        let result = index.filter_bin(5, 10, |_| true);
-        assert!(result.is_empty());
-
-        // Filter on out-of-range bin
-        let result = index.filter_bin(255, 10, |_| true);
+        let result = index.filter_bin(b(5), 10, |_| true);
         assert!(result.is_empty());
     }
 }

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -2,6 +2,30 @@
 //!
 //! This crate re-exports canonical Swarm primitives from `nectar-primitives`
 //! and adds vertex-specific node configuration types.
+//!
+//! # Proximity types: keep them distinct
+//!
+//! Three types share the `0..=MAX_PO` (`u8`) range but mean different things.
+//! Conflating them (the bee `po: u8` habit) is the historical bug-surface, so
+//! the type system keeps them apart. Use the right one and the single named
+//! bridges between them:
+//!
+//! - [`ProximityOrder`]: the symmetric XOR-distance **metric** between two
+//!   addresses (`addr.proximity(other)`). Use it directly only to rank by
+//!   closeness to an arbitrary target (e.g. a chunk). It is NOT a table index.
+//! - [`Bin`]: the **index** of a peer's slot in the local node's routing table.
+//!   The only `ProximityOrder -> Bin` bridge is `Bin::from` (relative to the
+//!   local overlay, capped at `max_po`). It keys per-bin storage and iteration.
+//!   It is NOT a free metric between arbitrary addresses.
+//! - [`NeighborhoodDepth`]: the distinguished **boundary** bin. Bins it
+//!   [`contains`](NeighborhoodDepth::contains) are the neighborhood (area of
+//!   responsibility); shallower bins are balanced. It is deliberately NOT
+//!   comparable with `Bin` - relate them only through `depth.contains(bin)` or
+//!   `depth.bin()`, so an accidental `bin >= depth` does not compile.
+//!
+//! Enumerate the bin space only through [`all_bins`], [`balanced_bins`], and
+//! [`neighborhood_bins`] (the sole places a `Bin` is built from a raw index).
+//! Extract the raw `u8` with `.get()` only at edges (logs, metrics, the wire).
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -9,10 +33,94 @@ mod validated;
 
 pub use validated::{ValidatedChunk, ValidationError};
 
-// Re-export canonical Swarm primitives from nectar.
+// Re-export canonical Swarm primitives from nectar. See the crate-level docs
+// for the ProximityOrder / Bin / NeighborhoodDepth distinction.
 pub use nectar_primitives::{Bin, NetworkId, Nonce, ProximityOrder, Timestamp, compute_overlay};
 
+use core::fmt;
+
 use nectar_primitives::SwarmAddress;
+
+/// The neighborhood-depth boundary: bins at or beyond `depth` are the
+/// neighborhood (the node's area of responsibility), shallower bins are
+/// balanced.
+///
+/// A distinguished [`Bin`] in a specific *role*, kept distinct from an
+/// arbitrary `Bin` so the two cannot be conflated. It is deliberately **not**
+/// comparable with `Bin`: relate them only through [`contains`](Self::contains)
+/// (membership) or [`bin`](Self::bin) (the boundary as an index). `Ord` among
+/// depths is provided (deeper depth is greater) for `max`/`>` on depths.
+///
+/// nectar owns the depth *math* (`recompute_neighborhood_depth`); this wrapper
+/// is the routing-layer type, per that function's contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NeighborhoodDepth(Bin);
+
+impl NeighborhoodDepth {
+    /// The shallowest depth (every bin is in the neighborhood).
+    pub const ZERO: Self = Self(Bin::ZERO);
+
+    /// Wrap a [`Bin`] as a depth. The only `Bin -> NeighborhoodDepth` bridge;
+    /// use it at the depth computation, not to coerce arbitrary bins.
+    #[inline]
+    #[must_use]
+    pub const fn new(bin: Bin) -> Self {
+        Self(bin)
+    }
+
+    /// The boundary as a [`Bin`]. Use when you genuinely need the depth as an
+    /// index.
+    #[inline]
+    #[must_use]
+    pub const fn bin(self) -> Bin {
+        self.0
+    }
+
+    /// The raw boundary index. For edges only (metric labels, wire, logs).
+    #[inline]
+    #[must_use]
+    pub const fn get(self) -> u8 {
+        self.0.get()
+    }
+
+    /// Whether `bin` is inside the neighborhood (`bin >= depth`).
+    ///
+    /// O(1): a single `u8` comparison, no iteration or allocation despite the
+    /// set-like name. Same cost as the raw `bin >= depth` it replaces.
+    #[inline]
+    #[must_use]
+    pub fn contains(self, bin: Bin) -> bool {
+        bin >= self.0
+    }
+}
+
+impl fmt::Display for NeighborhoodDepth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "depth={}", self.0.get())
+    }
+}
+
+/// Iterate every bin `0..=max`, ascending. Double-ended, so `.rev()` walks
+/// deepest-first. This and the two depth-relative iterators below are the only
+/// places a `Bin` is constructed from a raw index.
+pub fn all_bins(max: Bin) -> impl DoubleEndedIterator<Item = Bin> + Clone {
+    (0..=max.get()).map(|po| Bin::new(po).unwrap_or(Bin::MAX))
+}
+
+/// Iterate the balanced bins `0..depth` (shallower than the neighborhood),
+/// ascending. Empty when `depth` is [`NeighborhoodDepth::ZERO`].
+pub fn balanced_bins(depth: NeighborhoodDepth) -> impl DoubleEndedIterator<Item = Bin> + Clone {
+    (0..depth.get()).map(|po| Bin::new(po).unwrap_or(Bin::MAX))
+}
+
+/// Iterate the neighborhood bins `depth..=max` (at or beyond the boundary),
+/// ascending.
+pub fn neighborhood_bins(
+    depth: NeighborhoodDepth,
+    max: Bin,
+) -> impl DoubleEndedIterator<Item = Bin> + Clone {
+    (depth.get()..=max.get()).map(|po| Bin::new(po).unwrap_or(Bin::MAX))
+}
 
 /// Overlay address for Swarm routing and peer identification.
 pub type OverlayAddress = SwarmAddress;
@@ -91,6 +199,68 @@ impl SwarmNodeType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn b(n: u8) -> Bin {
+        Bin::new(n).expect("valid bin")
+    }
+
+    #[test]
+    fn neighborhood_depth_contains_at_or_beyond() {
+        let depth = NeighborhoodDepth::new(b(5));
+        // Shallower bins are balanced (not in the neighborhood).
+        assert!(!depth.contains(b(0)));
+        assert!(!depth.contains(b(4)));
+        // The boundary and deeper bins are in the neighborhood.
+        assert!(depth.contains(b(5)));
+        assert!(depth.contains(b(6)));
+        assert!(depth.contains(Bin::MAX));
+    }
+
+    #[test]
+    fn neighborhood_depth_zero_contains_every_bin() {
+        let depth = NeighborhoodDepth::ZERO;
+        assert!(depth.contains(Bin::ZERO));
+        assert!(depth.contains(Bin::MAX));
+        assert_eq!(depth.get(), 0);
+        assert_eq!(depth.bin(), Bin::ZERO);
+    }
+
+    #[test]
+    fn neighborhood_depth_ord_is_by_boundary() {
+        assert!(NeighborhoodDepth::new(b(7)) > NeighborhoodDepth::new(b(3)));
+        assert_eq!(
+            NeighborhoodDepth::new(b(7)).max(NeighborhoodDepth::new(b(3))),
+            NeighborhoodDepth::new(b(7))
+        );
+    }
+
+    #[test]
+    fn bin_iterators_partition_the_table() {
+        let depth = NeighborhoodDepth::new(b(3));
+        let max = b(5);
+
+        let balanced: Vec<u8> = balanced_bins(depth).map(Bin::get).collect();
+        let neighborhood: Vec<u8> = neighborhood_bins(depth, max).map(Bin::get).collect();
+        let all: Vec<u8> = all_bins(max).map(Bin::get).collect();
+
+        assert_eq!(balanced, vec![0, 1, 2]);
+        assert_eq!(neighborhood, vec![3, 4, 5]);
+        assert_eq!(all, vec![0, 1, 2, 3, 4, 5]);
+
+        // Balanced + neighborhood exactly cover the table, no overlap.
+        let mut union = balanced;
+        union.extend(neighborhood);
+        assert_eq!(union, all);
+
+        // Double-ended: neighborhood walks deepest-first reversed.
+        let rev: Vec<u8> = neighborhood_bins(depth, max).rev().map(Bin::get).collect();
+        assert_eq!(rev, vec![5, 4, 3]);
+    }
+
+    #[test]
+    fn balanced_bins_empty_at_zero_depth() {
+        assert_eq!(balanced_bins(NeighborhoodDepth::ZERO).count(), 0);
+    }
 
     #[test]
     fn bootnode_requires_persistent_identity_and_nonce() {

--- a/crates/swarm/rpc/Cargo.toml
+++ b/crates/swarm/rpc/Cargo.toml
@@ -11,6 +11,7 @@ description = "Swarm protocol RPC services for Vertex"
 [dependencies]
 # Internal dependencies
 vertex-swarm-api = { workspace = true }
+vertex-swarm-primitives = { workspace = true }
 
 # Primitives
 hex = { workspace = true }

--- a/crates/swarm/rpc/src/grpc/node.rs
+++ b/crates/swarm/rpc/src/grpc/node.rs
@@ -2,6 +2,7 @@
 
 use tonic::{Request, Response, Status};
 use vertex_swarm_api::{SwarmTopologyPeers, SwarmTopologyState, SwarmTopologyStats};
+use vertex_swarm_primitives::Bin;
 
 use crate::proto::node::{
     BinInfo, GetStatusRequest, GetStatusResponse, GetTopologyRequest, GetTopologyResponse,
@@ -31,7 +32,7 @@ impl<T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Send + Sy
     ) -> Result<Response<GetStatusResponse>, Status> {
         Ok(Response::new(GetStatusResponse {
             overlay_address: self.topology.overlay_address().to_string(),
-            depth: self.topology.depth() as u32,
+            depth: u32::from(self.topology.depth().get()),
             connected_peers: self.topology.connected_peers_count() as u32,
             known_peers: self.topology.routing_peers_count() as u32,
             pending_connections: self.topology.pending_connections_count() as u32,
@@ -47,9 +48,11 @@ impl<T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Send + Sy
         let bins: Vec<BinInfo> = bin_sizes
             .iter()
             .enumerate()
-            .map(|(po, (connected, known))| {
+            .map(|(idx, (connected, known))| {
                 let (connected_addrs, peer_info) = if *connected > 0 {
-                    let details = self.topology.connected_peer_details_in_bin(po as u8);
+                    let details = self
+                        .topology
+                        .connected_peer_details_in_bin(Bin::new(idx as u8).unwrap_or(Bin::MAX));
                     let addrs = details.iter().map(|(o, _)| o.to_string()).collect();
                     let info = details
                         .into_iter()
@@ -64,7 +67,7 @@ impl<T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Send + Sy
                 };
 
                 BinInfo {
-                    proximity_order: po as u32,
+                    proximity_order: idx as u32,
                     connected_peers: *connected as u32,
                     known_peers: *known as u32,
                     connected_peer_addresses: connected_addrs,
@@ -75,7 +78,7 @@ impl<T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Send + Sy
 
         Ok(Response::new(GetTopologyResponse {
             overlay_address: self.topology.overlay_address().to_string(),
-            depth: self.topology.depth() as u32,
+            depth: u32::from(self.topology.depth().get()),
             bins,
         }))
     }

--- a/crates/swarm/test-utils/src/topology.rs
+++ b/crates/swarm/test-utils/src/topology.rs
@@ -7,7 +7,7 @@ use vertex_swarm_api::{
     SwarmTopologyState, SwarmTopologyStats,
 };
 use vertex_swarm_identity::Identity;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
 
 use crate::test_identity_arc;
 
@@ -128,8 +128,8 @@ impl SwarmTopologyState for MockTopology {
         self.identity.as_ref()
     }
 
-    fn depth(&self) -> u8 {
-        self.depth
+    fn depth(&self) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(Bin::new(self.depth).unwrap_or(Bin::MAX))
     }
 }
 
@@ -138,19 +138,19 @@ impl SwarmTopologyRouting for MockTopology {
         Vec::new()
     }
 
-    fn neighbors(&self, _depth: u8) -> Vec<OverlayAddress> {
+    fn neighbors(&self, _depth: NeighborhoodDepth) -> Vec<OverlayAddress> {
         Vec::new()
     }
 }
 
 impl SwarmTopologyPeers for MockTopology {
-    fn connected_peers_in_bin(&self, _po: u8) -> Vec<OverlayAddress> {
+    fn connected_peers_in_bin(&self, _po: Bin) -> Vec<OverlayAddress> {
         Vec::new()
     }
 
     fn connected_peer_details_in_bin(
         &self,
-        _po: u8,
+        _po: Bin,
     ) -> Vec<(OverlayAddress, Vec<libp2p::Multiaddr>)> {
         Vec::new()
     }
@@ -185,7 +185,7 @@ mod tests {
         assert_eq!(topo.connected_peers_count(), 0);
         assert_eq!(topo.routing_peers_count(), 0);
         assert_eq!(topo.stored_peers_count(), 0);
-        assert_eq!(topo.depth(), 0);
+        assert_eq!(topo.depth().get(), 0);
     }
 
     #[test]
@@ -194,7 +194,7 @@ mod tests {
 
         assert_eq!(topo.connected_peers_count(), 10);
         assert_eq!(topo.routing_peers_count(), 50);
-        assert_eq!(topo.depth(), 4);
+        assert_eq!(topo.depth().get(), 4);
     }
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(topo.connected_peers_count(), 5);
         assert_eq!(topo.routing_peers_count(), 20);
         assert_eq!(topo.stored_peers_count(), 100);
-        assert_eq!(topo.depth(), 3);
+        assert_eq!(topo.depth().get(), 3);
     }
 
     #[test]
@@ -225,8 +225,8 @@ mod tests {
     fn test_swarm_topology_trait() {
         let topo = MockTopology::new(5, 10, 2);
 
-        assert_eq!(topo.depth(), 2);
-        assert!(topo.neighbors(0).is_empty());
+        assert_eq!(topo.depth().get(), 2);
+        assert!(topo.neighbors(NeighborhoodDepth::ZERO).is_empty());
         assert_eq!(topo.bin_sizes().len(), 32);
     }
 }

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -33,7 +33,7 @@ use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::{PeerManager, StoredPeer};
 use vertex_swarm_peer_score::PeerScore;
 use vertex_swarm_peer_score::SwarmScoringConfig;
-use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
+use vertex_swarm_primitives::{Bin, OverlayAddress, SwarmNodeType, all_bins};
 use vertex_swarm_spec::HasSpec;
 
 use crate::DialReason;
@@ -559,7 +559,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             debug!(
                 %peer_id,
                 overlay = %candidate.overlay,
-                bin = candidate.bin,
+                bin = candidate.bin.get(),
                 phase = ?candidate.phase,
                 "Evicting peer: bin overpopulated after depth change"
             );
@@ -589,17 +589,18 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     }
 
     /// Push routing gauges for a single bin and global totals.
-    pub(crate) fn push_routing_gauges(&self, po: u8) {
-        let po_str = po_label(po);
-        let (connected, known) = self.routing.bin_peer_counts(po);
-        let (dialing, handshaking, active) = self.routing.bin_phase_counts(po);
+    pub(crate) fn push_routing_gauges(&self, bin: Bin) {
+        // The metric label key stays "po" (the established observability name).
+        let label = po_label(bin.get());
+        let (connected, known) = self.routing.bin_peer_counts(bin);
+        let (dialing, handshaking, active) = self.routing.bin_phase_counts(bin);
 
-        metrics::gauge!("topology_bin_connected_peers", "po" => po_str).set(connected as f64);
-        metrics::gauge!("topology_bin_known_peers", "po" => po_str).set(known as f64);
-        metrics::gauge!("topology_bin_dialing", "po" => po_str).set(dialing as f64);
-        metrics::gauge!("topology_bin_handshaking", "po" => po_str).set(handshaking as f64);
-        metrics::gauge!("topology_bin_active", "po" => po_str).set(active as f64);
-        metrics::gauge!("topology_bin_effective", "po" => po_str)
+        metrics::gauge!("topology_bin_connected_peers", "po" => label).set(connected as f64);
+        metrics::gauge!("topology_bin_known_peers", "po" => label).set(known as f64);
+        metrics::gauge!("topology_bin_dialing", "po" => label).set(dialing as f64);
+        metrics::gauge!("topology_bin_handshaking", "po" => label).set(handshaking as f64);
+        metrics::gauge!("topology_bin_active", "po" => label).set(active as f64);
+        metrics::gauge!("topology_bin_effective", "po" => label)
             .set((dialing + handshaking + active) as f64);
     }
 
@@ -607,33 +608,33 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     pub(crate) fn push_bin_targets(&self) {
         let depth = self.routing.depth();
         let limits = self.routing.limits();
-        let bin_count = self.routing.bin_sizes().len();
 
-        for po in 0..bin_count {
-            let po_str = po_label(po as u8);
-            let target = limits.target(po as u8, depth);
+        for bin in all_bins(self.routing.max_bin()) {
+            let label = po_label(bin.get());
+            let target = limits.target(bin, depth);
             let target_val = if target == usize::MAX {
                 -1.0
             } else {
                 target as f64
             };
-            let ceiling_val = limits.ceiling(po as u8, depth);
+            let ceiling_val = limits.ceiling(bin, depth);
             let ceiling = if ceiling_val == usize::MAX {
                 -1.0
             } else {
                 ceiling_val as f64
             };
 
-            metrics::gauge!("topology_bin_target_peers", "po" => po_str).set(target_val);
-            metrics::gauge!("topology_bin_ceiling_peers", "po" => po_str).set(ceiling);
+            metrics::gauge!("topology_bin_target_peers", "po" => label).set(target_val);
+            metrics::gauge!("topology_bin_ceiling_peers", "po" => label).set(ceiling);
         }
 
         metrics::gauge!("topology_bin_nominal_peers").set(limits.nominal() as f64);
     }
 
-    /// Get the proximity order for a peer relative to our overlay address.
-    pub(crate) fn proximity(&self, peer: &OverlayAddress) -> u8 {
-        self.identity.overlay_address().proximity(peer).get()
+    /// The [`Bin`] a peer occupies in this node's table (its proximity order to
+    /// the local overlay).
+    pub(crate) fn bin_for(&self, peer: &OverlayAddress) -> Bin {
+        Bin::from(self.identity.overlay_address().proximity(peer))
     }
 
     /// Check if we can advertise to a peer based on address scope.
@@ -890,7 +891,7 @@ impl<I: SwarmIdentity + Clone> Drop for TopologyBehaviour<I> {
         info!(
             active_peers = active,
             pending_connections = pending,
-            depth,
+            depth = depth.get(),
             "Topology behaviour shutting down"
         );
     }

--- a/crates/swarm/topology/src/connection_handlers.rs
+++ b/crates/swarm/topology/src/connection_handlers.rs
@@ -111,8 +111,8 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         RoutingCapacity::disconnected(&*self.routing, &overlay);
 
         // Push event-driven routing gauges for the affected bin
-        let po = self.proximity(&overlay);
-        self.push_routing_gauges(po);
+        let bin = self.bin_for(&overlay);
+        self.push_routing_gauges(bin);
 
         // Capacity freed - coalesced evaluation in poll()
         self.evaluator_handle.trigger_evaluation();
@@ -160,10 +160,10 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
         if new_depth != old_depth {
             self.push_bin_targets();
-            self.gossip.send(GossipInput::DepthChanged(new_depth));
+            self.gossip.send(GossipInput::DepthChanged(new_depth.get()));
             self.emit_event(TopologyEvent::DepthChanged {
-                old_depth,
-                new_depth,
+                old_depth: old_depth.get(),
+                new_depth: new_depth.get(),
             });
             if new_depth > old_depth {
                 self.trim_overpopulated_bins();

--- a/crates/swarm/topology/src/gossip/tasks.rs
+++ b/crates/swarm/topology/src/gossip/tasks.rs
@@ -19,7 +19,7 @@ use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent, NoAddresses
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::PeerManager;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
 use vertex_swarm_spec::Spec;
 
 use super::GossipInput;
@@ -620,7 +620,7 @@ impl<I: SwarmIdentity> GossipTask<I> {
             &self.local_overlay,
             &self.peer_manager,
             &self.connection_registry,
-            self.current_depth,
+            NeighborhoodDepth::new(Bin::new(self.current_depth).unwrap_or(Bin::MAX)),
         )
     }
 
@@ -632,7 +632,7 @@ impl<I: SwarmIdentity> GossipTask<I> {
         peer_selection::known_neighborhood_peers(
             &self.local_overlay,
             &self.peer_manager,
-            depth,
+            NeighborhoodDepth::new(Bin::new(depth).unwrap_or(Bin::MAX)),
             exclude,
         )
     }
@@ -861,7 +861,7 @@ mod tests {
             &state.ctx.local_overlay,
             &state.ctx.peer_manager,
             &state.ctx.connection_registry,
-            0,
+            NeighborhoodDepth::ZERO,
         );
         assert!(neighbors.is_empty());
     }

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -11,7 +11,7 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer_manager::PeerManager;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
 
 use crate::behaviour::ConnectionRegistry;
 use crate::events::TopologyEvent;
@@ -104,7 +104,7 @@ impl<I: SwarmIdentity> SwarmTopologyState for TopologyHandle<I> {
         &self.identity
     }
 
-    fn depth(&self) -> u8 {
+    fn depth(&self) -> NeighborhoodDepth {
         self.routing.depth()
     }
 }
@@ -114,22 +114,22 @@ impl<I: SwarmIdentity> SwarmTopologyRouting for TopologyHandle<I> {
         self.routing.closest_to(address, count)
     }
 
-    fn neighbors(&self, depth: u8) -> Vec<OverlayAddress> {
+    fn neighbors(&self, depth: NeighborhoodDepth) -> Vec<OverlayAddress> {
         self.routing.neighbors(depth)
     }
 }
 
 impl<I: SwarmIdentity> SwarmTopologyPeers for TopologyHandle<I> {
-    fn connected_peers_in_bin(&self, po: u8) -> Vec<OverlayAddress> {
-        self.routing.connected_overlays_in_bin(po)
+    fn connected_peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress> {
+        self.routing.connected_overlays_in_bin(bin)
     }
 
     fn connected_peer_details_in_bin(
         &self,
-        po: u8,
+        bin: Bin,
     ) -> Vec<(OverlayAddress, Vec<libp2p::Multiaddr>)> {
         self.routing
-            .connected_overlays_in_bin(po)
+            .connected_overlays_in_bin(bin)
             .into_iter()
             .map(|overlay| {
                 let multiaddrs = self
@@ -219,7 +219,7 @@ pub struct RoutingStats {
 
 #[derive(Debug, Clone)]
 pub struct BinStats {
-    pub po: u8,
+    pub bin: u8,
     pub connected: usize,
     pub known: usize,
     pub dialing: usize,
@@ -243,15 +243,16 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
         let bins: Vec<BinStats> = bin_sizes
             .iter()
             .enumerate()
-            .map(|(po, (connected, known))| {
+            .map(|(idx, (connected, known))| {
+                let bin = Bin::new(idx as u8).unwrap_or(Bin::MAX);
                 let (dialing, handshaking, active) = bin_phases
-                    .get(po)
+                    .get(idx)
                     .map(|(_, d, h, a)| (*d, *h, *a))
                     .unwrap_or((0, 0, 0));
-                let target = limits.target(po as u8, depth);
-                let ceiling = limits.ceiling(po as u8, depth);
+                let target = limits.target(bin, depth);
+                let ceiling = limits.ceiling(bin, depth);
                 BinStats {
-                    po: po as u8,
+                    bin: idx as u8,
                     connected: *connected,
                     known: *known,
                     dialing,
@@ -266,7 +267,7 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
 
         RoutingStats {
             bins,
-            depth,
+            depth: depth.get(),
             known_peers_total: self.routing.known_peers_total(),
             connected_peers_total: self.routing.connected_peers_total(),
         }

--- a/crates/swarm/topology/src/kademlia/candidate_queues.rs
+++ b/crates/swarm/topology/src/kademlia/candidate_queues.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashSet, VecDeque};
 
 use parking_lot::Mutex;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Bin, OverlayAddress};
 
 /// Per-bin FIFO queues for connection candidates with global dedup.
 pub(crate) struct CandidateQueues {
@@ -24,13 +24,13 @@ impl CandidateQueues {
     }
 
     /// Enqueue a candidate in the given bin. Returns true if newly inserted.
-    pub(super) fn push(&self, bin: u8, peer: OverlayAddress) -> bool {
+    pub(super) fn push(&self, bin: Bin, peer: OverlayAddress) -> bool {
         let mut pending = self.pending.lock();
         if !pending.insert(peer) {
             return false;
         }
 
-        if let Some(queue) = self.bins.get(bin as usize) {
+        if let Some(queue) = self.bins.get(bin.as_index()) {
             let mut q = queue.lock();
             q.push_back(peer);
             // Cap per-bin: drop oldest if over limit
@@ -72,6 +72,10 @@ impl CandidateQueues {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn b(n: u8) -> Bin {
+        Bin::new(n).expect("valid bin")
+    }
     use nectar_primitives::SwarmAddress;
 
     #[test]
@@ -79,16 +83,16 @@ mod tests {
         let queues = CandidateQueues::new(32, 16);
         let peer = SwarmAddress::with_first_byte(0x80);
 
-        assert!(queues.push(0, peer));
+        assert!(queues.push(b(0), peer));
         // Dedup: second push returns false
-        assert!(!queues.push(0, peer));
+        assert!(!queues.push(b(0), peer));
 
         let drained = queues.drain_all();
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0], peer);
 
         // After drain, can push again
-        assert!(queues.push(0, peer));
+        assert!(queues.push(b(0), peer));
     }
 
     #[test]
@@ -97,8 +101,8 @@ mod tests {
         let lo = SwarmAddress::with_first_byte(0x80);
         let hi = SwarmAddress::with_first_byte(0x40);
 
-        queues.push(0, lo);
-        queues.push(1, hi);
+        queues.push(b(0), lo);
+        queues.push(b(1), hi);
 
         let drained = queues.drain_all();
         assert_eq!(drained.len(), 2);
@@ -115,9 +119,9 @@ mod tests {
         let p2 = SwarmAddress::with_first_byte(0x81);
         let p3 = SwarmAddress::with_first_byte(0x82);
 
-        assert!(queues.push(0, p1));
-        assert!(queues.push(0, p2));
-        assert!(queues.push(0, p3));
+        assert!(queues.push(b(0), p1));
+        assert!(queues.push(b(0), p2));
+        assert!(queues.push(b(0), p3));
 
         // p1 should have been evicted (cap=2)
         let queued = queues.snapshot_queued();
@@ -133,7 +137,7 @@ mod tests {
         let peer = SwarmAddress::with_first_byte(0x80);
 
         // Bin 5 doesn't exist (only 0-3)
-        assert!(!queues.push(5, peer));
+        assert!(!queues.push(b(5), peer));
         assert!(queues.snapshot_queued().is_empty());
     }
 }

--- a/crates/swarm/topology/src/kademlia/candidates.rs
+++ b/crates/swarm/topology/src/kademlia/candidates.rs
@@ -4,7 +4,9 @@ use std::collections::{HashMap, HashSet};
 
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_peer_manager::{PeerManager, ProximityIndex};
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{
+    Bin, NeighborhoodDepth, OverlayAddress, balanced_bins, neighborhood_bins,
+};
 
 use super::limits::LimitsSnapshot;
 
@@ -44,7 +46,7 @@ pub(crate) struct CandidateSelector<'a> {
     candidates: Vec<OverlayAddress>,
     max_candidates: usize,
     /// Per-bin selection counts to enforce capacity limits.
-    bin_selections: HashMap<u8, usize>,
+    bin_selections: HashMap<Bin, usize>,
 }
 
 impl<'a> CandidateSelector<'a> {
@@ -79,7 +81,7 @@ impl<'a> CandidateSelector<'a> {
     }
 
     /// Get count of candidates already selected for a bin.
-    pub(crate) fn bin_selected(&self, bin: u8) -> usize {
+    pub(crate) fn bin_selected(&self, bin: Bin) -> usize {
         self.bin_selections.get(&bin).copied().unwrap_or(0)
     }
 
@@ -113,7 +115,7 @@ impl<'a> CandidateSelector<'a> {
     pub(crate) fn try_add_with_bin_capacity<I: SwarmIdentity>(
         &mut self,
         peer: OverlayAddress,
-        bin: u8,
+        bin: Bin,
         effective_count: usize,
         peer_manager: &PeerManager<I>,
     ) -> bool {
@@ -161,31 +163,31 @@ impl<'a> CandidateSelector<'a> {
 pub(crate) fn select_neighborhood_candidates<I: SwarmIdentity>(
     selector: &mut CandidateSelector<'_>,
     peer_manager: &PeerManager<I>,
-    connected_counts: impl Fn(u8) -> usize,
-    max_po: u8,
+    connected_counts: impl Fn(Bin) -> usize,
+    max_bin: Bin,
 ) {
     let depth = selector.snapshot().limits.depth;
 
     // Iterate from highest PO down to depth
-    for po in (depth..=max_po).rev() {
+    for bin in neighborhood_bins(depth, max_bin).rev() {
         if selector.is_full() {
             break;
         }
 
-        let effective = connected_counts(po);
-        let already_selected = selector.bin_selected(po);
+        let effective = connected_counts(bin);
+        let already_selected = selector.bin_selected(bin);
 
         if !selector
             .snapshot()
             .limits
-            .needs_more(po, effective + already_selected)
+            .needs_more(bin, effective + already_selected)
         {
             continue;
         }
 
         // Get peers from this bin (LRU order via KnownPeers)
-        for peer in peer_manager.dialable_overlays_in_bin(po, selector.remaining()) {
-            if !selector.try_add_with_bin_capacity(peer, po, effective, peer_manager) {
+        for peer in peer_manager.dialable_overlays_in_bin(bin, selector.remaining()) {
+            if !selector.try_add_with_bin_capacity(peer, bin, effective, peer_manager) {
                 continue;
             }
         }
@@ -196,24 +198,24 @@ pub(crate) fn select_neighborhood_candidates<I: SwarmIdentity>(
 pub(crate) fn select_balanced_candidates<I: SwarmIdentity>(
     selector: &mut CandidateSelector<'_>,
     peer_manager: &PeerManager<I>,
-    connected_counts: impl Fn(u8) -> usize,
+    connected_counts: impl Fn(Bin) -> usize,
 ) {
     let depth = selector.snapshot().limits.depth;
-    if depth == 0 {
+    if depth == NeighborhoodDepth::ZERO {
         return;
     }
 
-    // Collect bin stats: (po, effective, deficit)
-    let mut bin_stats: Vec<(u8, usize, usize)> = Vec::new();
+    // Collect bin stats: (bin, effective, deficit)
+    let mut bin_stats: Vec<(Bin, usize, usize)> = Vec::new();
 
-    for po in 0..depth {
-        let effective = connected_counts(po);
-        let already_selected = selector.bin_selected(po);
+    for bin in balanced_bins(depth) {
+        let effective = connected_counts(bin);
+        let already_selected = selector.bin_selected(bin);
 
         if !selector
             .snapshot()
             .limits
-            .needs_more(po, effective + already_selected)
+            .needs_more(bin, effective + already_selected)
         {
             continue;
         }
@@ -221,16 +223,16 @@ pub(crate) fn select_balanced_candidates<I: SwarmIdentity>(
         let deficit = selector
             .snapshot()
             .limits
-            .deficit(po, effective + already_selected);
+            .deficit(bin, effective + already_selected);
         if deficit > 0 {
-            bin_stats.push((po, effective, deficit));
+            bin_stats.push((bin, effective, deficit));
         }
     }
 
     // Sort by PO descending (prioritize higher bins)
     bin_stats.sort_by_key(|b| std::cmp::Reverse(b.0));
 
-    for (po, effective, deficit) in bin_stats {
+    for (bin, effective, deficit) in bin_stats {
         if selector.is_full() {
             break;
         }
@@ -239,11 +241,11 @@ pub(crate) fn select_balanced_candidates<I: SwarmIdentity>(
         let to_add = deficit.min(selector.remaining());
         let mut added = 0;
 
-        for peer in peer_manager.dialable_overlays_in_bin(po, to_add) {
+        for peer in peer_manager.dialable_overlays_in_bin(bin, to_add) {
             if added >= to_add || selector.is_full() {
                 break;
             }
-            if selector.try_add_with_bin_capacity(peer, po, effective, peer_manager) {
+            if selector.try_add_with_bin_capacity(peer, bin, effective, peer_manager) {
                 added += 1;
             }
         }
@@ -255,6 +257,14 @@ mod tests {
     use super::super::DepthAwareLimits;
     use super::*;
     use vertex_swarm_test_utils::make_overlay;
+
+    fn b(n: u8) -> Bin {
+        Bin::new(n).expect("valid bin")
+    }
+
+    fn d(n: u8) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(b(n))
+    }
 
     fn test_proximity_index() -> ProximityIndex {
         ProximityIndex::new(OverlayAddress::from([0u8; 32]), 31, 0)
@@ -276,7 +286,7 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         let snapshot = CandidateSnapshot {
-            limits: LimitsSnapshot::capture(&limits, 8),
+            limits: LimitsSnapshot::capture(&limits, d(8)),
             in_progress,
             queued,
         };
@@ -300,7 +310,7 @@ mod tests {
     fn test_connected_peer_rejected_by_selector() {
         let limits = DepthAwareLimits::new(160, 3);
         let snapshot = CandidateSnapshot {
-            limits: LimitsSnapshot::capture(&limits, 0),
+            limits: LimitsSnapshot::capture(&limits, d(0)),
             in_progress: HashSet::new(),
             queued: HashSet::new(),
         };
@@ -324,7 +334,7 @@ mod tests {
     fn test_selector_prevents_duplicates() {
         let limits = DepthAwareLimits::new(160, 3);
         let snapshot = CandidateSnapshot {
-            limits: LimitsSnapshot::capture(&limits, 0),
+            limits: LimitsSnapshot::capture(&limits, d(0)),
             in_progress: HashSet::new(),
             queued: HashSet::new(),
         };
@@ -343,7 +353,7 @@ mod tests {
     fn test_selector_respects_max() {
         let limits = DepthAwareLimits::new(160, 3);
         let snapshot = CandidateSnapshot {
-            limits: LimitsSnapshot::capture(&limits, 0),
+            limits: LimitsSnapshot::capture(&limits, d(0)),
             in_progress: HashSet::new(),
             queued: HashSet::new(),
         };
@@ -363,7 +373,7 @@ mod tests {
     fn test_bin_selection_tracking() {
         let limits = DepthAwareLimits::new(160, 3);
         let snapshot = CandidateSnapshot {
-            limits: LimitsSnapshot::capture(&limits, 0),
+            limits: LimitsSnapshot::capture(&limits, d(0)),
             in_progress: HashSet::new(),
             queued: HashSet::new(),
         };
@@ -371,13 +381,13 @@ mod tests {
         let connected = test_proximity_index();
         let mut selector = CandidateSelector::new(&snapshot, &connected, 10);
 
-        assert_eq!(selector.bin_selected(0), 0);
-        assert_eq!(selector.bin_selected(5), 0);
+        assert_eq!(selector.bin_selected(b(0)), 0);
+        assert_eq!(selector.bin_selected(b(5)), 0);
 
         // After adding peers, bin counts should update
         // Note: try_add doesn't track bin (use try_add_with_bin_capacity for that)
         selector.try_add(make_overlay(1));
-        assert_eq!(selector.bin_selected(0), 0); // try_add doesn't track bins
+        assert_eq!(selector.bin_selected(b(0)), 0); // try_add doesn't track bins
 
         // We'd need a PeerManager to test try_add_with_bin_capacity
     }

--- a/crates/swarm/topology/src/kademlia/config.rs
+++ b/crates/swarm/topology/src/kademlia/config.rs
@@ -66,6 +66,15 @@ impl KademliaConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vertex_swarm_primitives::{Bin, NeighborhoodDepth};
+
+    fn b(n: u8) -> Bin {
+        Bin::new(n).expect("valid bin")
+    }
+
+    fn d(n: u8) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(b(n))
+    }
 
     #[test]
     fn test_config_default() {
@@ -94,9 +103,9 @@ mod tests {
         // Headroom is internal; verify depth-aware behavior works
         // At depth 8, bin 7 target = 35. With headroom 8, ceiling = 43.
         // At target + 7 = 42, should still accept inbound
-        assert!(config.limits.should_accept_inbound(7, 8, 35 + 7));
+        assert!(config.limits.should_accept_inbound(b(7), d(8), 35 + 7));
         // At target + 8 = 43, should not accept
-        assert!(!config.limits.should_accept_inbound(7, 8, 35 + 8));
+        assert!(!config.limits.should_accept_inbound(b(7), d(8), 35 + 8));
     }
 
     #[test]

--- a/crates/swarm/topology/src/kademlia/limits.rs
+++ b/crates/swarm/topology/src/kademlia/limits.rs
@@ -3,6 +3,8 @@
 //! Allocates more peers to higher bins (closer neighbors) where peers are
 //! scarcer and more valuable for retrieval parallelization.
 
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth};
+
 /// Default minimum peers per bin (floor for depth calculation).
 const DEFAULT_NOMINAL: usize = 3;
 
@@ -68,9 +70,10 @@ impl DepthAwareLimits {
         self.total_target
     }
 
-    /// Target for bin at depth. Returns `usize::MAX` for neighborhood bins (>= depth).
-    pub(crate) fn target(&self, bin: u8, depth: u8) -> usize {
-        if depth == 0 {
+    /// Target for bin at depth. Returns `usize::MAX` for neighborhood bins
+    /// (`depth.contains(bin)`).
+    pub(crate) fn target(&self, bin: Bin, depth: NeighborhoodDepth) -> usize {
+        if depth == NeighborhoodDepth::ZERO {
             // Bootstrap: no neighborhood established yet. Fill every bin
             // aggressively toward `bootstrap_target` so bins reach the
             // saturation frontier quickly and depth can climb. Bounded so a
@@ -78,21 +81,22 @@ impl DepthAwareLimits {
             return self.bootstrap_target;
         }
 
-        if bin >= depth {
+        if depth.contains(bin) {
             // Neighborhood: connect to ALL available
             usize::MAX
         } else {
             // Linear taper: bin i gets weight (i + 1)
             // weight_sum = depth × (depth + 1) / 2
-            let weight = bin as usize + 1;
-            let weight_sum = (depth as usize) * (depth as usize + 1) / 2;
+            let weight = bin.as_index() + 1;
+            let d = depth.get() as usize;
+            let weight_sum = d * (d + 1) / 2;
             let allocated = self.total_target.saturating_mul(weight) / weight_sum;
             allocated.max(self.nominal)
         }
     }
 
     /// Check if bin needs more peers at specified depth.
-    pub(crate) fn needs_more(&self, bin: u8, depth: u8, connected: usize) -> bool {
+    pub(crate) fn needs_more(&self, bin: Bin, depth: NeighborhoodDepth, connected: usize) -> bool {
         let target = self.target(bin, depth);
         if target == usize::MAX {
             // Neighborhood: always want more if available
@@ -103,7 +107,7 @@ impl DepthAwareLimits {
     }
 
     /// Deficit from target at specified depth.
-    pub(crate) fn deficit(&self, bin: u8, depth: u8, connected: usize) -> usize {
+    pub(crate) fn deficit(&self, bin: Bin, depth: NeighborhoodDepth, connected: usize) -> usize {
         let target = self.target(bin, depth);
         if target == usize::MAX {
             // Neighborhood: report large deficit to prioritize
@@ -114,7 +118,7 @@ impl DepthAwareLimits {
     }
 
     /// Surplus above target at specified depth (0 if at or below target).
-    pub(crate) fn surplus(&self, bin: u8, depth: u8, connected: usize) -> usize {
+    pub(crate) fn surplus(&self, bin: Bin, depth: NeighborhoodDepth, connected: usize) -> usize {
         let target = self.target(bin, depth);
         if target == usize::MAX {
             0
@@ -124,7 +128,7 @@ impl DepthAwareLimits {
     }
 
     /// Target + inbound headroom (max before rejecting inbound). `usize::MAX` for neighborhood.
-    pub(crate) fn ceiling(&self, bin: u8, depth: u8) -> usize {
+    pub(crate) fn ceiling(&self, bin: Bin, depth: NeighborhoodDepth) -> usize {
         let target = self.target(bin, depth);
         if target == usize::MAX {
             usize::MAX
@@ -134,7 +138,12 @@ impl DepthAwareLimits {
     }
 
     /// Check if bin should accept inbound (allows headroom above target).
-    pub(crate) fn should_accept_inbound(&self, bin: u8, depth: u8, connected: usize) -> bool {
+    pub(crate) fn should_accept_inbound(
+        &self,
+        bin: Bin,
+        depth: NeighborhoodDepth,
+        connected: usize,
+    ) -> bool {
         let target = self.target(bin, depth);
         if target == usize::MAX {
             // Neighborhood: always accept
@@ -145,18 +154,22 @@ impl DepthAwareLimits {
     }
 
     /// Estimate depth from known peer distribution (highest bin with >= nominal peers).
-    pub(crate) fn estimate_depth_from_known(&self, known_bin_sizes: &[usize]) -> u8 {
+    pub(crate) fn estimate_depth_from_known(&self, known_bin_sizes: &[usize]) -> NeighborhoodDepth {
         // Find highest bin with >= nominal known peers
-        for (po, &count) in known_bin_sizes.iter().enumerate().rev() {
+        for (idx, &count) in known_bin_sizes.iter().enumerate().rev() {
             if count >= self.nominal {
-                return po as u8;
+                return NeighborhoodDepth::new(Bin::new(idx as u8).unwrap_or(Bin::MAX));
             }
         }
-        0
+        NeighborhoodDepth::ZERO
     }
 
     /// Effective depth: max(connected_depth, estimated_depth) for bootstrap.
-    pub(crate) fn effective_depth(&self, connected_depth: u8, known_bin_sizes: &[usize]) -> u8 {
+    pub(crate) fn effective_depth(
+        &self,
+        connected_depth: NeighborhoodDepth,
+        known_bin_sizes: &[usize],
+    ) -> NeighborhoodDepth {
         let estimated = self.estimate_depth_from_known(known_bin_sizes);
         connected_depth.max(estimated)
     }
@@ -171,45 +184,45 @@ impl DepthAwareLimits {
     }
 
     /// Expected available peers in bin (exponential estimate from uniform distribution).
-    pub(crate) fn expected_available(&self, bin: u8, depth: u8) -> usize {
-        if depth == 0 || bin >= depth {
+    pub(crate) fn expected_available(&self, bin: Bin, depth: NeighborhoodDepth) -> usize {
+        if depth == NeighborhoodDepth::ZERO || depth.contains(bin) {
             // Neighborhood bins or no depth: sparse, return nominal
             self.nominal
         } else {
             // Exponential growth as bin decreases
-            let shift = (depth - bin).min(20); // Cap to avoid overflow
+            let shift = (depth.get() - bin.get()).min(20); // Cap to avoid overflow
             self.nominal.saturating_mul(1 << shift)
         }
     }
 
     /// Total expected peers across all bins below depth.
-    pub(crate) fn total_expected_at_depth(&self, depth: u8) -> usize {
-        if depth == 0 {
+    pub(crate) fn total_expected_at_depth(&self, depth: NeighborhoodDepth) -> usize {
+        if depth == NeighborhoodDepth::ZERO {
             return 0;
         }
         // Sum of geometric series: nominal × (2 + 4 + 8 + ... + 2^depth)
         // = nominal × 2 × (2^depth - 1)
-        let two_to_depth = 1usize << depth.min(20);
+        let two_to_depth = 1usize << depth.get().min(20);
         self.nominal
             .saturating_mul(2)
             .saturating_mul(two_to_depth.saturating_sub(1))
     }
 
     /// Estimate depth by projecting known peer distribution to higher bins.
-    pub(crate) fn estimate_depth_projected(&self, known_bin_sizes: &[usize]) -> u8 {
+    pub(crate) fn estimate_depth_projected(&self, known_bin_sizes: &[usize]) -> NeighborhoodDepth {
         // Find a reference bin with significant population
         let mut ref_bin = 0u8;
         let mut ref_count = 0usize;
 
-        for (po, &count) in known_bin_sizes.iter().enumerate() {
+        for (idx, &count) in known_bin_sizes.iter().enumerate() {
             if count > ref_count {
-                ref_bin = po as u8;
+                ref_bin = idx as u8;
                 ref_count = count;
             }
         }
 
         if ref_count < self.nominal {
-            return 0;
+            return NeighborhoodDepth::ZERO;
         }
 
         // Project population to higher bins using exponential decay
@@ -217,7 +230,7 @@ impl DepthAwareLimits {
         let mut estimated_depth = ref_bin;
         let mut projected = ref_count;
 
-        while projected >= self.nominal && estimated_depth < 31 {
+        while projected >= self.nominal && estimated_depth < Bin::MAX.get() {
             estimated_depth += 1;
             projected /= 2;
         }
@@ -227,14 +240,14 @@ impl DepthAwareLimits {
             estimated_depth -= 1;
         }
 
-        estimated_depth
+        NeighborhoodDepth::new(Bin::new(estimated_depth).unwrap_or(Bin::MAX))
     }
 
     /// Target using effective depth (for allocation with known peer distribution).
     pub(crate) fn target_effective(
         &self,
-        bin: u8,
-        connected_depth: u8,
+        bin: Bin,
+        connected_depth: NeighborhoodDepth,
         known_bin_sizes: &[usize],
     ) -> usize {
         self.target(bin, self.effective_depth(connected_depth, known_bin_sizes))
@@ -243,34 +256,34 @@ impl DepthAwareLimits {
 
 /// Snapshot of limits at a specific depth for TOCTOU-safe candidate selection.
 pub(crate) struct LimitsSnapshot {
-    pub depth: u8,
+    pub depth: NeighborhoodDepth,
     limits: DepthAwareLimits,
 }
 
 impl LimitsSnapshot {
-    pub(crate) fn capture(limits: &DepthAwareLimits, depth: u8) -> Self {
+    pub(crate) fn capture(limits: &DepthAwareLimits, depth: NeighborhoodDepth) -> Self {
         Self {
             depth,
             limits: limits.clone(),
         }
     }
 
-    pub(crate) fn needs_more(&self, bin: u8, connected: usize) -> bool {
+    pub(crate) fn needs_more(&self, bin: Bin, connected: usize) -> bool {
         self.limits.needs_more(bin, self.depth, connected)
     }
 
-    pub(crate) fn deficit(&self, bin: u8, connected: usize) -> usize {
+    pub(crate) fn deficit(&self, bin: Bin, connected: usize) -> usize {
         self.limits.deficit(bin, self.depth, connected)
     }
 }
 
 #[cfg(test)]
 impl LimitsSnapshot {
-    pub(crate) fn target(&self, bin: u8) -> usize {
+    pub(crate) fn target(&self, bin: Bin) -> usize {
         self.limits.target(bin, self.depth)
     }
 
-    pub(crate) fn surplus(&self, bin: u8, connected: usize) -> usize {
+    pub(crate) fn surplus(&self, bin: Bin, connected: usize) -> usize {
         self.limits.surplus(bin, self.depth, connected)
     }
 }
@@ -278,6 +291,15 @@ impl LimitsSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Shorthand to build a Bin in tests.
+    fn b(n: u8) -> Bin {
+        Bin::new(n).expect("valid bin")
+    }
+
+    fn d(n: u8) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(b(n))
+    }
 
     #[test]
     fn test_linear_taper_depth_8() {
@@ -287,13 +309,13 @@ mod tests {
         // Bin 7: 160 × 8 / 36 = 35.5 → 35
         // Bin 0: 160 × 1 / 36 = 4.4 → max(4, 3) = 4
 
-        assert_eq!(limits.target(7, 8), 35);
-        assert_eq!(limits.target(6, 8), 31); // 160 × 7 / 36 = 31.1
-        assert_eq!(limits.target(0, 8), 4); // 160 × 1 / 36 = 4.4
+        assert_eq!(limits.target(b(7), d(8)), 35);
+        assert_eq!(limits.target(b(6), d(8)), 31); // 160 × 7 / 36 = 31.1
+        assert_eq!(limits.target(b(0), d(8)), 4); // 160 × 1 / 36 = 4.4
 
         // Neighborhood (bin >= depth) returns MAX
-        assert_eq!(limits.target(8, 8), usize::MAX);
-        assert_eq!(limits.target(10, 8), usize::MAX);
+        assert_eq!(limits.target(b(8), d(8)), usize::MAX);
+        assert_eq!(limits.target(b(10), d(8)), usize::MAX);
     }
 
     #[test]
@@ -301,13 +323,13 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Bin 7 target = 35
-        assert!(limits.needs_more(7, 8, 0));
-        assert!(limits.needs_more(7, 8, 34));
-        assert!(!limits.needs_more(7, 8, 35));
-        assert!(!limits.needs_more(7, 8, 40));
+        assert!(limits.needs_more(b(7), d(8), 0));
+        assert!(limits.needs_more(b(7), d(8), 34));
+        assert!(!limits.needs_more(b(7), d(8), 35));
+        assert!(!limits.needs_more(b(7), d(8), 40));
 
         // Neighborhood always needs more
-        assert!(limits.needs_more(8, 8, 1000));
+        assert!(limits.needs_more(b(8), d(8), 1000));
     }
 
     #[test]
@@ -315,12 +337,12 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3).with_inbound_headroom(4);
 
         // Bin 7 target = 35, ceiling = 35 + 4 = 39
-        assert!(limits.should_accept_inbound(7, 8, 35));
-        assert!(limits.should_accept_inbound(7, 8, 38));
-        assert!(!limits.should_accept_inbound(7, 8, 39));
+        assert!(limits.should_accept_inbound(b(7), d(8), 35));
+        assert!(limits.should_accept_inbound(b(7), d(8), 38));
+        assert!(!limits.should_accept_inbound(b(7), d(8), 39));
 
         // Neighborhood always accepts
-        assert!(limits.should_accept_inbound(8, 8, 1000));
+        assert!(limits.should_accept_inbound(b(8), d(8), 1000));
     }
 
     #[test]
@@ -328,14 +350,14 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Bin 7: 3 × 2^1 = 6
-        assert_eq!(limits.expected_available(7, 8), 6);
+        assert_eq!(limits.expected_available(b(7), d(8)), 6);
         // Bin 6: 3 × 2^2 = 12
-        assert_eq!(limits.expected_available(6, 8), 12);
+        assert_eq!(limits.expected_available(b(6), d(8)), 12);
         // Bin 0: 3 × 2^8 = 768
-        assert_eq!(limits.expected_available(0, 8), 768);
+        assert_eq!(limits.expected_available(b(0), d(8)), 768);
 
         // Neighborhood returns nominal
-        assert_eq!(limits.expected_available(8, 8), 3);
+        assert_eq!(limits.expected_available(b(8), d(8)), 3);
     }
 
     #[test]
@@ -343,29 +365,29 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Depth 8: 3 × 2 × (256 - 1) = 1530
-        assert_eq!(limits.total_expected_at_depth(8), 1530);
+        assert_eq!(limits.total_expected_at_depth(d(8)), 1530);
 
         // Depth 10: 3 × 2 × (1024 - 1) = 6138
-        assert_eq!(limits.total_expected_at_depth(10), 6138);
+        assert_eq!(limits.total_expected_at_depth(d(10)), 6138);
     }
 
     #[test]
     fn test_snapshot_consistency() {
         let limits = DepthAwareLimits::new(160, 3);
 
-        let snapshot = LimitsSnapshot::capture(&limits, 8);
+        let snapshot = LimitsSnapshot::capture(&limits, d(8));
 
         // Snapshot captures depth at creation time
-        assert_eq!(snapshot.depth, 8);
-        assert_eq!(snapshot.target(7), 35); // Uses depth 8 calculation
+        assert_eq!(snapshot.depth.get(), 8);
+        assert_eq!(snapshot.target(b(7)), 35); // Uses depth 8 calculation
 
         // A different snapshot at depth 10 has different targets
-        let snapshot10 = LimitsSnapshot::capture(&limits, 10);
-        assert_eq!(snapshot10.depth, 10);
+        let snapshot10 = LimitsSnapshot::capture(&limits, d(10));
+        assert_eq!(snapshot10.depth.get(), 10);
 
         // Original snapshot unchanged
-        assert_eq!(snapshot.depth, 8);
-        assert_eq!(snapshot.target(7), 35);
+        assert_eq!(snapshot.depth.get(), 8);
+        assert_eq!(snapshot.target(b(7)), 35);
     }
 
     #[test]
@@ -373,10 +395,10 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Bin 7 target at depth 8 = 35
-        assert_eq!(limits.deficit(7, 8, 0), 35);
-        assert_eq!(limits.deficit(7, 8, 20), 15);
-        assert_eq!(limits.deficit(7, 8, 35), 0);
-        assert_eq!(limits.deficit(7, 8, 40), 0);
+        assert_eq!(limits.deficit(b(7), d(8), 0), 35);
+        assert_eq!(limits.deficit(b(7), d(8), 20), 15);
+        assert_eq!(limits.deficit(b(7), d(8), 35), 0);
+        assert_eq!(limits.deficit(b(7), d(8), 40), 0);
     }
 
     #[test]
@@ -385,20 +407,20 @@ mod tests {
 
         // All bins fill toward bootstrap_target when depth is 0 (aggressive
         // bootstrap so bins reach the saturation frontier and depth can climb).
-        assert_eq!(limits.target(0, 0), DEFAULT_BOOTSTRAP_TARGET);
-        assert_eq!(limits.target(7, 0), DEFAULT_BOOTSTRAP_TARGET);
-        assert_eq!(limits.target(31, 0), DEFAULT_BOOTSTRAP_TARGET);
+        assert_eq!(limits.target(b(0), d(0)), DEFAULT_BOOTSTRAP_TARGET);
+        assert_eq!(limits.target(b(7), d(0)), DEFAULT_BOOTSTRAP_TARGET);
+        assert_eq!(limits.target(b(31), d(0)), DEFAULT_BOOTSTRAP_TARGET);
     }
 
     #[test]
     fn test_various_total_targets() {
         // Light client
         let light = DepthAwareLimits::new(32, 2);
-        assert!(light.target(7, 8) < 10);
+        assert!(light.target(b(7), d(8)) < 10);
 
         // Robust retrieval
         let robust = DepthAwareLimits::new(256, 4);
-        assert!(robust.target(7, 8) > 50);
+        assert!(robust.target(b(7), d(8)) > 50);
     }
 
     #[test]
@@ -407,7 +429,7 @@ mod tests {
 
         // No known peers -> depth 0
         let empty: Vec<usize> = vec![0; 32];
-        assert_eq!(limits.estimate_depth_from_known(&empty), 0);
+        assert_eq!(limits.estimate_depth_from_known(&empty).get(), 0);
 
         // Known peers in low bins only -> depth based on highest populated
         let mut known = vec![0; 32];
@@ -417,14 +439,14 @@ mod tests {
         known[3] = 10; // bin 3: 10 peers
         known[4] = 5; // bin 4: 5 >= nominal
         known[5] = 2; // bin 5: 2 < nominal
-        assert_eq!(limits.estimate_depth_from_known(&known), 4);
+        assert_eq!(limits.estimate_depth_from_known(&known).get(), 4);
 
         // Known peers in higher bins -> higher estimated depth
         known[6] = 3; // bin 6: exactly nominal
-        assert_eq!(limits.estimate_depth_from_known(&known), 6);
+        assert_eq!(limits.estimate_depth_from_known(&known).get(), 6);
 
         known[7] = 3; // bin 7: exactly nominal
-        assert_eq!(limits.estimate_depth_from_known(&known), 7);
+        assert_eq!(limits.estimate_depth_from_known(&known).get(), 7);
     }
 
     #[test]
@@ -433,18 +455,18 @@ mod tests {
 
         // No known peers, connected depth 0 -> effective depth = 0
         let empty: Vec<usize> = vec![0; 32];
-        assert_eq!(limits.effective_depth(0, &empty), 0);
+        assert_eq!(limits.effective_depth(d(0), &empty).get(), 0);
 
         // Known peers estimate depth 5, connected depth 0
         let mut known = vec![0; 32];
         known[0] = 100;
         known[5] = 3;
-        let estimated = limits.estimate_depth_from_known(&known);
+        let estimated = limits.estimate_depth_from_known(&known).get();
         assert_eq!(estimated, 5);
-        assert_eq!(limits.effective_depth(0, &known), 5);
+        assert_eq!(limits.effective_depth(d(0), &known).get(), 5);
 
         // Connected depth higher than estimated -> use connected
-        assert_eq!(limits.effective_depth(7, &known), 7);
+        assert_eq!(limits.effective_depth(d(7), &known).get(), 7);
     }
 
     #[test]
@@ -455,7 +477,7 @@ mod tests {
         // back to the depth-0 bootstrap target.
         let empty: Vec<usize> = vec![0; 32];
         assert_eq!(
-            limits.target_effective(5, 0, &empty),
+            limits.target_effective(b(5), d(0), &empty),
             DEFAULT_BOOTSTRAP_TARGET
         );
 
@@ -464,7 +486,7 @@ mod tests {
         known[0] = 100;
         known[5] = 3;
         // At depth 5: bin 4 should have linear-tapered target
-        let target = limits.target_effective(4, 0, &known);
+        let target = limits.target_effective(b(4), d(0), &known);
         assert!(target > 3); // Should be more than nominal due to tapering
     }
 
@@ -476,12 +498,12 @@ mod tests {
         let mut known = vec![0; 32];
         known[0] = 768;
         // Projects: bin 1 = 384, bin 2 = 192, ..., bin 7 = 6, bin 8 = 3
-        let projected = limits.estimate_depth_projected(&known);
+        let projected = limits.estimate_depth_projected(&known).get();
         assert!((7..=9).contains(&projected), "projected = {}", projected);
 
         // Fewer peers in bin 0 suggests lower depth
         known[0] = 24; // 24 / 2 = 12, /2 = 6, /2 = 3 -> depth ~3
-        let projected = limits.estimate_depth_projected(&known);
+        let projected = limits.estimate_depth_projected(&known).get();
         assert!((2..=4).contains(&projected), "projected = {}", projected);
     }
 
@@ -490,9 +512,9 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Bin 7 target at depth 8 = 35, connected < target
-        assert_eq!(limits.surplus(7, 8, 0), 0);
-        assert_eq!(limits.surplus(7, 8, 20), 0);
-        assert_eq!(limits.surplus(7, 8, 34), 0);
+        assert_eq!(limits.surplus(b(7), d(8), 0), 0);
+        assert_eq!(limits.surplus(b(7), d(8), 20), 0);
+        assert_eq!(limits.surplus(b(7), d(8), 34), 0);
     }
 
     #[test]
@@ -500,7 +522,7 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Bin 7 target at depth 8 = 35, connected == target
-        assert_eq!(limits.surplus(7, 8, 35), 0);
+        assert_eq!(limits.surplus(b(7), d(8), 35), 0);
     }
 
     #[test]
@@ -508,8 +530,8 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Bin 7 target at depth 8 = 35, connected > target
-        assert_eq!(limits.surplus(7, 8, 40), 5);
-        assert_eq!(limits.surplus(7, 8, 36), 1);
+        assert_eq!(limits.surplus(b(7), d(8), 40), 5);
+        assert_eq!(limits.surplus(b(7), d(8), 36), 1);
     }
 
     #[test]
@@ -517,8 +539,8 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // Neighborhood bins (>= depth) have target MAX, surplus always 0
-        assert_eq!(limits.surplus(8, 8, 1000), 0);
-        assert_eq!(limits.surplus(10, 8, 500), 0);
+        assert_eq!(limits.surplus(b(8), d(8), 1000), 0);
+        assert_eq!(limits.surplus(b(10), d(8), 500), 0);
     }
 
     #[test]
@@ -527,10 +549,10 @@ mod tests {
         // depth = 0: all bins fill toward bootstrap_target (18); no surplus
         // below it. (Eviction never runs at depth 0 anyway - it scans 0..depth.)
 
-        assert_eq!(limits.surplus(0, 0, 2), 0);
-        assert_eq!(limits.surplus(0, 0, 18), 0);
-        assert_eq!(limits.surplus(0, 0, 20), 2);
-        assert_eq!(limits.surplus(7, 0, 25), 7);
+        assert_eq!(limits.surplus(b(0), d(0), 2), 0);
+        assert_eq!(limits.surplus(b(0), d(0), 18), 0);
+        assert_eq!(limits.surplus(b(0), d(0), 20), 2);
+        assert_eq!(limits.surplus(b(7), d(0), 25), 7);
     }
 
     #[test]
@@ -538,27 +560,27 @@ mod tests {
         let limits = DepthAwareLimits::new(160, 3);
 
         // At depth 5: bin 4 target = 160 × 5 / 15 = 53
-        assert_eq!(limits.surplus(4, 5, 40), 0);
-        assert_eq!(limits.surplus(4, 5, 53), 0);
-        assert_eq!(limits.surplus(4, 5, 60), 7);
+        assert_eq!(limits.surplus(b(4), d(5), 40), 0);
+        assert_eq!(limits.surplus(b(4), d(5), 53), 0);
+        assert_eq!(limits.surplus(b(4), d(5), 60), 7);
 
         // At depth 8: bin 4 target = 160 × 5 / 36 = 22
-        assert_eq!(limits.surplus(4, 8, 40), 18);
-        assert_eq!(limits.surplus(4, 8, 22), 0);
+        assert_eq!(limits.surplus(b(4), d(8), 40), 18);
+        assert_eq!(limits.surplus(b(4), d(8), 22), 0);
     }
 
     #[test]
     fn test_snapshot_surplus() {
         let limits = DepthAwareLimits::new(160, 3);
 
-        let snapshot = LimitsSnapshot::capture(&limits, 8);
+        let snapshot = LimitsSnapshot::capture(&limits, d(8));
 
         // Bin 7 target = 35
-        assert_eq!(snapshot.surplus(7, 30), 0);
-        assert_eq!(snapshot.surplus(7, 35), 0);
-        assert_eq!(snapshot.surplus(7, 40), 5);
+        assert_eq!(snapshot.surplus(b(7), 30), 0);
+        assert_eq!(snapshot.surplus(b(7), 35), 0);
+        assert_eq!(snapshot.surplus(b(7), 40), 5);
 
         // Neighborhood
-        assert_eq!(snapshot.surplus(8, 1000), 0);
+        assert_eq!(snapshot.surplus(b(8), 1000), 0);
     }
 }

--- a/crates/swarm/topology/src/kademlia/peer_selection.rs
+++ b/crates/swarm/topology/src/kademlia/peer_selection.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::PeerManager;
-use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress, neighborhood_bins};
 
 use crate::behaviour::ConnectionRegistry;
 
@@ -20,13 +20,13 @@ pub(crate) fn connected_neighbors<I: SwarmIdentity>(
     local_overlay: &OverlayAddress,
     peer_manager: &PeerManager<I>,
     connection_registry: &ConnectionRegistry,
-    depth: u8,
+    depth: NeighborhoodDepth,
 ) -> Vec<OverlayAddress> {
     connection_registry
         .active_ids()
         .into_iter()
         .filter(|overlay| {
-            local_overlay.proximity(overlay).get() >= depth
+            depth.contains(Bin::from(local_overlay.proximity(overlay)))
                 && peer_manager.node_type(overlay) == Some(SwarmNodeType::Storer)
         })
         .collect()
@@ -36,13 +36,13 @@ pub(crate) fn connected_neighbors<I: SwarmIdentity>(
 pub(crate) fn known_neighborhood_peers<I: SwarmIdentity>(
     _local_overlay: &OverlayAddress,
     peer_manager: &PeerManager<I>,
-    depth: u8,
+    depth: NeighborhoodDepth,
     exclude: Option<&OverlayAddress>,
 ) -> Vec<SwarmPeer> {
-    let max_po = peer_manager.index().max_po();
+    let max_bin = Bin::new(peer_manager.index().max_po()).unwrap_or(Bin::MAX);
     let mut overlays = Vec::new();
-    for po in depth..=max_po {
-        for overlay in peer_manager.storer_overlays_in_bin(po, usize::MAX) {
+    for bin in neighborhood_bins(depth, max_bin) {
+        for overlay in peer_manager.storer_overlays_in_bin(bin, usize::MAX) {
             if exclude.is_some_and(|e| &overlay == e) {
                 continue;
             }
@@ -141,7 +141,7 @@ mod tests {
             &ctx.local_overlay,
             &ctx.peer_manager,
             &ctx.connection_registry,
-            0,
+            NeighborhoodDepth::ZERO,
         );
         assert!(neighbors.is_empty());
     }

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -20,7 +20,10 @@ use tracing::{debug, info, trace};
 use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use vertex_swarm_peer_manager::PeerManager;
 use vertex_swarm_peer_manager::ProximityIndex;
-use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
+use vertex_swarm_primitives::{
+    Bin, NeighborhoodDepth, OverlayAddress, SwarmNodeType, all_bins, balanced_bins,
+    neighborhood_bins,
+};
 
 /// Connection phase for capacity tracking.
 #[derive(PartialEq, Eq)]
@@ -40,24 +43,24 @@ pub(crate) enum EvictionPhase {
 /// A peer identified for eviction due to bin overpopulation.
 pub(crate) struct EvictionCandidate {
     pub(crate) overlay: OverlayAddress,
-    pub(crate) bin: u8,
+    pub(crate) bin: Bin,
     pub(crate) phase: EvictionPhase,
 }
 
-fn atomic_inc(vec: &[AtomicUsize], po: u8) {
-    if let Some(c) = vec.get(po as usize) {
+fn atomic_inc(vec: &[AtomicUsize], bin: Bin) {
+    if let Some(c) = vec.get(bin.as_index()) {
         c.fetch_add(1, Ordering::Relaxed);
     }
 }
 
-fn atomic_dec(vec: &[AtomicUsize], po: u8) {
-    if let Some(c) = vec.get(po as usize) {
+fn atomic_dec(vec: &[AtomicUsize], bin: Bin) {
+    if let Some(c) = vec.get(bin.as_index()) {
         c.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
-fn atomic_load(vec: &[AtomicUsize], po: u8) -> usize {
-    vec.get(po as usize)
+fn atomic_load(vec: &[AtomicUsize], bin: Bin) -> usize {
+    vec.get(bin.as_index())
         .map_or(0, |c| c.load(Ordering::Relaxed))
 }
 
@@ -134,32 +137,39 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
     /// return `true`; eviction in oversaturated neighborhoods is a
     /// separate concern handled by a future `AcceptEvict` decision.
     pub(crate) fn admission_within_capacity(&self, overlay: &OverlayAddress, extra: usize) -> bool {
-        let po = self.proximity(overlay);
+        let bin = self.bin_for(overlay);
         let depth = self.depth();
-        let ceiling = self.config.limits.ceiling(po, depth);
+        let ceiling = self.config.limits.ceiling(bin, depth);
         if ceiling == usize::MAX {
             return true;
         }
-        self.effective_count(po).saturating_add(extra) <= ceiling
+        self.effective_count(bin).saturating_add(extra) <= ceiling
     }
 
-    fn effective_count(&self, po: u8) -> usize {
-        atomic_load(&self.dialing_counts, po)
-            + atomic_load(&self.handshaking_counts, po)
-            + atomic_load(&self.active_counts, po)
+    fn effective_count(&self, bin: Bin) -> usize {
+        atomic_load(&self.dialing_counts, bin)
+            + atomic_load(&self.handshaking_counts, bin)
+            + atomic_load(&self.active_counts, bin)
+    }
+
+    /// The deepest bin in this routing table, as a typed [`Bin`].
+    pub(crate) fn max_bin(&self) -> Bin {
+        Bin::new(self.max_po).unwrap_or(Bin::MAX)
     }
 
     fn base(&self) -> OverlayAddress {
         self.identity.overlay_address()
     }
 
-    fn proximity(&self, peer: &OverlayAddress) -> u8 {
-        self.base().proximity(peer).get().min(self.max_po)
+    /// The [`Bin`] a peer occupies in this node's table (its proximity
+    /// order to the local overlay, capped at `max_po`).
+    fn bin_for(&self, peer: &OverlayAddress) -> Bin {
+        Bin::new(self.base().proximity(peer).get().min(self.max_po)).unwrap_or(Bin::MAX)
     }
 
     /// Capture state for candidate selection (lightweight: banned/backoff checked live).
     #[tracing::instrument(skip(self), level = "trace")]
-    fn capture_candidate_state(&self, effective_depth: u8) -> CandidateSnapshot {
+    fn capture_candidate_state(&self, effective_depth: NeighborhoodDepth) -> CandidateSnapshot {
         let queued_set = self.candidate_queues.snapshot_queued();
         let in_progress: HashSet<OverlayAddress> = vertex_observability::timed_read(
             &self.connection_phases,
@@ -183,7 +193,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
     /// the neighborhood by the low watermark. Crucially this caps depth at the
     /// shallowest empty or unsaturated bin, so a gap below the deepest populated
     /// bin pulls depth shallower rather than reporting a too-deep neighborhood.
-    fn recalc_depth(&self) -> u8 {
+    fn recalc_depth(&self) -> NeighborhoodDepth {
         let spec = self.identity.spec();
         let sizes = self.connected_peers.bin_sizes();
         let mut counts = [0u8; 32];
@@ -191,13 +201,12 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
             *slot = u8::try_from(size).unwrap_or(u8::MAX);
         }
 
-        recompute_neighborhood_depth(
+        let depth = recompute_neighborhood_depth(
             &counts,
             spec.saturation_peers(),
             spec.neighborhood_low_watermark(),
-        )
-        .get()
-        .min(self.max_po)
+        );
+        NeighborhoodDepth::new(Bin::new(depth.get().min(self.max_po)).unwrap_or(Bin::MAX))
     }
 
     /// Log the current routing status showing bin populations.
@@ -209,18 +218,18 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         let depth = self.depth();
 
         let mut bin_status = String::with_capacity(128);
-        for po in 0..=self.max_po {
-            let idx = po as usize;
+        for bin in 0..=self.max_po {
+            let idx = bin as usize;
             let c = connected_bins.get(idx).copied().unwrap_or(0);
             let k = known_bins.get(idx).copied().unwrap_or(0);
             if c > 0 || k > 0 {
                 if !bin_status.is_empty() {
                     bin_status.push(' ');
                 }
-                if po == depth {
-                    let _ = write!(bin_status, "[{po}:{c}/{k}]");
+                if bin == depth.get() {
+                    let _ = write!(bin_status, "[{bin}:{c}/{k}]");
                 } else {
-                    let _ = write!(bin_status, "{po}:{c}/{k}");
+                    let _ = write!(bin_status, "{bin}:{c}/{k}");
                 }
             }
         }
@@ -233,7 +242,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         }
 
         debug!(
-            depth,
+            depth = depth.get(),
             connected = total_connected,
             known = total_known,
             bins = %bin_status,
@@ -243,22 +252,22 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
 
     /// Identify peers to evict from overpopulated bins (handshaking first, then lowest-score active).
     pub(crate) fn eviction_candidates(&self) -> Vec<EvictionCandidate> {
-        let depth = self.depth.load(Ordering::Relaxed);
+        let depth = self.depth();
         let phases = self.connection_phases.read();
         let mut candidates = Vec::new();
 
         // Pre-group handshaking peers by bin: O(in_progress) total
-        let mut handshaking_by_bin: HashMap<u8, Vec<OverlayAddress>> = HashMap::new();
+        let mut handshaking_by_bin: HashMap<Bin, Vec<OverlayAddress>> = HashMap::new();
         for (overlay, phase) in phases.iter() {
             if *phase == ConnectionPhase::Handshaking {
                 handshaking_by_bin
-                    .entry(self.proximity(overlay))
+                    .entry(self.bin_for(overlay))
                     .or_default()
                     .push(*overlay);
             }
         }
 
-        for bin in 0..depth {
+        for bin in balanced_bins(depth) {
             let effective = self.effective_count(bin);
             let surplus = self.config.limits.surplus(bin, depth, effective);
             if surplus == 0 {
@@ -311,15 +320,15 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         candidates
     }
 
-    pub(crate) fn depth(&self) -> u8 {
-        self.depth.load(Ordering::Relaxed)
+    pub(crate) fn depth(&self) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(Bin::new(self.depth.load(Ordering::Relaxed)).unwrap_or(Bin::MAX))
     }
 
     /// Connected peers in the neighborhood (bins >= depth).
-    pub(crate) fn neighbors(&self, depth: u8) -> Vec<OverlayAddress> {
+    pub(crate) fn neighbors(&self, depth: NeighborhoodDepth) -> Vec<OverlayAddress> {
         let mut result = Vec::new();
-        for po in depth..=self.max_po {
-            result.extend(self.connected_peers.peers_in_bin(po));
+        for bin in neighborhood_bins(depth, self.max_bin()) {
+            result.extend(self.connected_peers.peers_in_bin(bin));
         }
         result
     }
@@ -331,8 +340,8 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
             .all_peers()
             .into_iter()
             .map(|peer| {
-                let po = address.proximity(&peer);
-                (peer, po)
+                let proximity = address.proximity(&peer);
+                (peer, proximity)
             })
             .collect();
 
@@ -357,28 +366,28 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
     }
 
     /// Get connected and known peer counts for a single bin.
-    pub(crate) fn bin_peer_counts(&self, po: u8) -> (usize, usize) {
+    pub(crate) fn bin_peer_counts(&self, bin: Bin) -> (usize, usize) {
         (
-            self.connected_peers.bin_size(po),
-            self.peer_manager.index().bin_size(po),
+            self.connected_peers.bin_size(bin),
+            self.peer_manager.index().bin_size(bin),
         )
     }
 
     /// Returns (dialing, handshaking, active) counts for bin.
-    pub(crate) fn bin_phase_counts(&self, po: u8) -> (usize, usize, usize) {
+    pub(crate) fn bin_phase_counts(&self, bin: Bin) -> (usize, usize, usize) {
         (
-            atomic_load(&self.dialing_counts, po),
-            atomic_load(&self.handshaking_counts, po),
-            atomic_load(&self.active_counts, po),
+            atomic_load(&self.dialing_counts, bin),
+            atomic_load(&self.handshaking_counts, bin),
+            atomic_load(&self.active_counts, bin),
         )
     }
 
-    /// Phase counts for all bins: (po, dialing, handshaking, active).
-    pub(crate) fn all_bin_phases(&self) -> Vec<(u8, usize, usize, usize)> {
-        (0..=self.max_po)
-            .map(|po| {
-                let (d, h, a) = self.bin_phase_counts(po);
-                (po, d, h, a)
+    /// Phase counts for all bins: (bin, dialing, handshaking, active).
+    pub(crate) fn all_bin_phases(&self) -> Vec<(Bin, usize, usize, usize)> {
+        all_bins(self.max_bin())
+            .map(|bin| {
+                let (d, h, a) = self.bin_phase_counts(bin);
+                (bin, d, h, a)
             })
             .collect()
     }
@@ -393,28 +402,32 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         self.connected_peers.len()
     }
 
-    pub(crate) fn connected_overlays_in_bin(&self, po: u8) -> Vec<OverlayAddress> {
-        self.connected_peers.peers_in_bin(po)
+    pub(crate) fn connected_overlays_in_bin(&self, bin: Bin) -> Vec<OverlayAddress> {
+        self.connected_peers.peers_in_bin(bin)
     }
 
     fn peer_connected(&self, peer: OverlayAddress) {
-        let po = self.proximity(&peer);
+        let bin = self.bin_for(&peer);
 
         if self.connected_peers.add(peer).is_ok() {
-            let old_depth = self.depth.load(Ordering::Relaxed);
+            let old_depth = self.depth();
             let new_depth = self.recalc_depth();
-            self.depth.store(new_depth, Ordering::Relaxed);
+            self.depth.store(new_depth.get(), Ordering::Relaxed);
 
             debug!(
                 %peer,
-                po,
-                depth = new_depth,
+                bin = bin.get(),
+                depth = new_depth.get(),
                 connected = self.connected_peers.len(),
                 "peer connected"
             );
 
             if new_depth != old_depth {
-                info!(old_depth, new_depth, "kademlia depth changed");
+                info!(
+                    old_depth = old_depth.get(),
+                    new_depth = new_depth.get(),
+                    "kademlia depth changed"
+                );
                 self.log_status();
             }
         }
@@ -422,22 +435,26 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
 
     fn peer_disconnected(&self, peer: &OverlayAddress) {
         if self.connected_peers.remove(peer) {
-            let po = self.proximity(peer);
+            let bin = self.bin_for(peer);
 
-            let old_depth = self.depth.load(Ordering::Relaxed);
+            let old_depth = self.depth();
             let new_depth = self.recalc_depth();
-            self.depth.store(new_depth, Ordering::Relaxed);
+            self.depth.store(new_depth.get(), Ordering::Relaxed);
 
             debug!(
                 %peer,
-                po,
-                depth = new_depth,
+                bin = bin.get(),
+                depth = new_depth.get(),
                 connected = self.connected_peers.len(),
                 "peer disconnected"
             );
 
             if new_depth != old_depth {
-                info!(old_depth, new_depth, "kademlia depth changed");
+                info!(
+                    old_depth = old_depth.get(),
+                    new_depth = new_depth.get(),
+                    "kademlia depth changed"
+                );
                 self.log_status();
             }
         }
@@ -446,8 +463,8 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
 
 impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
     fn try_reserve_dial(&self, overlay: &OverlayAddress, _node_type: SwarmNodeType) -> bool {
-        let po = self.proximity(overlay);
-        let effective = self.effective_count(po);
+        let bin = self.bin_for(overlay);
+        let effective = self.effective_count(bin);
 
         let mut phases = self.connection_phases.write();
 
@@ -456,11 +473,11 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
         }
 
         // Use depth-aware limits for capacity decision
-        if !self.config.limits.needs_more(po, self.depth(), effective) {
+        if !self.config.limits.needs_more(bin, self.depth(), effective) {
             return false;
         }
 
-        atomic_inc(&self.dialing_counts, po);
+        atomic_inc(&self.dialing_counts, bin);
         phases.insert(*overlay, ConnectionPhase::Dialing);
         record_phase_transition(phase::NONE, phase::DIALING);
         true
@@ -469,35 +486,35 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
     fn release_dial(&self, overlay: &OverlayAddress) {
         let mut phases = self.connection_phases.write();
         if let Some(ConnectionPhase::Dialing) = phases.remove(overlay) {
-            let po = self.proximity(overlay);
-            atomic_dec(&self.dialing_counts, po);
+            let bin = self.bin_for(overlay);
+            atomic_dec(&self.dialing_counts, bin);
             record_phase_transition(phase::DIALING, phase::NONE);
         }
     }
 
     fn dial_connected(&self, overlay: &OverlayAddress) {
-        let po = self.proximity(overlay);
+        let bin = self.bin_for(overlay);
         let mut phases = self.connection_phases.write();
 
         if let Some(phase) = phases.get_mut(overlay)
             && *phase == ConnectionPhase::Dialing
         {
-            atomic_dec(&self.dialing_counts, po);
-            atomic_inc(&self.handshaking_counts, po);
+            atomic_dec(&self.dialing_counts, bin);
+            atomic_inc(&self.handshaking_counts, bin);
             *phase = ConnectionPhase::Handshaking;
             record_phase_transition(phase::DIALING, phase::HANDSHAKING);
         }
     }
 
     fn handshake_completed(&self, overlay: &OverlayAddress) {
-        let po = self.proximity(overlay);
+        let bin = self.bin_for(overlay);
         let mut phases = self.connection_phases.write();
 
         if let Some(phase) = phases.get_mut(overlay)
             && *phase == ConnectionPhase::Handshaking
         {
-            atomic_dec(&self.handshaking_counts, po);
-            atomic_inc(&self.active_counts, po);
+            atomic_dec(&self.handshaking_counts, bin);
+            atomic_inc(&self.active_counts, bin);
             *phase = ConnectionPhase::Active;
             record_phase_transition(phase::HANDSHAKING, phase::ACTIVE);
         }
@@ -506,8 +523,8 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
     fn release_handshake(&self, overlay: &OverlayAddress) {
         let mut phases = self.connection_phases.write();
         if let Some(ConnectionPhase::Handshaking) = phases.remove(overlay) {
-            let po = self.proximity(overlay);
-            atomic_dec(&self.handshaking_counts, po);
+            let bin = self.bin_for(overlay);
+            atomic_dec(&self.handshaking_counts, bin);
             record_phase_transition(phase::HANDSHAKING, phase::NONE);
         }
     }
@@ -515,18 +532,18 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
     fn disconnected(&self, overlay: &OverlayAddress) {
         let mut phases = self.connection_phases.write();
         if let Some(phase) = phases.remove(overlay) {
-            let po = self.proximity(overlay);
+            let bin = self.bin_for(overlay);
             match phase {
                 ConnectionPhase::Dialing => {
-                    atomic_dec(&self.dialing_counts, po);
+                    atomic_dec(&self.dialing_counts, bin);
                     record_phase_transition(phase::DIALING, phase::NONE);
                 }
                 ConnectionPhase::Handshaking => {
-                    atomic_dec(&self.handshaking_counts, po);
+                    atomic_dec(&self.handshaking_counts, bin);
                     record_phase_transition(phase::HANDSHAKING, phase::NONE);
                 }
                 ConnectionPhase::Active => {
-                    atomic_dec(&self.active_counts, po);
+                    atomic_dec(&self.active_counts, bin);
                     record_phase_transition(phase::ACTIVE, phase::NONE);
                 }
             }
@@ -534,8 +551,8 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
     }
 
     fn should_accept_inbound(&self, overlay: &OverlayAddress, _node_type: SwarmNodeType) -> bool {
-        let po = self.proximity(overlay);
-        let effective = self.effective_count(po);
+        let bin = self.bin_for(overlay);
+        let effective = self.effective_count(bin);
 
         let phases = vertex_observability::timed_read(
             &self.connection_phases,
@@ -545,15 +562,15 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
             && self
                 .config
                 .limits
-                .should_accept_inbound(po, self.depth(), effective)
+                .should_accept_inbound(bin, self.depth(), effective)
     }
 
     fn reserve_inbound(&self, overlay: &OverlayAddress) {
-        let po = self.proximity(overlay);
+        let bin = self.bin_for(overlay);
         let mut phases = self.connection_phases.write();
 
         if !phases.contains_key(overlay) {
-            atomic_inc(&self.handshaking_counts, po);
+            atomic_inc(&self.handshaking_counts, bin);
             phases.insert(*overlay, ConnectionPhase::Handshaking);
             record_phase_transition(phase::NONE, phase::HANDSHAKING);
         }
@@ -587,7 +604,7 @@ impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
     #[tracing::instrument(skip(self), level = "debug")]
     pub(crate) fn evaluate_connections(&self) {
         // Use effective depth (max of connected and estimated) for allocation
-        let connected_depth = self.depth.load(Ordering::Relaxed);
+        let connected_depth = self.depth();
         let known_bin_sizes = self.peer_manager.index().bin_sizes();
         let effective_depth = self
             .config
@@ -596,8 +613,9 @@ impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
 
         if effective_depth != connected_depth {
             trace!(
-                connected_depth,
-                effective_depth, "using estimated depth for allocation"
+                connected_depth = connected_depth.get(),
+                effective_depth = effective_depth.get(),
+                "using estimated depth for allocation"
             );
         }
 
@@ -612,13 +630,13 @@ impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
         select_neighborhood_candidates(
             &mut selector,
             &self.peer_manager,
-            |po| self.effective_count(po),
-            self.max_po,
+            |bin| self.effective_count(bin),
+            self.max_bin(),
         );
         let neighbor_candidates = selector.len();
 
-        select_balanced_candidates(&mut selector, &self.peer_manager, |po| {
-            self.effective_count(po)
+        select_balanced_candidates(&mut selector, &self.peer_manager, |bin| {
+            self.effective_count(bin)
         });
         let balanced_candidates = selector.len() - neighbor_candidates;
 
@@ -626,8 +644,8 @@ impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
 
         let mut added = 0usize;
         for c in new_candidates {
-            let po = self.proximity(&c);
-            if self.candidate_queues.push(po, c) {
+            let bin = self.bin_for(&c);
+            if self.candidate_queues.push(bin, c) {
                 added += 1;
             }
         }
@@ -651,6 +669,14 @@ mod tests {
     use nectar_primitives::SwarmAddress;
     use vertex_swarm_test_utils::{MockIdentity, make_swarm_peer_minimal};
 
+    fn b(n: u8) -> Bin {
+        Bin::new(n).expect("valid bin")
+    }
+
+    fn d(n: u8) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(b(n))
+    }
+
     fn make_routing(
         base: OverlayAddress,
         config: KademliaConfig,
@@ -670,7 +696,7 @@ mod tests {
         let config = KademliaConfig::default();
         let (routing, _pm) = make_routing(base, config);
 
-        assert_eq!(routing.depth(), 0);
+        assert_eq!(routing.depth().get(), 0);
         assert_eq!(routing.connected_peers.len(), 0);
     }
 
@@ -706,9 +732,9 @@ mod tests {
             .with_bootstrap_target(2);
         let (routing, _pm) = make_routing(base, config);
 
-        let peer1 = SwarmAddress::with_first_byte(0x80); // po=0
-        let peer2 = SwarmAddress::with_first_byte(0xc0); // po=0
-        let peer3 = SwarmAddress::with_first_byte(0xa0); // po=0
+        let peer1 = SwarmAddress::with_first_byte(0x80); // bin=0
+        let peer2 = SwarmAddress::with_first_byte(0xc0); // bin=0
+        let peer3 = SwarmAddress::with_first_byte(0xa0); // bin=0
 
         // First reserve succeeds (effective=0 < target=2)
         assert!(routing.try_reserve_dial(&peer1, SwarmNodeType::Storer));
@@ -732,24 +758,24 @@ mod tests {
         let config = KademliaConfig::default().with_nominal(2);
         let (routing, _pm) = make_routing(base, config);
 
-        let peer = SwarmAddress::with_first_byte(0x80); // po=0
+        let peer = SwarmAddress::with_first_byte(0x80); // bin=0
 
         // Reserve dial
         assert!(routing.try_reserve_dial(&peer, SwarmNodeType::Storer));
-        assert_eq!(routing.effective_count(0), 1);
+        assert_eq!(routing.effective_count(b(0)), 1);
 
         // Transition to handshaking
         routing.dial_connected(&peer);
-        assert_eq!(routing.effective_count(0), 1);
+        assert_eq!(routing.effective_count(b(0)), 1);
 
         // Transition to active
         routing.handshake_completed(&peer);
-        assert_eq!(routing.effective_count(0), 1);
-        assert_eq!(atomic_load(&routing.active_counts, 0), 1);
+        assert_eq!(routing.effective_count(b(0)), 1);
+        assert_eq!(atomic_load(&routing.active_counts, b(0)), 1);
 
         // Disconnect
         RoutingCapacity::disconnected(&*routing, &peer);
-        assert_eq!(routing.effective_count(0), 0);
+        assert_eq!(routing.effective_count(b(0)), 0);
     }
 
     #[test]
@@ -792,11 +818,11 @@ mod tests {
         let base = SwarmAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
-        assert_eq!(routing.depth(), 0);
+        assert_eq!(routing.depth().get(), 0);
         for idx in 0..2 {
             SwarmRouting::connected(&*routing, addr_in_bin(5, idx));
         }
-        assert_eq!(routing.depth(), 0);
+        assert_eq!(routing.depth().get(), 0);
     }
 
     #[test]
@@ -815,7 +841,11 @@ mod tests {
             SwarmRouting::connected(&*routing, addr_in_bin(8, idx));
         }
 
-        assert_eq!(routing.depth(), 1, "gap below the deep bin must cap depth");
+        assert_eq!(
+            routing.depth().get(),
+            1,
+            "gap below the deep bin must cap depth"
+        );
     }
 
     #[test]
@@ -834,7 +864,7 @@ mod tests {
             SwarmRouting::connected(&*routing, addr_in_bin(3, idx));
         }
 
-        assert_eq!(routing.depth(), 3);
+        assert_eq!(routing.depth().get(), 3);
     }
 
     #[test]
@@ -878,10 +908,10 @@ mod tests {
         SwarmRouting::connected(&*routing, peer_po1);
         SwarmRouting::connected(&*routing, peer_po5);
 
-        let neighbors_d0 = routing.neighbors(0);
+        let neighbors_d0 = routing.neighbors(d(0));
         assert_eq!(neighbors_d0.len(), 3);
 
-        let neighbors_d2 = routing.neighbors(2);
+        let neighbors_d2 = routing.neighbors(d(2));
         assert_eq!(neighbors_d2.len(), 1);
         assert_eq!(neighbors_d2[0], peer_po5);
     }
@@ -931,16 +961,16 @@ mod tests {
         let (routing, _pm) = make_routing(base, config);
 
         // Initially depth=0, all bins fill toward the bootstrap target
-        assert_eq!(routing.config.limits.target(0, 0), 18);
-        assert_eq!(routing.config.limits.target(7, 0), 18);
+        assert_eq!(routing.config.limits.target(b(0), d(0)), 18);
+        assert_eq!(routing.config.limits.target(b(7), d(0)), 18);
 
         // At depth 8, targets should vary by bin
         // Bin 7: 160 × 8 / 36 = 35
-        assert_eq!(routing.config.limits.target(7, 8), 35);
+        assert_eq!(routing.config.limits.target(b(7), d(8)), 35);
         // Bin 0: 160 × 1 / 36 = 4
-        assert_eq!(routing.config.limits.target(0, 8), 4);
+        assert_eq!(routing.config.limits.target(b(0), d(8)), 4);
         // Neighborhood (bin >= depth) returns MAX
-        assert_eq!(routing.config.limits.target(8, 8), usize::MAX);
+        assert_eq!(routing.config.limits.target(b(8), d(8)), usize::MAX);
     }
 
     #[test]
@@ -954,7 +984,7 @@ mod tests {
         assert!(candidates.is_empty());
 
         // Add peers below nominal - still no surplus
-        let peer1 = SwarmAddress::with_first_byte(0x80); // po=0
+        let peer1 = SwarmAddress::with_first_byte(0x80); // bin=0
         SwarmRouting::connected(&*routing, peer1);
         let candidates = routing.eviction_candidates();
         assert!(candidates.is_empty());
@@ -962,8 +992,8 @@ mod tests {
 
     /// Helper to directly place a peer as Active in routing state (bypasses capacity checks).
     fn force_active(routing: &KademliaRouting<MockIdentity>, peer: OverlayAddress) {
-        let po = routing.proximity(&peer);
-        atomic_inc(&routing.active_counts, po);
+        let bin = routing.bin_for(&peer);
+        atomic_inc(&routing.active_counts, bin);
         routing
             .connection_phases
             .write()
@@ -973,8 +1003,8 @@ mod tests {
 
     /// Helper to directly place a peer as Handshaking in routing state.
     fn force_handshaking(routing: &KademliaRouting<MockIdentity>, peer: OverlayAddress) {
-        let po = routing.proximity(&peer);
-        atomic_inc(&routing.handshaking_counts, po);
+        let bin = routing.bin_for(&peer);
+        atomic_inc(&routing.handshaking_counts, bin);
         routing
             .connection_phases
             .write()
@@ -987,7 +1017,7 @@ mod tests {
         let config = KademliaConfig::default(); // nominal=3, total_target=160
         let (routing, _pm) = make_routing(base, config);
 
-        // Place 5 active peers in bin 0 (po=0)
+        // Place 5 active peers in bin 0 (bin=0)
         let active_peers: Vec<_> = (0..5)
             .map(|i| {
                 let mut bytes = [0x00u8; 32];
@@ -1048,7 +1078,7 @@ mod tests {
         assert_eq!(candidates.len(), 2);
         for c in &candidates {
             assert_eq!(c.phase, EvictionPhase::Active);
-            assert_eq!(c.bin, 0);
+            assert_eq!(c.bin.get(), 0);
         }
     }
 
@@ -1078,7 +1108,7 @@ mod tests {
             connect(addr_in_bin(2, idx));
         }
 
-        assert_eq!(routing.depth(), 2);
+        assert_eq!(routing.depth().get(), 2);
 
         let candidates = routing.eviction_candidates();
         // Below-depth bins (0, 1) overflow their small target; the neighborhood
@@ -1086,7 +1116,7 @@ mod tests {
         assert!(!candidates.is_empty());
         for c in &candidates {
             assert!(
-                c.bin < routing.depth(),
+                !routing.depth().contains(c.bin),
                 "neighborhood bin {} should not produce candidates",
                 c.bin
             );

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -69,7 +69,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             %peer_id,
             %overlay,
             ?node_type,
-            po = self.proximity(&overlay),
+            bin = self.bin_for(&overlay).get(),
             "Handshake completed"
         );
 
@@ -210,21 +210,21 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             .reachability()
             .update_from_handshake(peer_id, true);
 
-        let po = self.proximity(&overlay);
+        let bin = self.bin_for(&overlay);
 
         let old_depth = self.routing.depth();
         self.routing.connected(overlay);
         let new_depth = self.routing.depth();
 
         // Push event-driven routing gauges for the affected bin
-        self.push_routing_gauges(po);
+        self.push_routing_gauges(bin);
 
         if new_depth != old_depth {
             self.push_bin_targets();
-            self.gossip.send(GossipInput::DepthChanged(new_depth));
+            self.gossip.send(GossipInput::DepthChanged(new_depth.get()));
             self.emit_event(TopologyEvent::DepthChanged {
-                old_depth,
-                new_depth,
+                old_depth: old_depth.get(),
+                new_depth: new_depth.get(),
             });
             if new_depth > old_depth {
                 self.trim_overpopulated_bins();


### PR DESCRIPTION
Stacked on #149. Closes #134.

## The problem

The routing layer carried bins as raw `u8` and conflated three distinct proximity concepts that share the `0..=31` range but mean different things. (An earlier revision of this PR keyed storage on `Bin` but still typed *depth* as a plain `Bin`, so depth and any bin stayed interchangeable.)

## The model

One type each, with single named bridges between them:

| Type | Is | Bridge in / out |
|---|---|---|
| **`ProximityOrder`** (nectar) | the symmetric XOR-distance **metric** between two addresses | produced by `addr.proximity(other)`; survives as a value only where it is genuinely a metric (ranking by closeness to a chunk in `closest_to`) |
| **`Bin`** (nectar) | the **index** of a peer's slot in the local node's routing table | the only `ProximityOrder -> Bin` bridge is `Bin::from` (relative to local, capped at `max_po`); keys `ProximityIndex`, phase accounting, candidate queues, and table iteration |
| **`NeighborhoodDepth`** (new, in `vertex-swarm-primitives`) | the distinguished **boundary** bin | `NeighborhoodDepth::new(bin)` only at the depth computation; `depth.bin()` / `depth.contains(bin)` out |

## Aggressive enforcement

- `NeighborhoodDepth` is **not** comparable with `Bin`. Relate them only through `depth.contains(bin)` (membership) or `depth.bin()` (the boundary as an index), so an accidental `bin >= depth` no longer compiles. (One real test even had this latent comparison; the type caught it.)
- `recalc_depth`, `depth()`, the `SwarmTopologyState::depth()` trait, and every depth-aware `limits` parameter are `NeighborhoodDepth`.
- Depth-relative iteration is `balanced_bins(depth)` / `neighborhood_bins(depth, max)`; full-table iteration is `all_bins(max)`. These three are the only places a `Bin` is built from a raw index.
- The raw `u8` is extracted with `.get()` only at edges: `tracing` fields, metric labels, the gRPC wire, and the still-`u8` gossip / event payloads.

## Home

All three value-types live together in `vertex-swarm-primitives` (re-exporting nectar's `ProximityOrder`/`Bin`, adding `NeighborhoodDepth` + the iterators). nectar's `recompute_neighborhood_depth` doc states the wrapper stays in the downstream routing layer.

## Tests

`NeighborhoodDepth` and the iterators get direct unit tests (`contains`, `ZERO`, `Ord`, table-partitioning). Full changed-crate suites green (`primitives`, `topology`, `peer-manager`, `api`, `rpc`, `test-utils`) plus the `bootnode_cluster` convergence test, whose depth assertions now read `NeighborhoodDepth::ZERO`.