### PR TITLE
feat(topology): trust local peers and protect them from bin-trim eviction

### DIFF
--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -166,6 +166,16 @@ pub trait SwarmNetworkConfig {
     fn mdns_enabled(&self) -> bool {
         true
     }
+
+    /// Whether same-subnet / private-LAN peers are protected from
+    /// capacity-driven bin trimming (default: true). When enabled, a local peer
+    /// ranks above a remote peer of the same reachability so an overpopulated
+    /// bin sheds remotes first. It never overrides liveness demotion or bans:
+    /// an unreachable local peer can still be evicted if it is the only
+    /// candidate left.
+    fn trust_local_peers(&self) -> bool {
+        true
+    }
 }
 
 /// Configuration for Swarm node identity.

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -49,6 +49,12 @@ pub struct NetworkArgs {
     #[serde(rename = "no_discovery")]
     pub disable_discovery: bool,
 
+    /// Stop trusting same-subnet / private-LAN peers, making them ordinary
+    /// bin-trim eviction candidates. Local peers are trusted by default.
+    #[arg(long = "network.no-trust-local-peers")]
+    #[serde(rename = "no_trust_local_peers")]
+    pub no_trust_local_peers: bool,
+
     /// Comma-separated list of bootstrap node multiaddresses.
     #[arg(long = "network.bootnodes", value_delimiter = ',')]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -115,6 +121,7 @@ impl Default for NetworkArgs {
     fn default() -> Self {
         Self {
             disable_discovery: false,
+            no_trust_local_peers: false,
             bootnodes_raw: Vec::new(),
             trusted_peers_raw: Vec::new(),
             port: DEFAULT_P2P_PORT,
@@ -179,6 +186,7 @@ pub struct NetworkConfig<R = KademliaConfig> {
     upnp: bool,
     mdns: bool,
     discovery_enabled: bool,
+    trust_local_peers: bool,
     max_peers: usize,
     idle_timeout: Duration,
     peer: PeerConfig,
@@ -208,6 +216,7 @@ impl<R> NetworkConfig<R> {
             upnp: self.upnp,
             mdns: self.mdns,
             discovery_enabled: self.discovery_enabled,
+            trust_local_peers: self.trust_local_peers,
             max_peers: self.max_peers,
             idle_timeout: self.idle_timeout,
             peer: self.peer,
@@ -243,6 +252,7 @@ impl Default for NetworkConfig<KademliaConfig> {
             upnp: false,
             mdns: true,
             discovery_enabled: true,
+            trust_local_peers: true,
             max_peers: DEFAULT_MAX_PEERS,
             idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
             peer: PeerConfig::default(),
@@ -313,6 +323,7 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
             upnp: args.upnp,
             mdns: args.mdns,
             discovery_enabled: !args.disable_discovery,
+            trust_local_peers: !args.no_trust_local_peers,
             max_peers: args.max_peers,
             idle_timeout: Duration::from_secs(args.idle_timeout_secs),
             peer: PeerConfig::from(&args.peer),
@@ -364,6 +375,10 @@ impl<R> SwarmNetworkConfig for NetworkConfig<R> {
 
     fn mdns_enabled(&self) -> bool {
         self.mdns
+    }
+
+    fn trust_local_peers(&self) -> bool {
+        self.trust_local_peers
     }
 }
 
@@ -430,6 +445,38 @@ mod tests {
         let config =
             NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
         assert!(config.mdns_enabled());
+    }
+
+    #[test]
+    fn trust_local_peers_default_enabled() {
+        // Local peers are trusted by default and protected from bin trimming.
+        let config =
+            NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
+        assert!(config.trust_local_peers());
+    }
+
+    #[test]
+    fn no_trust_local_peers_flag_flips_default() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            network: NetworkArgs,
+        }
+
+        // Default leaves trust on; the negation flag disables it.
+        let default = TestCli::try_parse_from(["test"]).expect("default should parse");
+        let config = NetworkConfig::try_from(&default.network).expect("valid args");
+        assert!(config.trust_local_peers(), "trust is on by default");
+
+        let parsed = TestCli::try_parse_from(["test", "--network.no-trust-local-peers"])
+            .expect("flag should parse");
+        let config = NetworkConfig::try_from(&parsed.network).expect("valid args");
+        assert!(
+            !config.trust_local_peers(),
+            "negation flag disables local-peer trust"
+        );
     }
 
     #[test]

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -135,6 +135,10 @@ impl<C: SwarmNetworkConfig> SwarmNetworkConfig for ConfigWithBootnodes<'_, C> {
     fn mdns_enabled(&self) -> bool {
         self.inner.mdns_enabled()
     }
+
+    fn trust_local_peers(&self) -> bool {
+        self.inner.trust_local_peers()
+    }
 }
 
 impl<C: SwarmPeerConfig> SwarmPeerConfig for ConfigWithBootnodes<'_, C> {

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -21,7 +21,7 @@ use libp2p::{
     },
 };
 use tracing::{debug, info};
-use vertex_net_local::{AddressScope, LocalCapabilities, same_subnet};
+use vertex_net_local::{AddressScope, LocalCapabilities, classify_multiaddr, same_subnet};
 use vertex_net_peer_store::NetPeerStore;
 use vertex_net_peer_store::error::StoreError;
 use vertex_swarm_api::SwarmScoreStore;
@@ -254,6 +254,11 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
     /// Agent versions received via identify, shared with identify behaviour.
     pub(crate) agent_versions: identify::AgentVersions,
 
+    /// When set, same-subnet / private-LAN peers are protected from
+    /// capacity-driven bin trimming by ranking above remotes of equal
+    /// reachability. Liveness demotion and bans stay authoritative.
+    pub(crate) trust_local_peers: bool,
+
     // Metrics
     pub(crate) metrics: Arc<TopologyMetrics>,
 }
@@ -275,6 +280,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         let bootnodes = network_config.bootnodes().to_vec();
         let trusted_peers = network_config.trusted_peers().to_vec();
         let nat_addrs = network_config.nat_addrs().to_vec();
+        let trust_local_peers = network_config.trust_local_peers();
 
         let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         let (command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
@@ -405,6 +411,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             ban_rx,
             peer_store,
             agent_versions,
+            trust_local_peers,
             pending_nat_external_addrs,
             metrics,
         };
@@ -547,13 +554,28 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     pub(crate) fn trim_overpopulated_bins(&mut self) {
         // Rank each candidate by reachability (the routing layer is overlay-keyed
         // and has no peer-id mapping; we own both the registry and the tracker).
+        // When local-peer trust is on, a same-subnet / private-LAN peer ranks
+        // above a remote peer of equal reachability: the tuple orders
+        // lexicographically and the routing layer evicts the lowest rank first,
+        // so `(reachability, is_local)` keeps locals last without ever
+        // overriding a liveness demotion (a remote `Reachable` still outranks a
+        // local `Unreachable`). With trust off, the locality bit is held at
+        // `false` so ranking matches the reachability-only behaviour.
         let tracker = self.nat_discovery.reachability();
+        let listen_addrs = self.nat_discovery.listen_addrs();
+        let trust_local = self.trust_local_peers;
+        let peer_manager = &self.peer_manager;
         let registry = &self.connection_registry;
         let candidates = self.routing.eviction_candidates(|overlay| {
-            registry
+            let reachability = registry
                 .resolve_peer_id(overlay)
                 .map(|peer_id| tracker.status(&peer_id))
-                .unwrap_or(crate::PeerReachability::Unknown)
+                .unwrap_or(crate::PeerReachability::Unknown);
+            let is_local = trust_local
+                && peer_manager
+                    .get_swarm_peer(overlay)
+                    .is_some_and(|peer| peer_is_local(&peer, &listen_addrs));
+            (reachability, is_local)
         });
         if candidates.is_empty() {
             return;
@@ -682,6 +704,27 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             }
         }
     }
