### PR TITLE
feat(swarm-builder): wire client upload + download verification

### DIFF
--- a/bin/vertex/src/cli.rs
+++ b/bin/vertex/src/cli.rs
@@ -10,8 +10,8 @@ use vertex_node_core::config::FullNodeConfig;
 use vertex_node_core::dirs::DataDirs;
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
 use vertex_swarm_builder::{
-    BootnodeConfig, ClientConfig, DefaultClientBuilder, DefaultNodeBuilder, DefaultStorerBuilder,
-    StorerConfig,
+    BootnodeConfig, ChunkVerifyConfig, ClientConfig, DefaultClientBuilder, DefaultNodeBuilder,
+    DefaultStorerBuilder, StorerConfig,
 };
 use vertex_swarm_node::ProtocolConfig;
 use vertex_swarm_node::args::ProtocolArgs;
@@ -118,6 +118,12 @@ pub async fn run() -> Result<()> {
         let identity = config.protocol.identity(spec.clone(), &dirs.network)?;
         let grpc_addr = socket_addr(&config.infra.api.grpc_addr, config.infra.api.grpc_port);
 
+        let retrieval = config.protocol.retrieval();
+        let verify = ChunkVerifyConfig {
+            verify_content: retrieval.verify_content,
+            verify_stamp: retrieval.verify_stamp,
+        };
+
         // Dispatch based on node type
         match node_type {
             SwarmNodeType::Client => {
@@ -126,7 +132,7 @@ pub async fn run() -> Result<()> {
                     .bandwidth_config()
                     .map_err(|e| eyre::eyre!("bandwidth config error: {}", e))?;
 
-                let node_config = ClientConfig::new(spec, identity, network, bandwidth);
+                let node_config = ClientConfig::new(spec, identity, network, bandwidth, verify);
 
                 let (task_fn, rpc_providers) = DefaultClientBuilder::from_config(node_config)
                     .build(&launch_ctx)
@@ -151,8 +157,15 @@ pub async fn run() -> Result<()> {
                 let local_store = config.protocol.local_store_config();
                 let storage = config.protocol.storage_config();
 
-                let node_config =
-                    StorerConfig::new(spec, identity, network, bandwidth, local_store, storage);
+                let node_config = StorerConfig::new(
+                    spec,
+                    identity,
+                    network,
+                    bandwidth,
+                    local_store,
+                    storage,
+                    verify,
+                );
 
                 let (task_fn, rpc_providers) = DefaultStorerBuilder::from_config(node_config)
                     .build(&launch_ctx)

--- a/crates/swarm/builder/src/config.rs
+++ b/crates/swarm/builder/src/config.rs
@@ -23,6 +23,8 @@ use vertex_swarm_redistribution::StorageConfig;
 use vertex_swarm_spec::Spec;
 use vertex_swarm_topology::KademliaConfig;
 
+use crate::verify::ChunkVerifyConfig;
+
 /// Implement shared config getters: `spec()`, `identity()`, `network()`.
 macro_rules! impl_common_config_getters {
     ($ty:ident) => {
@@ -87,6 +89,7 @@ pub struct ClientConfig {
     identity: Arc<Identity>,
     network: NetworkConfig<KademliaConfig>,
     bandwidth: DefaultBandwidthConfig,
+    verify: ChunkVerifyConfig,
 }
 
 impl ClientConfig {
@@ -95,17 +98,24 @@ impl ClientConfig {
         identity: Arc<Identity>,
         network: NetworkConfig<KademliaConfig>,
         bandwidth: DefaultBandwidthConfig,
+        verify: ChunkVerifyConfig,
     ) -> Self {
         Self {
             spec,
             identity,
             network,
             bandwidth,
+            verify,
         }
     }
 
     pub fn bandwidth(&self) -> &DefaultBandwidthConfig {
         &self.bandwidth
+    }
+
+    /// Verification checks applied to downloaded chunks.
+    pub fn verify(&self) -> ChunkVerifyConfig {
+        self.verify
     }
 }
 
@@ -121,6 +131,7 @@ pub struct StorerConfig {
     bandwidth: DefaultBandwidthConfig,
     local_store: LocalStoreConfig,
     storage: StorageConfig,
+    verify: ChunkVerifyConfig,
 }
 
 impl StorerConfig {
@@ -131,6 +142,7 @@ impl StorerConfig {
         bandwidth: DefaultBandwidthConfig,
         local_store: LocalStoreConfig,
         storage: StorageConfig,
+        verify: ChunkVerifyConfig,
     ) -> Self {
         Self {
             spec,
@@ -139,11 +151,17 @@ impl StorerConfig {
             bandwidth,
             local_store,
             storage,
+            verify,
         }
     }
 
     pub fn bandwidth(&self) -> &DefaultBandwidthConfig {
         &self.bandwidth
+    }
+
+    /// Verification checks applied to downloaded chunks.
+    pub fn verify(&self) -> ChunkVerifyConfig {
+        self.verify
     }
 
     pub fn local_store(&self) -> &LocalStoreConfig {

--- a/crates/swarm/builder/src/handle.rs
+++ b/crates/swarm/builder/src/handle.rs
@@ -8,6 +8,10 @@ use vertex_tasks::{GracefulShutdown, NodeTask, NodeTaskFn};
 
 use crate::providers::NetworkChunkProvider;
 use crate::rpc::{BootnodeRpcProviders, ClientRpcProviders, StorerRpcProviders};
+use crate::verify::VerifyingChunkProvider;
+
+/// Network chunk provider wrapped with config-gated download verification.
+type VerifiedChunkProvider = VerifyingChunkProvider<NetworkChunkProvider<Arc<Identity>>>;
 
 /// Build output from launching a Swarm node.
 ///
@@ -58,9 +62,7 @@ impl<P: HasTopology> BuiltNode<P> {
 pub type BuiltBootnode = BuiltNode<BootnodeRpcProviders<Arc<Identity>>>;
 
 /// Built client node (topology + chunk retrieval).
-pub type BuiltClient =
-    BuiltNode<ClientRpcProviders<Arc<Identity>, NetworkChunkProvider<Arc<Identity>>>>;
+pub type BuiltClient = BuiltNode<ClientRpcProviders<Arc<Identity>, VerifiedChunkProvider>>;
 
 /// Built storer node (topology + chunks + storage).
-pub type BuiltStorer =
-    BuiltNode<StorerRpcProviders<Arc<Identity>, NetworkChunkProvider<Arc<Identity>>>>;
+pub type BuiltStorer = BuiltNode<StorerRpcProviders<Arc<Identity>, VerifiedChunkProvider>>;

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -27,6 +27,10 @@ use crate::config::{BootnodeConfig, ClientConfig, StorerConfig};
 use crate::error::SwarmNodeError;
 use crate::providers::NetworkChunkProvider;
 use crate::rpc::{BootnodeRpcProviders, ClientRpcProviders, StorerRpcProviders};
+use crate::verify::VerifyingChunkProvider;
+
+/// Network chunk provider wrapped with config-gated download verification.
+type VerifiedChunkProvider = VerifyingChunkProvider<NetworkChunkProvider<Arc<Identity>>>;
 
 type PeerStore = Arc<dyn NetPeerStore<StoredPeer>>;
 type PeerScoreStore = Arc<dyn SwarmScoreStore<Score = PeerScore, Error = StoreError>>;
@@ -201,7 +205,7 @@ impl SwarmLaunchConfig for BootnodeConfig {
 #[async_trait]
 impl SwarmLaunchConfig for ClientConfig {
     type Types = ClientLaunchTypes;
-    type Providers = ClientRpcProviders<Arc<Identity>, NetworkChunkProvider<Arc<Identity>>>;
+    type Providers = ClientRpcProviders<Arc<Identity>, VerifiedChunkProvider>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -226,7 +230,8 @@ impl SwarmLaunchConfig for ClientConfig {
 
         let topology = node.topology_handle().clone();
         let chunk_provider = NetworkChunkProvider::new(client_handle, topology.clone());
-        let providers = ClientRpcProviders::new(topology, chunk_provider);
+        let verified_provider = VerifyingChunkProvider::new(chunk_provider, self.verify());
+        let providers = ClientRpcProviders::new(topology, verified_provider);
 
         // Spawn client service as independent task with graceful shutdown
         ctx.executor()
@@ -248,7 +253,7 @@ impl SwarmLaunchConfig for ClientConfig {
 #[async_trait]
 impl SwarmLaunchConfig for StorerConfig {
     type Types = StorerLaunchTypes;
-    type Providers = StorerRpcProviders<Arc<Identity>, NetworkChunkProvider<Arc<Identity>>>;
+    type Providers = StorerRpcProviders<Arc<Identity>, VerifiedChunkProvider>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -278,7 +283,8 @@ impl SwarmLaunchConfig for StorerConfig {
 
         let topology = node.topology_handle().clone();
         let chunk_provider = NetworkChunkProvider::new(client_handle, topology.clone());
-        let providers = StorerRpcProviders::new(topology, chunk_provider);
+        let verified_provider = VerifyingChunkProvider::new(chunk_provider, self.verify());
+        let providers = StorerRpcProviders::new(topology, verified_provider);
 
         // Spawn client service as independent task with graceful shutdown
         ctx.executor()

--- a/crates/swarm/builder/src/node.rs
+++ b/crates/swarm/builder/src/node.rs
@@ -22,6 +22,7 @@ use vertex_swarm_topology::KademliaConfig;
 use crate::config::{BootnodeConfig, ClientConfig, StorerConfig};
 use crate::error::SwarmNodeError;
 use crate::handle::{BuiltBootnode, BuiltClient, BuiltNode, BuiltStorer};
+use crate::verify::ChunkVerifyConfig;
 
 /// Fluent transformation API for builders.
 pub trait BuilderExt: Sized {
@@ -91,6 +92,7 @@ where
         ClientNodeBuilder {
             base: self,
             accounting,
+            verify: ChunkVerifyConfig::default(),
         }
     }
 }
@@ -104,6 +106,7 @@ where
 {
     base: NodeBuilder<I, N>,
     accounting: A,
+    verify: ChunkVerifyConfig,
 }
 
 impl<I, N, A> BuilderExt for ClientNodeBuilder<I, N, A>
@@ -122,6 +125,12 @@ where
 {
     pub fn spec(&self) -> &Arc<Spec> {
         self.base.spec()
+    }
+
+    /// Set the verification checks applied to downloaded chunks.
+    pub fn with_verify(mut self, verify: ChunkVerifyConfig) -> Self {
+        self.verify = verify;
+        self
     }
 
     /// Transition to storer builder by adding storage.
@@ -226,8 +235,11 @@ impl DefaultClientBuilder {
         identity: Arc<Identity>,
         network: NetworkConfig<KademliaConfig>,
         bandwidth: DefaultBandwidthConfig,
+        verify: ChunkVerifyConfig,
     ) -> Self {
-        NodeBuilder::new(spec, identity, network).with_accounting(bandwidth)
+        NodeBuilder::new(spec, identity, network)
+            .with_accounting(bandwidth)
+            .with_verify(verify)
     }
 
     pub fn from_config(config: ClientConfig) -> Self {
@@ -236,6 +248,7 @@ impl DefaultClientBuilder {
             config.identity().clone(),
             config.network().clone(),
             config.bandwidth().clone(),
+            config.verify(),
         )
     }
 
@@ -246,6 +259,7 @@ impl DefaultClientBuilder {
             self.base.identity,
             self.base.network,
             self.accounting,
+            self.verify,
         )
     }
 
@@ -268,9 +282,11 @@ impl DefaultStorerBuilder {
         bandwidth: DefaultBandwidthConfig,
         local_store: LocalStoreConfig,
         storage: StorageConfig,
+        verify: ChunkVerifyConfig,
     ) -> Self {
         NodeBuilder::new(spec, identity, network)
             .with_accounting(bandwidth)
+            .with_verify(verify)
             .with_storage(local_store, storage)
     }
 
@@ -282,6 +298,7 @@ impl DefaultStorerBuilder {
             config.bandwidth().clone(),
             config.local_store().clone(),
             config.storage().clone(),
+            config.verify(),
         )
     }
 
@@ -294,6 +311,7 @@ impl DefaultStorerBuilder {
             self.client.accounting,
             self.local_store,
             self.storage,
+            self.client.verify,
         )
     }
 

--- a/crates/swarm/builder/src/providers.rs
+++ b/crates/swarm/builder/src/providers.rs
@@ -9,6 +9,9 @@ use vertex_swarm_api::{
 use vertex_swarm_node::ClientHandle;
 use vertex_swarm_topology::TopologyHandle;
 
+/// Number of closest peers to try when pushing a chunk before giving up.
+const PUSH_CANDIDATE_COUNT: usize = 5;
+
 /// Chunk provider using ClientHandle for network retrieval.
 #[derive(Clone)]
 pub struct NetworkChunkProvider<I: SwarmIdentity> {
@@ -74,19 +77,54 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
     }
 }
 
+impl<I: SwarmIdentity> NetworkChunkProvider<I> {
+    /// Push `chunk` to the storer peers closest to its address, returning the
+    /// first receipt.
+    ///
+    /// Walks the closest candidates in order and returns the first storer that
+    /// accepts the chunk. The client handle correlates a push response to its
+    /// request by chunk address alone, so the candidates are tried sequentially
+    /// rather than raced.
+    async fn push_to_closest(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+        let address = *chunk.address();
+        let closest = self.topology.closest_to(&address, PUSH_CANDIDATE_COUNT);
+
+        if closest.is_empty() {
+            return Err(SwarmError::NoStorer {
+                chunk_address: address,
+            });
+        }
+
+        let mut last_error = None;
+        for peer in closest {
+            match self.client_handle.push_chunk(peer, chunk.clone()).await {
+                Ok(receipt) => return Ok(receipt),
+                Err(e) => last_error = Some(SwarmError::network_msg(e.to_string())),
+            }
+        }
+
+        Err(last_error.unwrap_or(SwarmError::NoStorer {
+            chunk_address: address,
+        }))
+    }
+}
+
 #[async_trait]
 impl<I: SwarmIdentity> SwarmChunkSender for NetworkChunkProvider<I> {
-    async fn send_chunk_unchecked(&self, _chunk: StampedChunk) -> SwarmResult<PushReceipt> {
-        // PushSync forwarding is wired up alongside the client send path; until
-        // that lands the upload endpoint reports the capability as unavailable.
-        Err(SwarmError::internal_msg(
-            "chunk upload is not yet supported",
-        ))
+    async fn send_chunk_unchecked(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+        self.push_to_closest(chunk).await
     }
 
-    async fn send_chunk(&self, _chunk: StampedChunk) -> SwarmResult<PushReceipt> {
-        Err(SwarmError::internal_msg(
-            "chunk upload is not yet supported",
-        ))
+    async fn send_chunk(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+        let address = *chunk.address();
+        chunk
+            .stamp()
+            .recover_signer(&address)
+            .map_err(|err| SwarmError::InvalidSignature {
+                chunk_address: address,
+                reason: err.to_string(),
+            })?;
+
+        self.push_to_closest(chunk).await
     }
 }

--- a/crates/swarm/builder/src/verify.rs
+++ b/crates/swarm/builder/src/verify.rs
@@ -17,7 +17,8 @@
 
 use async_trait::async_trait;
 use vertex_swarm_api::{
-    ChunkAddress, ChunkRetrievalResult, StampedChunk, SwarmChunkProvider, SwarmError, SwarmResult,
+    ChunkAddress, ChunkRetrievalResult, PushReceipt, StampedChunk, SwarmChunkProvider,
+    SwarmChunkSender, SwarmError, SwarmResult,
 };
 
 /// Which checks the [`VerifyingChunkProvider`] applies to retrieved chunks.
@@ -116,6 +117,23 @@ where
     }
 }
 
+/// Uploads bypass the download-side verification and forward straight to the
+/// wrapped sender. [`ChunkVerifyConfig`] governs retrieved chunks only; the
+/// upload path keeps its own stamp validation in [`SwarmChunkSender::send_chunk`].
+#[async_trait]
+impl<P> SwarmChunkSender for VerifyingChunkProvider<P>
+where
+    P: SwarmChunkSender,
+{
+    async fn send_chunk_unchecked(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+        self.inner.send_chunk_unchecked(chunk).await
+    }
+
+    async fn send_chunk(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+        self.inner.send_chunk(chunk).await
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
@@ -124,7 +142,8 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use nectar_postage::{Stamp, StampDigest, StampIndex};
-    use vertex_swarm_api::{AnyChunk, Chunk, ContentChunk};
+    use nectar_primitives::Nonce;
+    use vertex_swarm_api::{AnyChunk, Chunk, ContentChunk, StorageRadius};
 
     /// In-test provider returning a canned stamped chunk for any request.
     struct MockProvider {
@@ -146,6 +165,22 @@ mod tests {
 
         fn has_chunk(&self, _address: &ChunkAddress) -> bool {
             true
+        }
+    }
+
+    #[async_trait]
+    impl SwarmChunkSender for MockProvider {
+        async fn send_chunk_unchecked(&self, _chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+            Ok(PushReceipt {
+                storer: self.served_by,
+                signature: alloy_primitives::Signature::from_raw(&[1u8; 65]).unwrap(),
+                nonce: Nonce::new([0u8; 32]),
+                storage_radius: StorageRadius::ZERO,
+            })
+        }
+
+        async fn send_chunk(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+            self.send_chunk_unchecked(chunk).await
         }
     }
 
@@ -281,6 +316,31 @@ mod tests {
         assert!(
             matches!(result, Err(SwarmError::InvalidSignature { .. })),
             "malformed stamp should fail signature recovery: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_forwards_to_inner_sender() {
+        let chunk = content_chunk();
+        let address = *chunk.address();
+        let stamped = stamped(chunk, valid_stamp(&address));
+
+        // Download verification settings must not affect the upload path.
+        let provider = VerifyingChunkProvider::new(
+            MockProvider {
+                chunk: stamped.clone(),
+                served_by: Default::default(),
+            },
+            ChunkVerifyConfig {
+                verify_content: true,
+                verify_stamp: true,
+            },
+        );
+
+        let receipt = provider.send_chunk(stamped).await;
+        assert!(
+            receipt.is_ok(),
+            "upload should forward to inner: {receipt:?}"
         );
     }
 }

--- a/crates/swarm/node/src/args/mod.rs
+++ b/crates/swarm/node/src/args/mod.rs
@@ -2,11 +2,13 @@
 
 mod network;
 mod peer;
+mod retrieval;
 mod spec;
 mod swarm;
 
 pub use network::{NetworkArgs, NetworkConfig};
 pub use peer::{PeerArgs, PeerConfig};
+pub use retrieval::RetrievalArgs;
 pub use spec::SwarmSpecArgs;
 pub use swarm::{NodeTypeArg, ProtocolArgs};
 pub use vertex_swarm_topology::RoutingArgs;

--- a/crates/swarm/node/src/args/retrieval.rs
+++ b/crates/swarm/node/src/args/retrieval.rs
@@ -1,0 +1,38 @@
+//! Chunk retrieval CLI arguments.
+//!
+//! Controls the verification applied to chunks downloaded from the network.
+//! Content integrity is already enforced when the retrieval codec reconstructs a
+//! chunk against the requested address, so the residual checks here are cheap: a
+//! defensive address re-assertion (on by default) and postage stamp signer
+//! recovery (off by default).
+
+use clap::Args;
+use serde::{Deserialize, Serialize};
+
+/// Default for the download-side content (address) re-assertion.
+const DEFAULT_VERIFY_CONTENT: bool = true;
+/// Default for the download-side postage stamp signer recovery.
+const DEFAULT_VERIFY_STAMP: bool = false;
+
+/// Chunk retrieval verification arguments.
+#[derive(Debug, Args, Clone, Serialize, Deserialize)]
+#[command(next_help_heading = "Retrieval")]
+#[serde(default)]
+pub struct RetrievalArgs {
+    /// Re-assert that a downloaded chunk's address matches the request.
+    #[arg(long = "retrieval.verify-content", default_value_t = DEFAULT_VERIFY_CONTENT)]
+    pub verify_content: bool,
+
+    /// Recover the postage stamp signer for downloaded chunks.
+    #[arg(long = "retrieval.verify-stamp", default_value_t = DEFAULT_VERIFY_STAMP)]
+    pub verify_stamp: bool,
+}
+
+impl Default for RetrievalArgs {
+    fn default() -> Self {
+        Self {
+            verify_content: DEFAULT_VERIFY_CONTENT,
+            verify_stamp: DEFAULT_VERIFY_STAMP,
+        }
+    }
+}

--- a/crates/swarm/node/src/args/swarm.rs
+++ b/crates/swarm/node/src/args/swarm.rs
@@ -11,7 +11,7 @@ use vertex_swarm_localstore::LocalStoreArgs;
 use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_redistribution::RedistributionArgs;
 
-use super::{NetworkArgs, SwarmSpecArgs};
+use super::{NetworkArgs, RetrievalArgs, SwarmSpecArgs};
 
 /// CLI argument for node mode selection. Maps to [`SwarmNodeType`].
 #[derive(
@@ -78,6 +78,10 @@ pub struct ProtocolArgs {
     /// Bandwidth accounting (includes pricing via `--bandwidth.base-price`).
     #[command(flatten)]
     pub bandwidth: BandwidthArgs,
+
+    /// Chunk retrieval verification.
+    #[command(flatten)]
+    pub retrieval: RetrievalArgs,
 
     #[command(flatten)]
     pub localstore: LocalStoreArgs,

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -15,7 +15,7 @@ use vertex_swarm_spec::Spec;
 
 use vertex_swarm_api::ConfigError;
 
-use crate::args::{NetworkArgs, NetworkConfig, ProtocolArgs};
+use crate::args::{NetworkArgs, NetworkConfig, ProtocolArgs, RetrievalArgs};
 
 /// Swarm protocol configuration (serializable Args layer).
 ///
@@ -29,6 +29,7 @@ pub struct ProtocolConfig {
     pub identity: IdentityArgs,
     pub network: NetworkArgs,
     pub bandwidth: BandwidthArgs,
+    pub retrieval: RetrievalArgs,
     pub localstore: LocalStoreArgs,
     pub redistribution: RedistributionArgs,
 }
@@ -58,6 +59,11 @@ impl ProtocolConfig {
     pub fn storage_config(&self) -> StorageConfig {
         self.redistribution.storage_config()
     }
+
+    /// Download-side chunk verification arguments.
+    pub fn retrieval(&self) -> &RetrievalArgs {
+        &self.retrieval
+    }
 }
 
 impl ProtocolConfig {
@@ -74,6 +80,7 @@ impl NodeProtocolConfig for ProtocolConfig {
         self.identity = args.identity.clone();
         self.network = args.network.clone();
         self.bandwidth = args.bandwidth.clone();
+        self.retrieval = args.retrieval.clone();
         self.localstore = args.localstore.clone();
         self.redistribution = args.redistribution.clone();
     }


### PR DESCRIPTION
Replaces the `NetworkChunkProvider` `SwarmChunkSender` stub with a real upload path and wires config-gated download verification into the launch flow.

## SwarmChunkSender on NetworkChunkProvider

`send_chunk`/`send_chunk_unchecked` now pick the storer peers closest to the chunk address via `topology.closest_to(...)` and push through `ClientHandle::push_chunk(peer, StampedChunk) -> PushReceipt`, returning the first receipt. `send_chunk` recovers the stamp signer against the chunk address with `Stamp::recover_signer` before pushing; `send_chunk_unchecked` skips that. An empty candidate set surfaces `SwarmError::NoStorer`.

## Config-gated download verification

The retrieval provider is wrapped in `VerifyingChunkProvider` for both the Client and Storer launch paths, driven by a new `ChunkVerifyConfig` field on `ClientConfig` and `StorerConfig`. Defaults keep content re-assertion on (cheap, retrieval already address-validates) and stamp recovery off. The wrapper forwards `SwarmChunkSender` to its inner sender, so verification governs downloads only and the upload path stays live.

## CLI / config knob

A `RetrievalArgs` group (`--retrieval.verify-content`, `--retrieval.verify-stamp`) is threaded through `ProtocolConfig` and mapped into `ChunkVerifyConfig` in the binary, consistent with the other protocol config groups.

## Upload gRPC path now live

`ChunkService` registration in `ClientRpcProviders`/`StorerRpcProviders` already required `SwarmChunkSender`; with the real sender in place the gRPC upload path reaches the network.

## Verification

`cargo fmt --all`, `cargo clippy --lib --all-features` and `cargo clippy --tests --benches --all-features` clean (run in the project nix dev shell so jemalloc builds), `cargo test -p vertex-swarm-builder` and `cargo test -p vertex-swarm-node` green, full `cargo build` green.