### PR TITLE
perf(handshake): cache self-record signing with stable timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8236,6 +8236,7 @@ dependencies = [
  "libp2p-swarm-test",
  "metrics",
  "nectar-primitives",
+ "parking_lot",
  "proptest",
  "proptest-arbitrary-interop",
  "quick-protobuf",

--- a/crates/swarm/net/handshake/Cargo.toml
+++ b/crates/swarm/net/handshake/Cargo.toml
@@ -39,6 +39,7 @@ libp2p-swarm.workspace = true
 
 ## misc
 bytes.workspace = true
+parking_lot.workspace = true
 thiserror.workspace = true
 
 ## tracing & metrics

--- a/crates/swarm/net/handshake/src/behaviour.rs
+++ b/crates/swarm/net/handshake/src/behaviour.rs
@@ -13,14 +13,18 @@ use libp2p::{
         THandlerInEvent, THandlerOutEvent, ToSwarm,
     },
 };
+use parking_lot::RwLock;
 use tracing::debug;
 use vertex_swarm_api::SwarmIdentity;
+use vertex_swarm_peer::{SwarmPeer, Timestamp};
+use vertex_swarm_spec::SwarmSpec;
 
 use vertex_net_peer_registry::ConnectionDirection;
 
 use crate::{
     AddressProvider, HandshakeError, HandshakeInfo, SharedAdmissionControl,
     admission::default_admission_control,
+    cache::{CachedSelfRecord, SELF_RECORD_REFRESH_INTERVAL, fingerprint, needs_resign},
     handler::{HandshakeCommand, HandshakeConfig, HandshakeHandler, HandshakeHandlerEvent},
 };
 
@@ -54,6 +58,10 @@ pub struct HandshakeBehaviour<I, A> {
     events: VecDeque<ToSwarm<HandshakeEvent, HandshakeCommand>>,
     /// Track direction per connection for event attribution.
     connection_directions: std::collections::HashMap<ConnectionId, ConnectionDirection>,
+    /// Self record signed once per address-set change (plus a periodic
+    /// refresh), reused byte-identically across handshakes with an unchanged
+    /// advertised set. See [`crate::cache`].
+    cached_record: RwLock<Option<CachedSelfRecord>>,
 }
 
 impl<I, A> HandshakeBehaviour<I, A>
@@ -70,7 +78,86 @@ where
             admission_control: default_admission_control(),
             events: VecDeque::new(),
             connection_directions: std::collections::HashMap::new(),
+            cached_record: RwLock::new(None),
         }
+    }
+
+    /// Return the signed self record to advertise to a peer reached at
+    /// `remote_addr`, reusing the cache when the advertised address set is
+    /// unchanged and fresh.
+    ///
+    /// Resolves the scope-filtered, ordered advertised set for the peer. An
+    /// empty set yields `None`: the protocol then signs a last-resort record
+    /// over just the peer-observed address during the exchange. A non-empty set
+    /// is fingerprinted; if the fingerprint matches a cached record still inside
+    /// [`SELF_RECORD_REFRESH_INTERVAL`] the cached record is cloned (same
+    /// timestamp, same signature), otherwise the record is re-signed with a
+    /// current timestamp and cached. Concurrent misses single-flight under the
+    /// write lock.
+    fn cached_self_record(&self, remote_addr: &Multiaddr) -> Option<SwarmPeer> {
+        let addrs = self.address_provider.addresses_for_peer(remote_addr);
+        if addrs.is_empty() {
+            return None;
+        }
+
+        let fp = fingerprint(&addrs);
+        let now = Timestamp::now();
+
+        // Fast path: a fresh cache hit needs only a read lock.
+        if let Some(cached) = self.cached_record.read().as_ref()
+            && !needs_resign(Some(cached), fp, now, SELF_RECORD_REFRESH_INTERVAL)
+        {
+            return Some(cached.record.clone());
+        }
+
+        // Slow path: re-sign under the write lock, double-checking so a
+        // concurrent miss that already signed is not duplicated.
+        let mut guard = self.cached_record.write();
+        if !needs_resign(guard.as_ref(), fp, now, SELF_RECORD_REFRESH_INTERVAL) {
+            // Safe: `needs_resign` returns false only when the cache is present.
+            if let Some(cached) = guard.as_ref() {
+                return Some(cached.record.clone());
+            }
+        }
+
+        match self.sign_self_record(addrs, now) {
+            Ok(record) => {
+                *guard = Some(CachedSelfRecord {
+                    fingerprint: fp,
+                    signed_at: now,
+                    record: record.clone(),
+                });
+                Some(record)
+            }
+            Err(error) => {
+                // A signing failure here is non-fatal: fall back to `None` so
+                // the protocol attempts the last-resort observed-address sign.
+                debug!(
+                    ?error,
+                    "self record signing failed; deferring to last-resort sign"
+                );
+                None
+            }
+        }
+    }
+
+    /// Sign a self record over `addrs` at `now`.
+    fn sign_self_record(
+        &self,
+        addrs: Vec<Multiaddr>,
+        now: Timestamp,
+    ) -> Result<SwarmPeer, HandshakeError> {
+        let signer = self.identity.signer();
+        SwarmPeer::sign(
+            &*signer,
+            addrs,
+            self.identity.overlay_address(),
+            self.identity.spec().network_id(),
+            self.identity.nonce(),
+            now,
+            None,
+        )
+        .map_err(HandshakeError::from)
     }
 
     /// Create with custom config.