+}
+
+/// Whether a peer is local: at least one of its multiaddrs is loopback,
+/// link-local, or on a directly-connected subnet shared with one of our listen
+/// addresses.
+///
+/// This is scope, not reachability. A same-subnet peer is
+/// [`AddressScope::Private`] yet locally reachable; the two stay distinct so
+/// trimming protection never masks a genuine liveness failure (tracked
+/// separately as [`crate::PeerReachability::Unreachable`]).
+pub(crate) fn peer_is_local(peer: &SwarmPeer, listen_addrs: &[Multiaddr]) -> bool {
+    peer.multiaddrs()
+        .iter()
+        .any(|peer_addr| match classify_multiaddr(peer_addr) {
+            Some(AddressScope::Loopback | AddressScope::LinkLocal) => true,
+            Some(AddressScope::Private) => listen_addrs
+                .iter()
+                .any(|our_addr| same_subnet(our_addr, peer_addr)),
+            // Public addresses (or addresses with no IP) are never local.
+            Some(AddressScope::Public) | None => false,
+        })
 }
 
 impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<I> {
@@ -930,6 +973,69 @@ mod tests {
     use super::*;
 
     use crate::kademlia::KademliaConfig;
+
+    use alloy_primitives::{Address, B256, Signature};
+    use nectar_primitives::SwarmAddress;
+    use vertex_swarm_peer::Timestamp;
+    use vertex_swarm_primitives::Nonce;
+
+    fn peer_with_addr(addr: &str) -> SwarmPeer {
+        SwarmPeer::from_parts(
+            vec![addr.parse().expect("valid multiaddr")],
+            Signature::test_signature(),
+            SwarmAddress::from(B256::repeat_byte(1)),
+            Nonce::ZERO,
+            Timestamp::from_seconds(1),
+            None,
+            Address::ZERO,
+        )
+    }
+
+    #[test]
+    fn peer_is_local_link_local_and_loopback() {
+        // Link-local and loopback are local without any listen-addr match; they
+        // are deterministic regardless of host interfaces.
+        let listen: Vec<Multiaddr> = Vec::new();
+        assert!(peer_is_local(
+            &peer_with_addr("/ip4/169.254.10.20/tcp/1634"),
+            &listen
+        ));
+        assert!(peer_is_local(
+            &peer_with_addr("/ip6/fe80::1/tcp/1634"),
+            &listen
+        ));
+        assert!(peer_is_local(
+            &peer_with_addr("/ip4/127.0.0.1/tcp/1634"),
+            &listen
+        ));
+    }
+
+    #[test]
+    fn peer_is_local_public_is_not_local() {
+        let listen = vec![
+            "/ip4/192.168.1.5/tcp/1634"
+                .parse::<Multiaddr>()
+                .expect("valid"),
+        ];
+        // An off-subnet public address is never local, even with a private
+        // listen address configured.
+        assert!(!peer_is_local(
+            &peer_with_addr("/ip4/8.8.8.8/tcp/1634"),
+            &listen
+        ));
+    }
+
+    #[test]
+    fn peer_is_local_private_requires_shared_subnet() {
+        // A private address with no matching listen subnet is not local: the
+        // same_subnet check is against our own listen addresses, so an empty
+        // listen set yields false for a private peer.
+        let listen: Vec<Multiaddr> = Vec::new();
+        assert!(!peer_is_local(
+            &peer_with_addr("/ip4/10.1.2.3/tcp/1634"),
+            &listen
+        ));
+    }
 
     #[test]
     fn test_topology_config() {

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -253,18 +253,19 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
     /// Identify peers to evict from overpopulated bins.
     ///
     /// Order: handshaking peers first (not yet established), then active peers
-    /// least worth keeping. Active victims are chosen by reachability then
-    /// score: `reachability(overlay)` (the lowest-ranked is evicted soonest)
-    /// breaks ties on the peer score. This matches the reference
-    /// implementation, whose prune prefers dropping unreachable peers.
-    /// `reachability` is supplied by the caller, which owns the
-    /// overlay->peer-id mapping and the reachability tracker; it returns any
-    /// `Ord` rank (the topology behaviour passes a `PeerReachability`, ordered
-    /// `Unreachable < Unknown < Reachable`), so this layer stays decoupled from
-    /// the reachability type.
+    /// least worth keeping. Active victims are chosen by rank then score:
+    /// `rank(overlay)` (the lowest-ranked is evicted soonest) breaks ties on the
+    /// peer score, preferring to drop unreachable peers.
+    /// `rank` is supplied by the caller, which owns the overlay->peer-id mapping
+    /// and the reachability tracker; it returns any `Ord` value, so this layer
+    /// stays decoupled from the rank type. The topology behaviour passes a
+    /// `PeerReachability` (ordered `Unreachable < Unknown < Reachable`), or a
+    /// `(PeerReachability, is_local)` tuple when local-peer trust is on: the
+    /// tuple orders lexicographically so a local peer ranks above a remote of
+    /// equal reachability and is evicted last.
     pub(crate) fn eviction_candidates<R: Ord>(
         &self,
-        reachability: impl Fn(&OverlayAddress) -> R,
+        rank: impl Fn(&OverlayAddress) -> R,
     ) -> Vec<EvictionCandidate> {
         let depth = self.depth();
         let phases = self.connection_phases.read();
@@ -302,7 +303,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
                 }
             }
 
-            // Phase 2: Active peers, least-reachable first then lowest score
+            // Phase 2: Active peers, lowest rank first then lowest score
             // (O(n) partial selection).
             if remaining > 0 {
                 let mut active_in_bin: Vec<_> = self
@@ -310,7 +311,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
                     .peers_in_bin(bin)
                     .into_iter()
                     .map(|overlay| {
-                        let rank = reachability(&overlay);
+                        let rank = rank(&overlay);
                         let score = self.peer_manager.get_peer_score(&overlay).unwrap_or(0.0);
                         (overlay, rank, score)
                     })
@@ -318,8 +319,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
 
                 if remaining < active_in_bin.len() {
                     active_in_bin.select_nth_unstable_by(remaining, |a, b| {
-                        // Evict least-reachable first (lower rank), breaking ties
-                        // on lowest score.
+                        // Evict lowest rank first, breaking ties on lowest score.
                         a.1.cmp(&b.1).then_with(|| {
                             a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal)
                         })
@@ -1135,6 +1135,82 @@ mod tests {
                 "least-reachable peer should be evicted before reachable ones"
             );
         }
+    }
+
+    #[test]
+    fn test_eviction_local_tiebreak_keeps_local_over_equal_remote() {
+        use crate::PeerReachability;
+
+        let base = SwarmAddress::with_first_byte(0x00);
+        let (routing, _pm) = make_routing(base, KademliaConfig::default());
+
+        // 6 active peers in bin 0; at depth 8 the target is 4, so surplus is 2.
+        let peers: Vec<_> = (0..6)
+            .map(|i| {
+                let mut bytes = [0x00u8; 32];
+                bytes[0] = 0x80 + i;
+                OverlayAddress::from(bytes)
+            })
+            .collect();
+        for &peer in &peers {
+            force_active(&routing, peer);
+        }
+        routing.depth.store(8, Ordering::Relaxed);
+
+        // Every peer has the same Unknown reachability; two are local. With the
+        // `(reachability, is_local)` tuple, `false < true`, so the two non-local
+        // peers rank lowest and are evicted while the locals are kept.
+        let local = [peers[1], peers[4]];
+        let candidates = routing
+            .eviction_candidates(|overlay| (PeerReachability::Unknown, local.contains(overlay)));
+
+        assert_eq!(candidates.len(), 2);
+        let evicted: Vec<_> = candidates.iter().map(|c| c.overlay).collect();
+        for peer in local {
+            assert!(
+                !evicted.contains(&peer),
+                "local peer must outrank a remote of equal reachability"
+            );
+        }
+    }
+
+    #[test]
+    fn test_eviction_remote_reachable_outranks_local_unreachable() {
+        use crate::PeerReachability;
+
+        let base = SwarmAddress::with_first_byte(0x00);
+        let (routing, _pm) = make_routing(base, KademliaConfig::default());
+
+        // 5 active peers in bin 0; at depth 8 the target is 4, so surplus is 1.
+        let peers: Vec<_> = (0..5)
+            .map(|i| {
+                let mut bytes = [0x00u8; 32];
+                bytes[0] = 0x80 + i;
+                OverlayAddress::from(bytes)
+            })
+            .collect();
+        for &peer in &peers {
+            force_active(&routing, peer);
+        }
+        routing.depth.store(8, Ordering::Relaxed);
+
+        // One local-but-unreachable peer; the rest are remote and reachable.
+        // Locality is the low-order tiebreak, so a genuine liveness failure
+        // (Unreachable) still ranks the local peer lowest and evicts it.
+        let dead_local = peers[2];
+        let candidates = routing.eviction_candidates(|overlay| {
+            if *overlay == dead_local {
+                (PeerReachability::Unreachable, true)
+            } else {
+                (PeerReachability::Reachable, false)
+            }
+        });
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].overlay, dead_local,
+            "an unreachable local is still evicted when it is the worst candidate"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #162

## What

Same-subnet / private-LAN peers are now trusted by default and protected from capacity-driven bin trimming. A local peer ranks above a remote peer of equal reachability, so an overpopulated bin sheds remotes first.

Eviction ranking changes from `PeerReachability` to a `(PeerReachability, is_local)` tuple. Locality is the low-order tiebreak: it never overrides a liveness demotion or a ban. A remote `Reachable` still outranks a local `Unreachable`, and an unreachable local peer is still evicted when it is the only candidate left.

## Locality definition

`peer_is_local` is scope-based, not reachability-based: a peer is local if any of its multiaddrs is loopback, link-local, or on a directly-connected subnet shared with one of our listen addresses. Public addresses (or addresses with no IP) are never local. Keeping scope and reachability distinct ensures trimming protection never masks a genuine liveness failure.

## Configuration

Trusted by default. Operators opt out with `--network.no-trust-local-peers`, which makes local peers ordinary eviction candidates (the locality bit is held `false`, so ranking falls back to reachability-only).

The new knob is surfaced through `SwarmNetworkConfig::trust_local_peers()` (default `true`), wired through `NetworkConfig` and the bootnode config wrapper.

## Tests

- `trust_local_peers_default_enabled`, `no_trust_local_peers_flag_flips_default`
- `peer_is_local_link_local_and_loopback`, `peer_is_local_public_is_not_local`, `peer_is_local_private_requires_shared_subnet`
- `test_eviction_local_tiebreak_keeps_local_over_equal_remote`, `test_eviction_remote_reachable_outranks_local_unreachable`

`cargo test`: api 2, topology 141. clippy (lib + tests) and fmt clean.

Note: touches `crates/swarm/node/src/args/network.rs`, which also changes in #165; whichever merges second needs a trivial rebase.