### PR TITLE
feat(peer-manager): resolve gossip peer records by signed timestamp

### DIFF
--- a/crates/swarm/peers/peer-manager/src/entry.rs
+++ b/crates/swarm/peers/peer-manager/src/entry.rs
@@ -201,6 +201,11 @@ impl PeerEntry {
         self.identity.read().0.clone()
     }
 
+    /// Signed wall-clock timestamp of the currently held peer record.
+    pub(crate) fn timestamp(&self) -> vertex_swarm_peer::Timestamp {
+        self.identity.read().0.timestamp()
+    }
+
     pub(crate) fn ip_capability(&self) -> IpCapability {
         self.identity.read().0.ip_capability()
     }

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -26,14 +26,14 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use dashmap::{DashMap, DashSet};
-use metrics::gauge;
+use metrics::{counter, gauge};
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 use vertex_net_local::IpCapability;
 use vertex_net_peer_store::NetPeerStore;
 use vertex_net_peer_store::error::StoreError;
 use vertex_swarm_api::{SwarmIdentity, SwarmPeerResolver, SwarmScoreStore, SwarmSpec};
-use vertex_swarm_peer::SwarmPeer;
+use vertex_swarm_peer::{SwarmPeer, Timestamp, check_timestamp};
 use vertex_swarm_peer_score::{PeerScore, ScoreCallbacks, SwarmScoringConfig};
 use vertex_swarm_primitives::{Bin, OverlayAddress, SwarmNodeType};
 
