### PR TITLE
fix(net): scope-filter advertised addresses; node-type-aware signed record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8334,6 +8334,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vertex-metrics",
+ "vertex-net-local",
  "vertex-observability",
  "void",
 ]

--- a/crates/net/local/src/capabilities.rs
+++ b/crates/net/local/src/capabilities.rs
@@ -9,6 +9,41 @@ use tracing::{debug, info};
 use crate::scope::{AddressScope, IpCapability, classify_multiaddr};
 use crate::system::same_subnet;
 
+/// Filter our candidate addresses to those appropriate to advertise to a peer
+/// of the given scope.
+///
+/// This is the single per-scope advertisement rule shared by every place that
+/// decides which of our own addresses a peer may learn (the handshake's
+/// [`LocalCapabilities::addresses_for_scope`], the identify behaviour, and the
+/// dial-eligibility check):
+/// - **public** peer: only public-scope candidates,
+/// - **private / link-local** peer: only candidates on the same subnet (requires
+///   `peer_addr`; without it none qualify),
+/// - **loopback** peer: loopback and private candidates.
+///
+/// Results are deduplicated, preserving input order.
+pub fn advertise_filter<'a>(
+    candidates: impl Iterator<Item = &'a Multiaddr>,
+    peer_scope: AddressScope,
+    peer_addr: Option<&Multiaddr>,
+) -> Vec<Multiaddr> {
+    let mut seen = HashSet::new();
+    candidates
+        .filter(|addr| match peer_scope {
+            AddressScope::Loopback => matches!(
+                classify_multiaddr(addr),
+                Some(AddressScope::Loopback | AddressScope::Private)
+            ),
+            AddressScope::Private | AddressScope::LinkLocal => {
+                peer_addr.is_some_and(|peer| same_subnet(addr, peer))
+            }
+            AddressScope::Public => classify_multiaddr(addr) == Some(AddressScope::Public),
+        })
+        .filter(|addr| seen.insert((*addr).clone()))
+        .cloned()
+        .collect()
+}
+
 /// Local node's network capabilities derived from libp2p listen addresses.
 ///
 /// Tracks listen addresses from libp2p events and computes IP capability.
@@ -82,46 +117,14 @@ impl LocalCapabilities {
     }
 
     /// Select listen addresses appropriate for a peer's network scope.
+    ///
+    /// Applies the shared [`advertise_filter`] rule over our listen addresses.
     pub fn addresses_for_scope(
         &self,
         peer_scope: AddressScope,
         peer_addr: Option<&Multiaddr>,
     ) -> Vec<Multiaddr> {
-        let listen = self.listen_addrs.read();
-
-        // Filter and deduplicate in one pass
-        let mut seen = HashSet::new();
-
-        match peer_scope {
-            AddressScope::Loopback => listen
-                .iter()
-                .filter(|addr| {
-                    matches!(
-                        classify_multiaddr(addr),
-                        Some(AddressScope::Loopback | AddressScope::Private)
-                    )
-                })
-                .filter(|addr| seen.insert((*addr).clone()))
-                .cloned()
-                .collect(),
-
-            AddressScope::Private | AddressScope::LinkLocal => match peer_addr {
-                Some(peer) => listen
-                    .iter()
-                    .filter(|addr| same_subnet(addr, peer))
-                    .filter(|addr| seen.insert((*addr).clone()))
-                    .cloned()
-                    .collect(),
-                None => Vec::new(),
-            },
-
-            AddressScope::Public => listen
-                .iter()
-                .filter(|addr| classify_multiaddr(addr) == Some(AddressScope::Public))
-                .filter(|addr| seen.insert((*addr).clone()))
-                .cloned()
-                .collect(),
-        }
+        advertise_filter(self.listen_addrs.read().iter(), peer_scope, peer_addr)
     }
 }
 

--- a/crates/net/local/src/capabilities.rs
+++ b/crates/net/local/src/capabilities.rs
@@ -204,4 +204,65 @@ mod tests {
         assert!(!addrs.iter().any(|a| a.to_string().contains("192.168")));
         assert!(addrs.iter().any(|a| a.to_string().contains("8.8.4.4")));
     }
