### PR TITLE
feat(swarm-rpc): add UploadChunk gRPC endpoint for pre-stamped chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8571,6 +8571,7 @@ name = "vertex-swarm-rpc"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "hex",
  "prost 0.13.5",
  "tokio",

--- a/crates/swarm/builder/src/providers.rs
+++ b/crates/swarm/builder/src/providers.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use nectar_primitives::SwarmAddress;
 use vertex_swarm_api::{
-    ChunkAddress, ChunkRetrievalResult, SwarmChunkProvider, SwarmError, SwarmIdentity, SwarmResult,
-    SwarmTopologyRouting,
+    AnyChunk, ChunkAddress, ChunkRetrievalResult, ChunkSendReceipt, SwarmChunkProvider,
+    SwarmChunkSender, SwarmError, SwarmIdentity, SwarmResult, SwarmTopologyRouting,
 };
 use vertex_swarm_node::ClientHandle;
 use vertex_swarm_topology::TopologyHandle;
@@ -72,5 +72,22 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
     fn has_chunk(&self, _address: &ChunkAddress) -> bool {
         // Client nodes don't have local storage
         false
+    }
+}
+
+#[async_trait]
+impl<I: SwarmIdentity> SwarmChunkSender for NetworkChunkProvider<I> {
+    async fn send_chunk_unchecked(&self, _chunk: AnyChunk) -> SwarmResult<ChunkSendReceipt> {
+        // PushSync forwarding is wired up alongside the client send path; until
+        // that lands the upload endpoint reports the capability as unavailable.
+        Err(SwarmError::internal_msg(
+            "chunk upload is not yet supported",
+        ))
+    }
+
+    async fn send_chunk(&self, _chunk: AnyChunk) -> SwarmResult<ChunkSendReceipt> {
+        Err(SwarmError::internal_msg(
+            "chunk upload is not yet supported",
+        ))
     }
 }

--- a/crates/swarm/builder/src/providers.rs
+++ b/crates/swarm/builder/src/providers.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use nectar_primitives::SwarmAddress;
 use vertex_swarm_api::{
-    AnyChunk, ChunkAddress, ChunkRetrievalResult, ChunkSendReceipt, SwarmChunkProvider,
+    ChunkAddress, ChunkRetrievalResult, PushReceipt, StampedChunk, SwarmChunkProvider,
     SwarmChunkSender, SwarmError, SwarmIdentity, SwarmResult, SwarmTopologyRouting,
 };
 use vertex_swarm_node::ClientHandle;
