### PR TITLE
feat(topology): self-confirm globally-routable IPv6 listen addresses

### DIFF
--- a/crates/net/local/src/lib.rs
+++ b/crates/net/local/src/lib.rs
@@ -11,5 +11,6 @@ pub mod system;
 pub use capabilities::{LocalCapabilities, advertise_filter};
 pub use scope::{
     AddressFamily, AddressScope, IpCapability, classify_multiaddr, family_order, is_dialable,
+    is_globally_routable_ipv6,
 };
 pub use system::{add_subnet, remove_subnet, same_subnet};

--- a/crates/net/local/src/scope.rs
+++ b/crates/net/local/src/scope.rs
@@ -85,6 +85,34 @@ pub fn classify_multiaddr(addr: &Multiaddr) -> Option<AddressScope> {
     extract_ip(addr).and_then(classify_ip)
 }
 
+/// Whether a multiaddr is a globally-routable IPv6 unicast address.
+///
+/// IPv6 has no NAT: a global unicast address bound on a local interface is
+/// reachable end-to-end by any peer, so a node listening on one can treat it as
+/// externally confirmed without a dial-back. The only caveat is a stateful
+/// firewall dropping unsolicited inbound packets; that is the operator's
+/// configuration, not an addressing question, and the same firewall would also
+/// fail an AutoNAT dial-back. Apply this only to listen addresses the node
+/// actually binds, never to observed or relayed addresses.
+///
+/// Returns `false` for IPv4 (which may sit behind NAT even when public-scope),
+/// for non-global IPv6 (loopback, unique-local, link-local, unspecified), and
+/// for family-less addresses (DNS).
+///
+/// ```
+/// use vertex_net_local::is_globally_routable_ipv6;
+///
+/// let global: libp2p::Multiaddr = "/ip6/2606:4700:4700::1111/tcp/1634".parse().unwrap();
+/// let ula: libp2p::Multiaddr = "/ip6/fd00::1/tcp/1634".parse().unwrap();
+/// let public_v4: libp2p::Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().unwrap();
+/// assert!(is_globally_routable_ipv6(&global));
+/// assert!(!is_globally_routable_ipv6(&ula));
+/// assert!(!is_globally_routable_ipv6(&public_v4));
+/// ```
+pub fn is_globally_routable_ipv6(addr: &Multiaddr) -> bool {
+    matches!(extract_ip(addr), Some(IpAddr::V6(ip)) if classify_ipv6(ip) == Some(AddressScope::Public))
+}
+
 /// IP version of an address (extracted from Protocol).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum IpVersion {
@@ -385,6 +413,35 @@ mod tests {
 
         let addr: Multiaddr = "/ip6/2607:f8b0:4004:800::200e/tcp/1234".parse().unwrap();
         assert_eq!(classify_multiaddr(&addr), Some(AddressScope::Public));
+    }
+
+    #[test]
+    fn test_is_globally_routable_ipv6() {
+        // Global unicast IPv6: yes.
+        let global: Multiaddr = "/ip6/2606:4700:4700::1111/tcp/1634".parse().unwrap();
+        assert!(is_globally_routable_ipv6(&global));
+        let global2: Multiaddr = "/ip6/2001:db8::1/tcp/1634".parse().unwrap();
+        assert!(is_globally_routable_ipv6(&global2));
+
+        // Non-global IPv6: no.
+        let ula: Multiaddr = "/ip6/fd00::1/tcp/1634".parse().unwrap();
+        assert!(!is_globally_routable_ipv6(&ula));
+        let link_local: Multiaddr = "/ip6/fe80::1/tcp/1634".parse().unwrap();
+        assert!(!is_globally_routable_ipv6(&link_local));
+        let loopback: Multiaddr = "/ip6/::1/tcp/1634".parse().unwrap();
+        assert!(!is_globally_routable_ipv6(&loopback));
+        let unspecified: Multiaddr = "/ip6/::/tcp/1634".parse().unwrap();
+        assert!(!is_globally_routable_ipv6(&unspecified));
+
+        // IPv4 (even public-scope): no, may sit behind NAT.
+        let public_v4: Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().unwrap();
+        assert!(!is_globally_routable_ipv6(&public_v4));
+        let private_v4: Multiaddr = "/ip4/192.168.1.1/tcp/1634".parse().unwrap();
+        assert!(!is_globally_routable_ipv6(&private_v4));
+
+        // Family-less (DNS): no.
+        let dns: Multiaddr = "/dns6/example.com/tcp/1634".parse().unwrap();
+        assert!(!is_globally_routable_ipv6(&dns));
     }
 
     #[test]

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -21,7 +21,9 @@ use libp2p::{
     },
 };
 use tracing::{debug, info};