+
+    // IPv6 scope rules: `::1` is loopback, `fc00::/7` (ULA) is private,
+    // `fe80::/10` is link-local, and a global unicast address is public.
+
+    #[test]
+    fn advertise_filter_public_peer_keeps_only_global_ipv6() {
+        let candidates = [
+            parse_addr("/ip6/::1/tcp/1634"),                  // loopback
+            parse_addr("/ip6/fd00::1/tcp/1634"),              // ULA (private)
+            parse_addr("/ip6/fe80::1/tcp/1634"),              // link-local
+            parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"), // global
+        ];
+        let peer = parse_addr("/ip6/2001:4860:4860::8888/tcp/5000"); // public peer
+        let out = advertise_filter(candidates.iter(), AddressScope::Public, Some(&peer));
+        assert_eq!(out, vec![parse_addr("/ip6/2606:4700:4700::1111/tcp/1634")]);
+    }
+
+    #[test]
+    fn advertise_filter_linklocal_ipv6_peer_keeps_same_subnet() {
+        // Two IPv6 link-local addresses are always same-subnet; a ULA is not
+        // same-subnet as a link-local peer.
+        let candidates = [
+            parse_addr("/ip6/fe80::abcd/tcp/1634"),
+            parse_addr("/ip6/fd00::1/tcp/1634"),
+        ];
+        let peer = parse_addr("/ip6/fe80::1234/tcp/5000");
+        let out = advertise_filter(candidates.iter(), AddressScope::LinkLocal, Some(&peer));
+        assert_eq!(out, vec![parse_addr("/ip6/fe80::abcd/tcp/1634")]);
+    }
+
+    #[test]
+    fn advertise_filter_loopback_peer_keeps_loopback_and_ula_ipv6() {
+        let candidates = [
+            parse_addr("/ip6/::1/tcp/1634"),                  // loopback
+            parse_addr("/ip6/fd00::1/tcp/1634"),              // ULA (private)
+            parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"), // global
+        ];
+        let peer = parse_addr("/ip6/::1/tcp/5000");
+        let out = advertise_filter(candidates.iter(), AddressScope::Loopback, Some(&peer));
+        assert!(out.contains(&parse_addr("/ip6/::1/tcp/1634")));
+        assert!(out.contains(&parse_addr("/ip6/fd00::1/tcp/1634")));
+        assert!(!out.contains(&parse_addr("/ip6/2606:4700:4700::1111/tcp/1634")));
+    }
+
+    #[test]
+    fn advertise_filter_mixed_stack_public_peer() {
+        // A dual-stack node advertising to a public peer: both the public IPv4
+        // and public IPv6 are kept, private/link-local of either family dropped.
+        let candidates = [
+            parse_addr("/ip4/192.168.1.10/tcp/1634"),
+            parse_addr("/ip4/8.8.4.4/tcp/1634"),
+            parse_addr("/ip6/fd00::1/tcp/1634"),
+            parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"),
+        ];
+        let peer = parse_addr("/ip4/8.8.8.8/tcp/5000");
+        let out = advertise_filter(candidates.iter(), AddressScope::Public, Some(&peer));
+        assert!(out.contains(&parse_addr("/ip4/8.8.4.4/tcp/1634")));
+        assert!(out.contains(&parse_addr("/ip6/2606:4700:4700::1111/tcp/1634")));
+        assert!(!out.contains(&parse_addr("/ip4/192.168.1.10/tcp/1634")));
+        assert!(!out.contains(&parse_addr("/ip6/fd00::1/tcp/1634")));
+    }
 }

--- a/crates/net/local/src/lib.rs
+++ b/crates/net/local/src/lib.rs
@@ -8,6 +8,6 @@ pub mod capabilities;
 pub mod scope;
 pub mod system;
 
-pub use capabilities::LocalCapabilities;
+pub use capabilities::{LocalCapabilities, advertise_filter};
 pub use scope::{AddressScope, IpCapability, classify_multiaddr, is_dialable};
 pub use system::{add_subnet, remove_subnet, same_subnet};

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -37,21 +37,80 @@ fn validate_observed_addr(
     }
 }
 
-/// Combine additional addresses with the observed address and create a signed SwarmPeer.
+/// Select the addresses to put in our signed record for this peer, and report
+/// whether we had to fall back to the (ephemeral) observed address.
 ///
