### PR TITLE
feat(topology): advertise verified-external addresses, order by reachability

### DIFF
--- a/crates/net/local/src/lib.rs
+++ b/crates/net/local/src/lib.rs
@@ -9,5 +9,7 @@ pub mod scope;
 pub mod system;
 
 pub use capabilities::{LocalCapabilities, advertise_filter};
-pub use scope::{AddressScope, IpCapability, classify_multiaddr, is_dialable};
+pub use scope::{
+    AddressFamily, AddressScope, IpCapability, classify_multiaddr, family_order, is_dialable,
+};
 pub use system::{add_subnet, remove_subnet, same_subnet};

--- a/crates/net/local/src/scope.rs
+++ b/crates/net/local/src/scope.rs
@@ -92,6 +92,70 @@ pub(crate) enum IpVersion {
     V6,
 }
 
+/// Address-family rank for advertisement ordering.
+///
+/// Lower ranks sort first. IPv6 leads, then IPv4, then anything without an
+/// explicit family (DNS, dnsaddr). This is the family tiebreaker used when
+/// ordering the addresses a node advertises so peers lead with the families
+/// most likely to be globally routable.
+///
+/// Note: this orders only by family. A node's dial preference may differ; some
+/// peers deprioritise IPv6 when dialing. Advertising IPv6-first does not force
+/// a peer to dial it first, so this is safe to apply unconditionally on the
+/// advertisement path.
+///
+/// ```
+/// use vertex_net_local::AddressFamily;
+///
+/// let v6: libp2p::Multiaddr = "/ip6/2001:db8::1/tcp/1634".parse().unwrap();
+/// let v4: libp2p::Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().unwrap();
+/// let dns: libp2p::Multiaddr = "/dnsaddr/example.com/tcp/1634".parse().unwrap();
+/// assert!(AddressFamily::of(&v6) < AddressFamily::of(&v4));
+/// assert!(AddressFamily::of(&v4) < AddressFamily::of(&dns));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AddressFamily {
+    /// IPv6 (or `/dns6/`).
+    V6,
+    /// IPv4 (or `/dns4/`).
+    V4,
+    /// No explicit family (`/dns/`, `/dnsaddr/`, or no IP component).
+    Other,
+}
+
+impl AddressFamily {
+    /// Classify a multiaddr by family for advertisement ordering.
+    pub fn of(addr: &Multiaddr) -> Self {
+        match IpVersion::from_multiaddr(addr) {
+            Some(IpVersion::V6) => Self::V6,
+            Some(IpVersion::V4) => Self::V4,
+            None => Self::Other,
+        }
+    }
+}
+
+/// Compare two multiaddrs by family for advertisement ordering: IPv6 before
+/// IPv4 before family-less addresses.
+///
+/// This is a partial key, not a total order: addresses of the same family
+/// compare `Equal`, so use it with a stable sort to preserve the caller's
+/// existing within-family order (for example tier order, or listen-address
+/// discovery order).
+///
+/// ```
+/// use vertex_net_local::family_order;
+///
+/// let mut addrs: Vec<libp2p::Multiaddr> = vec![
+///     "/ip4/8.8.8.8/tcp/1634".parse().unwrap(),
+///     "/ip6/2001:db8::1/tcp/1634".parse().unwrap(),
+/// ];
+/// addrs.sort_by(family_order);
+/// assert!(addrs[0].to_string().contains("ip6"));
+/// ```
+pub fn family_order(a: &Multiaddr, b: &Multiaddr) -> std::cmp::Ordering {
+    AddressFamily::of(a).cmp(&AddressFamily::of(b))
+}
+
 /// Check if a multiaddr is dialable given local IP capability.
 ///
 /// Filters by IP version reachability and non-public subnet reachability.
@@ -570,6 +634,52 @@ mod tests {
                 cap
             );
         }