-use vertex_net_local::{AddressScope, LocalCapabilities, classify_multiaddr, same_subnet};
+use vertex_net_local::{
+    AddressScope, LocalCapabilities, classify_multiaddr, is_globally_routable_ipv6, same_subnet,
+};
 use vertex_net_peer_store::NetPeerStore;
 use vertex_net_peer_store::error::StoreError;
 use vertex_swarm_api::SwarmScoreStore;
@@ -782,6 +784,18 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
                 let capability_became_known =
                     self.nat_discovery.on_new_listen_addr(info.addr.clone());
 
+                // A globally-routable IPv6 listen address is reachable end-to-end
+                // without a dial-back: IPv6 has no NAT, so binding a global unicast
+                // address is sufficient (subject only to a stateful firewall, which
+                // would equally fail AutoNAT). Self-confirm it as an external
+                // address so it lands in the verified tier immediately and AutoNAT
+                // can spend its candidate budget on the harder IPv4/NAT case.
+                if is_globally_routable_ipv6(info.addr) {
+                    debug!(address = %info.addr, "Self-confirming globally-routable IPv6 listen address");
+                    self.pending_actions
+                        .push_back(ToSwarm::ExternalAddrConfirmed(info.addr.clone()));
+                }
+
                 if capability_became_known {
                     debug!("Network capability now known, triggering immediate dial");
                     self.evaluator_handle.trigger_evaluation();
@@ -972,6 +986,12 @@ impl<I: SwarmIdentity + Clone> Drop for TopologyBehaviour<I> {
 mod tests {
     use super::*;
 
+    use std::task::{Context, Poll};
+
+    use libp2p::core::transport::ListenerId;
+    use libp2p::swarm::behaviour::NewListenAddr;
+    use vertex_swarm_identity::Identity;
+
     use crate::kademlia::KademliaConfig;
 
     use alloy_primitives::{Address, B256, Signature};
@@ -1045,5 +1065,149 @@ mod tests {
 
         assert_eq!(config.dial_interval, Duration::from_secs(10));
         assert_eq!(config.kademlia.limits.nominal(), 3);
+    }
+
+    /// Minimal `SwarmBootnodeConfig` for behaviour construction in tests.
+    #[derive(Default)]
+    struct TestNetworkConfig {
+        peer: TestPeerConfig,
+        routing: KademliaConfig,
+    }
+
+    impl vertex_swarm_api::SwarmNetworkConfig for TestNetworkConfig {
+        fn listen_addrs(&self) -> &[Multiaddr] {
+            &[]
+        }
+        fn bootnodes(&self) -> &[Multiaddr] {
+            &[]
+        }
+        fn trusted_peers(&self) -> &[Multiaddr] {
+            &[]
+        }
+        fn discovery_enabled(&self) -> bool {
+            true
+        }
+        fn max_peers(&self) -> usize {
+            16
+        }
+        fn idle_timeout(&self) -> Duration {
+            Duration::from_secs(30)
+        }
+        fn nat_addrs(&self) -> &[Multiaddr] {
+            &[]
+        }
+        fn nat_auto_enabled(&self) -> bool {
+            false
+        }
+    }
+
+    #[derive(Default)]
+    struct TestPeerConfig;
+
+    impl vertex_swarm_api::PeerConfigValues for TestPeerConfig {
+        fn ban_threshold(&self) -> f64 {
+            vertex_swarm_api::DEFAULT_PEER_BAN_THRESHOLD
+        }
+    }
+
+    impl vertex_swarm_api::SwarmPeerConfig for TestNetworkConfig {
+        type Peers = TestPeerConfig;
+        fn peers(&self) -> &Self::Peers {
+            &self.peer
+        }
+    }
+
+    impl vertex_swarm_api::SwarmRoutingConfig for TestNetworkConfig {
+        type Routing = KademliaConfig;
+        fn routing(&self) -> &Self::Routing {
+            &self.routing
+        }
+    }
+
+    /// Drive the behaviour's poll loop until it yields the first `ToSwarm`, or
+    /// return `None` once it parks. Tests only assert on the external-address
+    /// actions, so a bounded number of polls is sufficient.
+    fn poll_one(
+        behaviour: &mut TopologyBehaviour<Identity>,
+        cx: &mut Context<'_>,
+    ) -> Option<ToSwarm<(), THandlerInEvent<ProtocolBehaviours<Identity>>>> {
+        match behaviour.poll(cx) {
+            Poll::Ready(action) => Some(action),
+            Poll::Pending => None,
+        }
+    }
+
+    /// Collect every `ExternalAddrConfirmed` address emitted across a bounded
+    /// number of poll iterations.
+    fn drain_confirmed_external(behaviour: &mut TopologyBehaviour<Identity>) -> Vec<Multiaddr> {
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut out = Vec::new();
+        for _ in 0..64 {
+            match poll_one(behaviour, &mut cx) {
+                Some(ToSwarm::ExternalAddrConfirmed(addr)) => out.push(addr),
+                Some(_) => {}
+                None => break,
+            }
+        }
+        out
+    }
+
+    fn new_listen_addr(behaviour: &mut TopologyBehaviour<Identity>, addr: &Multiaddr) {
+        behaviour.on_swarm_event(FromSwarm::NewListenAddr(NewListenAddr {
+            listener_id: ListenerId::next(),
+            addr,
+        }));
+    }
+
+    /// A globally-routable IPv6 listen address is self-confirmed as an external
+    /// address (IPv6 has no NAT), while a public IPv4 listen address is not (it
+    /// may sit behind NAT and still requires AutoNAT verification).
+    #[tokio::test]
+    async fn global_ipv6_listen_addr_self_confirmed_ipv4_not() {
+        // The topology stack expects a global TaskExecutor.
+        let _tm = vertex_tasks::TaskManager::current();
+
+        let identity = Identity::random(vertex_swarm_spec::init_testnet(), SwarmNodeType::Storer);
+        let (mut behaviour, _handle) = TopologyBehaviour::new(
+            identity,
+            TopologyConfig::new(),
+            &TestNetworkConfig::default(),
+            None,
+            None,
+        )
+        .expect("build topology behaviour");
+
+        // Drain the initial poll (no static NAT addresses configured here).
+        let _ = drain_confirmed_external(&mut behaviour);
+
+        let v6: Multiaddr = "/ip6/2606:4700:4700::1111/tcp/1634".parse().unwrap();
+        let v4: Multiaddr = "/ip4/8.8.8.8/tcp/1634".parse().unwrap();
+        let v6_ula: Multiaddr = "/ip6/fd00::1/tcp/1634".parse().unwrap();
+        let v6_unspec: Multiaddr = "/ip6/::/tcp/1634".parse().unwrap();
+
+        new_listen_addr(&mut behaviour, &v6);
+        new_listen_addr(&mut behaviour, &v4);
+        new_listen_addr(&mut behaviour, &v6_ula);
+        new_listen_addr(&mut behaviour, &v6_unspec);
+
+        let confirmed = drain_confirmed_external(&mut behaviour);
+
+        assert!(
+            confirmed.contains(&v6),
+            "global IPv6 listen address must be self-confirmed, got {confirmed:?}"
+        );
+        assert!(
+            !confirmed.contains(&v4),
+            "public IPv4 listen address must NOT be self-confirmed, got {confirmed:?}"
+        );
+        assert!(
+            !confirmed.contains(&v6_ula),
+            "unique-local IPv6 must NOT be self-confirmed, got {confirmed:?}"
+        );
+        assert!(
+            !confirmed.contains(&v6_unspec),
+            "unspecified IPv6 must NOT be self-confirmed, got {confirmed:?}"
+        );
     }
 }

--- a/docs/networking/address-management.md
+++ b/docs/networking/address-management.md
@@ -83,6 +83,7 @@ NAT traversal runs as a cluster of top-level libp2p behaviours that sit beside i
 - **AutoNAT v2 client** picks up each candidate, asks a peer that speaks `/libp2p/autonat/2/dial-request` to dial it back over a fresh port, and on success emits `ExternalAddrConfirmed`.
 - **AutoNAT v2 server** performs dial-backs for other peers. A completed dial-back proves the remote peer accepts inbound connections, so the node promotes it to `Reachable` in the topology reachability tracker via `on_autonat_peer_confirmed()`.
 - **UPnP** (`libp2p::upnp::tokio`) asks the LAN IGD gateway to map the listen port and emits `ExternalAddrConfirmed` for the mapped address.
+- **Globally-routable IPv6 listen addresses** are self-confirmed without a dial-back. When `vertex-swarm-topology` sees a `NewListenAddr` carrying a global unicast IPv6 address it actually binds, it emits `ExternalAddrConfirmed` for that address directly. IPv6 has no NAT, so a bound global unicast address is reachable end-to-end; the only caveat is a stateful firewall dropping unsolicited inbound packets, which is operator configuration and would equally fail an AutoNAT dial-back. This applies only to listen addresses we bind, never to observed or relayed candidates, and only to IPv6: a public-scope IPv4 listen address may still sit behind NAT and is left for AutoNAT to verify. The effect is that an IPv6 listen address reaches the verified advertisement tier immediately, letting the AutoNAT v2 client spend its score-ranked candidate budget on the harder IPv4/NAT case.
 
 The swarm broadcasts every `ExternalAddrConfirmed` to all behaviours, so the topology behaviour learns about verified addresses without any per-behaviour plumbing.
 
@@ -129,5 +130,5 @@ The record we sign during the handshake is what a full-node peer stores and goss
 
 ### IPv6 vs IPv4
 
-Most IPv6 addresses are globally routable (except loopback, link-local, ULA, and documentation ranges). IPv4 is more complex due to NAT prevalence. For IPv4, only explicitly public listen addresses or configured NAT addresses are trusted.
+Most IPv6 addresses are globally routable (except loopback, link-local, ULA, and documentation ranges). IPv4 is more complex due to NAT prevalence. For IPv4, only explicitly public listen addresses or configured NAT addresses are trusted. This asymmetry is also why a global unicast IPv6 listen address is self-confirmed as an external address while a public-scope IPv4 listen address is not (see the AutoNAT v2 and UPnP section).
 


### PR DESCRIPTION
Closes #164

## What

When the topology behaviour sees a `NewListenAddr` carrying a globally-routable IPv6 unicast address it actually binds, it self-confirms that address as external by emitting `ToSwarm::ExternalAddrConfirmed`, the same mechanism already used for static NAT addresses. This implements Option 1 from #164.

## Why

IPv6 has no NAT: a global unicast address bound on a local interface is reachable end-to-end without a dial-back. The only caveat is a stateful firewall dropping unsolicited inbound packets, which is operator configuration and would equally fail an AutoNAT dial-back. This applies only to listen addresses we bind, never to observed or relayed candidates, and only to IPv6: a public-scope IPv4 listen address may still sit behind NAT and is left for AutoNAT to verify.

The effect is that an IPv6 listen address reaches the verified advertisement tier immediately (composing with #160's IPv6-first ordering), letting the AutoNAT v2 client spend its score-ranked candidate budget on the harder IPv4/NAT case. This is the practical lever for #164's IPv6 prioritization goal: the libp2p autonat v2 client selects candidates purely by observation-frequency score and exposes no address-family preference.

## How

New `vertex_net_local::is_globally_routable_ipv6(addr)` returns true only for global unicast IPv6 (false for IPv4 even when public-scope, for non-global IPv6, and for family-less addresses). The topology behaviour calls it in the `NewListenAddr` arm.

## Tests

- `test_is_globally_routable_ipv6` (net-local), plus a doctest
- `global_ipv6_listen_addr_self_confirmed_ipv4_not` (topology): a global IPv6 listen address is self-confirmed while public IPv4, ULA, and unspecified IPv6 are not

`cargo test`: net-local 55 + 3 doctests, topology 137. clippy (lib + tests) and fmt clean.

Docs updated in `docs/networking/address-management.md` (AutoNAT/UPnP section and the IPv6-vs-IPv4 note).