-/// Additional addresses come first, observed address is appended last (most important).
-/// Duplicates of the observed address are filtered from additional addresses.
-fn prepare_local_peer<I: SwarmIdentity>(
-    identity: &I,
+/// `additional_addrs` are our already-scope-filtered advertised addresses. The
+/// observed address (the peer's view of us) is appended only when it is
+/// trustworthy as a reachable address (inbound), or as a last resort to satisfy
+/// the non-empty requirement (outbound with nothing real). The returned bool is
+/// `true` only in that last-resort case. See [`prepare_local_peer`].
+fn select_local_addrs(
     additional_addrs: &[Multiaddr],
     observed_addr: &Multiaddr,
-) -> Result<SwarmPeer, HandshakeError> {
+    direction: ConnectionDirection,
+) -> (Vec<Multiaddr>, bool) {
     let mut addrs: Vec<Multiaddr> = additional_addrs
         .iter()
         .filter(|a| *a != observed_addr)
         .cloned()
         .collect();
-    addrs.push(observed_addr.clone());
+
+    // Inbound: the observed address is genuinely reachable (the peer reached us
+    // at it), so it is a real address, not a fallback.
+    if direction == ConnectionDirection::Inbound {
+        addrs.push(observed_addr.clone());
+        return (addrs, false);
+    }
+
+    // Outbound: the observed address is our ephemeral NAT source port. Only use
+    // it as a last resort to keep the record non-empty for the >=1 requirement.
+    if addrs.is_empty() {
+        addrs.push(observed_addr.clone());
+        return (addrs, true);
+    }
+
+    (addrs, false)
+}
+
+/// Combine our scope-filtered addresses with the peer-observed address and
+/// create a signed `SwarmPeer` (the record the peer stores and gossips).
+///
+/// The observed address is the peer's view of us. It is trustworthy as a
+/// reachable address only on an **inbound** connection, where the peer dialed
+/// our actual listen address and reached it; that case is the primary way a
+/// port-forwarded node learns its public address without static config, so we
+/// append it. On an **outbound** connection the observed address is our
+/// ephemeral NAT source port, which is connection-specific and would pollute
+/// hive gossip, so it is not added.
+///
+/// Both vertex and bee reject a signed record with zero multiaddrs
+/// (`SwarmPeer::sign` / bee `ParseAddress`), so when we have nothing else to
+/// advertise the observed address is included as a last resort to keep the
+/// handshake alive. Such an entry is transient: it is superseded once AutoNAT
+/// v2 / UPnP confirms a real external address (newer timestamp wins).
+fn prepare_local_peer<I: SwarmIdentity>(
+    identity: &I,
+    additional_addrs: &[Multiaddr],
+    observed_addr: &Multiaddr,
+    direction: ConnectionDirection,
+) -> Result<SwarmPeer, HandshakeError> {
+    let (addrs, ephemeral_fallback) =
+        select_local_addrs(additional_addrs, observed_addr, direction);
+
+    // A full (storer) node's record is gossiped network-wide, so it must carry a
+    // real reachable address. Falling back to the ephemeral observed address
+    // means this storer is unreachable and is about to advertise an address no
+    // peer can dial. A light (client) node is never gossiped, so its fallback is
+    // harmless and silent. The fallback self-heals once AutoNAT v2 / UPnP / a
+    // static NAT address provides a real one.
+    if ephemeral_fallback && identity.is_full_node() {
+        warn!(
+            observed = %observed_addr,
+            "full node has no reachable address; advertising an ephemeral address that peers \
+             cannot dial. Configure --network.nat-addr or enable AutoNAT v2 / UPnP."
+        );
+    }
 
     let signer = identity.signer();
     SwarmPeer::sign(
@@ -182,8 +241,12 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             validate_observed_addr(&observed_multiaddr, local_peer_id)?;
         }
 
-        let local_peer =
-            prepare_local_peer(&self.identity, &self.additional_addrs, &observed_multiaddr)?;
+        let local_peer = prepare_local_peer(
+            &self.identity,
+            &self.additional_addrs,
+            &observed_multiaddr,
+            ConnectionDirection::Inbound,
+        )?;
 
         // Echo what we observed about the dialer (their `remote_addr` as
         // libp2p reported it) back in the SYNACK; the dialer validates the
@@ -300,8 +363,12 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             validate_observed_addr(&observed_multiaddr, local_peer_id)?;
         }
 
-        let local_peer =
-            prepare_local_peer(&self.identity, &self.additional_addrs, &observed_multiaddr)?;
+        let local_peer = prepare_local_peer(
+            &self.identity,
+            &self.additional_addrs,
+            &observed_multiaddr,
+            ConnectionDirection::Outbound,
+        )?;
 
         // Consult admission control before sending ACK so a reject
         // aborts cleanly without committing to the exchange.
@@ -328,5 +395,65 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
         futures::AsyncWriteExt::close(&mut stream).await?;
 
         Ok(info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().expect("valid multiaddr")
+    }
+
+    #[test]
+    fn inbound_appends_observed_reachable_address() {
+        // Inbound: the peer reached us at the observed address, so it is a real
+        // reachable address worth advertising (e.g. port-forward discovery), not
+        // an ephemeral fallback.
+        let additional = vec![addr("/ip4/8.8.4.4/tcp/1634")];
+        let observed = addr("/ip4/203.0.113.7/tcp/1634");
+        let (out, fallback) =
+            select_local_addrs(&additional, &observed, ConnectionDirection::Inbound);
+        assert!(out.contains(&addr("/ip4/8.8.4.4/tcp/1634")));
+        assert!(out.contains(&observed));
+        assert!(!fallback);
+    }
+
+    #[test]
+    fn outbound_does_not_append_ephemeral_observed() {
+        // Outbound: the observed address is our ephemeral NAT source port, which
+        // must not pollute the gossiped record when we already advertise a real
+        // address.
+        let additional = vec![addr("/ip4/8.8.4.4/tcp/1634")];
+        let observed = addr("/ip4/203.0.113.7/tcp/54321");
+        let (out, fallback) =
+            select_local_addrs(&additional, &observed, ConnectionDirection::Outbound);
+        assert_eq!(out, vec![addr("/ip4/8.8.4.4/tcp/1634")]);
+        assert!(!out.contains(&observed));
+        assert!(!fallback);
+    }
+
+    #[test]
+    fn outbound_uses_observed_only_as_last_resort() {
+        // With nothing real to advertise, the observed address keeps the record
+        // non-empty so the handshake completes (bee rejects zero-underlay
+        // records). The fallback flag is set so a full node can warn; the entry
+        // is transient until AutoNAT v2 / UPnP confirms a real address.
+        let observed = addr("/ip4/203.0.113.7/tcp/54321");
+        let (out, fallback) = select_local_addrs(&[], &observed, ConnectionDirection::Outbound);
+        assert_eq!(out, vec![observed]);
+        assert!(fallback);
+    }
+
+    #[test]
+    fn observed_is_not_duplicated() {
+        // The observed address present in additional_addrs is not added twice.
+        let observed = addr("/ip4/203.0.113.7/tcp/1634");
+        let additional = vec![observed.clone()];
+        let (out, fallback) =
+            select_local_addrs(&additional, &observed, ConnectionDirection::Inbound);
+        assert_eq!(out, vec![observed]);
+        assert!(!fallback);
     }
 }

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -447,6 +447,26 @@ mod tests {
     }
 
     #[test]