@@ -120,6 +207,7 @@ where
         debug!(%peer, ?connection_id, %remote_addr, "Creating inbound handshake handler");
         self.connection_directions
             .insert(connection_id, ConnectionDirection::Inbound);
+        let self_record = self.cached_self_record(remote_addr);
         Ok(HandshakeHandler::new_inbound(
             self.config.clone(),
             self.identity.clone(),
@@ -127,6 +215,7 @@ where
             remote_addr.clone(),
             self.address_provider.clone(),
             self.admission_control.clone(),
+            self_record,
         ))
     }
 
@@ -141,6 +230,7 @@ where
         debug!(%peer, ?connection_id, %addr, "Creating outbound handshake handler");
         self.connection_directions
             .insert(connection_id, ConnectionDirection::Outbound);
+        let self_record = self.cached_self_record(addr);
         Ok(HandshakeHandler::new_outbound(
             self.config.clone(),
             self.identity.clone(),
@@ -148,6 +238,7 @@ where
             addr.clone(),
             self.address_provider.clone(),
             self.admission_control.clone(),
+            self_record,
         ))
     }
 
@@ -207,5 +298,104 @@ where
             return Poll::Ready(event);
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vertex_swarm_test_utils::test_identity_arc;
+
+    /// Address provider returning a fixed advertised set regardless of peer.
+    struct StubAddresses {
+        addrs: Vec<Multiaddr>,
+    }
+
+    impl AddressProvider for StubAddresses {
+        fn addresses_for_peer(&self, _peer_addr: &Multiaddr) -> Vec<Multiaddr> {
+            self.addrs.clone()
+        }
+
+        fn local_peer_id(&self) -> Option<&PeerId> {
+            None
+        }
+    }
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().expect("valid multiaddr")
+    }
+
+    fn behaviour(addrs: Vec<Multiaddr>) -> HandshakeBehaviour<impl SwarmIdentity, StubAddresses> {
+        HandshakeBehaviour::new(
+            test_identity_arc(),
+            Arc::new(StubAddresses { addrs }),
+            "test",
+        )
+    }
+
+    #[test]
+    fn cached_record_is_byte_identical_across_calls() {
+        // The core property: with an unchanged advertised set, two consecutive
+        // signs return the same record (same timestamp, same signature), so a
+        // receiver sees no delta to store and re-gossip.
+        let remote = addr("/ip4/198.51.100.4/tcp/1634");
+        let behaviour = behaviour(vec![addr("/ip4/8.8.4.4/tcp/1634")]);
+
+        let first = behaviour
+            .cached_self_record(&remote)
+            .expect("non-empty set signs a record");
+        let second = behaviour
+            .cached_self_record(&remote)
+            .expect("cached record is reused");
+
+        assert_eq!(
+            first.timestamp(),
+            second.timestamp(),
+            "cached record keeps a stable timestamp"
+        );
+        assert_eq!(
+            first.signature(),
+            second.signature(),
+            "cached record keeps a byte-identical signature"
+        );
+        assert_eq!(first, second, "cached record is byte-identical");
+    }
+
+    #[test]
+    fn changing_address_set_resigns() {
+        // A different advertised set produces a different fingerprint, so the
+        // record is re-signed (different multiaddrs, and a fresh signature).
+        let remote = addr("/ip4/198.51.100.4/tcp/1634");
+        let behaviour = behaviour(vec![addr("/ip4/8.8.4.4/tcp/1634")]);
+        let first = behaviour
+            .cached_self_record(&remote)
+            .expect("non-empty set signs a record");
+
+        // Swap the advertised set under the same behaviour by rebuilding it; the
+        // cache is keyed by fingerprint, so a new set re-signs.
+        let behaviour2 = HandshakeBehaviour::new(
+            test_identity_arc(),
+            Arc::new(StubAddresses {
+                addrs: vec![addr("/ip4/1.1.1.1/tcp/1634")],
+            }),
+            "test",
+        );
+        let other = behaviour2
+            .cached_self_record(&remote)
+            .expect("non-empty set signs a record");
+
+        assert_ne!(
+            first.multiaddrs(),
+            other.multiaddrs(),
+            "a different advertised set yields a different record"
+        );
+    }
+
+    #[test]
+    fn empty_address_set_yields_no_cached_record() {
+        // An empty advertised set defers to the protocol's last-resort sign.
+        let remote = addr("/ip4/198.51.100.4/tcp/1634");
+        let behaviour = behaviour(Vec::new());
+        assert!(behaviour.cached_self_record(&remote).is_none());
     }
 }