+    }
+
+    #[test]
+    fn test_address_family_of() {
+        let v6: Multiaddr = "/ip6/2001:db8::1/tcp/1634".parse().unwrap();
+        let v4: Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().unwrap();
+        let dns6: Multiaddr = "/dns6/example.com/tcp/1634".parse().unwrap();
+        let dns4: Multiaddr = "/dns4/example.com/tcp/1634".parse().unwrap();
+        let dnsaddr: Multiaddr = "/dnsaddr/example.com/tcp/1634".parse().unwrap();
+
+        assert_eq!(AddressFamily::of(&v6), AddressFamily::V6);
+        assert_eq!(AddressFamily::of(&v4), AddressFamily::V4);
+        assert_eq!(AddressFamily::of(&dns6), AddressFamily::V6);
+        assert_eq!(AddressFamily::of(&dns4), AddressFamily::V4);
+        assert_eq!(AddressFamily::of(&dnsaddr), AddressFamily::Other);
+    }
+
+    #[test]
+    fn test_family_order_ipv6_before_ipv4_before_other() {
+        assert!(AddressFamily::V6 < AddressFamily::V4);
+        assert!(AddressFamily::V4 < AddressFamily::Other);
+
+        let v6: Multiaddr = "/ip6/2001:db8::1/tcp/1634".parse().unwrap();
+        let v4: Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().unwrap();
+        let dns: Multiaddr = "/dnsaddr/example.com/tcp/1634".parse().unwrap();
+
+        assert_eq!(family_order(&v6, &v4), std::cmp::Ordering::Less);
+        assert_eq!(family_order(&v4, &v6), std::cmp::Ordering::Greater);
+        assert_eq!(family_order(&v4, &dns), std::cmp::Ordering::Less);
+        assert_eq!(family_order(&v6, &v6), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn test_family_order_stable_within_family() {
+        // A stable sort with this comparator must preserve input order among
+        // addresses of the same family.
+        let a: Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().unwrap();
+        let b: Multiaddr = "/ip4/1.1.1.1/tcp/1634".parse().unwrap();
+        let c: Multiaddr = "/ip6/2001:db8::1/tcp/1634".parse().unwrap();
+        let d: Multiaddr = "/ip6/2001:db8::2/tcp/1634".parse().unwrap();
+
+        let mut addrs = vec![a.clone(), b.clone(), c.clone(), d.clone()];
+        addrs.sort_by(family_order);
+
+        // IPv6 first, preserving c before d; then IPv4, preserving a before b.
+        assert_eq!(addrs, vec![c, d, a, b]);
     }
 
     #[test]

--- a/crates/swarm/topology/src/nat_discovery.rs
+++ b/crates/swarm/topology/src/nat_discovery.rs
@@ -9,7 +9,10 @@ use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
 use parking_lot::Mutex;
 use tracing::{debug, info, warn};
-use vertex_net_local::{AddressScope, IpCapability, LocalCapabilities, classify_multiaddr};
+use vertex_net_local::{
+    AddressScope, IpCapability, LocalCapabilities, advertise_filter, classify_multiaddr,
+    family_order,
+};
 use vertex_swarm_net_handshake::AddressProvider;
 
 use crate::reachability::ReachabilityTracker;
@@ -204,26 +207,53 @@ impl LocalAddressManager {
             || self.observed_reachable.load(Ordering::Relaxed)
     }
 
-    /// Select addresses to advertise to peer during handshake, filtered by peer scope.
+    /// Select addresses to advertise to peer during handshake, filtered by peer
+    /// scope and ordered by likely reachability.
     ///
     /// Does NOT include observed addresses (handshake adds those separately).
+    ///
+    /// The advertised list is built in reachability tiers and then ordered:
+    /// 1. verified-reachable addresses (AutoNAT v2 / UPnP confirmed external),
+    /// 2. public listen addresses,
+    /// 3. static NAT addresses,
+    ///
+    /// and within each tier IPv6 leads IPv4. A peer reads this order as a hint
+    /// only; its own dial preference may reorder families, so leading with
+    /// verified-reachable IPv6 helps without removing any address a peer could
+    /// otherwise use.
     pub fn addresses_for_peer(&self, peer_addr: &Multiaddr) -> Vec<Multiaddr> {
         let peer_scope = classify_multiaddr(peer_addr).unwrap_or(AddressScope::Public);
 
-        // Start with addresses from local capabilities
-        let local_addrs = self.local.addresses_for_scope(peer_scope, Some(peer_addr));
+        // Tier 1: verified external addresses (public-scope by construction).
+        // Scope-filter consistently with the rest so they never leak to a
+        // loopback/private peer they do not apply to.
+        let confirmed = self.confirmed_external_addrs.lock();
+        let mut verified = advertise_filter(confirmed.iter(), peer_scope, Some(peer_addr));
+        drop(confirmed);
 
-        // NAT addresses for non-loopback peers
-        let nat_addrs = self
+        // Tier 2: public (or scope-appropriate) listen addresses.
+        let mut listen_addrs = self.local.addresses_for_scope(peer_scope, Some(peer_addr));
+
+        // Tier 3: static NAT addresses for non-loopback peers.
+        let mut nat_addrs: Vec<Multiaddr> = self
             .nat_addrs
             .iter()
             .filter(|_| peer_scope != AddressScope::Loopback)
-            .cloned();
+            .cloned()
+            .collect();
 
-        // Deduplicate
+        // Tier is the primary key; family (IPv6 before IPv4) is the secondary
+        // key within a tier. Stable-sort each tier independently, then chain in
+        // tier order, so a global family sort never reorders across tiers.
+        verified.sort_by(family_order);
+        listen_addrs.sort_by(family_order);
+        nat_addrs.sort_by(family_order);
+
+        // Deduplicate across tiers, preserving tier order.
         let mut seen = HashSet::new();
-        let addrs: Vec<Multiaddr> = local_addrs
+        let addrs: Vec<Multiaddr> = verified
             .into_iter()
+            .chain(listen_addrs)
             .chain(nat_addrs)
             .filter(|addr| seen.insert(addr.clone()))
             .collect();
@@ -245,15 +275,31 @@ impl LocalAddressManager {
             .collect()
     }
 
-    /// All known addresses (listen + NAT).
+    /// All known addresses, ordered by likely reachability.
+    ///
+    /// Tiers mirror [`Self::addresses_for_peer`]: verified external addresses,
+    /// then listen addresses, then static NAT addresses, with IPv6 leading IPv4
+    /// within each tier. No peer-scope filter is applied here; this is the full
+    /// local view.
     pub fn all_addresses(&self) -> Vec<Multiaddr> {
-        let listen_addrs = self.local.listen_addrs();
-        let nat_addrs = self.nat_addrs.iter().cloned();
+        let mut verified: Vec<Multiaddr> = self
+            .confirmed_external_addrs
+            .lock()
+            .iter()
+            .cloned()
+            .collect();
+        let mut listen_addrs = self.local.listen_addrs();
+        let mut nat_addrs = self.nat_addrs.clone();
 
-        // Deduplicate
+        verified.sort_by(family_order);
+        listen_addrs.sort_by(family_order);
+        nat_addrs.sort_by(family_order);
+
+        // Deduplicate across tiers, preserving tier order.
         let mut seen = HashSet::new();
-        listen_addrs
+        verified
             .into_iter()
+            .chain(listen_addrs)
             .chain(nat_addrs)
             .filter(|addr| seen.insert(addr.clone()))
             .collect()
@@ -352,6 +398,134 @@ mod tests {
         // Loopback peer should NOT see NAT address
         assert!(!addrs.iter().any(|a| a.to_string().contains("203.0.113.50")));
         assert!(addrs.iter().any(|a| a.to_string().contains("127.0.0.1")));
+    }
+
+    /// Index of the first address whose string contains `needle`.
+    fn position_of(addrs: &[Multiaddr], needle: &str) -> Option<usize> {
+        addrs.iter().position(|a| a.to_string().contains(needle))
+    }
+
+    #[test]
+    fn test_addresses_for_peer_includes_confirmed_external() {
+        let local = Arc::new(LocalCapabilities::new());
+        local.on_new_listen_addr(parse_addr("/ip4/8.8.4.4/tcp/1634"));
+        let manager = LocalAddressManager::new(local, vec![]);
+
+        // A verified external address must be advertised to a public peer.
+        manager.on_external_addr_confirmed(&parse_addr("/ip4/203.0.113.7/tcp/1634"));
+
+        let public_peer = parse_addr("/ip4/8.8.8.8/tcp/5000");
+        let addrs = manager.addresses_for_peer(&public_peer);
+
+        assert!(addrs.iter().any(|a| a.to_string().contains("203.0.113.7")));
+        assert!(addrs.iter().any(|a| a.to_string().contains("8.8.4.4")));
+    }
+
+    #[test]
+    fn test_addresses_for_peer_verified_first_then_ipv6_within_tier() {
+        let local = Arc::new(LocalCapabilities::new());
+        // Public listen addresses, both families.
+        local.on_new_listen_addr(parse_addr("/ip4/8.8.4.4/tcp/1634"));
+        local.on_new_listen_addr(parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"));
+
+        // Static NAT address (tier 3).
+        let nat = parse_addr("/ip4/198.51.100.9/tcp/1634");
+        let manager = LocalAddressManager::new(local, vec![nat]);
+
+        // Verified external addresses (tier 1), both families.
+        manager.on_external_addr_confirmed(&parse_addr("/ip4/203.0.113.7/tcp/1634"));
+        manager.on_external_addr_confirmed(&parse_addr("/ip6/2001:db8::7/tcp/1634"));
+
+        let public_peer = parse_addr("/ip4/8.8.8.8/tcp/5000");
+        let addrs = manager.addresses_for_peer(&public_peer);
+
+        // Tier ordering: verified before listen before NAT.
+        let verified_v6 = position_of(&addrs, "2001:db8::7").unwrap();
+        let verified_v4 = position_of(&addrs, "203.0.113.7").unwrap();
+        let listen_v6 = position_of(&addrs, "2606:4700:4700::1111").unwrap();
+        let listen_v4 = position_of(&addrs, "8.8.4.4").unwrap();
+        let nat_v4 = position_of(&addrs, "198.51.100.9").unwrap();
+
+        // Within tier 1: IPv6 before IPv4.
+        assert!(verified_v6 < verified_v4);
+        // Tier 1 entirely before tier 2.
+        assert!(verified_v4 < listen_v6);
+        // Within tier 2: IPv6 before IPv4.
+        assert!(listen_v6 < listen_v4);
+        // Tier 2 entirely before tier 3.
+        assert!(listen_v4 < nat_v4);
+    }
+
+    #[test]
+    fn test_addresses_for_peer_ipv6_public_peer() {
+        let local = Arc::new(LocalCapabilities::new());
+        local.on_new_listen_addr(parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"));
+        let manager = LocalAddressManager::new(local, vec![]);
+
+        manager.on_external_addr_confirmed(&parse_addr("/ip6/2001:db8::7/tcp/1634"));
+
+        let public_peer = parse_addr("/ip6/2001:4860:4860::8888/tcp/5000");
+        let addrs = manager.addresses_for_peer(&public_peer);
+
+        let verified = position_of(&addrs, "2001:db8::7").unwrap();
+        let listen = position_of(&addrs, "2606:4700:4700::1111").unwrap();
+        assert!(verified < listen);
+    }
+
+    #[test]
+    fn test_confirmed_external_not_leaked_to_loopback_peer() {
+        let local = Arc::new(LocalCapabilities::new());
+        local.on_new_listen_addr(parse_addr("/ip4/127.0.0.1/tcp/1634"));
+        let manager = LocalAddressManager::new(local, vec![]);
+
+        manager.on_external_addr_confirmed(&parse_addr("/ip4/203.0.113.7/tcp/1634"));
+
+        let loopback_peer = parse_addr("/ip4/127.0.0.2/tcp/5000");
+        let addrs = manager.addresses_for_peer(&loopback_peer);
+
+        // Loopback peer must not learn our public verified address.
+        assert!(!addrs.iter().any(|a| a.to_string().contains("203.0.113.7")));
+        assert!(addrs.iter().any(|a| a.to_string().contains("127.0.0.1")));
+    }
+
+    #[test]
+    fn test_confirmed_external_not_leaked_to_private_peer() {
+        let local = Arc::new(LocalCapabilities::new());
+        local.on_new_listen_addr(parse_addr("/ip4/192.168.1.10/tcp/1634"));
+        let manager = LocalAddressManager::new(local, vec![]);
+
+        manager.on_external_addr_confirmed(&parse_addr("/ip4/203.0.113.7/tcp/1634"));
+
+        // Private peer on a different subnet: public scope filter rejects the
+        // verified address (advertise_filter same-subnet rule).
+        let private_peer = parse_addr("/ip4/10.0.0.5/tcp/5000");
+        let addrs = manager.addresses_for_peer(&private_peer);
+
+        assert!(!addrs.iter().any(|a| a.to_string().contains("203.0.113.7")));
+    }
+
+    #[test]
+    fn test_all_addresses_orders_verified_first_then_ipv6() {
+        let local = Arc::new(LocalCapabilities::new());
+        local.on_new_listen_addr(parse_addr("/ip4/8.8.4.4/tcp/1634"));
+        local.on_new_listen_addr(parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"));
+
+        let nat = parse_addr("/ip4/198.51.100.9/tcp/1634");
+        let manager = LocalAddressManager::new(local, vec![nat]);
+
+        manager.on_external_addr_confirmed(&parse_addr("/ip6/2001:db8::7/tcp/1634"));
+
+        let all = manager.all_addresses();
+
+        let verified_v6 = position_of(&all, "2001:db8::7").unwrap();
+        let listen_v6 = position_of(&all, "2606:4700:4700::1111").unwrap();
+        let listen_v4 = position_of(&all, "8.8.4.4").unwrap();
+        let nat_v4 = position_of(&all, "198.51.100.9").unwrap();
+
+        // Verified tier first, listen tier IPv6-before-IPv4, NAT tier last.
+        assert!(verified_v6 < listen_v6);
+        assert!(listen_v6 < listen_v4);
+        assert!(listen_v4 < nat_v4);
     }
 
     #[test]


### PR DESCRIPTION
Fixes two gaps in what we advertise to peers (the addresses signed into our handshake record and gossiped by full-node peers).

## Changes
- `LocalAddressManager::addresses_for_peer` / `all_addresses` (`nat_discovery.rs`) now include the AutoNAT v2 / UPnP-verified `confirmed_external_addrs`, which were previously tracked but never advertised. They are scope-filtered through the shared `vertex_net_local::advertise_filter`, so a public verified address never leaks to a loopback or off-subnet private peer.
- The advertised list is ordered by tier (verified-external, then public listen, then static NAT) and IPv6-first within each tier, so peers lead with the addresses most likely to be reachable.
- New `AddressFamily` / `family_order` comparator in `vertex-net-local` (pure, unit-tested). The dialer's local `IpVersion` is intentionally left as-is to avoid pulling net-local's `netdev` dependency into the dialer.

## Compatibility
No conformance vectors changed: the handshake/peer interop vectors sign fixed multiaddr lists and do not exercise `addresses_for_peer`. Reordering is interop-safe because a receiver re-sorts advertised multiaddrs by its own dial preference, so order is a hint, not semantically binding. Note: bee deprioritizes IPv6 on dial, so the IPv6-first order mainly benefits vertex-to-vertex; bee peers still prefer our IPv4 (no regression).

## Follow-up (not in this PR)
AutoNAT v2 client IPv6-test prioritization: the libp2p autonat v2 client has no family-preference API (it tests by observation-frequency). The lever for routable IPv6 is pre-confirming via `ExternalAddrConfirmed`.

## Testing
net-local (family comparator: ordering, stable-within-family) and topology (verified-external inclusion, tier+family ordering, loopback/off-subnet no-leak, `all_addresses`) suites, covering both IPv4 and IPv6. peer + handshake suites pass unchanged. clippy/fmt clean.