### PR TITLE
feat(swarm-chequebook): on-chain chequebook backend behind `chain` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-contract"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8b60d71b92824e095b4003ff01fd2bc923017b7568997c5f459240e83499c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-dyn-abi"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +359,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.16.4",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +417,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -509,6 +594,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-transport"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+dependencies = [
+ "alloy-json-rpc",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "itertools 0.14.0",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-trie"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,7 +720,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -607,7 +731,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -994,6 +1118,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,7 +1302,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1566,6 +1712,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1941,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2272,7 +2437,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2489,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2660,6 +2825,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2977,6 +3148,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -3261,6 +3434,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,7 +3640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
- "core-foundation",
+ "core-foundation 0.9.4",
  "fnv",
  "futures",
  "if-addrs",
@@ -3601,7 +3789,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4256,6 +4444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,7 +4884,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4836,6 +5033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4872,7 +5075,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -4887,7 +5090,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.6",
@@ -5144,6 +5347,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -5534,7 +5743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5579,7 +5788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5592,7 +5801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5715,6 +5924,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6055,6 +6265,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6220,7 +6467,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6229,12 +6476,25 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -6248,11 +6508,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6308,6 +6596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6406,6 +6703,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6727,7 +7047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6920,7 +7240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -6956,7 +7276,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7161,6 +7481,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -7665,6 +7995,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8116,7 +8447,9 @@ dependencies = [
 name = "vertex-swarm-bandwidth-chequebook"
 version = "0.1.0"
 dependencies = [
+ "alloy-contract",
  "alloy-primitives",
+ "alloy-provider",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -8360,7 +8693,7 @@ dependencies = [
  "libp2p",
  "libp2p-swarm",
  "libp2p-swarm-test",
- "lru",
+ "lru 0.12.5",
  "metrics",
  "parking_lot",
  "quick-protobuf",
@@ -8933,6 +9266,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8950,6 +9297,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8980,7 +9336,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,28 +1118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,15 +1688,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cobs"
@@ -2818,6 +2787,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,12 +2809,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3434,21 +3412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,6 +3421,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4715,6 +4694,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5033,10 +5029,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -5924,7 +5957,6 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6277,21 +6309,19 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -6476,25 +6506,12 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -6508,39 +6525,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7484,12 +7473,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "rustls",
+ "native-tls",
  "tokio",
 ]
 
@@ -8036,6 +8025,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -9297,15 +9292,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,8 +214,14 @@ alloy-sol-types = { version = "1.6" }
 alloy-chains = { version = "0.2", default-features = false }
 # On-chain interaction (RPC client + typed contract calls). Native-only; gated
 # behind per-crate `chain` features so the default and wasm dependency cones do
-# not pull an Ethereum RPC stack.
-alloy-provider = { version = "2.0" }
+# not pull an Ethereum RPC stack. The rustls TLS path drags in a platform
+# root-certs crate under a license outside the workspace allow-list, so the HTTP
+# transport uses native-tls (system OpenSSL) instead. This is native-only, which
+# matches the `chain` feature never entering the wasm cone.
+alloy-provider = { version = "2.0", default-features = false, features = [
+    "reqwest",
+    "reqwest-native-tls",
+] }
 alloy-contract = { version = "2.0" }
 
 ## tracing & telemetry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,11 @@ alloy-signer = { version = "2.0" }
 alloy-signer-local = { version = "2.0", features = ["eip712", "keystore"] }
 alloy-sol-types = { version = "1.6" }
 alloy-chains = { version = "0.2", default-features = false }
+# On-chain interaction (RPC client + typed contract calls). Native-only; gated
+# behind per-crate `chain` features so the default and wasm dependency cones do
+# not pull an Ethereum RPC stack.
+alloy-provider = { version = "2.0" }
+alloy-contract = { version = "2.0" }
 
 ## tracing & telemetry
 tracing = "0.1"

--- a/crates/swarm/AGENTS.md
+++ b/crates/swarm/AGENTS.md
@@ -9,7 +9,7 @@ Root-level rules in `/AGENTS.md` apply here too. The notes below are the area-sp
 - `primitives`, `forks`, `spec`, `identity`: pure data and configuration. `nectar-primitives` is the canonical source for chunk and address types.
 - `peers/peer`: the `SwarmPeer` record with the EIP-191 handshake signature (distinct from postage EIP-191 signing, which lives upstream in `nectar-postage`). See the follow-up tracked at `nxm-rs/vertex` for extracting the sign-data primitive to nectar.
 - `peers/peer-manager`, `peers/peer-score`: lifecycle, persistence, scoring.
-- `bandwidth/{core,pricing,pseudosettle}`: per-peer balances in Accounting Units (AU). `swap` and `chequebook` are workspace-disabled.
+- `bandwidth/{core,pricing,pseudosettle}`: per-peer balances in Accounting Units (AU). `chequebook` holds cheque types, signing, and the on-chain backend (the latter behind the default-off `chain` feature so the wasm cone stays lean). `swap` is workspace-disabled.
 - `api`: the trait chain `SwarmPrimitives` to `SwarmNetworkTypes` to `SwarmClientTypes` to `SwarmStorerTypes`. Strictly libp2p-free with the documented `Multiaddr` exception.
 - `builder`: layered builders that produce `BuiltBootnode`, `BuiltClient`, `BuiltStorer`.
 - `node`: composes the libp2p `NetworkBehaviour` and exposes `BootNode`, `ClientNode`, `StorerNode`. This is where libp2p shows up.

--- a/crates/swarm/bandwidth/chequebook/Cargo.toml
+++ b/crates/swarm/bandwidth/chequebook/Cargo.toml
@@ -23,6 +23,10 @@ alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-signer = { workspace = true }
 
+# alloy (on-chain interaction, behind the `chain` feature)
+alloy-provider = { workspace = true, optional = true }
+alloy-contract = { workspace = true, optional = true }
+
 # misc
 bytes = { workspace = true }
 thiserror.workspace = true
@@ -30,6 +34,12 @@ strum = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 base64 = { workspace = true }
+
+[features]
+default = []
+# On-chain chequebook backend. Pulls in an Ethereum RPC client and typed
+# contract calls. Native-only: do not enable in the wasm dependency cone.
+chain = ["dep:alloy-provider", "dep:alloy-contract"]
 
 [dev-dependencies]
 alloy-signer-local = { workspace = true }

--- a/crates/swarm/bandwidth/chequebook/src/chain.rs
+++ b/crates/swarm/bandwidth/chequebook/src/chain.rs
@@ -1,0 +1,456 @@
+//! On-chain interaction layer for SWAP chequebooks.
+//!
+//! This module wires the off-chain [`SignedCheque`] type to the on-chain
+//! ERC20SimpleSwap chequebook contract and its factory. It is gated behind the
+//! crate `chain` feature so the default and wasm dependency cones never pull an
+//! Ethereum RPC stack.
+//!
+//! The layer is split into a transport-agnostic [`ChequebookChain`] trait and a
+//! provider-backed implementation, [`ProviderChequebookChain`], built over an
+//! alloy [`Provider`] and the contract bindings from `nectar_contracts`.
+//!
+//! # Address sources
+//!
+//! Chequebook, factory and BZZ token addresses are network-specific and must be
+//! supplied through [`ChainConfig`]. The deployments for the live networks live
+//! in `nectar_contracts::{mainnet, testnet}`; this layer never hardcodes a
+//! single network. [`ChainConfig::for_deployments`] derives a config from those
+//! deployment constants for convenience.
+//!
+//! # Reads vs writes
+//!
+//! Balance queries ([`ChequebookChain::balance`], [`ChequebookChain::liquid_balance`],
+//! [`ChequebookChain::liquid_balance_for`], [`ChequebookChain::paid_out`]) are
+//! `eth_call` reads against a chequebook address. Cashing
+//! ([`ChequebookChain::cash_cheque`], [`ChequebookChain::cash_cheque_beneficiary`])
+//! and deployment ([`ChequebookChain::deploy_chequebook`]) submit transactions
+//! signed by the provider's wallet.
+
+use alloy_contract::CallBuilder;
+use alloy_primitives::{Address, B256, U256};
+use alloy_provider::Provider;
+use nectar_contracts::{IChequebook, IChequebookFactory};
+
+use crate::SignedCheque;
+
+/// Errors that can occur during on-chain chequebook interaction.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum ChainError {
+    /// An `eth_call` read against the chequebook contract failed.
+    #[error("contract call failed: {0}")]
+    Call(String),
+
+    /// Submitting or awaiting a transaction failed.
+    #[error("transaction failed: {0}")]
+    Transaction(String),
+
+    /// The chequebook deployment transaction did not emit a deployed address.
+    #[error("deployment did not report a chequebook address")]
+    MissingDeployedAddress,
+}
+
+/// Network-specific addresses required to interact with chequebooks on a chain.
+///
+/// These addresses differ between networks (Gnosis Chain mainnet, Sepolia
+/// testnet). Derive them from the `nectar_contracts` deployment constants with
+/// [`ChainConfig::for_deployments`] or set them explicitly from operator config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainConfig {
+    /// Chequebook factory (SimpleSwapFactory) contract address.
+    pub factory: Address,
+    /// BZZ token contract address backing chequebook balances.
+    pub bzz_token: Address,
+}
+
+impl ChainConfig {
+    /// Build a config from `nectar_contracts` deployment structs.
+    ///
+    /// ```
+    /// use nectar_contracts::mainnet;
+    /// use vertex_swarm_bandwidth_chequebook::chain::ChainConfig;
+    ///
+    /// let cfg = ChainConfig::for_deployments(mainnet::CHEQUEBOOK_FACTORY, mainnet::BZZ_TOKEN);
+    /// assert_eq!(cfg.factory, mainnet::CHEQUEBOOK_FACTORY.address);
+    /// assert_eq!(cfg.bzz_token, mainnet::BZZ_TOKEN.address);
+    /// ```
+    #[must_use]
+    pub const fn for_deployments(
+        factory: nectar_contracts::ChequebookFactory,
+        bzz_token: nectar_contracts::Token,
+    ) -> Self {
+        Self {
+            factory: factory.address,
+            bzz_token: bzz_token.address,
+        }
+    }
+}
+
+/// On-chain chequebook operations.
+///
+/// Implementations talk to a single chain reachable over the configured RPC
+/// transport. A chequebook address is passed per call so one backend can serve
+/// reads against multiple counterparties' chequebooks, while writes are signed
+/// by the backend's wallet.
+#[expect(
+    async_fn_in_trait,
+    reason = "single in-crate provider impl; no Send bound needed across the FFI/gRPC boundary"
+)]
+pub trait ChequebookChain {
+    /// Total BZZ balance held by the chequebook contract.
+    async fn balance(&self, chequebook: Address) -> Result<U256, ChainError>;
+
+    /// Liquid (uncommitted) balance available across all beneficiaries.
+    async fn liquid_balance(&self, chequebook: Address) -> Result<U256, ChainError>;
+
+    /// Liquid balance available to a specific beneficiary.
+    async fn liquid_balance_for(
+        &self,
+        chequebook: Address,
+        beneficiary: Address,
+    ) -> Result<U256, ChainError>;
+
+    /// Cumulative amount already paid out to a beneficiary.
+    async fn paid_out(&self, chequebook: Address, beneficiary: Address)
+    -> Result<U256, ChainError>;
+
+    /// Deploy a new chequebook for `issuer` via the configured factory.
+    ///
+    /// Returns the transaction hash. The deployed address is reported through
+    /// the factory's `SimpleSwapDeployed` event in the receipt; resolving it is
+    /// left to the caller, which holds the receipt-handling policy.
+    async fn deploy_chequebook(
+        &self,
+        issuer: Address,
+        default_hard_deposit_timeout: U256,
+        salt: B256,
+    ) -> Result<B256, ChainError>;
+
+    /// Cash a cheque on behalf of a beneficiary, paying `recipient`.
+    ///
+    /// `caller_payout` is the bounty the caller takes for submitting the
+    /// transaction; `issuer_sig` authorises that bounty. The beneficiary
+    /// signature is taken from the [`SignedCheque`].
+    async fn cash_cheque(
+        &self,
+        cheque: &SignedCheque,
+        recipient: Address,
+        caller_payout: U256,
+        issuer_sig: &[u8],
+    ) -> Result<B256, ChainError>;
+
+    /// Cash a cheque as the beneficiary, paying `recipient`.
+    ///
+    /// Uses the issuer signature carried by the [`SignedCheque`].
+    async fn cash_cheque_beneficiary(
+        &self,
+        cheque: &SignedCheque,
+        recipient: Address,
+    ) -> Result<B256, ChainError>;
+}
+
+/// Provider-backed [`ChequebookChain`] implementation.
+///
+/// Wraps an alloy [`Provider`] (which carries the RPC transport and, for writes,
+/// the wallet) and the [`ChainConfig`] addresses. Reads go through `eth_call`;
+/// writes are signed and broadcast by the provider's wallet filler.
+#[derive(Debug, Clone)]
+pub struct ProviderChequebookChain<P> {
+    provider: P,
+    config: ChainConfig,
+}
+
+impl<P> ProviderChequebookChain<P> {
+    /// Build a backend over a provider and network config.
+    pub const fn new(provider: P, config: ChainConfig) -> Self {
+        Self { provider, config }
+    }
+
+    /// The network addresses this backend is configured for.
+    #[must_use]
+    pub const fn config(&self) -> &ChainConfig {
+        &self.config
+    }
+
+    /// The underlying provider.
+    pub const fn provider(&self) -> &P {
+        &self.provider
+    }
+}
+
+impl<P: Provider> ProviderChequebookChain<P> {
+    /// Execute a chequebook read call and map errors into [`ChainError::Call`].
+    async fn read_call<C: alloy_sol_types::SolCall>(
+        &self,
+        chequebook: Address,
+        call: C,
+    ) -> Result<C::Return, ChainError> {
+        CallBuilder::new_sol(&self.provider, &chequebook, &call)
+            .call()
+            .await
+            .map_err(|e| ChainError::Call(e.to_string()))
+    }
+}
+
+impl<P: Provider> ChequebookChain for ProviderChequebookChain<P> {
+    async fn balance(&self, chequebook: Address) -> Result<U256, ChainError> {
+        self.read_call(chequebook, IChequebook::balanceCall {})
+            .await
+    }
+
+    async fn liquid_balance(&self, chequebook: Address) -> Result<U256, ChainError> {
+        self.read_call(chequebook, IChequebook::liquidBalanceCall {})
+            .await
+    }
+
+    async fn liquid_balance_for(
+        &self,
+        chequebook: Address,
+        beneficiary: Address,
+    ) -> Result<U256, ChainError> {
+        self.read_call(
+            chequebook,
+            IChequebook::liquidBalanceForCall { beneficiary },
+        )
+        .await
+    }
+
+    async fn paid_out(
+        &self,
+        chequebook: Address,
+        beneficiary: Address,
+    ) -> Result<U256, ChainError> {
+        self.read_call(chequebook, IChequebook::paidOutCall { beneficiary })
+            .await
+    }
+
+    async fn deploy_chequebook(
+        &self,
+        issuer: Address,
+        default_hard_deposit_timeout: U256,
+        salt: B256,
+    ) -> Result<B256, ChainError> {
+        let call = IChequebookFactory::deploySimpleSwapCall {
+            issuer,
+            defaultHardDepositTimeoutDuration: default_hard_deposit_timeout,
+            salt,
+        };
+        let pending = CallBuilder::new_sol(&self.provider, &self.config.factory, &call)
+            .send()
+            .await
+            .map_err(|e| ChainError::Transaction(e.to_string()))?;
+        Ok(*pending.tx_hash())
+    }
+
+    async fn cash_cheque(
+        &self,
+        cheque: &SignedCheque,
+        recipient: Address,
+        caller_payout: U256,
+        issuer_sig: &[u8],
+    ) -> Result<B256, ChainError> {
+        let call = IChequebook::cashChequeCall {
+            beneficiary: cheque.cheque.beneficiary,
+            recipient,
+            cumulativePayout: cheque.cheque.cumulativePayout,
+            beneficiarySig: alloy_primitives::Bytes(cheque.signature.clone()),
+            callerPayout: caller_payout,
+            issuerSig: alloy_primitives::Bytes::copy_from_slice(issuer_sig),
+        };
+        let pending = CallBuilder::new_sol(&self.provider, &cheque.cheque.chequebook, &call)
+            .send()
+            .await
+            .map_err(|e| ChainError::Transaction(e.to_string()))?;
+        Ok(*pending.tx_hash())
+    }
+
+    async fn cash_cheque_beneficiary(
+        &self,
+        cheque: &SignedCheque,
+        recipient: Address,
+    ) -> Result<B256, ChainError> {
+        let call = IChequebook::cashChequeBeneficiaryCall {
+            recipient,
+            cumulativePayout: cheque.cheque.cumulativePayout,
+            issuerSig: alloy_primitives::Bytes(cheque.signature.clone()),
+        };
+        let pending = CallBuilder::new_sol(&self.provider, &cheque.cheque.chequebook, &call)
+            .send()
+            .await
+            .map_err(|e| ChainError::Transaction(e.to_string()))?;
+        Ok(*pending.tx_hash())
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    //! Tests here exercise call/transaction *encoding* only.
+    //!
+    //! There is no live chain in CI, so the calldata that the bindings produce
+    //! for `cashCheque`, `cashChequeBeneficiary` and `deploySimpleSwap` is
+    //! checked against `SolCall::abi_encode`, and reads are exercised against an
+    //! alloy mock provider that asserts the request calldata and returns canned
+    //! ABI-encoded values. A real on-chain cashout (sending a signed tx to a
+    //! node and confirming a receipt) is deliberately out of scope for CI.
+
+    use super::*;
+    use alloy_primitives::{Bytes, address, b256};
+    use alloy_provider::ProviderBuilder;
+    use alloy_provider::mock::Asserter;
+    use alloy_sol_types::{SolCall, SolValue};
+
+    use crate::{Cheque, ChequeExt};
+
+    fn cheque() -> SignedCheque {
+        let c = Cheque::new(
+            address!("1111111111111111111111111111111111111111"),
+            address!("2222222222222222222222222222222222222222"),
+            U256::from(1_000_000u64),
+        );
+        SignedCheque::new(c, bytes::Bytes::from(vec![7u8; 65]))
+    }
+
+    #[test]
+    fn cash_cheque_beneficiary_calldata() {
+        let c = cheque();
+        let call = IChequebook::cashChequeBeneficiaryCall {
+            recipient: address!("3333333333333333333333333333333333333333"),
+            cumulativePayout: c.cheque.cumulativePayout,
+            issuerSig: Bytes(c.signature.clone()),
+        };
+        let encoded = call.abi_encode();
+
+        // Selector is the first four bytes of the ABI encoding.
+        assert_eq!(
+            encoded.get(..4).unwrap(),
+            IChequebook::cashChequeBeneficiaryCall::SELECTOR
+        );
+        // Round-trips back to the same arguments.
+        let decoded = IChequebook::cashChequeBeneficiaryCall::abi_decode(&encoded).unwrap();
+        assert_eq!(decoded.recipient, call.recipient);
+        assert_eq!(decoded.cumulativePayout, U256::from(1_000_000u64));
+        assert_eq!(decoded.issuerSig, Bytes(c.signature.clone()));
+    }
+
+    #[test]
+    fn cash_cheque_calldata() {
+        let c = cheque();
+        let issuer_sig = vec![9u8; 65];
+        let call = IChequebook::cashChequeCall {
+            beneficiary: c.cheque.beneficiary,
+            recipient: address!("3333333333333333333333333333333333333333"),
+            cumulativePayout: c.cheque.cumulativePayout,
+            beneficiarySig: Bytes(c.signature.clone()),
+            callerPayout: U256::from(42u64),
+            issuerSig: Bytes::copy_from_slice(&issuer_sig),
+        };
+        let encoded = call.abi_encode();
+        assert_eq!(
+            encoded.get(..4).unwrap(),
+            IChequebook::cashChequeCall::SELECTOR
+        );
+
+        let decoded = IChequebook::cashChequeCall::abi_decode(&encoded).unwrap();
+        assert_eq!(decoded.beneficiary, c.cheque.beneficiary);
+        assert_eq!(decoded.beneficiarySig, Bytes(c.signature.clone()));
+        assert_eq!(decoded.callerPayout, U256::from(42u64));
+        assert_eq!(decoded.issuerSig, Bytes::from(issuer_sig));
+    }
+
+    #[test]
+    fn deploy_simple_swap_calldata() {
+        let call = IChequebookFactory::deploySimpleSwapCall {
+            issuer: address!("4444444444444444444444444444444444444444"),
+            defaultHardDepositTimeoutDuration: U256::from(86_400u64),
+            salt: b256!("00000000000000000000000000000000000000000000000000000000000000aa"),
+        };
+        let encoded = call.abi_encode();
+        assert_eq!(
+            encoded.get(..4).unwrap(),
+            IChequebookFactory::deploySimpleSwapCall::SELECTOR
+        );
+
+        let decoded = IChequebookFactory::deploySimpleSwapCall::abi_decode(&encoded).unwrap();
+        assert_eq!(
+            decoded.defaultHardDepositTimeoutDuration,
+            U256::from(86_400u64)
+        );
+    }
+
+    #[tokio::test]
+    async fn balance_read_decodes_mock_response() {
+        // The mock provider returns a canned ABI-encoded u256 for eth_call.
+        let asserter = Asserter::new();
+        let expected = U256::from(123_456_789u64);
+        asserter.push_success(&Bytes::from(expected.abi_encode()));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let backend = ProviderChequebookChain::new(
+            provider,
+            ChainConfig::for_deployments(
+                nectar_contracts::testnet::CHEQUEBOOK_FACTORY,
+                nectar_contracts::testnet::BZZ_TOKEN,
+            ),
+        );
+
+        let got = backend
+            .balance(address!("5555555555555555555555555555555555555555"))
+            .await
+            .unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[tokio::test]
+    async fn paid_out_read_decodes_mock_response() {
+        let asserter = Asserter::new();
+        let expected = U256::from(7u64);
+        asserter.push_success(&Bytes::from(expected.abi_encode()));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let backend = ProviderChequebookChain::new(
+            provider,
+            ChainConfig::for_deployments(
+                nectar_contracts::mainnet::CHEQUEBOOK_FACTORY,
+                nectar_contracts::mainnet::BZZ_TOKEN,
+            ),
+        );
+
+        let got = backend
+            .paid_out(
+                address!("5555555555555555555555555555555555555555"),
+                address!("2222222222222222222222222222222222222222"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn config_pulls_addresses_from_deployments() {
+        let cfg = ChainConfig::for_deployments(
+            nectar_contracts::mainnet::CHEQUEBOOK_FACTORY,
+            nectar_contracts::mainnet::BZZ_TOKEN,
+        );
+        assert_eq!(
+            cfg.factory,
+            nectar_contracts::mainnet::CHEQUEBOOK_FACTORY.address
+        );
+        assert_eq!(cfg.bzz_token, nectar_contracts::mainnet::BZZ_TOKEN.address);
+        assert_ne!(cfg.factory, Address::ZERO);
+        // Addresses differ between networks; the layer never hardcodes one.
+        let testnet = ChainConfig::for_deployments(
+            nectar_contracts::testnet::CHEQUEBOOK_FACTORY,
+            nectar_contracts::testnet::BZZ_TOKEN,
+        );
+        assert_ne!(cfg.factory, testnet.factory);
+    }
+
+    #[test]
+    fn error_reason_labels_are_snake_case() {
+        let label: &'static str = (&ChainError::MissingDeployedAddress).into();
+        assert_eq!(label, "missing_deployed_address");
+        let label: &'static str = (&ChainError::Call(String::new())).into();
+        assert_eq!(label, "call");
+    }
+}

--- a/crates/swarm/bandwidth/chequebook/src/lib.rs
+++ b/crates/swarm/bandwidth/chequebook/src/lib.rs
@@ -41,6 +41,9 @@
 
 pub mod cheque;
 
+#[cfg(feature = "chain")]
+pub mod chain;
+
 pub use cheque::{Cheque, ChequeExt, SignedCheque};
 
 // Re-export commonly used types


### PR DESCRIPTION
Adds the on-chain interaction layer for SWAP cheques: chequebook deploy, cheque cashout, and balance reads via an alloy provider over the `nectar_contracts` bindings.

## What changed

`crates/swarm/bandwidth/chequebook/` gains a `chain` module behind a new crate feature `chain` (default off). The module exposes:

- `ChequebookChain`: an async trait with `balance`, `liquid_balance`, `liquid_balance_for(beneficiary)`, `paid_out(beneficiary)`, `deploy_chequebook(issuer, ...)` via the factory `deploySimpleSwap`, and `cash_cheque` / `cash_cheque_beneficiary` taking a `SignedCheque`.
- `ProviderChequebookChain<P>`: an alloy-provider-backed implementation over the `nectar_contracts` `IChequebook` / `IChequebookFactory` bindings.
- `ChainConfig`: factory and BZZ token addresses, derivable from the `nectar_contracts` deployment constants via `ChainConfig::for_deployments`. The layer takes addresses from config and never hardcodes a single network; mainnet and testnet addresses both flow through the same path.

`alloy-provider` and `alloy-contract` are added as optional workspace dependencies, matching the existing alloy `2.0` line. They are gated behind the `chain` feature so the default and wasm dependency cones stay lean: `cargo tree` confirms neither crate is pulled without the feature.

The crate stays libp2p-free. Errors are a `thiserror` enum with `strum::IntoStaticStr` for clean metric `reason` labels.

## Testing

Unit tests cover the call and transaction encoding the bindings produce for `cashCheque`, `cashChequeBeneficiary`, and `deploySimpleSwap` (selector plus argument round-trip), and exercise read decoding (`balance`, `paid_out`) against an alloy mock provider returning canned ABI-encoded values.

A live on-chain cashout (sending a signed transaction to a node and confirming a receipt) is deliberately out of CI scope; this is called out in the test module comment.

Verified locally: `cargo test -p vertex-swarm-bandwidth-chequebook --features chain`, default-feature build (no alloy-provider pulled), and `--features chain` build all pass.