### PR TITLE
docs(swarm): document embedded protocol assumptions (#122)

### DIFF
--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -1,4 +1,24 @@
 //! Handshake protocol for Swarm peer authentication and identity exchange.
+//!
+//! Wire protocol id [`PROTOCOL`] = `/swarm/handshake/15.0.0/handshake`. A new
+//! connection exchanges syn/synack/ack frames to prove control of an overlay
+//! key, agree on the network id, and learn the remote's node type, multiaddrs,
+//! and welcome message before the connection is admitted to the topology.
+//!
+//! # Protocol assumptions not in the Book of Swarm
+//!
+//! - [`HANDSHAKE_TIMEOUT`] = 15 seconds bounds the whole exchange. The handler
+//!   arms it per operation, and the topology reuses it as the dialer's in-flight
+//!   timeout and the stale-pending cleanup window. A peer that upgrades the
+//!   transport but does not finish the handshake within this window is
+//!   disconnected and its slot freed, so a stalled or half-open peer cannot pin
+//!   a connection indefinitely.
+//! - `MAX_WELCOME_MESSAGE_CHARS` = 140 caps the free-form welcome string. The
+//!   limit is enforced on decode in the codec (`welcome_message_from_proto`),
+//!   counted in Unicode scalar values rather than bytes, and an over-long
+//!   message fails the handshake with a validation error rather than being
+//!   truncated. Bounding it stops an untrusted peer from spending our memory on
+//!   a field that carries no protocol meaning.
 
 use std::time::Duration;
 
@@ -32,10 +52,15 @@ pub use admission::{
 /// Protocol name for handshake.
 pub const PROTOCOL: &str = "/swarm/handshake/15.0.0/handshake";
 
-/// Timeout for handshake operations.
+/// Timeout for the full handshake exchange.
+///
+/// The topology reuses this as the dialer in-flight timeout and the
+/// stale-pending cleanup window; see the crate-level docs.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 
-/// Maximum length of welcome message in characters.
+/// Maximum welcome-message length, in Unicode scalar values.
+///
+/// Enforced on decode in the codec; an over-long message fails the handshake.
 const MAX_WELCOME_MESSAGE_CHARS: usize = 140;
 
 /// Information from a completed handshake.

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -3,6 +3,23 @@
 //! Connected and recently-accessed peers live in a hot DashMap cache.
 //! All known overlays are tracked in the ProximityIndex. Peer data for
 //! cold peers lives in the database and is loaded on demand.
+//!
+//! # Capacity defaults
+//!
+//! These bounds size the in-memory structures; they are not specified by the
+//! Book of Swarm and can be overridden at construction.
+//!
+//! - `DEFAULT_MAX_PER_BIN` (128) bounds how many overlays the proximity index
+//!   keeps per bin. Topology targets 3-35 connected peers per bin, so 128 leaves
+//!   3.7-42x headroom for the known-but-unconnected candidates a bin draws from.
+//! - `DEFAULT_MAX_HOT_PEERS` (500) bounds the hot DashMap cache of full peer
+//!   records. It comfortably covers the connected set (total target ~160 plus
+//!   inbound headroom) and the recently-touched cold peers a dial round visits,
+//!   so a steady-state node serves from memory while colder peers spill to the
+//!   database.
+//! - `DEFAULT_WRITE_BUFFER_CAPACITY` (64) is the number of dirty records buffered
+//!   before an automatic flush, amortizing store writes without holding enough in
+//!   memory to lose much on a crash.
 
 use std::marker::PhantomData;
 use std::sync::{Arc, Weak};
@@ -33,10 +50,15 @@ use crate::write_buffer::WriteBuffer;
 /// With topology targets of 3-35 peers per bin, 128 gives 3.7-42x headroom.
 pub(crate) const DEFAULT_MAX_PER_BIN: usize = 128;
 
-/// Default maximum hot peers in DashMap cache.
+/// Default maximum hot peers in the DashMap cache.
+///
+/// Covers the connected set plus recently-touched cold peers; see the
+/// module-level capacity notes.
 const DEFAULT_MAX_HOT_PEERS: usize = 500;
 
-/// Default write buffer capacity before auto-flush.
+/// Default number of dirty records buffered before an automatic flush.
+///
+/// Amortizes store writes; see the module-level capacity notes.
 const DEFAULT_WRITE_BUFFER_CAPACITY: usize = 64;
 
 /// Peer lifecycle manager with hot/cold storage architecture.

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -58,13 +58,21 @@ use crate::nat_discovery::LocalAddressManager;
 /// Type-erased peer store supporting both file-based and database-backed storage.
 type PeerStore = Arc<dyn NetPeerStore<StoredPeer>>;
 
-/// Default interval between connection evaluation rounds.
+/// Default interval between connection-evaluation rounds.
+///
+/// Each round reconsiders which bins are under target and issues new dials.
+/// Shorter wastes work on a stable table; longer slows convergence after churn.
 pub const DEFAULT_DIAL_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Post-handshake connections shorter than this are penalized as early disconnects.
+/// Post-handshake connections shorter than this are penalized as early
+/// disconnects, so a peer that repeatedly connects and immediately leaves is
+/// scored down.
 const DEFAULT_EARLY_DISCONNECT_THRESHOLD: Duration = Duration::from_secs(30);
 
 /// Default interval between periodic peer saves to persistent storage.
+///
+/// Trades store-write frequency against how many freshly learned peers a crash
+/// can lose.
 const DEFAULT_PEER_SAVE_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Event broadcast buffer (256 allows burst without blocking poll loop).

--- a/crates/swarm/topology/src/kademlia/config.rs
+++ b/crates/swarm/topology/src/kademlia/config.rs
@@ -1,8 +1,19 @@
 //! Kademlia routing configuration.
+//!
+//! [`KademliaConfig`] bundles the depth-aware per-bin targets (see the `limits`
+//! module) with the per-round candidate budget. Each connection-evaluation round
+//! selects at most `max_neighbor_candidates + max_balanced_candidates` new peers
+//! to dial, split between the neighborhood (depth) bins and the balanced
+//! (non-depth) bins below them. The 16 / 16 default gives a 32-candidate budget
+//! per round, roughly one slot per Kademlia bin, so a single round can make
+//! progress on every bin without flooding the dialer. The depth-aware targets,
+//! not this budget, decide how many candidates actually become connections.
 
 use super::limits::DepthAwareLimits;
 
+/// Max new neighborhood (depth-bin) candidates enqueued per evaluation round.
 const DEFAULT_MAX_NEIGHBOR_CANDIDATES: usize = 16;
+/// Max new balanced (non-depth-bin) candidates enqueued per evaluation round.
 const DEFAULT_MAX_BALANCED_CANDIDATES: usize = 16;
 
 /// Configuration for Kademlia routing.

--- a/crates/swarm/topology/src/kademlia/limits.rs
+++ b/crates/swarm/topology/src/kademlia/limits.rs
@@ -5,13 +5,18 @@
 
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth};
 
-/// Default minimum peers per bin (floor for depth calculation).
+/// Default minimum peers per bin (floor for the linear taper and for depth
+/// estimation). A bin is considered populated once it holds this many peers.
 const DEFAULT_NOMINAL: usize = 3;
 
-/// Default total connected peer target.
+/// Default total connected-peer target across all bins. The linear taper
+/// distributes this budget, weighting bins closer to the neighborhood more
+/// heavily where peers are scarcer and more valuable for retrieval.
 const DEFAULT_TOTAL_TARGET: usize = 160;
 
-/// Default ceiling for inbound connections above target.
+/// Default headroom for inbound connections above a bin's target. Accepting a
+/// few extra inbound per bin keeps reachable peers connected without letting any
+/// single bin grow unbounded.
 pub(crate) const DEFAULT_INBOUND_HEADROOM: usize = 4;
 
 /// Default per-bin fill target during bootstrap (`depth == 0`).

--- a/crates/swarm/topology/src/lib.rs
+++ b/crates/swarm/topology/src/lib.rs
@@ -2,6 +2,29 @@
 //!
 //! Provides libp2p behaviour, handlers, and Kademlia routing for Swarm peer
 //! discovery and connection management.
+//!
+//! # Timing and capacity assumptions
+//!
+//! These defaults are not specified by the Book of Swarm; they trade
+//! responsiveness against churn and memory. They live in the `behaviour` module
+//! and can be overridden through [`TopologyConfig`].
+//!
+//! - [`DEFAULT_DIAL_INTERVAL`] (5s) is the cadence of the connection-evaluation
+//!   loop: how often the behaviour reconsiders which bins are under target and
+//!   issues new dials. Shorter wastes work on a stable table; longer slows
+//!   convergence after churn.
+//! - `DEFAULT_EARLY_DISCONNECT_THRESHOLD` (30s) is the floor below which a
+//!   post-handshake connection that drops is scored as an early disconnect, so a
+//!   peer that repeatedly connects and immediately leaves is penalized.
+//! - `DEFAULT_PEER_SAVE_INTERVAL` (300s) bounds how often the known-peer set is
+//!   flushed to persistent storage, trading store writes against how many freshly
+//!   learned peers a crash can lose.
+//! - `EVENT_CHANNEL_CAPACITY` (256) and `COMMAND_CHANNEL_CAPACITY` (64) size the
+//!   event-broadcast and command buffers so a burst does not block the poll loop
+//!   while staying bounded.
+//! - The dialer tracks at most 256 in-flight dials, each bounded by the
+//!   handshake timeout; the per-bin routing targets, not this cap, are the real
+//!   gate on how many become connections.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 


### PR DESCRIPTION
Closes #122.

This completes the remaining four clusters of the umbrella issue (hive and pseudosettle were already documented), so merging this closes #122 in full.

Adds crate-level `//!` rationale and per-constant `///` docs explaining the embedded protocol assumptions that previously only lived in commit messages:

- `vertex-swarm-net-handshake`: why `HANDSHAKE_TIMEOUT` is 15s and what it triggers (handler timeout, dialer in-flight timeout, stale-pending cleanup), and why `MAX_WELCOME_MESSAGE_CHARS` is 140 and where it is enforced.
- `vertex-swarm-topology`: a timing/capacity section covering dial interval, early-disconnect threshold, peer-save interval, the event/command channel capacities, and the 256 in-flight dial cap.
- `vertex-swarm-peer-manager`: a capacity-defaults section justifying per-bin (128), hot-cache (500), and write-buffer (64) bounds against the topology targets.
- `vertex-swarm-topology::kademlia`: the per-round candidate budget (16 neighbor + 16 balanced), plus rationale for nominal, total target, and inbound headroom.

Documentation only; no behaviour change. `cargo fmt`, library `clippy`, and `RUSTDOCFLAGS=-D warnings cargo doc` all clean on the touched crates.