### PR TITLE
feat(mdns): wire libp2p mDNS for zero-config LAN peer discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,7 @@ libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8
     "identify",
     "upnp",
     "autonat",
+    "mdns",
     "ping",
 ] }
 quick-protobuf = "0.8"

--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -159,6 +159,13 @@ pub trait SwarmNetworkConfig {
     fn upnp_enabled(&self) -> bool {
         false
     }
+
+    /// Whether mDNS local peer discovery is enabled (default: true). Lets two
+    /// nodes on the same LAN discover and connect to each other without
+    /// bootnodes or NAT configuration. The multicast traffic stays link-local.
+    fn mdns_enabled(&self) -> bool {
+        true
+    }
 }
 
 /// Configuration for Swarm node identity.

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -34,6 +34,11 @@ fn default_autonat() -> bool {
     true
 }
 
+/// Default for mdns (local LAN peer discovery enabled by default).
+fn default_mdns() -> bool {
+    true
+}
+
 /// P2P network CLI arguments.
 #[derive(Debug, Args, Clone, Serialize, Deserialize)]
 #[command(next_help_heading = "Networking")]
@@ -82,6 +87,11 @@ pub struct NetworkArgs {
     #[serde(default)]
     pub upnp: bool,
 
+    /// Enable mDNS local LAN peer discovery (enabled by default).
+    #[arg(long = "network.mdns", default_value_t = true)]
+    #[serde(default = "default_mdns")]
+    pub mdns: bool,
+
     /// Maximum number of peers.
     #[arg(long = "network.max-peers", default_value_t = DEFAULT_MAX_PEERS)]
     pub max_peers: usize,
@@ -113,6 +123,7 @@ impl Default for NetworkArgs {
             nat_auto: true,
             autonat: true,
             upnp: false,
+            mdns: true,
             max_peers: DEFAULT_MAX_PEERS,
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             peer: PeerArgs::default(),
@@ -166,6 +177,7 @@ pub struct NetworkConfig<R = KademliaConfig> {
     nat_auto: bool,
     autonat: bool,
     upnp: bool,
+    mdns: bool,
     discovery_enabled: bool,
     max_peers: usize,
     idle_timeout: Duration,
@@ -194,6 +206,7 @@ impl<R> NetworkConfig<R> {
             nat_auto: self.nat_auto,
             autonat: self.autonat,
             upnp: self.upnp,
+            mdns: self.mdns,
             discovery_enabled: self.discovery_enabled,
             max_peers: self.max_peers,
             idle_timeout: self.idle_timeout,
@@ -228,6 +241,7 @@ impl Default for NetworkConfig<KademliaConfig> {
             nat_auto: true,
             autonat: true,
             upnp: false,
+            mdns: true,
             discovery_enabled: true,
             max_peers: DEFAULT_MAX_PEERS,
             idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
@@ -297,6 +311,7 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
             nat_auto: args.nat_auto,
             autonat: args.autonat,
             upnp: args.upnp,
+            mdns: args.mdns,
             discovery_enabled: !args.disable_discovery,
             max_peers: args.max_peers,
             idle_timeout: Duration::from_secs(args.idle_timeout_secs),
@@ -345,6 +360,10 @@ impl<R> SwarmNetworkConfig for NetworkConfig<R> {
 
     fn upnp_enabled(&self) -> bool {
         self.upnp
+    }
+
+    fn mdns_enabled(&self) -> bool {
+        self.mdns
     }
 }
 
@@ -403,6 +422,44 @@ mod tests {
         let config = NetworkConfig::try_from(&args).expect("valid args");
         assert!(!config.autonat_enabled());
         assert!(config.upnp_enabled());
+    }
+
+    #[test]
+    fn mdns_default_enabled() {
+        // mDNS local LAN discovery is on by default for zero-bootnode bootstrap.
+        let config =
+            NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
+        assert!(config.mdns_enabled());
+    }
+
+    #[test]
+    fn mdns_flag_parses() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            network: NetworkArgs,
+        }
+
+        // The flag is registered under its `network.mdns` long name and parses
+        // with no value, leaving mDNS enabled by default.
+        let parsed =
+            TestCli::try_parse_from(["test", "--network.mdns"]).expect("flag should parse");
+        assert!(parsed.network.mdns, "mDNS is enabled by default");
+
+        let default = TestCli::try_parse_from(["test"]).expect("default should parse");
+        assert!(default.network.mdns, "mDNS defaults to enabled");
+    }
+
+    #[test]
+    fn mdns_flag_propagates() {
+        let args = NetworkArgs {
+            mdns: false,
+            ..Default::default()
+        };
+        let config = NetworkConfig::try_from(&args).expect("valid args");
+        assert!(!config.mdns_enabled());
     }
 
     #[test]

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -2,6 +2,8 @@
 
 use eyre::Result;
 use libp2p::autonat::v2 as autonat;
+use libp2p::mdns;
+use libp2p::multiaddr::Protocol;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::upnp;
 use libp2p::{Multiaddr, PeerId, Swarm, swarm::NetworkBehaviour, swarm::SwarmEvent};
@@ -9,7 +11,7 @@ use nectar_primitives::SwarmAddress;
 use tracing::{debug, info, trace, warn};
 use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
 use vertex_swarm_net_identify as identify;
-use vertex_swarm_topology::{TopologyBehaviour, TopologyHandle};
+use vertex_swarm_topology::{TopologyBehaviour, TopologyCommand, TopologyHandle};
 
 /// Optional NAT-traversal behaviours shared by every node type.
 ///
@@ -21,18 +23,95 @@ pub(crate) struct NatBehaviours {
     pub(crate) autonat_client: Toggle<autonat::client::Behaviour>,
     pub(crate) autonat_server: Toggle<autonat::server::Behaviour>,
     pub(crate) upnp: Toggle<upnp::tokio::Behaviour>,
+    /// Whether mDNS discovery is enabled. The behaviour itself is built in the
+    /// node `from_parts`, where the local [`PeerId`] is available.
+    pub(crate) mdns_enabled: bool,
 }
 
 impl NatBehaviours {
     /// Build the NAT behaviours from a network configuration.
     ///
-    /// AutoNAT v2 is enabled by default for every node type; UPnP is opt-in.
+    /// AutoNAT v2 and mDNS are enabled by default for every node type; UPnP is
+    /// opt-in.
     pub(crate) fn from_config(config: &impl SwarmNetworkConfig) -> Self {
         let autonat = config.autonat_enabled();
         Self {
             autonat_client: Toggle::from(autonat.then(autonat::client::Behaviour::default)),
             autonat_server: Toggle::from(autonat.then(autonat::server::Behaviour::default)),
             upnp: Toggle::from(config.upnp_enabled().then(upnp::tokio::Behaviour::default)),
+            mdns_enabled: config.mdns_enabled(),
+        }
+    }
+}
+
+/// Build the mDNS discovery behaviour as a [`Toggle`].
+///
+/// mDNS construction is fallible (it binds a multicast socket) and needs the
+/// local [`PeerId`], so it is built in the node behaviour `from_parts` rather
+/// than alongside the config-only NAT behaviours. A bind failure never aborts
+/// node startup: the behaviour is logged and left disabled.
+///
+/// A future browser/wasm client would gate this off, since mDNS has no
+/// `wasm32-unknown-unknown` transport; the node crate is not in the wasm cone.
+pub(crate) fn build_mdns_toggle(enabled: bool, peer_id: PeerId) -> Toggle<mdns::tokio::Behaviour> {
+    if !enabled {
+        return Toggle::from(None);
+    }
+    match mdns::tokio::Behaviour::new(mdns::Config::default(), peer_id) {
+        Ok(behaviour) => Toggle::from(Some(behaviour)),
+        Err(error) => {
+            warn!(%error, "mDNS discovery disabled: failed to start multicast listener");
+            Toggle::from(None)
+        }
+    }
+}
+
+/// Turn an mDNS-discovered `(peer, addr)` pair into a dialable multiaddr.
+///
+/// Returns `None` for our own [`PeerId`] (mDNS hears its own announcements).
+/// Otherwise appends `/p2p/<peer_id>` when the address lacks a peer component
+/// so the dial resolves to a concrete peer; an address that already carries a
+/// `/p2p/` is returned unchanged.
+pub(crate) fn mdns_dial_addr(
+    local_peer_id: &PeerId,
+    peer_id: PeerId,
+    addr: Multiaddr,
+) -> Option<Multiaddr> {
+    if peer_id == *local_peer_id {
+        return None;
+    }
+    let has_p2p = addr.iter().any(|p| matches!(p, Protocol::P2p(_)));
+    if has_p2p {
+        Some(addr)
+    } else {
+        Some(addr.with(Protocol::P2p(peer_id)))
+    }
+}
+
+/// Handle an mDNS event by dialing freshly discovered LAN peers.
+///
+/// `Discovered` peers are dialed as `DialTarget::Unknown` through the topology;
+/// the overlay address is learned at the Swarm handshake. `Expired` is only
+/// logged: an mDNS TTL lapse is not connection state and must not tear down a
+/// live connection.
+pub(crate) fn handle_mdns_event<I: SwarmIdentity + Clone>(
+    local_peer_id: PeerId,
+    topology: &mut TopologyBehaviour<I>,
+    event: mdns::Event,
+) {
+    match event {
+        mdns::Event::Discovered(peers) => {
+            for (peer_id, addr) in peers {
+                if let Some(dial_addr) = mdns_dial_addr(&local_peer_id, peer_id, addr) {
+                    debug!(%peer_id, %dial_addr, "Dialing mDNS-discovered LAN peer");
+                    topology.on_command(TopologyCommand::Dial(dial_addr));
+                }
+            }
+        }
+        mdns::Event::Expired(peers) => {
+            for (peer_id, addr) in peers {
+                debug!(%peer_id, %addr, "mDNS record expired");
+            }
         }
     }
 }
@@ -242,5 +321,50 @@ pub(crate) fn handle_identify_event(identify: &mut identify::Behaviour, event: i
         identify::Event::Error { peer_id, error, .. } => {
             warn!(%peer_id, %error, "Identify error");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::identity::Keypair;
+
+    use super::*;
+
+    fn random_peer_id() -> PeerId {
+        Keypair::generate_ed25519().public().to_peer_id()
+    }
+
+    #[test]
+    fn mdns_dial_addr_appends_p2p_when_missing() {
+        let local = random_peer_id();
+        let peer = random_peer_id();
+        let addr: Multiaddr = "/ip4/192.168.1.10/tcp/1634".parse().expect("valid addr");
+
+        let dial = mdns_dial_addr(&local, peer, addr).expect("peer should be dialable");
+
+        let expected: Multiaddr = format!("/ip4/192.168.1.10/tcp/1634/p2p/{peer}")
+            .parse()
+            .expect("valid addr");
+        assert_eq!(dial, expected);
+    }
+
+    #[test]
+    fn mdns_dial_addr_keeps_existing_p2p() {
+        let local = random_peer_id();
+        let peer = random_peer_id();
+        let addr: Multiaddr = format!("/ip4/192.168.1.10/tcp/1634/p2p/{peer}")
+            .parse()
+            .expect("valid addr");
+
+        let dial = mdns_dial_addr(&local, peer, addr.clone()).expect("peer should be dialable");
+        assert_eq!(dial, addr);
+    }
+
+    #[test]
+    fn mdns_dial_addr_skips_self() {
+        let local = random_peer_id();
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/1634".parse().expect("valid addr");
+
+        assert!(mdns_dial_addr(&local, local, addr).is_none());
     }
 }

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -10,6 +10,7 @@
 use eyre::Result;
 use futures::StreamExt;
 use libp2p::autonat::v2 as autonat;
+use libp2p::mdns;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::upnp;
 use libp2p::{PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
@@ -44,6 +45,7 @@ pub(crate) struct BootnodeBehaviour<I: SwarmIdentity + Clone> {
     pub(crate) autonat_client: Toggle<autonat::client::Behaviour>,
     pub(crate) autonat_server: Toggle<autonat::server::Behaviour>,
     pub(crate) upnp: Toggle<upnp::tokio::Behaviour>,
+    pub(crate) mdns: Toggle<mdns::tokio::Behaviour>,
     pub(crate) topology: TopologyBehaviour<I>,
     pub(crate) client: ClientBehaviour,
 }
@@ -56,6 +58,7 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
         nat: NatBehaviours,
     ) -> Self {
         let agent_versions = topology.agent_versions();
+        let peer_id = local_public_key.to_peer_id();
         Self {
             // Identify advertises addresses scoped to each peer (see
             // `addresses_for_remote`): a public peer never receives our private
@@ -67,6 +70,7 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
             autonat_client: nat.autonat_client,
             autonat_server: nat.autonat_server,
             upnp: nat.upnp,
+            mdns: super::base::build_mdns_toggle(nat.mdns_enabled, peer_id),
             topology,
             client: ClientBehaviour::new(ClientBehaviourConfig::for_role(SwarmNodeType::Bootnode)),
         }
@@ -90,6 +94,7 @@ pub enum BootnodeEvent {
     AutonatClient(autonat::client::Event),
     AutonatServer(autonat::server::Event),
     Upnp(upnp::Event),
+    Mdns(mdns::Event),
     Topology(()),
     Client(ClientEvent),
 }
@@ -115,6 +120,12 @@ impl From<autonat::server::Event> for BootnodeEvent {
 impl From<upnp::Event> for BootnodeEvent {
     fn from(event: upnp::Event) -> Self {
         BootnodeEvent::Upnp(event)
+    }
+}
+
+impl From<mdns::Event> for BootnodeEvent {
+    fn from(event: mdns::Event) -> Self {
+        BootnodeEvent::Mdns(event)
     }
 }
 
@@ -233,6 +244,14 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
             }
             BootnodeEvent::Upnp(event) => {
                 super::base::handle_upnp_event(event);
+            }
+            BootnodeEvent::Mdns(event) => {
+                let local_peer_id = *self.base.swarm.local_peer_id();
+                super::base::handle_mdns_event(
+                    local_peer_id,
+                    &mut self.base.swarm.behaviour_mut().topology,
+                    event,
+                );
             }
             BootnodeEvent::Topology(_) => {}
             BootnodeEvent::Client(event) => {

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -131,6 +131,10 @@ impl<C: SwarmNetworkConfig> SwarmNetworkConfig for ConfigWithBootnodes<'_, C> {
     fn upnp_enabled(&self) -> bool {
         self.inner.upnp_enabled()
     }
+
+    fn mdns_enabled(&self) -> bool {
+        self.inner.mdns_enabled()
+    }
 }
 
 impl<C: SwarmPeerConfig> SwarmPeerConfig for ConfigWithBootnodes<'_, C> {

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use eyre::Result;
 use futures::StreamExt;
 use libp2p::autonat::v2 as autonat;
+use libp2p::mdns;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::upnp;
 use libp2p::{Multiaddr, PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
@@ -41,6 +42,7 @@ pub(crate) struct ClientNodeBehaviour<I: SwarmIdentity + Clone> {
     pub(crate) autonat_client: Toggle<autonat::client::Behaviour>,
     pub(crate) autonat_server: Toggle<autonat::server::Behaviour>,
     pub(crate) upnp: Toggle<upnp::tokio::Behaviour>,
+    pub(crate) mdns: Toggle<mdns::tokio::Behaviour>,
     pub(crate) topology: TopologyBehaviour<I>,
     pub(crate) client: ClientBehaviour,
 }
@@ -52,6 +54,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
         nat: NatBehaviours,
     ) -> Self {
         let agent_versions = topology.agent_versions();
+        let peer_id = local_public_key.to_peer_id();
         Self {
             // Identify advertises addresses scoped to each peer (see
             // `addresses_for_remote`), so a public peer never receives our
@@ -65,6 +68,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
             autonat_client: nat.autonat_client,
             autonat_server: nat.autonat_server,
             upnp: nat.upnp,
+            mdns: super::base::build_mdns_toggle(nat.mdns_enabled, peer_id),
             topology,
             client: ClientBehaviour::new(ClientBehaviourConfig::default()),
         }
@@ -78,6 +82,7 @@ pub enum ClientNodeEvent {
     AutonatClient(autonat::client::Event),
     AutonatServer(autonat::server::Event),
     Upnp(upnp::Event),
+    Mdns(mdns::Event),
     Topology(()),
     Client(ClientEvent),
 }
@@ -103,6 +108,12 @@ impl From<autonat::server::Event> for ClientNodeEvent {
 impl From<upnp::Event> for ClientNodeEvent {
     fn from(event: upnp::Event) -> Self {
         ClientNodeEvent::Upnp(event)
+    }
+}
+
+impl From<mdns::Event> for ClientNodeEvent {
+    fn from(event: mdns::Event) -> Self {
+        ClientNodeEvent::Mdns(event)
     }
 }
 
@@ -243,6 +254,14 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
             }
             ClientNodeEvent::Upnp(event) => {
                 super::base::handle_upnp_event(event);
+            }
+            ClientNodeEvent::Mdns(event) => {
+                let local_peer_id = *self.base.swarm.local_peer_id();
+                super::base::handle_mdns_event(
+                    local_peer_id,
+                    &mut self.base.swarm.behaviour_mut().topology,
+                    event,
+                );
             }
             ClientNodeEvent::Topology(_) => {}
             ClientNodeEvent::Client(event) => {


### PR DESCRIPTION
Wires libp2p mDNS as a top-level `Toggle` sibling behaviour in every node type (the AutoNAT v2 / UPnP wiring from #156 is the template), so two vertex nodes on the same LAN auto-discover and connect with no bootnodes or NAT configuration.

## Changes
- Workspace `Cargo.toml`: add `mdns` to the libp2p features.
- `SwarmNetworkConfig::mdns_enabled()` (default true), threaded through `NetworkArgs` (`--network.mdns`) / `NetworkConfig` / `ConfigWithBootnodes`.
- `mdns: Toggle<mdns::tokio::Behaviour>` on `BootnodeBehaviour` and `ClientNodeBehaviour`, built in `from_parts` from the local PeerId; a bind failure logs a warning and disables rather than aborting startup. Storer inherits via ClientNode.
- Shared `handle_mdns_event`: `Discovered` peers are dialed through the existing `Unknown` dial -> handshake -> routing path (`/p2p/` appended if missing, self skipped); `Expired` is debug-logged only (mDNS expiry is not connection state).

## Compatibility
mDNS is link-local multicast with no `/swarm` wire bytes; bee does not run mDNS. Purely additive, no fork gate, no bee regression. Default-on because it is needed for zero-bootnode LAN bootstrap and the traffic never leaves the broadcast domain.

## Testing
Config round-trip + flag tests, and pure-helper unit tests for the discovered-address transform (append `/p2p/`, skip self). No real-multicast integration test (flaky on CI). `vertex-swarm-node --features cli` and `vertex-swarm-topology` suites pass; clippy/fmt clean.

## Note
Found a pre-existing quirk in the bare-bool network flags (`--network.upnp`/`--network.autonat`/`--network.mdns`): clap only accepts the bare `--network.mdns` form, not `=false`; disable is via config file. Out of scope here.