@@ -469,6 +469,13 @@ impl<I: SwarmIdentity> PeerManager<I> {
 
     /// Store a single discovered peer.
     ///
+    /// Discovered peers arrive via hive gossip, so the gossip timestamp policy
+    /// (via [`check_timestamp`]) is applied before
+    /// any overwrite: a record that is stale, replayed, too frequent, or dated
+    /// implausibly far into the future is dropped rather than clobbering the
+    /// stored record. Rejections increment `peer_manager_gossip_timestamp_rejected_total`
+    /// with a `reason` label and the existing overlay is returned unchanged.
+    ///
     /// For hot peers, updates addresses (preserves handshake-confirmed node_type).
     /// For cold peers, just touches the LRU index.
     /// For new peers, adds to index and buffers a write to DB.
@@ -476,7 +483,11 @@ impl<I: SwarmIdentity> PeerManager<I> {
     pub fn store_discovered_peer(&self, swarm_peer: SwarmPeer) -> OverlayAddress {
         let overlay = OverlayAddress::from(*swarm_peer.overlay());
         if let Some(entry) = self.peers.get(&overlay) {
-            // Hot peer - update addresses (dirty flag set by entry)
+            // Hot peer - resolve the gossip timestamp against the stored record
+            // before overwriting, then update addresses (dirty flag set by entry).
+            if self.reject_stale_gossip(&overlay, swarm_peer.timestamp(), Some(entry.timestamp())) {
+                return overlay;
+            }
             entry.update_addresses(swarm_peer);
             self.index.touch(&overlay);
         } else if self.store.is_some() {
@@ -494,7 +505,17 @@ impl<I: SwarmIdentity> PeerManager<I> {
                     self.index.touch(&overlay);
                 }
                 Err(AddError::BinFull) => {
-                    // Bin at capacity - save to DB only, don't add to index
+                    // Bin at capacity - save to DB only, don't add to index.
+                    // Resolve against the persisted record's timestamp first so
+                    // a stale gossip record cannot overwrite a newer stored one.
+                    let existing = self
+                        .store
+                        .as_ref()
+                        .and_then(|s| s.get(&overlay).ok().flatten())
+                        .map(|r| r.peer.timestamp());
+                    if self.reject_stale_gossip(&overlay, swarm_peer.timestamp(), existing) {
+                        return overlay;
+                    }
                     let record = StoredPeer::new_discovered(swarm_peer);
                     if self.write_buffer.push(record) {
                         self.flush_write_buffer();
@@ -506,6 +527,39 @@ impl<I: SwarmIdentity> PeerManager<I> {
             self.insert_peer(overlay, swarm_peer, SwarmNodeType::Client);
         }
         overlay
+    }
+
+    /// Apply the gossip timestamp policy for a known peer.
+    ///
+    /// Returns `true` when the candidate record must be dropped (the caller
+    /// keeps the stored record untouched). On rejection a
+    /// `peer_manager_gossip_timestamp_rejected_total` counter is incremented
+    /// with the rejection `reason` label and a debug line is logged.
+    fn reject_stale_gossip(
+        &self,
+        overlay: &OverlayAddress,
+        candidate: Timestamp,
+        existing: Option<Timestamp>,
+    ) -> bool {
+        let now = Timestamp::from_seconds(unix_timestamp_secs() as i64);
+        match check_timestamp(candidate, existing, now) {
+            Ok(()) => false,
+            Err(rejection) => {
+                counter!(
+                    "peer_manager_gossip_timestamp_rejected_total",
+                    "reason" => rejection.reason(),
+                )
+                .increment(1);
+                debug!(
+                    ?overlay,
+                    reason = rejection.reason(),
+                    candidate = candidate.get(),
+                    existing = existing.map(|t| t.get()),
+                    "dropping stale gossip peer record"
+                );
+                true
+            }
+        }
     }
 
     /// Store multiple peers discovered via Hive gossip.
@@ -670,7 +724,9 @@ mod tests {
     use super::*;
     use vertex_net_peer_store::MemoryPeerStore;
     use vertex_swarm_api::SwarmScoreStore;
-    use vertex_swarm_test_utils::{MockIdentity, test_overlay, test_swarm_peer};
+    use vertex_swarm_test_utils::{
+        MockIdentity, test_overlay, test_swarm_peer, test_swarm_peer_with_timestamp,
+    };
 
     fn mock_identity() -> MockIdentity {
         MockIdentity::with_overlay(test_overlay(0))
@@ -686,6 +742,85 @@ mod tests {
         assert_eq!(stored, overlay);
         assert!(pm.get_swarm_peer(&overlay).is_some());
         assert!(pm.index().exists(&overlay));
+    }
+
+    #[test]
+    fn test_store_discovered_peer_rejects_older_timestamp() {
+        let pm = PeerManager::new(&mock_identity());
+        let overlay = test_overlay(1);
+        let base = 1_700_000_000;
+
+        // Seed a known peer with a recent record (port 1000).
+        let newer = test_swarm_peer_with_timestamp(1, base, 1000);
+        pm.store_discovered_peer(newer);
+        assert!(
+            pm.get_swarm_peer(&overlay)
+                .unwrap()
+                .multiaddr()
+                .unwrap()
+                .to_string()
+                .contains("/tcp/1000/")
+        );
+
+        // An older gossip record (port 2000) must NOT overwrite the stored one.
+        let older = test_swarm_peer_with_timestamp(1, base - 10_000, 2000);
+        let stored = pm.store_discovered_peer(older);
+        assert_eq!(stored, overlay);
+        assert!(
+            pm.get_swarm_peer(&overlay)
+                .unwrap()
+                .multiaddr()
+                .unwrap()
+                .to_string()
+                .contains("/tcp/1000/"),
+            "older gossip record must not clobber the newer stored addresses"
+        );
+    }
+
+    #[test]
+    fn test_store_discovered_peer_accepts_sufficiently_newer_timestamp() {
+        let pm = PeerManager::new(&mock_identity());
+        let overlay = test_overlay(1);
+        let base = 1_700_000_000;
+
+        // Seed with an old record (port 1000).
+        pm.store_discovered_peer(test_swarm_peer_with_timestamp(1, base, 1000));
+
+        // A record well beyond MIN_UPDATE_INTERVAL (port 3000) overwrites it.
+        let interval = vertex_swarm_peer::MIN_UPDATE_INTERVAL.as_secs() as i64;
+        let fresh = test_swarm_peer_with_timestamp(1, base + interval + 1, 3000);
+        pm.store_discovered_peer(fresh);
+        assert!(
+            pm.get_swarm_peer(&overlay)
+                .unwrap()
+                .multiaddr()
+                .unwrap()
+                .to_string()
+                .contains("/tcp/3000/"),
+            "a sufficiently newer record must replace the stored addresses"
+        );
+    }
+
+    #[test]
+    fn test_store_discovered_peer_rejects_too_soon_timestamp() {
+        let pm = PeerManager::new(&mock_identity());
+        let overlay = test_overlay(1);
+        let base = 1_700_000_000;
+
+        pm.store_discovered_peer(test_swarm_peer_with_timestamp(1, base, 1000));
+
+        // Newer, but inside MIN_UPDATE_INTERVAL: dropped as too_soon.
+        let too_soon = test_swarm_peer_with_timestamp(1, base + 10, 4000);
+        pm.store_discovered_peer(too_soon);
+        assert!(
+            pm.get_swarm_peer(&overlay)
+                .unwrap()
+                .multiaddr()
+                .unwrap()
+                .to_string()
+                .contains("/tcp/1000/"),
+            "a too-soon gossip record must not replace the stored addresses"
+        );
     }
 
     #[test]

--- a/crates/swarm/peers/peer/src/lib.rs
+++ b/crates/swarm/peers/peer/src/lib.rs
@@ -13,10 +13,14 @@
 pub mod error;
 mod serde_multiaddr;
 pub mod swarm_peer;
+pub mod timestamp_policy;
 
 pub use error::SwarmPeerError;
 pub use serde_multiaddr::{deserialize_multiaddrs, serialize_multiaddrs};
 pub use swarm_peer::{Nonce, SwarmPeer, SwarmPeerWire, Timestamp};
+pub use timestamp_policy::{
+    MAX_CLOCK_SKEW, MIN_UPDATE_INTERVAL, TimestampRejection, check_timestamp,
+};
 
 pub use nectar_primitives::SwarmAddress;
 pub use nectar_swarms::{NamedSwarm, Swarm, SwarmKind};

--- a/crates/swarm/peers/peer/src/timestamp_policy.rs
+++ b/crates/swarm/peers/peer/src/timestamp_policy.rs
@@ -1,0 +1,211 @@
+//! Receiver-side conflict resolution for signed peer-record timestamps.
+//!
+//! Every [`SwarmPeer`](crate::SwarmPeer) carries a signed wall-clock
+//! [`Timestamp`]. When a fresh record arrives for an overlay we already hold,
+//! the timestamp decides whether the new record supersedes the stored one or
+//! is dropped as stale, replayed, or too frequent.
+//!
+//! This is purely receiver-side policy: it inspects no wire bytes beyond the
+//! already-parsed timestamp and changes nothing on the wire. The structural
+//! checks (non-positive timestamp, clock-skew window) live in
+//! [`SwarmPeer::parse`](crate::SwarmPeer::parse); this module only resolves a
+//! freshly parsed record against the existing stored record, so it does not
+//! re-validate the `<= 0` / future-dated cases when a record has already been
+//! parsed. The standalone in-future guard here covers callers that hand a raw
+//! timestamp without going through `parse`.
+
+use crate::Timestamp;
+use std::time::Duration;
+
+/// Records dated further than this into the future are rejected as
+/// implausible (the remote clock is too far ahead of ours).
+///
+/// Vertex-tuned and tunable independently of the parse-side skew window.
+pub const MAX_CLOCK_SKEW: Duration = Duration::from_secs(60);
+
+/// A gossiped record must improve on the stored timestamp by at least this
+/// much to be accepted, throttling replay and flood of near-identical
+/// re-advertisements between genuine address changes.
+pub const MIN_UPDATE_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Reason a candidate record's timestamp was rejected.
+///
+/// The `strum::IntoStaticStr` snake-case rendering is the `reason` metric
+/// label: `invalid`, `in_future`, `stale`, `too_soon`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum TimestampRejection {
+    /// Timestamp is non-positive.
+    #[error("timestamp must be strictly positive")]
+    Invalid,
+    /// Timestamp is dated more than [`MAX_CLOCK_SKEW`] into the future.
+    #[error("timestamp dated too far into the future")]
+    InFuture,
+    /// Not strictly newer than the stored record.
+    #[error("timestamp not newer than the stored record")]
+    Stale,
+    /// Newer, but within [`MIN_UPDATE_INTERVAL`] of the stored record.
+    #[error("timestamp within the minimum update interval")]
+    TooSoon,
+}
+
+impl TimestampRejection {
+    /// Static `reason` label for metrics.
+    #[inline]
+    #[must_use]
+    pub fn reason(self) -> &'static str {
+        self.into()
+    }
+}
+
+/// Decide whether a gossiped `candidate` record supersedes the `existing`
+/// stored one.
+///
+/// This is the conflict-resolution rule for **second-hand gossip records**,
+/// which may be stale or replayed copies relayed by another peer. First-hand
+/// handshake records are not run through this: a live, identity-verified peer is
+/// authoritative for its own addresses, so its record is accepted on the
+/// structural validity that [`SwarmPeer::parse`](crate::SwarmPeer::parse) already
+/// enforces (positive timestamp, clock-skew window).
+///
+/// `existing` is `None` when no prior record is held for the overlay, in which
+/// case any structurally-valid record is accepted. `now` is the local
+/// wall-clock time; pass it in (rather than reading the clock here) so the
+/// function stays pure and wasm-friendly.
+///
+/// Semantics:
+///
+/// - non-positive candidate: [`TimestampRejection::Invalid`];
+/// - candidate more than [`MAX_CLOCK_SKEW`] ahead of `now`:
+///   [`TimestampRejection::InFuture`];
+/// - no existing record, or a stored record with timestamp `<= 0` (legacy,
+///   pre-timestamp): accepted;
+/// - not strictly newer than `existing`: [`TimestampRejection::Stale`];
+/// - strictly newer but within [`MIN_UPDATE_INTERVAL`] of `existing`:
+///   [`TimestampRejection::TooSoon`] (throttles replay and re-advertisement
+///   flood between genuine address changes).
+pub fn check_timestamp(
+    candidate: Timestamp,
+    existing: Option<Timestamp>,
+    now: Timestamp,
+) -> Result<(), TimestampRejection> {
+    if candidate.get() <= 0 {
+        return Err(TimestampRejection::Invalid);
+    }
+
+    let skew = i64::try_from(MAX_CLOCK_SKEW.as_secs()).unwrap_or(i64::MAX);
+    if candidate.get() > now.get().saturating_add(skew) {
+        return Err(TimestampRejection::InFuture);
+    }
+
+    // First record for this overlay, or a legacy stored record that predates
+    // signed timestamps: accept unconditionally.
+    let existing = match existing {
+        Some(ts) if ts.get() > 0 => ts,
+        _ => return Ok(()),
+    };
+
+    if candidate.get() <= existing.get() {
+        return Err(TimestampRejection::Stale);
+    }
+    let min_interval = i64::try_from(MIN_UPDATE_INTERVAL.as_secs()).unwrap_or(i64::MAX);
+    if candidate.get() <= existing.get().saturating_add(min_interval) {
+        return Err(TimestampRejection::TooSoon);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: i64 = 1_700_000_000;
+
+    fn ts(secs: i64) -> Timestamp {
+        Timestamp::from_seconds(secs)
+    }
+
+    fn now() -> Timestamp {
+        ts(NOW)
+    }
+
+    #[test]
+    fn no_existing_record_accepts() {
+        assert!(check_timestamp(ts(NOW), None, now()).is_ok());
+    }
+
+    #[test]
+    fn legacy_zero_existing_is_overwritten() {
+        // A stored record with timestamp 0 (pre-timestamp) is always replaced.
+        assert!(
+            check_timestamp(ts(NOW), Some(ts(0)), now()).is_ok(),
+            "gossip should overwrite a legacy zero-timestamp record"
+        );
+    }
+
+    #[test]
+    fn non_positive_candidate_is_invalid() {
+        let err = check_timestamp(ts(0), Some(ts(NOW - 1000)), now()).unwrap_err();
+        assert_eq!(err, TimestampRejection::Invalid);
+        assert_eq!(err.reason(), "invalid");
+
+        let err = check_timestamp(ts(-5), None, now()).unwrap_err();
+        assert_eq!(err, TimestampRejection::Invalid);
+    }
+
+    #[test]
+    fn in_future_beyond_skew_is_rejected() {
+        let skew = MAX_CLOCK_SKEW.as_secs() as i64;
+        // Exactly at the boundary is accepted.
+        assert!(
+            check_timestamp(ts(NOW + skew), None, now()).is_ok(),
+            "+MAX_CLOCK_SKEW boundary is accepted"
+        );
+        // One second past the boundary is rejected.
+        let err = check_timestamp(ts(NOW + skew + 1), None, now()).unwrap_err();
+        assert_eq!(err, TimestampRejection::InFuture);
+        assert_eq!(err.reason(), "in_future");
+    }
+
+    #[test]
+    fn gossip_accepts_strictly_newer_beyond_interval() {
+        let existing = ts(NOW - 10_000);
+        let interval = MIN_UPDATE_INTERVAL.as_secs() as i64;
+        let candidate = ts(existing.get() + interval + 1);
+        assert!(check_timestamp(candidate, Some(existing), now()).is_ok());
+    }
+
+    #[test]
+    fn gossip_rejects_equal_as_stale() {
+        let existing = ts(NOW - 1000);
+        let err = check_timestamp(existing, Some(existing), now()).unwrap_err();
+        assert_eq!(err, TimestampRejection::Stale);
+        assert_eq!(err.reason(), "stale");
+    }
+
+    #[test]
+    fn gossip_rejects_older_as_stale() {
+        let existing = ts(NOW - 1000);
+        let older = ts(existing.get() - 500);
+        let err = check_timestamp(older, Some(existing), now()).unwrap_err();
+        assert_eq!(err, TimestampRejection::Stale);
+    }
+
+    #[test]
+    fn gossip_rejects_within_interval_as_too_soon() {
+        let existing = ts(NOW - 10_000);
+        let interval = MIN_UPDATE_INTERVAL.as_secs() as i64;
+        // Strictly newer but inside the interval: too_soon.
+        let candidate = ts(existing.get() + interval);
+        let err = check_timestamp(candidate, Some(existing), now()).unwrap_err();
+        assert_eq!(err, TimestampRejection::TooSoon);
+        assert_eq!(err.reason(), "too_soon");
+
+        // One second inside the interval is still too soon.
+        let candidate = ts(existing.get() + 1);
+        let err = check_timestamp(candidate, Some(existing), now()).unwrap_err();
+        assert_eq!(err, TimestampRejection::TooSoon);
+    }
+}

--- a/crates/swarm/test-utils/src/lib.rs
+++ b/crates/swarm/test-utils/src/lib.rs
@@ -34,6 +34,7 @@ pub mod topology;
 pub use identity::{MockIdentity, test_identity, test_identity_arc, test_identity_with_type};
 pub use peer::{
     make_overlay, make_swarm_peer_minimal, test_overlay, test_peer, test_peer_id, test_swarm_peer,
+    test_swarm_peer_with_timestamp,
 };
 pub use spec::{TEST_NETWORK_ID, test_spec, test_spec_isolated, test_spec_with_network_id};
 pub use topology::MockTopology;

--- a/crates/swarm/test-utils/src/peer.rs
+++ b/crates/swarm/test-utils/src/peer.rs
@@ -93,6 +93,31 @@ pub fn test_swarm_peer(n: u8) -> SwarmPeer {
     )
 }
 
+/// Create a test peer for overlay `n` with an explicit timestamp and a
+/// distinguishable multiaddr port.
+///
+/// Same overlay/PeerId as [`test_swarm_peer`] but with a caller-chosen signed
+/// timestamp and a `port`-tagged multiaddr, so conflict-resolution tests can
+/// tell which record won by inspecting the stored multiaddrs.
+pub fn test_swarm_peer_with_timestamp(n: u8, timestamp: i64, port: u16) -> SwarmPeer {
+    let overlay = SwarmAddress::from(B256::repeat_byte(n));
+    let peer_id = test_peer_id(n);
+    let multiaddrs = vec![
+        format!("/ip4/127.0.0.{}/tcp/{}/p2p/{}", n, port, peer_id)
+            .parse()
+            .expect("valid multiaddr"),
+    ];
+    SwarmPeer::from_parts(
+        multiaddrs,
+        Signature::test_signature(),
+        overlay,
+        Nonce::ZERO,
+        Timestamp::from_seconds(timestamp),
+        None,
+        Address::ZERO,
+    )
+}
+
 /// Create a SwarmAddress with a specific first byte.
 ///
 /// The first byte is set to `byte`, remaining bytes are zero.


### PR DESCRIPTION
The signed `SwarmPeer.timestamp` was never consulted: `store_discovered_peer` unconditionally overwrote a known peer's record, so an older or replayed gossip record silently clobbered a newer one and there was no flood protection. This ports bee's conflict-resolution semantics for gossip.

## Changes
- New pure `check_timestamp(candidate, existing, now)` in `vertex-swarm-peer` (owns `SwarmPeer`/`Timestamp`, libp2p-light). A `thiserror` `TimestampRejection` enum derives `strum::IntoStaticStr` so `reason()` yields `invalid` / `in_future` / `stale` / `too_soon`.
- Matches bee's `bzz.CheckTimestamp` semantics with vertex-tuned named constants `MAX_CLOCK_SKEW = 60s`, `MIN_UPDATE_INTERVAL = 300s`: reject non-positive, reject in-future-beyond-skew, reject not-strictly-newer (stale), reject within-update-interval (too_soon).
- Applied in `PeerManager::store_discovered_peer` before the overwrite (hot entry and the `BinFull` persisted path), incrementing `peer_manager_gossip_timestamp_rejected_total{reason}` and debug-logging on rejection. Legacy timestamp-0 records are still overwritten by any valid record.

## Why gossip-only (deliberate, not a follow-up)
The handshake path is intentionally not subject to this. A handshake record is first-hand: we verify the peer's identity and signature live, so the peer is authoritative for its own addresses. Its record is accepted on the structural validity `SwarmPeer::parse` already enforces (positive timestamp, clock-skew window). Running a live handshake record through a stale-versus-stored check would let a cached record override the peer's own current addresses, for example after the peer changed address and its clock regressed; that is wrong. The staleness check exists precisely because gossip records are second-hand relayed copies that can be stale or replayed.

## Compatibility
Receiver-side policy only, no wire change, no fork gate. `now` uses the existing `unix_timestamp_secs()` helper (keeps the WASM-compat concern, #62, consistent).

## Testing
Pure `check_timestamp` cases (no-existing, legacy-zero, invalid, in_future boundary, newer/equal/older, too_soon) asserting both the variant and the `reason` label; peer-manager cases (older does not overwrite, sufficiently-newer does, too-soon does not). peer / peer-manager / topology suites pass; clippy/fmt clean. Rebased onto current main (includes #159 + #160).