@@ -76,7 +76,7 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
 
 #[async_trait]
 impl<I: SwarmIdentity> SwarmChunkSender for NetworkChunkProvider<I> {
-    async fn send_chunk_unchecked(&self, _chunk: AnyChunk) -> SwarmResult<ChunkSendReceipt> {
+    async fn send_chunk_unchecked(&self, _chunk: StampedChunk) -> SwarmResult<PushReceipt> {
         // PushSync forwarding is wired up alongside the client send path; until
         // that lands the upload endpoint reports the capability as unavailable.
         Err(SwarmError::internal_msg(
@@ -84,7 +84,7 @@ impl<I: SwarmIdentity> SwarmChunkSender for NetworkChunkProvider<I> {
         ))
     }
 
-    async fn send_chunk(&self, _chunk: AnyChunk) -> SwarmResult<ChunkSendReceipt> {
+    async fn send_chunk(&self, _chunk: StampedChunk) -> SwarmResult<PushReceipt> {
         Err(SwarmError::internal_msg(
             "chunk upload is not yet supported",
         ))

--- a/crates/swarm/builder/src/rpc.rs
+++ b/crates/swarm/builder/src/rpc.rs
@@ -1,7 +1,7 @@
 //! RPC providers for Swarm nodes.
 
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
-use vertex_swarm_api::{HasTopology, SwarmChunkProvider, SwarmIdentity};
+use vertex_swarm_api::{HasTopology, SwarmChunkProvider, SwarmChunkSender, SwarmIdentity};
 use vertex_swarm_rpc::{ChunkService, NodeService, proto};
 use vertex_swarm_topology::TopologyHandle;
 
@@ -25,7 +25,7 @@ impl<I: SwarmIdentity, C: Send + Sync> HasTopology for ClientRpcProviders<I, C> 
     }
 }
 
-impl<I: SwarmIdentity, C: SwarmChunkProvider + Clone> RegistersGrpcServices
+impl<I: SwarmIdentity, C: SwarmChunkProvider + SwarmChunkSender + Clone> RegistersGrpcServices
     for ClientRpcProviders<I, C>
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
@@ -90,7 +90,7 @@ impl<I: SwarmIdentity, C: Send + Sync> HasTopology for StorerRpcProviders<I, C> 
     }
 }
 
-impl<I: SwarmIdentity, C: SwarmChunkProvider + Clone> RegistersGrpcServices
+impl<I: SwarmIdentity, C: SwarmChunkProvider + SwarmChunkSender + Clone> RegistersGrpcServices
     for StorerRpcProviders<I, C>
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {

--- a/crates/swarm/rpc/Cargo.toml
+++ b/crates/swarm/rpc/Cargo.toml
@@ -24,6 +24,9 @@ tokio = { workspace = true, features = ["sync", "rt"] }
 tonic.workspace = true
 prost.workspace = true
 
+[dev-dependencies]
+bytes = { workspace = true }
+
 [build-dependencies]
 tonic-build.workspace = true
 

--- a/crates/swarm/rpc/proto/chunk.proto
+++ b/crates/swarm/rpc/proto/chunk.proto
@@ -9,6 +9,19 @@ service Chunk {
 
   // HasChunk checks if a chunk exists locally.
   rpc HasChunk(HasChunkRequest) returns (HasChunkResponse);
+
+  // UploadChunk pushes a pre-stamped chunk to the Swarm network.
+  // The chunk is forwarded to the responsible storer via PushSync.
+  rpc UploadChunk(UploadChunkRequest) returns (UploadChunkResponse);
+}
+
+// ChunkType identifies how the chunk data is reconstructed on upload.
+enum ChunkType {
+  // Content-addressed chunk (CAC): the address is the BMT hash of the data.
+  CHUNK_TYPE_CONTENT = 0;
+
+  // Single-owner chunk (SOC): the data carries id, signature, and BMT body.
+  CHUNK_TYPE_SINGLE_OWNER = 1;
 }
 
 message RetrieveChunkRequest {
@@ -35,4 +48,32 @@ message HasChunkRequest {
 message HasChunkResponse {
   // Whether the chunk exists locally.
   bool exists = 1;
+}
+
+message UploadChunkRequest {
+  // The chunk payload.
+  //
+  // For a content chunk this is the BMT body (span + data). For a single-owner
+  // chunk this is the full wire encoding (id + signature + BMT body).
+  bytes data = 1;
+
+  // Pre-computed postage stamp attached to this chunk.
+  bytes stamp = 2;
+
+  // Chunk address (hex encoded, 64 chars).
+  string address = 3;
+
+  // How the data field is interpreted when reconstructing the chunk.
+  ChunkType chunk_type = 4;
+
+  // Validate the stamp signature against the chunk before sending.
+  //
+  // Pre-stamped uploads are trusted by default. Set this to request signature
+  // validation prior to forwarding the chunk.
+  bool validate = 5;
+}
+
+message UploadChunkResponse {
+  // Overlay address of the storer that accepted this chunk (hex encoded).
+  string storer = 1;
 }

--- a/crates/swarm/rpc/proto/chunk.proto
+++ b/crates/swarm/rpc/proto/chunk.proto
@@ -76,4 +76,13 @@ message UploadChunkRequest {
 message UploadChunkResponse {
   // Overlay address of the storer that accepted this chunk (hex encoded).
   string storer = 1;
+
+  // The storer's signature over the receipt (65 bytes).
+  bytes signature = 2;
+
+  // The nonce the storer used when signing the receipt (32 bytes).
+  bytes nonce = 3;
+
+  // The storer's storage radius at the time of acceptance.
+  uint32 storage_radius = 4;
 }

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -1,19 +1,20 @@
-//! Chunk service implementation for Swarm chunk retrieval.
+//! Chunk service implementation for Swarm chunk retrieval and upload.
 
 use hex::FromHex;
 use tonic::{Request, Response, Status};
 use vertex_swarm_api::{
-    AnyChunk, ChunkAddress, ContentChunk, SingleOwnerChunk, SwarmChunkProvider, SwarmChunkSender,
+    ChunkAddress, PushReceipt, Stamp, StampedChunk, SwarmChunkProvider, SwarmChunkSender,
 };
 
 use crate::proto::chunk::{
-    ChunkType, HasChunkRequest, HasChunkResponse, RetrieveChunkRequest, RetrieveChunkResponse,
+    HasChunkRequest, HasChunkResponse, RetrieveChunkRequest, RetrieveChunkResponse,
     UploadChunkRequest, UploadChunkResponse, chunk_server::Chunk,
 };
 
 /// Chunk service implementation.
 ///
-/// Provides gRPC endpoints for retrieving chunks from the Swarm network.
+/// Provides gRPC endpoints for retrieving and uploading chunks on the Swarm
+/// network.
 pub struct ChunkService<P> {
     provider: P,
 }
@@ -37,42 +38,23 @@ fn parse_chunk_address(hex: &str) -> Result<ChunkAddress, Status> {
     Ok(ChunkAddress::new(bytes))
 }
 
-/// Reconstruct an `AnyChunk` from an upload request payload.
+/// Build a [`StampedChunk`] from an upload request payload.
 ///
-/// The `data` field is interpreted according to `chunk_type`: a content chunk
-/// carries the BMT body, a single-owner chunk carries the full wire encoding.
-/// The reconstructed chunk is verified against the supplied address.
+/// The proto carries raw bytes at this boundary; convert them to typed values
+/// immediately. The chunk is reconstructed from `data` and verified against
+/// `address`: a lying address makes reconstruction fail, so the address is
+/// self-validating against the payload. The stamp is parsed from its wire bytes
+/// and paired with the chunk.
 #[allow(clippy::result_large_err)]
-fn reconstruct_chunk(req: &UploadChunkRequest) -> Result<AnyChunk, Status> {
+fn parse_stamped_chunk(req: &UploadChunkRequest) -> Result<StampedChunk, Status> {
     let address = parse_chunk_address(&req.address)?;
 
-    let chunk_type = ChunkType::try_from(req.chunk_type)
-        .map_err(|_| Status::invalid_argument(format!("Unknown chunk type: {}", req.chunk_type)))?;
+    let stamp = Stamp::try_from_slice(&req.stamp)
+        .map_err(|e| Status::invalid_argument(format!("Invalid postage stamp: {}", e)))?;
 
-    let chunk = match chunk_type {
-        ChunkType::Content => {
-            // Parse the full BMT body (span + data) from the wire encoding, the
-            // same shape `RetrieveChunk` returns, so a retrieved content chunk
-            // round-trips back into an upload. The BMT hash is recomputed from
-            // the body, letting the verify step below reject an address that
-            // lies about the payload.
-            let content = ContentChunk::try_from(req.data.as_slice())
-                .map_err(|e| Status::invalid_argument(format!("Invalid content chunk: {}", e)))?;
-            AnyChunk::Content(content)
-        }
-        ChunkType::SingleOwner => {
-            let soc = SingleOwnerChunk::try_from(req.data.as_slice()).map_err(|e| {
-                Status::invalid_argument(format!("Invalid single-owner chunk: {}", e))
-            })?;
-            AnyChunk::SingleOwner(soc)
-        }
-    };
-
-    chunk.verify(&address).map_err(|e| {
-        Status::invalid_argument(format!("Chunk address does not match payload: {}", e))
-    })?;
-
-    Ok(chunk)
+    StampedChunk::reconstruct(address, req.data.clone().into(), stamp).map_err(|e| {
+        Status::invalid_argument(format!("Chunk does not match the supplied address: {}", e))
+    })
 }
 
 #[tonic::async_trait]
@@ -112,25 +94,37 @@ impl<P: SwarmChunkProvider + SwarmChunkSender> Chunk for ChunkService<P> {
 
     /// Upload a pre-stamped chunk to the network.
     ///
-    /// The request carries the postage stamp in `stamp`; it is threaded to the
-    /// storer once `SwarmChunkSender` accepts the stamp alongside the chunk.
+    /// The chunk and its postage stamp travel together as a [`StampedChunk`] and
+    /// are forwarded to the responsible storer via PushSync. The response carries
+    /// the full [`PushReceipt`] so the caller receives the storer's proof of
+    /// acceptance.
     async fn upload_chunk(
         &self,
         request: Request<UploadChunkRequest>,
     ) -> Result<Response<UploadChunkResponse>, Status> {
         let req = request.into_inner();
-        let chunk = reconstruct_chunk(&req)?;
+        let stamped = parse_stamped_chunk(&req)?;
 
         // Pre-stamped uploads are trusted by default; opt in to validation.
         let receipt = if req.validate {
-            self.provider.send_chunk(chunk).await
+            self.provider.send_chunk(stamped).await
         } else {
-            self.provider.send_chunk_unchecked(chunk).await
+            self.provider.send_chunk_unchecked(stamped).await
         }
         .map_err(|e| Status::internal(format!("Chunk upload failed: {}", e)))?;
 
+        let PushReceipt {
+            storer,
+            signature,
+            nonce,
+            storage_radius,
+        } = receipt;
+
         Ok(Response::new(UploadChunkResponse {
-            storer: receipt.storer.to_string(),
+            storer: storer.to_string(),
+            signature: signature.as_bytes().to_vec(),
+            nonce: nonce.as_slice().to_vec(),
+            storage_radius: u32::from(storage_radius.get()),
         }))
     }
 }
@@ -138,9 +132,10 @@ impl<P: SwarmChunkProvider + SwarmChunkSender> Chunk for ChunkService<P> {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use vertex_swarm_api::Chunk as _;
+    use vertex_swarm_api::{AnyChunk, Chunk as _, ContentChunk};
 
     use super::*;
+    use crate::proto::chunk::ChunkType;
 
     /// Build a content chunk from raw data and return its wire encoding (span +
     /// data) alongside its address, matching what the upload handler expects.
@@ -161,44 +156,45 @@ mod tests {
     }
 
     #[test]
-    fn reconstruct_content_chunk_roundtrips() {
+    fn parse_stamped_content_chunk_roundtrips() {
         let (wire, address) = content_wire(b"reconstruct me");
 
         let req = content_request(wire, &address);
-        let chunk = reconstruct_chunk(&req).expect("valid content chunk");
+        let stamped = parse_stamped_chunk(&req).expect("valid stamped chunk");
 
-        assert_eq!(chunk.address(), &address);
-        assert!(matches!(chunk, AnyChunk::Content(_)));
+        assert_eq!(stamped.address(), &address);
+        assert!(matches!(stamped.chunk(), AnyChunk::Content(_)));
     }
 
     #[test]
-    fn reconstruct_rejects_malformed_address() {
+    fn parse_rejects_malformed_address() {
         let (wire, _) = content_wire(b"any");
         let mut req = content_request(wire, &ChunkAddress::default());
         req.address = "not-hex".to_string();
 
-        let err = reconstruct_chunk(&req).expect_err("malformed address must fail");
+        let err = parse_stamped_chunk(&req).expect_err("malformed address must fail");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 
     #[test]
-    fn reconstruct_rejects_address_mismatch() {
+    fn parse_rejects_address_mismatch() {
         let (wire, _) = content_wire(b"payload");
         // Address that does not match the BMT hash of the payload.
         let wrong = ChunkAddress::new([0xab; 32]);
 
         let req = content_request(wire, &wrong);
-        let err = reconstruct_chunk(&req).expect_err("address mismatch must fail");
+        let err = parse_stamped_chunk(&req).expect_err("address mismatch must fail");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 
     #[test]
-    fn reconstruct_rejects_unknown_chunk_type() {
+    fn parse_rejects_malformed_stamp() {
         let (wire, address) = content_wire(b"payload");
         let mut req = content_request(wire, &address);
-        req.chunk_type = 99;
+        // A stamp shorter than the fixed wire size cannot parse.
+        req.stamp = vec![0u8; 10];
 
-        let err = reconstruct_chunk(&req).expect_err("unknown chunk type must fail");
+        let err = parse_stamped_chunk(&req).expect_err("malformed stamp must fail");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 }

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -2,11 +2,13 @@
 
 use hex::FromHex;
 use tonic::{Request, Response, Status};
-use vertex_swarm_api::{ChunkAddress, SwarmChunkProvider};
+use vertex_swarm_api::{
+    AnyChunk, ChunkAddress, ContentChunk, SingleOwnerChunk, SwarmChunkProvider, SwarmChunkSender,
+};
 
 use crate::proto::chunk::{
-    HasChunkRequest, HasChunkResponse, RetrieveChunkRequest, RetrieveChunkResponse,
-    chunk_server::Chunk,
+    ChunkType, HasChunkRequest, HasChunkResponse, RetrieveChunkRequest, RetrieveChunkResponse,
+    UploadChunkRequest, UploadChunkResponse, chunk_server::Chunk,
 };
 
 /// Chunk service implementation.
@@ -35,8 +37,44 @@ fn parse_chunk_address(hex: &str) -> Result<ChunkAddress, Status> {
     Ok(ChunkAddress::new(bytes))
 }
 
+/// Reconstruct an `AnyChunk` from an upload request payload.
+///
+/// The `data` field is interpreted according to `chunk_type`: a content chunk
+/// carries the BMT body, a single-owner chunk carries the full wire encoding.
+/// The reconstructed chunk is verified against the supplied address.
+#[allow(clippy::result_large_err)]
+fn reconstruct_chunk(req: &UploadChunkRequest) -> Result<AnyChunk, Status> {
+    let address = parse_chunk_address(&req.address)?;
+
+    let chunk_type = ChunkType::try_from(req.chunk_type)
+        .map_err(|_| Status::invalid_argument(format!("Unknown chunk type: {}", req.chunk_type)))?;
+
+    let chunk = match chunk_type {
+        ChunkType::Content => {
+            // Build from data so the BMT hash is recomputed rather than trusted,
+            // letting the verify step below catch an address that lies about the
+            // payload.
+            let content = ContentChunk::new(req.data.clone())
+                .map_err(|e| Status::invalid_argument(format!("Invalid content chunk: {}", e)))?;
+            AnyChunk::Content(content)
+        }
+        ChunkType::SingleOwner => {
+            let soc = SingleOwnerChunk::try_from(req.data.as_slice()).map_err(|e| {
+                Status::invalid_argument(format!("Invalid single-owner chunk: {}", e))
+            })?;
+            AnyChunk::SingleOwner(soc)
+        }
+    };
+
+    chunk.verify(&address).map_err(|e| {
+        Status::invalid_argument(format!("Chunk address does not match payload: {}", e))
+    })?;
+
+    Ok(chunk)
+}
+
 #[tonic::async_trait]
-impl<P: SwarmChunkProvider> Chunk for ChunkService<P> {
+impl<P: SwarmChunkProvider + SwarmChunkSender> Chunk for ChunkService<P> {
     async fn retrieve_chunk(
         &self,
         request: Request<RetrieveChunkRequest>,
@@ -64,5 +102,90 @@ impl<P: SwarmChunkProvider> Chunk for ChunkService<P> {
 
         let exists = self.provider.has_chunk(&address);
         Ok(Response::new(HasChunkResponse { exists }))
+    }
+
+    /// Upload a pre-stamped chunk to the network.
+    ///
+    /// The request carries the postage stamp in `stamp`; it is threaded to the
+    /// storer once `SwarmChunkSender` accepts the stamp alongside the chunk.
+    async fn upload_chunk(
+        &self,
+        request: Request<UploadChunkRequest>,
+    ) -> Result<Response<UploadChunkResponse>, Status> {
+        let req = request.into_inner();
+        let chunk = reconstruct_chunk(&req)?;
+
+        // Pre-stamped uploads are trusted by default; opt in to validation.
+        let receipt = if req.validate {
+            self.provider.send_chunk(chunk).await
+        } else {
+            self.provider.send_chunk_unchecked(chunk).await
+        }
+        .map_err(|e| Status::internal(format!("Chunk upload failed: {}", e)))?;
+
+        Ok(Response::new(UploadChunkResponse {
+            storer: receipt.storer.to_string(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vertex_swarm_api::Chunk as _;
+
+    use super::*;
+
+    fn content_request(data: Vec<u8>, address: &ChunkAddress) -> UploadChunkRequest {
+        UploadChunkRequest {
+            data,
+            stamp: vec![0u8; 113],
+            address: hex::encode(address.as_bytes()),
+            chunk_type: ChunkType::Content as i32,
+            validate: false,
+        }
+    }
+
+    #[test]
+    fn reconstruct_content_chunk_roundtrips() {
+        let data = b"reconstruct me".to_vec();
+        let original: ContentChunk = ContentChunk::new(data.clone()).unwrap();
+        let address = *original.address();
+
+        let req = content_request(data, &address);
+        let chunk = reconstruct_chunk(&req).expect("valid content chunk");
+
+        assert_eq!(chunk.address(), &address);
+        assert!(matches!(chunk, AnyChunk::Content(_)));
+    }
+
+    #[test]
+    fn reconstruct_rejects_malformed_address() {
+        let data = b"any".to_vec();
+        let mut req = content_request(data, &ChunkAddress::default());
+        req.address = "not-hex".to_string();
+
+        let err = reconstruct_chunk(&req).expect_err("malformed address must fail");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn reconstruct_rejects_address_mismatch() {
+        let data = b"payload".to_vec();
+        // Address that does not match the BMT hash of the payload.
+        let wrong = ChunkAddress::new([0xab; 32]);
+
+        let req = content_request(data, &wrong);
+        let err = reconstruct_chunk(&req).expect_err("address mismatch must fail");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn reconstruct_rejects_unknown_chunk_type() {
+        let data = b"payload".to_vec();
+        let mut req = content_request(data, &ChunkAddress::default());
+        req.chunk_type = 99;
+
+        let err = reconstruct_chunk(&req).expect_err("unknown chunk type must fail");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 }

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -51,10 +51,12 @@ fn reconstruct_chunk(req: &UploadChunkRequest) -> Result<AnyChunk, Status> {
 
     let chunk = match chunk_type {
         ChunkType::Content => {
-            // Build from data so the BMT hash is recomputed rather than trusted,
-            // letting the verify step below catch an address that lies about the
-            // payload.
-            let content = ContentChunk::new(req.data.clone())
+            // Parse the full BMT body (span + data) from the wire encoding, the
+            // same shape `RetrieveChunk` returns, so a retrieved content chunk
+            // round-trips back into an upload. The BMT hash is recomputed from
+            // the body, letting the verify step below reject an address that
+            // lies about the payload.
+            let content = ContentChunk::try_from(req.data.as_slice())
                 .map_err(|e| Status::invalid_argument(format!("Invalid content chunk: {}", e)))?;
             AnyChunk::Content(content)
         }
@@ -131,9 +133,18 @@ impl<P: SwarmChunkProvider + SwarmChunkSender> Chunk for ChunkService<P> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
     use vertex_swarm_api::Chunk as _;
 
     use super::*;
+
+    /// Build a content chunk from raw data and return its wire encoding (span +
+    /// data) alongside its address, matching what the upload handler expects.
+    fn content_wire(data: &[u8]) -> (Vec<u8>, ChunkAddress) {
+        let chunk: ContentChunk = ContentChunk::new(data.to_vec()).expect("valid content chunk");
+        let address = *chunk.address();
+        (Bytes::from(chunk).to_vec(), address)
+    }
 
     fn content_request(data: Vec<u8>, address: &ChunkAddress) -> UploadChunkRequest {
         UploadChunkRequest {
@@ -147,11 +158,9 @@ mod tests {
 
     #[test]
     fn reconstruct_content_chunk_roundtrips() {
-        let data = b"reconstruct me".to_vec();
-        let original: ContentChunk = ContentChunk::new(data.clone()).unwrap();
-        let address = *original.address();
+        let (wire, address) = content_wire(b"reconstruct me");
 
-        let req = content_request(data, &address);
+        let req = content_request(wire, &address);
         let chunk = reconstruct_chunk(&req).expect("valid content chunk");
 
         assert_eq!(chunk.address(), &address);
@@ -160,8 +169,8 @@ mod tests {
 
     #[test]
     fn reconstruct_rejects_malformed_address() {
-        let data = b"any".to_vec();
-        let mut req = content_request(data, &ChunkAddress::default());
+        let (wire, _) = content_wire(b"any");
+        let mut req = content_request(wire, &ChunkAddress::default());
         req.address = "not-hex".to_string();
 
         let err = reconstruct_chunk(&req).expect_err("malformed address must fail");
@@ -170,19 +179,19 @@ mod tests {
 
     #[test]
     fn reconstruct_rejects_address_mismatch() {
-        let data = b"payload".to_vec();
+        let (wire, _) = content_wire(b"payload");
         // Address that does not match the BMT hash of the payload.
         let wrong = ChunkAddress::new([0xab; 32]);
 
-        let req = content_request(data, &wrong);
+        let req = content_request(wire, &wrong);
         let err = reconstruct_chunk(&req).expect_err("address mismatch must fail");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 
     #[test]
     fn reconstruct_rejects_unknown_chunk_type() {
-        let data = b"payload".to_vec();
-        let mut req = content_request(data, &ChunkAddress::default());
+        let (wire, address) = content_wire(b"payload");
+        let mut req = content_request(wire, &address);
         req.chunk_type = 99;
 
         let err = reconstruct_chunk(&req).expect_err("unknown chunk type must fail");

--- a/crates/swarm/rpc/src/lib.rs
+++ b/crates/swarm/rpc/src/lib.rs
@@ -32,7 +32,8 @@ pub trait GrpcServiceProvider {
 impl<Topo, Chunk> GrpcServiceProvider for vertex_swarm_api::RpcProviders<Topo, Chunk>
 where
     Topo: vertex_swarm_api::SwarmTopology + Clone + Send + Sync + 'static,
-    Chunk: vertex_swarm_api::SwarmChunkProvider + Clone + 'static,
+    Chunk:
+        vertex_swarm_api::SwarmChunkProvider + vertex_swarm_api::SwarmChunkSender + Clone + 'static,
 {
     fn register_grpc_services(
         &self,


### PR DESCRIPTION
## What

Adds an `UploadChunk` RPC to the `Chunk` gRPC service so client nodes can push a pre-stamped chunk to the Swarm network.

The request carries the chunk payload (`data`), its postage `stamp`, the hex `address`, a `ChunkType` discriminator that selects content versus single-owner reconstruction, and a `validate` flag.

## How

`reconstruct_chunk` rebuilds an `AnyChunk` from the request. Content chunks are built from `data` so the BMT hash is recomputed rather than trusted, and the result is verified against the supplied address; a mismatching address is rejected with `InvalidArgument`. Single-owner chunks are parsed from the full wire encoding and verified the same way.

`upload_chunk` forwards the chunk through `SwarmChunkSender`. Pre-stamped uploads are sent via `send_chunk_unchecked` by default; setting `validate` routes through `send_chunk` for stamp-signature validation.

The `Chunk` service impl now requires `SwarmChunkProvider + SwarmChunkSender`. The builder RPC providers (`ClientRpcProviders`, `StorerRpcProviders`) and the generic `GrpcServiceProvider` impl gain the matching bound so the workspace keeps compiling. `NetworkChunkProvider` gains a `SwarmChunkSender` impl that reports the capability as unavailable until the PushSync send path lands.

## Notes

The `SwarmChunkSender` trait accepts only an `AnyChunk`, so the request stamp is not yet threaded to the storer. The `data`/`address`/type reconstruction and the gRPC surface are in place; forwarding the stamp follows once the sender trait carries it alongside the chunk.

## Tests

Unit tests cover content-chunk reconstruction roundtrip, malformed address, address mismatch, and unknown chunk type.