--- a/crates/swarm/net/handshake/src/cache.rs
+++ b/crates/swarm/net/handshake/src/cache.rs
@@ -1,0 +1,174 @@
+//! Cached self-record signing.
+//!
+//! Signing our own [`SwarmPeer`] record is one ECDSA operation. The advertised
+//! address set rarely changes, so signing it on every connection wastes work and
+//! produces a different signed record each time (only the timestamp moves). A
+//! receiver stores and re-gossips that record, so an advancing timestamp on an
+//! otherwise-identical record churns the network for no semantic gain.
+//!
+//! This module caches the signed record keyed by a fingerprint of the address
+//! set. While the set is unchanged the same byte-identical record (same
+//! timestamp, same signature) is reused across handshakes. The record is
+//! re-signed only when the set changes or when [`SELF_RECORD_REFRESH_INTERVAL`]
+//! elapses, so the cached timestamp means "when the advertised set last changed
+//! or was last refreshed", not "now at each handshake".
+
+use std::{
+    hash::{Hash, Hasher},
+    time::Duration,
+};
+
+use libp2p::Multiaddr;
+use vertex_swarm_peer::{SwarmPeer, Timestamp};
+
+/// How often a stable node re-signs its self record to advance the timestamp.
+///
+/// A receiver rejects a record whose timestamp falls outside its clock-skew
+/// tolerance (`SwarmPeer::parse` returns `TimestampOutsideSkewWindow`; the
+/// mainnet window is around six hours). A cached record must therefore be
+/// refreshed well inside that window so a long-lived node never ages out of a
+/// peer's acceptance range. One hour is comfortably below the skew window and
+/// above the gossip-side minimum update interval (300 seconds), so a periodic
+/// refresh reads as a normal record update rather than a too-soon replay.
+pub(crate) const SELF_RECORD_REFRESH_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// A signed self record cached against the address set that produced it.
+#[derive(Clone, Debug)]
+pub(crate) struct CachedSelfRecord {
+    /// Fingerprint of the ordered address set the record was signed over.
+    pub(crate) fingerprint: u64,
+    /// When the record was signed (its embedded timestamp).
+    pub(crate) signed_at: Timestamp,
+    /// The signed record, reused byte-identically while the set is unchanged.
+    pub(crate) record: SwarmPeer,
+}
+
+/// Fingerprint an already-ordered address set.
+///
+/// The set is deterministically ordered by the address provider, so it is
+/// hashed as-is: two calls with the same ordered set produce the same value,
+/// and any add, remove, or reorder changes it.
+pub(crate) fn fingerprint(addrs: &[Multiaddr]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    addrs.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Decide whether the self record must be re-signed.
+///
+/// Returns `true` when there is no cached record, when the address set changed
+/// (different fingerprint), or when the cached record is at least `refresh` old.
+/// Pure and side-effect free so it is cheap to unit test.
+pub(crate) fn needs_resign(
+    cached: Option<&CachedSelfRecord>,
+    fingerprint: u64,
+    now: Timestamp,
+    refresh: Duration,
+) -> bool {
+    let Some(cached) = cached else {
+        return true;
+    };
+    if cached.fingerprint != fingerprint {
+        return true;
+    }
+    let elapsed = now.get().saturating_sub(cached.signed_at.get());
+    let refresh_secs = i64::try_from(refresh.as_secs()).unwrap_or(i64::MAX);
+    elapsed >= refresh_secs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record_at(fingerprint: u64, signed_at: i64) -> CachedSelfRecord {
+        // The record body is irrelevant to `needs_resign`; only the fingerprint
+        // and timestamp drive the decision. Build a placeholder via a real sign
+        // so the type is well formed.
+        use alloy_signer_local::LocalSigner;
+        use vertex_swarm_peer::SwarmPeer;
+
+        let signer = LocalSigner::random();
+        let record = SwarmPeer::sign(
+            &signer,
+            vec!["/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr")],
+            nectar_primitives::SwarmAddress::with_first_byte(0x01),
+            1.into(),
+            nectar_primitives::Nonce::ZERO,
+            Timestamp::from_seconds(signed_at.max(1)),
+            None,
+        )
+        .expect("sign record");
+        CachedSelfRecord {
+            fingerprint,
+            signed_at: Timestamp::from_seconds(signed_at),
+            record,
+        }
+    }
+
+    #[test]
+    fn no_cache_needs_resign() {
+        assert!(needs_resign(
+            None,
+            42,
+            Timestamp::from_seconds(1_000),
+            SELF_RECORD_REFRESH_INTERVAL,
+        ));
+    }
+
+    #[test]
+    fn same_fingerprint_within_interval_keeps_cache() {
+        let cached = record_at(42, 1_000);
+        // 100s later, well inside the one-hour refresh window.
+        assert!(!needs_resign(
+            Some(&cached),
+            42,
+            Timestamp::from_seconds(1_100),
+            SELF_RECORD_REFRESH_INTERVAL,
+        ));
+    }
+
+    #[test]
+    fn different_fingerprint_needs_resign() {
+        let cached = record_at(42, 1_000);
+        assert!(needs_resign(
+            Some(&cached),
+            43,
+            Timestamp::from_seconds(1_100),
+            SELF_RECORD_REFRESH_INTERVAL,
+        ));
+    }
+
+    #[test]
+    fn same_fingerprint_past_interval_needs_resign() {
+        let cached = record_at(42, 1_000);
+        let now = Timestamp::from_seconds(1_000 + SELF_RECORD_REFRESH_INTERVAL.as_secs() as i64);
+        assert!(needs_resign(
+            Some(&cached),
+            42,
+            now,
+            SELF_RECORD_REFRESH_INTERVAL,
+        ));
+    }
+
+    #[test]
+    fn fingerprint_is_order_sensitive() {
+        let a: Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().expect("valid multiaddr");
+        let b: Multiaddr = "/ip4/1.1.1.1/tcp/1634".parse().expect("valid multiaddr");
+        assert_ne!(
+            fingerprint(&[a.clone(), b.clone()]),
+            fingerprint(&[b, a]),
+            "reordering the set changes the fingerprint"
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_stable() {
+        let a: Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().expect("valid multiaddr");
+        let b: Multiaddr = "/ip4/1.1.1.1/tcp/1634".parse().expect("valid multiaddr");
+        assert_eq!(
+            fingerprint(&[a.clone(), b.clone()]),
+            fingerprint(&[a, b]),
+            "the same ordered set produces the same fingerprint"
+        );
+    }
+}

--- a/crates/swarm/net/handshake/src/handler.rs
+++ b/crates/swarm/net/handshake/src/handler.rs
@@ -20,6 +20,7 @@ use libp2p::{
 };
 use tracing::{debug, warn};
 use vertex_swarm_api::SwarmIdentity;
+use vertex_swarm_peer::SwarmPeer;
 
 use crate::{
     AddressProvider, ConnectionDirection, HANDSHAKE_TIMEOUT, HandshakeError, HandshakeInfo,
@@ -91,6 +92,11 @@ pub struct HandshakeHandler<I, A> {
     address_provider: Arc<A>,
     /// Admission gate forwarded into [`HandshakeProtocol`].
     admission_control: SharedAdmissionControl,
+    /// Pre-signed self record from the behaviour cache, reused across
+    /// handshakes with an unchanged advertised address set. `None` when the
+    /// advertised set is empty, in which case the protocol signs a last-resort
+    /// record over the peer-observed address.
+    self_record: Option<SwarmPeer>,
     state: State,
     pending_event: Option<HandshakeHandlerEvent>,
     should_initiate: bool,
@@ -110,6 +116,7 @@ where
         remote_addr: Multiaddr,
         address_provider: Arc<A>,
         admission_control: SharedAdmissionControl,
+        self_record: Option<SwarmPeer>,
     ) -> Self {
         Self {
             config,
@@ -118,6 +125,7 @@ where
             remote_addr,
             address_provider,
             admission_control,
+            self_record,
             state: State::Pending,
             pending_event: None,
             should_initiate: false,
@@ -133,6 +141,7 @@ where
         remote_addr: Multiaddr,
         address_provider: Arc<A>,
         admission_control: SharedAdmissionControl,
+        self_record: Option<SwarmPeer>,
     ) -> Self {
         Self {
             config,
@@ -141,6 +150,7 @@ where
             remote_addr,
             address_provider,
             admission_control,
+            self_record,
             state: State::Pending,
             pending_event: None,
             should_initiate: true,
@@ -155,6 +165,7 @@ where
             remote_addr: self.remote_addr.clone(),
             address_provider: self.address_provider.clone(),
             admission_control: self.admission_control.clone(),
+            self_record: self.self_record.clone(),
             direction,
             purpose: self.config.purpose,
         }
@@ -295,6 +306,10 @@ pub struct HandshakeUpgrade<I, A> {
     /// Forwarded into [`HandshakeProtocol`] so admission control can run
     /// before the local side commits to the final exchange message.
     admission_control: SharedAdmissionControl,
+    /// Pre-signed self record from the behaviour cache. `None` means the
+    /// advertised set was empty and the protocol must do the last-resort
+    /// observed-address sign.
+    self_record: Option<SwarmPeer>,
     /// Direction this upgrade was created for; drives which arm of the
     /// protocol runs and which side the admission gate sees.
     direction: ConnectionDirection,
@@ -309,6 +324,7 @@ impl<I, A> Clone for HandshakeUpgrade<I, A> {
             remote_addr: self.remote_addr.clone(),
             address_provider: self.address_provider.clone(),
             admission_control: self.admission_control.clone(),
+            self_record: self.self_record.clone(),
             direction: self.direction,
             purpose: self.purpose,
         }
@@ -334,14 +350,13 @@ where
     A: AddressProvider + 'static,
 {
     fn build_protocol(self) -> HandshakeProtocol<Arc<I>> {
-        let additional_addrs = self.address_provider.addresses_for_peer(&self.remote_addr);
         let local_peer_id = self.address_provider.local_peer_id().copied();
 
         let mut protocol = HandshakeProtocol::new(
             self.identity,
             self.peer_id,
             self.remote_addr,
-            additional_addrs,
+            self.self_record,
             self.purpose,
         )
         .with_admission_control(self.admission_control, self.direction);

--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -30,6 +30,8 @@ pub use behaviour::{HandshakeBehaviour, HandshakeEvent};
 
 mod handler;
 
+mod cache;
+
 mod codec;
 
 mod protocol;

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -40,63 +40,56 @@ fn validate_observed_addr(
 /// Select the addresses to put in our signed record for this peer, and report
 /// whether we had to fall back to the (ephemeral) observed address.
 ///
-/// `additional_addrs` are our already-scope-filtered advertised addresses. The
-/// observed address (the peer's view of us) is appended only when it is
-/// trustworthy as a reachable address (inbound), or as a last resort to satisfy
-/// the non-empty requirement (outbound with nothing real). The returned bool is
-/// `true` only in that last-resort case. See [`prepare_local_peer`].
+/// `additional_addrs` are our already-scope-filtered advertised addresses. A
+/// non-empty set is used as-is; the peer-observed address is never appended to
+/// it, so the resulting record is peer-independent and can be cached and reused
+/// across handshakes. The observed address is used only as a last resort, for
+/// both directions, when we have nothing real to advertise; the returned bool
+/// is `true` only in that case. See [`prepare_local_peer`].
+///
+/// The NAT-discovery role the inbound observed address used to serve (a
+/// port-forwarded node learning its public address) is now covered by AutoNAT
+/// v2 plus advertising confirmed-external addresses, so the observed address no
+/// longer needs to enter the common-case record.
 fn select_local_addrs(
     additional_addrs: &[Multiaddr],
     observed_addr: &Multiaddr,
-    direction: ConnectionDirection,
 ) -> (Vec<Multiaddr>, bool) {
-    let mut addrs: Vec<Multiaddr> = additional_addrs
+    let addrs: Vec<Multiaddr> = additional_addrs
         .iter()
         .filter(|a| *a != observed_addr)
         .cloned()
         .collect();
 
-    // Inbound: the observed address is genuinely reachable (the peer reached us
-    // at it), so it is a real address, not a fallback.
-    if direction == ConnectionDirection::Inbound {
-        addrs.push(observed_addr.clone());
+    // A non-empty advertised set is used as-is for both directions.
+    if !addrs.is_empty() {
         return (addrs, false);
     }
 
-    // Outbound: the observed address is our ephemeral NAT source port. Only use
-    // it as a last resort to keep the record non-empty for the >=1 requirement.
-    if addrs.is_empty() {
-        addrs.push(observed_addr.clone());
-        return (addrs, true);
-    }
-
-    (addrs, false)
+    // Last resort: with nothing real to advertise the observed address keeps the
+    // record non-empty for the >=1 requirement. Transient until AutoNAT v2 /
+    // UPnP / a static NAT address confirms a real one.
+    (vec![observed_addr.clone()], true)
 }
 
-/// Combine our scope-filtered addresses with the peer-observed address and
-/// create a signed `SwarmPeer` (the record the peer stores and gossips).
+/// Sign a last-resort `SwarmPeer` over the peer-observed address.
 ///
-/// The observed address is the peer's view of us. It is trustworthy as a
-/// reachable address only on an **inbound** connection, where the peer dialed
-/// our actual listen address and reached it; that case is the primary way a
-/// port-forwarded node learns its public address without static config, so we
-/// append it. On an **outbound** connection the observed address is our
-/// ephemeral NAT source port, which is connection-specific and would pollute
-/// hive gossip, so it is not added.
+/// Used only when the behaviour cache produced no record because the advertised
+/// address set was empty (a node with no listen, NAT, or confirmed-external
+/// address). The common case signs once per address-set change in the behaviour
+/// and reuses a cached, peer-independent record; this path keeps the handshake
+/// alive when there is nothing else to advertise.
 ///
 /// Both vertex and bee reject a signed record with zero multiaddrs
-/// (`SwarmPeer::sign` / bee `ParseAddress`), so when we have nothing else to
-/// advertise the observed address is included as a last resort to keep the
-/// handshake alive. Such an entry is transient: it is superseded once AutoNAT
-/// v2 / UPnP confirms a real external address (newer timestamp wins).
+/// (`SwarmPeer::sign` / bee `ParseAddress`), so the observed address is included
+/// to satisfy the non-empty requirement. Such an entry is transient: it is
+/// superseded once AutoNAT v2 / UPnP confirms a real external address (newer
+/// timestamp wins).
 fn prepare_local_peer<I: SwarmIdentity>(
     identity: &I,
-    additional_addrs: &[Multiaddr],
     observed_addr: &Multiaddr,
-    direction: ConnectionDirection,
 ) -> Result<SwarmPeer, HandshakeError> {
-    let (addrs, ephemeral_fallback) =
-        select_local_addrs(additional_addrs, observed_addr, direction);
+    let (addrs, ephemeral_fallback) = select_local_addrs(&[], observed_addr);
 
     // A full (storer) node's record is gossiped network-wide, so it must carry a
     // real reachable address. Falling back to the ephemeral observed address
@@ -135,7 +128,11 @@ pub(crate) struct HandshakeProtocol<I: SwarmIdentity> {
     peer_id: PeerId,
     local_peer_id: Option<PeerId>,
     remote_addr: Multiaddr,
-    additional_addrs: Vec<Multiaddr>,
+    /// Pre-signed self record from the behaviour cache, reused byte-identically
+    /// across handshakes with an unchanged advertised address set. `None` when
+    /// the advertised set was empty; the exchange then signs a last-resort
+    /// record over the peer-observed address via [`prepare_local_peer`].
+    self_record: Option<SwarmPeer>,
     /// Optional admission gate. When set, the protocol consults it as
     /// soon as the remote peer's identity is verified and aborts with
     /// [`HandshakeError::AdmissionRejected`] on a `Reject` decision.
@@ -148,7 +145,7 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
         identity: I,
         peer_id: PeerId,
         remote_addr: Multiaddr,
-        additional_addrs: Vec<Multiaddr>,
+        self_record: Option<SwarmPeer>,
         purpose: &'static str,
     ) -> Self {
         Self {
@@ -156,7 +153,7 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             peer_id,
             local_peer_id: None,
             remote_addr,
-            additional_addrs,
+            self_record,
             admission_control: None,
             purpose,
         }
@@ -241,12 +238,13 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             validate_observed_addr(&observed_multiaddr, local_peer_id)?;
         }
 
-        let local_peer = prepare_local_peer(
-            &self.identity,
-            &self.additional_addrs,
-            &observed_multiaddr,
-            ConnectionDirection::Inbound,
-        )?;
+        // Use the cached, peer-independent record when the behaviour produced
+        // one; otherwise the advertised set was empty, so sign a last-resort
+        // record over the address the peer observed.
+        let local_peer = match self.self_record.clone() {
+            Some(record) => record,
+            None => prepare_local_peer(&self.identity, &observed_multiaddr)?,
+        };
 
         // Echo what we observed about the dialer (their `remote_addr` as
         // libp2p reported it) back in the SYNACK; the dialer validates the
@@ -363,12 +361,13 @@ impl<I: SwarmIdentity> HandshakeProtocol<I> {
             validate_observed_addr(&observed_multiaddr, local_peer_id)?;
         }
 
-        let local_peer = prepare_local_peer(
-            &self.identity,
-            &self.additional_addrs,
-            &observed_multiaddr,
-            ConnectionDirection::Outbound,
-        )?;
+        // Use the cached, peer-independent record when the behaviour produced
+        // one; otherwise the advertised set was empty, so sign a last-resort
+        // record over the address the peer observed.
+        let local_peer = match self.self_record.clone() {
+            Some(record) => record,
+            None => prepare_local_peer(&self.identity, &observed_multiaddr)?,
+        };
 
         // Consult admission control before sending ACK so a reject
         // aborts cleanly without committing to the exchange.
@@ -407,73 +406,71 @@ mod tests {
     }
 
     #[test]
-    fn inbound_appends_observed_reachable_address() {
-        // Inbound: the peer reached us at the observed address, so it is a real
-        // reachable address worth advertising (e.g. port-forward discovery), not
-        // an ephemeral fallback.
+    fn inbound_uses_advertised_set_without_observed() {
+        // A non-empty advertised set is used as-is. The observed address is no
+        // longer appended on inbound: the record stays peer-independent so it can
+        // be cached and reused across handshakes. AutoNAT v2 covers the
+        // NAT-discovery role the inbound observed-append used to serve.
         let additional = vec![addr("/ip4/8.8.4.4/tcp/1634")];
         let observed = addr("/ip4/203.0.113.7/tcp/1634");
-        let (out, fallback) =
-            select_local_addrs(&additional, &observed, ConnectionDirection::Inbound);
-        assert!(out.contains(&addr("/ip4/8.8.4.4/tcp/1634")));
-        assert!(out.contains(&observed));
-        assert!(!fallback);
-    }
-
-    #[test]
-    fn outbound_does_not_append_ephemeral_observed() {
-        // Outbound: the observed address is our ephemeral NAT source port, which
-        // must not pollute the gossiped record when we already advertise a real
-        // address.
-        let additional = vec![addr("/ip4/8.8.4.4/tcp/1634")];
-        let observed = addr("/ip4/203.0.113.7/tcp/54321");
-        let (out, fallback) =
-            select_local_addrs(&additional, &observed, ConnectionDirection::Outbound);
+        let (out, fallback) = select_local_addrs(&additional, &observed);
         assert_eq!(out, vec![addr("/ip4/8.8.4.4/tcp/1634")]);
         assert!(!out.contains(&observed));
         assert!(!fallback);
     }
 
     #[test]
-    fn outbound_uses_observed_only_as_last_resort() {
+    fn does_not_append_ephemeral_observed() {
+        // The observed address is never appended to a non-empty set, so an
+        // ephemeral NAT source port cannot pollute the gossiped record.
+        let additional = vec![addr("/ip4/8.8.4.4/tcp/1634")];
+        let observed = addr("/ip4/203.0.113.7/tcp/54321");
+        let (out, fallback) = select_local_addrs(&additional, &observed);
+        assert_eq!(out, vec![addr("/ip4/8.8.4.4/tcp/1634")]);
+        assert!(!out.contains(&observed));
+        assert!(!fallback);
+    }
+
+    #[test]
+    fn uses_observed_only_as_last_resort() {
         // With nothing real to advertise, the observed address keeps the record
-        // non-empty so the handshake completes (bee rejects zero-underlay
-        // records). The fallback flag is set so a full node can warn; the entry
+        // non-empty so the handshake completes (a zero-multiaddr record is
+        // rejected). The fallback flag is set so a full node can warn; the entry
         // is transient until AutoNAT v2 / UPnP confirms a real address.
         let observed = addr("/ip4/203.0.113.7/tcp/54321");
-        let (out, fallback) = select_local_addrs(&[], &observed, ConnectionDirection::Outbound);
+        let (out, fallback) = select_local_addrs(&[], &observed);
         assert_eq!(out, vec![observed]);
         assert!(fallback);
     }
 
     #[test]
-    fn ipv6_inbound_appends_global_observed() {
-        // The direction policy is address-family-agnostic: a global IPv6 observed
-        // address on an inbound connection is appended like its IPv4 peer.
+    fn ipv6_advertised_set_used_without_observed() {
+        // The policy is address-family-agnostic: a non-empty IPv6 advertised set
+        // is used as-is and the observed address is not appended.
         let additional = vec![addr("/ip6/2606:4700:4700::1111/tcp/1634")];
         let observed = addr("/ip6/2001:4860:4860::8888/tcp/1634");
-        let (out, fallback) =
-            select_local_addrs(&additional, &observed, ConnectionDirection::Inbound);
-        assert!(out.contains(&observed));
+        let (out, fallback) = select_local_addrs(&additional, &observed);
+        assert_eq!(out, vec![addr("/ip6/2606:4700:4700::1111/tcp/1634")]);
+        assert!(!out.contains(&observed));
         assert!(!fallback);
     }
 
     #[test]
-    fn ipv6_outbound_last_resort_sets_fallback() {
+    fn ipv6_last_resort_sets_fallback() {
         let observed = addr("/ip6/2001:4860:4860::8888/tcp/54321");
-        let (out, fallback) = select_local_addrs(&[], &observed, ConnectionDirection::Outbound);
+        let (out, fallback) = select_local_addrs(&[], &observed);
         assert_eq!(out, vec![observed]);
         assert!(fallback);
     }
 
     #[test]
-    fn observed_is_not_duplicated() {
-        // The observed address present in additional_addrs is not added twice.
+    fn observed_is_filtered_from_advertised_set() {
+        // If the observed address is already in the advertised set it is filtered
+        // out, and an otherwise-empty result falls back to the observed address.
         let observed = addr("/ip4/203.0.113.7/tcp/1634");
         let additional = vec![observed.clone()];
-        let (out, fallback) =
-            select_local_addrs(&additional, &observed, ConnectionDirection::Inbound);
+        let (out, fallback) = select_local_addrs(&additional, &observed);
         assert_eq!(out, vec![observed]);
-        assert!(!fallback);
+        assert!(fallback);
     }
 }

--- a/crates/swarm/topology/src/nat_discovery.rs
+++ b/crates/swarm/topology/src/nat_discovery.rs
@@ -210,7 +210,9 @@ impl LocalAddressManager {
     /// Select addresses to advertise to peer during handshake, filtered by peer
     /// scope and ordered by likely reachability.
     ///
-    /// Does NOT include observed addresses (handshake adds those separately).
+    /// Does NOT include observed addresses. The handshake signs this set as-is
+    /// into a cacheable, peer-independent record and only falls back to the
+    /// peer-observed address when this set is empty.
     ///
     /// The advertised list is built in reachability tiers and then ordered:
     /// 1. verified-reachable addresses (AutoNAT v2 / UPnP confirmed external),


### PR DESCRIPTION
`prepare_local_peer` signed our self `SwarmPeer` record with `Timestamp::now()` on every handshake (one ECDSA sign per connection), so an unchanged advertised address set produced a different signed record each time. Receivers store and re-gossip that record, so an advancing timestamp on otherwise-identical content churns the network for no semantic gain. This is the producer-side complement to #161 (which only rejects such churn on the receive side), and the root-cause version of the fix discussed in ethersphere/bee#5493.

## Changes
- `HandshakeBehaviour` caches the signed self-record keyed by a fingerprint of the (deterministically ordered) advertised address set. While the set is unchanged it reuses a byte-identical record (same timestamp, same signature) across handshakes, so we re-sign only when the set changes. Computed at connection establishment, threaded to the handler/protocol. `LocalAddressManager` and the `AddressProvider` trait are untouched.
- The timestamp now means "when the advertised set last changed or was last refreshed", not "now at each handshake". A `SELF_RECORD_REFRESH_INTERVAL` (1h) re-signs a stable node periodically so its record never ages out of a receiver's clock-skew window (`SwarmPeer::parse` rejects timestamps outside ~6h as `TimestampOutsideSkewWindow`); 1h is well under that window and above #161's 300s `too_soon` floor, so a refresh reads as a normal update.
- The observed-address append is now last-resort only (empty set) for both inbound and outbound, so the common-case record is peer-independent and cacheable. The NAT-discovery role the inbound observed-append served is covered by AutoNAT v2 (#156) and advertising confirmed-external addresses (#160).

## Composition with #161
An unchanged record presents an equal timestamp, which #161 treats as `Stale` (a silent no-op), not `too_soon`. So this is what actually eliminates the churn #161 would otherwise just reject; the hourly refresh advances the timestamp by more than the 300s interval and is accepted as a normal update.

## Compatibility
No wire-format change and no conformance vectors changed: the peer sign/parse interop vectors pass unchanged (the signed bytes are identical for fixed inputs aside from the now-stable timestamp). The residual hourly refresh is inherent to wall-clock-plus-skew-window records; eliminating it entirely (seq-style ordering without a freshness window) is a future SWIP/hardfork, not this PR.

## Testing
Pure `needs_resign` unit tests (no-cache, same-fingerprint-within-interval, fingerprint-change, past-interval) and fingerprint stability/order-sensitivity; a behaviour-level test asserting two consecutive cached signs of an unchanged set return a byte-identical record (same timestamp and signature); `select_local_addrs` tests updated for last-resort-only semantics. handshake (28), peer + interop, and topology suites pass; clippy/fmt clean.