+    fn ipv6_inbound_appends_global_observed() {
+        // The direction policy is address-family-agnostic: a global IPv6 observed
+        // address on an inbound connection is appended like its IPv4 peer.
+        let additional = vec![addr("/ip6/2606:4700:4700::1111/tcp/1634")];
+        let observed = addr("/ip6/2001:4860:4860::8888/tcp/1634");
+        let (out, fallback) =
+            select_local_addrs(&additional, &observed, ConnectionDirection::Inbound);
+        assert!(out.contains(&observed));
+        assert!(!fallback);
+    }
+
+    #[test]
+    fn ipv6_outbound_last_resort_sets_fallback() {
+        let observed = addr("/ip6/2001:4860:4860::8888/tcp/54321");
+        let (out, fallback) = select_local_addrs(&[], &observed, ConnectionDirection::Outbound);
+        assert_eq!(out, vec![observed]);
+        assert!(fallback);
+    }
+
+    #[test]
     fn observed_is_not_duplicated() {
         // The observed address present in additional_addrs is not added twice.
         let observed = addr("/ip4/203.0.113.7/tcp/1634");

--- a/crates/swarm/net/identify/Cargo.toml
+++ b/crates/swarm/net/identify/Cargo.toml
@@ -19,6 +19,7 @@ futures-timer = "3.0"
 ## p2p
 libp2p.workspace = true
 libp2p-swarm.workspace = true
+vertex-net-local.workspace = true
 
 ## codec
 asynchronous-codec.workspace = true

--- a/crates/swarm/net/identify/src/behaviour.rs
+++ b/crates/swarm/net/identify/src/behaviour.rs
@@ -24,7 +24,7 @@ use libp2p::swarm::{
     behaviour::{ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm},
 };
 
-use vertex_net_local::{AddressScope, classify_multiaddr, same_subnet};
+use vertex_net_local::{AddressScope, advertise_filter, classify_multiaddr};
 
 use crate::{
     Config,
@@ -95,23 +95,15 @@ fn select_addresses_for_remote<'a>(
     hide_listen_addrs: bool,
 ) -> HashSet<Multiaddr> {
     let scope = classify_multiaddr(remote_addr).unwrap_or(AddressScope::Public);
-    let mut addrs = HashSet::new();
 
-    if !hide_listen_addrs {
-        for listen in listen_addrs {
-            let keep = match scope {
-                AddressScope::Loopback => matches!(
-                    classify_multiaddr(listen),
-                    Some(AddressScope::Loopback | AddressScope::Private)
-                ),
-                AddressScope::Private | AddressScope::LinkLocal => same_subnet(listen, remote_addr),
-                AddressScope::Public => classify_multiaddr(listen) == Some(AddressScope::Public),
-            };
-            if keep {
-                addrs.insert(listen.clone());
-            }
-        }
-    }
+    // Scope-filter our listen addresses with the shared advertisement rule.
+    let mut addrs: HashSet<Multiaddr> = if hide_listen_addrs {
+        HashSet::new()
+    } else {
+        advertise_filter(listen_addrs, scope, Some(remote_addr))
+            .into_iter()
+            .collect()
+    };
 
     // Confirmed external addresses are public and dialable; advertise them to
     // any non-loopback peer (filtered to public scope defensively).

--- a/crates/swarm/net/identify/src/behaviour.rs
+++ b/crates/swarm/net/identify/src/behaviour.rs
@@ -788,6 +788,35 @@ mod tests {
         assert!(!out.contains(&addr("/ip4/203.0.113.7/tcp/1634")));
     }
 
+    // IPv6: `::1` loopback, `fd00::/8` ULA (private), `fe80::/10` link-local,
+    // global unicast public.
+
+    #[test]
+    fn ipv6_public_peer_gets_only_global_listen_and_external() {
+        let listen = vec![
+            addr("/ip6/::1/tcp/1634"),
+            addr("/ip6/fd00::1/tcp/1634"),
+            addr("/ip6/2606:4700:4700::1111/tcp/1634"),
+        ];
+        let external = vec![addr("/ip6/2001:4860:4860::8888/tcp/1634")];
+        let out = select(&listen, &external, "/ip6/2a00:1450::1/tcp/5000", false);
+        assert!(out.contains(&addr("/ip6/2606:4700:4700::1111/tcp/1634")));
+        assert!(out.contains(&addr("/ip6/2001:4860:4860::8888/tcp/1634")));
+        assert!(!out.contains(&addr("/ip6/::1/tcp/1634")));
+        assert!(!out.contains(&addr("/ip6/fd00::1/tcp/1634")));
+    }
+
+    #[test]
+    fn ipv6_linklocal_peer_gets_same_subnet_listen() {
+        let listen = vec![
+            addr("/ip6/fe80::abcd/tcp/1634"),
+            addr("/ip6/fd00::1/tcp/1634"),
+        ];
+        let out = select(&listen, &[], "/ip6/fe80::1234/tcp/5000", false);
+        assert!(out.contains(&addr("/ip6/fe80::abcd/tcp/1634")));
+        assert!(!out.contains(&addr("/ip6/fd00::1/tcp/1634")));
+    }
+
     #[test]
     fn hide_listen_addrs_advertises_only_external() {
         let listen = vec![addr("/ip4/8.8.4.4/tcp/1634")];

--- a/crates/swarm/net/identify/src/behaviour.rs
+++ b/crates/swarm/net/identify/src/behaviour.rs
@@ -24,6 +24,8 @@ use libp2p::swarm::{
     behaviour::{ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm},
 };
 
+use vertex_net_local::{AddressScope, classify_multiaddr, same_subnet};
+
 use crate::{
     Config,
     error::UpgradeError,
@@ -72,6 +74,56 @@ fn is_tcp_addr(addr: &Multiaddr) -> bool {
     };
 
     matches!(first, Ip4(_) | Ip6(_) | Dns(_) | Dns4(_) | Dns6(_)) && matches!(second, Tcp(_))
+}
+
+/// Select which of our addresses to advertise to a peer, filtered by the peer's
+/// address scope so internal addresses never leak to public peers.
+///
+/// Mirrors the handshake's `addresses_for_scope` policy so identify and the
+/// handshake agree on what a given peer may learn:
+/// - a public peer sees only public-scope listen addresses,
+/// - a private/link-local peer sees only same-subnet listen addresses,
+/// - a loopback peer sees loopback/private listen addresses.
+///
+/// Confirmed external addresses (public, e.g. AutoNAT v2 or UPnP) are advertised
+/// to any non-loopback peer. When `hide_listen_addrs` is set, listen addresses
+/// are omitted entirely and only external addresses are advertised.
+fn select_addresses_for_remote<'a>(
+    listen_addrs: impl Iterator<Item = &'a Multiaddr>,
+    external_addrs: impl Iterator<Item = &'a Multiaddr>,
+    remote_addr: &Multiaddr,
+    hide_listen_addrs: bool,
+) -> HashSet<Multiaddr> {
+    let scope = classify_multiaddr(remote_addr).unwrap_or(AddressScope::Public);
+    let mut addrs = HashSet::new();
+
+    if !hide_listen_addrs {
+        for listen in listen_addrs {
+            let keep = match scope {
+                AddressScope::Loopback => matches!(
+                    classify_multiaddr(listen),
+                    Some(AddressScope::Loopback | AddressScope::Private)
+                ),
+                AddressScope::Private | AddressScope::LinkLocal => same_subnet(listen, remote_addr),
+                AddressScope::Public => classify_multiaddr(listen) == Some(AddressScope::Public),
+            };
+            if keep {
+                addrs.insert(listen.clone());
+            }
+        }
+    }
+
+    // Confirmed external addresses are public and dialable; advertise them to
+    // any non-loopback peer (filtered to public scope defensively).
+    if scope != AddressScope::Loopback {
+        for external in external_addrs {
+            if classify_multiaddr(external) == Some(AddressScope::Public) {
+                addrs.insert(external.clone());
+            }
+        }
+    }
+
+    addrs
 }
 
 /// Maximum cached agent versions (bounds memory from peer churn).
@@ -274,12 +326,22 @@ impl Behaviour {
         }
     }
 
-    fn all_addresses(&self) -> HashSet<Multiaddr> {
-        let mut addrs = HashSet::from_iter(self.external_addresses.iter().cloned());
-        if !self.config.hide_listen_addrs {
-            addrs.extend(self.listen_addresses.iter().cloned());
-        };
-        addrs
+    /// Select which of our addresses to advertise to a peer, filtered by the
+    /// peer's address scope so internal addresses never leak to public peers.
+    ///
+    /// Mirrors the handshake's `addresses_for_scope` policy so identify and the
+    /// handshake agree on what a given peer may learn: a public peer sees only
+    /// public-scope listen addresses, a private/link-local peer sees only
+    /// same-subnet listen addresses, and a loopback peer sees loopback/private
+    /// addresses. Confirmed external addresses (public, e.g. AutoNAT v2 or UPnP)
+    /// are advertised to any non-loopback peer.
+    fn addresses_for_remote(&self, remote_addr: &Multiaddr) -> HashSet<Multiaddr> {
+        select_addresses_for_remote(
+            self.listen_addresses.iter(),
+            self.external_addresses.iter(),
+            remote_addr,
+            self.config.hide_listen_addrs,
+        )
     }
 
     fn emit_new_external_addr_candidate_event(
@@ -347,7 +409,7 @@ impl NetworkBehaviour for Behaviour {
             self.config.protocol_version.clone(),
             self.config.agent_version.clone(),
             remote_addr.clone(),
-            self.all_addresses(),
+            self.addresses_for_remote(remote_addr),
         ))
     }
 
@@ -376,7 +438,7 @@ impl NetworkBehaviour for Behaviour {
             self.config.protocol_version.clone(),
             self.config.agent_version.clone(),
             addr.clone(),
-            self.all_addresses(),
+            self.addresses_for_remote(&addr),
         ))
     }
 
@@ -504,15 +566,23 @@ impl NetworkBehaviour for Behaviour {
         let external_addr_changed = self.external_addresses.on_swarm_event(&event);
 
         if listen_addr_changed || external_addr_changed {
-            let change_events = self
+            // Recompute per connection: each peer's advertised set is scoped to
+            // its own remote address (stored at connection establishment), so a
+            // changed listen/external address never leaks across scopes.
+            let conns: Vec<(PeerId, ConnectionId, Multiaddr)> = self
                 .connected
                 .iter()
-                .flat_map(|(peer, map)| map.keys().map(|id| (*peer, id)))
-                .map(|(peer_id, connection_id)| ToSwarm::NotifyHandler {
-                    peer_id,
-                    handler: NotifyHandler::One(*connection_id),
-                    event: InEvent::AddressesChanged(self.all_addresses()),
-                })
+                .flat_map(|(peer, map)| map.iter().map(|(id, addr)| (*peer, *id, addr.clone())))
+                .collect();
+            let change_events = conns
+                .into_iter()
+                .map(
+                    |(peer_id, connection_id, remote_addr)| ToSwarm::NotifyHandler {
+                        peer_id,
+                        handler: NotifyHandler::One(connection_id),
+                        event: InEvent::AddressesChanged(self.addresses_for_remote(&remote_addr)),
+                    },
+                )
                 .collect::<Vec<_>>();
 
             self.events.extend(change_events)
@@ -634,5 +704,104 @@ impl KeyType {
             KeyType::PublicKey(pubkey) => pubkey,
             KeyType::Keypair { public_key, .. } => public_key,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().expect("valid multiaddr")
+    }
+
+    fn select(
+        listen: &[Multiaddr],
+        external: &[Multiaddr],
+        remote: &str,
+        hide: bool,
+    ) -> HashSet<Multiaddr> {
+        select_addresses_for_remote(listen.iter(), external.iter(), &addr(remote), hide)
+    }
+
+    #[test]
+    fn public_peer_gets_only_public_addresses() {
+        let listen = vec![
+            addr("/ip4/127.0.0.1/tcp/1634"),
+            addr("/ip4/192.168.1.10/tcp/1634"),
+            addr("/ip4/8.8.4.4/tcp/1634"),
+        ];
+        let out = select(&listen, &[], "/ip4/8.8.8.8/tcp/5000", false);
+        assert!(out.contains(&addr("/ip4/8.8.4.4/tcp/1634")));
+        assert!(!out.contains(&addr("/ip4/127.0.0.1/tcp/1634")));
+        assert!(!out.contains(&addr("/ip4/192.168.1.10/tcp/1634")));
+    }
+
+    #[test]
+    fn public_peer_gets_confirmed_external_address() {
+        // A NAT'd node (private listen only) still advertises its verified
+        // external address to a public peer, and nothing private.
+        let listen = vec![addr("/ip4/192.168.1.10/tcp/1634")];
+        let external = vec![addr("/ip4/203.0.113.7/tcp/1634")];
+        let out = select(&listen, &external, "/ip4/8.8.8.8/tcp/5000", false);
+        assert_eq!(out.len(), 1);
+        assert!(out.contains(&addr("/ip4/203.0.113.7/tcp/1634")));
+    }
+
+    #[test]
+    fn public_peer_gets_empty_set_when_no_public_address() {
+        // A purely-private node leaks nothing to a public peer.
+        let listen = vec![
+            addr("/ip4/127.0.0.1/tcp/1634"),
+            addr("/ip4/10.0.0.5/tcp/1634"),
+        ];
+        let out = select(&listen, &[], "/ip4/8.8.8.8/tcp/5000", false);
+        assert!(out.is_empty());
+    }
+
+    // Link-local addresses are always same-subnet by definition, so they
+    // exercise the Private/LinkLocal branch deterministically (true private
+    // subnets depend on the host's interfaces).
+    #[test]
+    fn linklocal_peer_gets_same_subnet_address() {
+        let listen = vec![
+            addr("/ip4/169.254.1.10/tcp/1634"),
+            addr("/ip4/10.9.9.9/tcp/1634"),
+        ];
+        let out = select(&listen, &[], "/ip4/169.254.1.50/tcp/5000", false);
+        assert!(out.contains(&addr("/ip4/169.254.1.10/tcp/1634")));
+        // A non-link-local address is not same-subnet as a link-local peer.
+        assert!(!out.contains(&addr("/ip4/10.9.9.9/tcp/1634")));
+    }
+
+    #[test]
+    fn linklocal_peer_also_gets_public_external() {
+        let listen = vec![addr("/ip4/169.254.1.10/tcp/1634")];
+        let external = vec![addr("/ip4/203.0.113.7/tcp/1634")];
+        let out = select(&listen, &external, "/ip4/169.254.1.50/tcp/5000", false);
+        assert!(out.contains(&addr("/ip4/169.254.1.10/tcp/1634")));
+        assert!(out.contains(&addr("/ip4/203.0.113.7/tcp/1634")));
+    }
+
+    #[test]
+    fn loopback_peer_gets_loopback_and_private_but_no_external() {
+        let listen = vec![
+            addr("/ip4/127.0.0.1/tcp/1634"),
+            addr("/ip4/192.168.1.10/tcp/1634"),
+        ];
+        let external = vec![addr("/ip4/203.0.113.7/tcp/1634")];
+        let out = select(&listen, &external, "/ip4/127.0.0.2/tcp/5000", false);
+        assert!(out.contains(&addr("/ip4/127.0.0.1/tcp/1634")));
+        assert!(out.contains(&addr("/ip4/192.168.1.10/tcp/1634")));
+        assert!(!out.contains(&addr("/ip4/203.0.113.7/tcp/1634")));
+    }
+
+    #[test]
+    fn hide_listen_addrs_advertises_only_external() {
+        let listen = vec![addr("/ip4/8.8.4.4/tcp/1634")];
+        let external = vec![addr("/ip4/203.0.113.7/tcp/1634")];
+        let out = select(&listen, &external, "/ip4/8.8.8.8/tcp/5000", true);
+        assert_eq!(out.len(), 1);
+        assert!(out.contains(&addr("/ip4/203.0.113.7/tcp/1634")));
     }
 }

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -57,10 +57,9 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
     ) -> Self {
         let agent_versions = topology.agent_versions();
         Self {
-            // Advertise listen addresses (even private IPs). Peers gate on
-            // "we have at least one addr" rather than reachability, and the
-            // handshake itself uses the libp2p-observed remote multiaddr, so
-            // private IPs in the identify payload are harmless.
+            // Identify advertises addresses scoped to each peer (see
+            // `addresses_for_remote`): a public peer never receives our private
+            // or loopback addresses, matching the handshake's policy.
             identify: identify::Behaviour::new(
                 identify::Config::new(local_public_key),
                 agent_versions,

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -53,10 +53,11 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
     ) -> Self {
         let agent_versions = topology.agent_versions();
         Self {
-            // Send listen addresses (even private IPs) so bee's peerstore has entries.
-            // waitPeerAddrs() returns immediately if len(addrs) > 0, regardless of
-            // whether addresses match or are reachable. The handshake protocol uses
-            // RemoteMultiaddr directly. Private IPs in gossip are harmless.
+            // Identify advertises addresses scoped to each peer (see
+            // `addresses_for_remote`), so a public peer never receives our
+            // private or loopback addresses. A NAT'd node with no public address
+            // sends an empty listen set to public peers; bee tolerates this
+            // (it falls back to the connection's remote multiaddr).
             identify: identify::Behaviour::new(
                 identify::Config::new(local_public_key),
                 agent_versions,

--- a/docs/networking/address-management.md
+++ b/docs/networking/address-management.md
@@ -109,7 +109,23 @@ NAT-mapped addresses contain ephemeral ports that are connection-specific. Each 
 
 ### What Bee Does
 
-Bee uses **static NAT configuration** (`--nat-addr`) for production deployments, not dynamic discovery. Bee does not reject an empty multiaddr list in the handshake: when its peerstore has no addresses for us it waits briefly (up to 10s) and then falls back to the connection's remote multiaddr. The vertex handshake appends the peer-observed address as a last-resort fallback so the advertised list is never empty and that wait is avoided.
+Bee uses **static NAT configuration** (`--nat-addr`) for production deployments, not dynamic discovery.
+
+Two distinct address requirements are easy to conflate. Bee tolerates an empty *peerstore* when building its own observation of us: if libp2p identify has not yet populated addresses for us, bee waits briefly (up to 10s) and then falls back to the connection's remote multiaddr. But bee rejects a *signed record* that carries zero multiaddrs: `ParseAddress` returns `ErrInvalidAddress` when the decoded underlay count is zero (the `0x99`-prefixed empty-list form decodes to zero and is rejected too). So our signed handshake record must always carry at least one multiaddr.
+
+### Only full (storer) nodes are gossiped
+
+A crucial property bounds all of this: **only full nodes are ever gossiped about.** Bee never writes a light (non-`FullNode`) peer to its addressbook and never broadcasts it (light peers live in a separate address-only container with no signed record); it also never dials a light node. Vertex matches this exactly: every hive-gossip payload producer selects from storer-only peer views, and a non-storer peer is never placed in a broadcast. So a `Client` node's signed handshake record never enters the network.
+
+This is what makes the NAT'd outbound-only case clean: such a node runs as a `Client`, and whatever it puts in its handshake record to satisfy bee's non-empty requirement is never re-advertised, so it cannot pollute hive.
+
+### What we put in our signed record
+
+The record we sign during the handshake is what a full-node peer stores and gossips, so it must be both non-empty (for bee) and free of unreachable junk (to avoid polluting hive). We build it from our scope-filtered advertised addresses (the shared `advertise_filter` rule in `vertex-net-local`, also used by identify) and append the peer-observed address only when it is trustworthy:
+
+- **Inbound** connection: the peer dialed our actual listen address and reached it, so the observed address is genuinely reachable (this is how a port-forwarded node learns its public address without static config). We append it.
+- **Outbound** connection: the observed address is our ephemeral NAT source port, connection-specific and useless to other peers. We do not append it.
+- **Last resort**: a NAT'd, outbound-only node with no real address still needs one entry to satisfy bee. It includes the observed address. For a `Client` this is harmless (the record is never gossiped). For a `Storer` it means the node is unreachable and would advertise an undialable address, so the handshake logs an operator warning; the entry is transient and is superseded once AutoNAT v2 / UPnP / a static NAT address provides a real one (the newer-timestamp record wins, see the gossip conflict-resolution path).
 
 ### IPv6 vs IPv4
 

--- a/docs/networking/address-management.md
+++ b/docs/networking/address-management.md
@@ -79,7 +79,7 @@ The per-peer `ReachabilityTracker` makes the same distinction for *other* nodes,
 
 NAT traversal runs as a cluster of top-level libp2p behaviours that sit beside identify in each node type (`vertex-swarm-node`). They collaborate through the swarm external-address machinery rather than through direct calls.
 
-- **identify** observes the remote-reported address and emits it as a `NewExternalAddrCandidate`.
+- **identify** observes the remote-reported address and emits it as a `NewExternalAddrCandidate`. The addresses identify advertises to a peer are scope-filtered per recipient (`select_addresses_for_remote`), mirroring the handshake policy: a public peer never receives our private or loopback listen addresses, only public-scope and confirmed-external ones.
 - **AutoNAT v2 client** picks up each candidate, asks a peer that speaks `/libp2p/autonat/2/dial-request` to dial it back over a fresh port, and on success emits `ExternalAddrConfirmed`.
 - **AutoNAT v2 server** performs dial-backs for other peers. A completed dial-back proves the remote peer accepts inbound connections, so the node promotes it to `Reachable` in the topology reachability tracker via `on_autonat_peer_confirmed()`.
 - **UPnP** (`libp2p::upnp::tokio`) asks the LAN IGD gateway to map the listen port and emits `ExternalAddrConfirmed` for the mapped address.
@@ -109,7 +109,7 @@ NAT-mapped addresses contain ephemeral ports that are connection-specific. Each 
 
 ### What Bee Does
 
-Bee uses **static NAT configuration** (`--nat-addr`) for production deployments, not dynamic discovery. Bee also requires at least one underlay address in the handshake (empty underlays are rejected). The handshake protocol handles this by appending the peer-reported observed address as a last-resort fallback.
+Bee uses **static NAT configuration** (`--nat-addr`) for production deployments, not dynamic discovery. Bee does not reject an empty multiaddr list in the handshake: when its peerstore has no addresses for us it waits briefly (up to 10s) and then falls back to the connection's remote multiaddr. The vertex handshake appends the peer-observed address as a last-resort fallback so the advertised list is never empty and that wait is avoided.
 
 ### IPv6 vs IPv4
 


### PR DESCRIPTION
Stacked on #156 (base `feat/autonat-v2-upnp`). Address-advertisement privacy: stop leaking internal addresses into what peers gossip, and converge the duplicated per-scope rule.

## Motivation

A peer's signed handshake record is what other peers store and gossip, and identify populates peers' address books. Two leaks fed internal/ephemeral addresses into the network:

- identify advertised every listen address (loopback, RFC-1918/ULA, link-local) to every peer regardless of scope.
- the handshake unconditionally appended the peer-observed address to our signed record; on an outbound connection that is our ephemeral NAT source port.

## Key fact (verified on both bee and vertex)

Only full (storer) nodes are ever gossiped. Bee keeps light peers in an address-only container with no signed record and never broadcasts or dials them; every vertex hive payload producer selects storer-only views. So a NAT'd outbound-only node runs as a `Client` and its record never enters hive.

## Changes

- **identify**: replace the unconditional `all_addresses()` with a scope-filtered `select_addresses_for_remote()`. A public peer receives only public-scope listen addresses plus confirmed-external (AutoNAT v2 / UPnP) addresses; a private/link-local peer only same-subnet; a loopback peer loopback/private. A NAT'd node sends an empty listen set to a public peer rather than its private addresses.
- **handshake**: append the peer-observed address to our signed record only when trustworthy. Inbound, the peer reached our real listen address (port-forward discovery), so it is appended. Outbound, the observed address is our ephemeral NAT source port, used only as a last resort to satisfy bee's non-empty-record requirement. On that last resort a full node logs an operator warning (it is unreachable and would advertise an undialable address); a client is silent. The entry self-heals once AutoNAT v2 / UPnP / a static NAT address provides a real one.
- **convergence**: collapse the triplicated per-scope advertisement rule into a single `vertex_net_local::advertise_filter`, now used by both `LocalCapabilities::addresses_for_scope` and identify. `can_advertise_to`, the reachability tracker, the gossip-eligibility filter, and the dial filter remain distinct concerns.
- **docs**: correct the note about bee and empty records (bee rejects a zero-underlay signed record via `ParseAddress`; it only tolerates an empty peerstore when building its own observation), and document the storer-only gossip property and the node-type-aware record policy.

## Testing

- New pure-function unit tests for the identify scope filter (10) and the handshake address selection (4, incl. the ephemeral-fallback flag).
- net-local (47), identify (10), handshake (17), topology (130), and node suites green.
- `cargo clippy --lib -- -D warnings` and the `--tests` variant clean; `cargo build -p vertex` succeeds.

## Follow-ups

Two notes filed on #148 (the dead empty-underlay "inbound-only" path, and a fork-gated empty-underlay record that would remove the ephemeral fallback vertex-to-vertex).