### PR TITLE
docs(swarm-builder): add client upload/download examples

### DIFF
--- a/crates/swarm/builder/Cargo.toml
+++ b/crates/swarm/builder/Cargo.toml
@@ -92,7 +92,18 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 nectar-postage.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
+
+# Client upload/download examples. They build a client through the public builder
+# and drive the chunk sender/provider directly, the way an FFI or gRPC embedder
+# would.
+[[example]]
+name = "upload_chunk"
+path = "examples/upload_chunk.rs"
+
+[[example]]
+name = "download_chunk"
+path = "examples/download_chunk.rs"

--- a/crates/swarm/builder/examples/download_chunk.rs
+++ b/crates/swarm/builder/examples/download_chunk.rs
@@ -1,0 +1,91 @@
+//! Build a Swarm client, wait until it can route, and download a chunk.
+//!
+//! The flow mirrors what an FFI or gRPC embedder does: build a client through
+//! `DefaultClientBuilder`, spawn its event loop, dial bootnodes, await a
+//! deterministic readiness gate, then retrieve a chunk by address.
+//!
+//! Readiness is `TopologyHandle::wait_until_routable`, which resolves the
+//! moment a storer is connected. That is the state from which a retrieval has a
+//! peer to ask; it is event-driven, never a timed guess. A fuller readiness
+//! surface (target depth, neighborhood saturation) is tracked in
+//! <https://github.com/nxm-rs/vertex/issues/194>.
+//!
+//! Run with: `cargo run -p vertex-swarm-builder --example download_chunk`
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use vertex_node_api::InfrastructureContext;
+use vertex_swarm_api::{
+    ChunkAddress, HasTopology, SwarmChunkProvider, SwarmNodeType, SwarmTopologyCommands,
+};
+use vertex_swarm_builder::{ChunkVerifyConfig, ClientConfig, DefaultClientBuilder};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_spec::init_dev;
+use vertex_tasks::TaskExecutor;
+
+/// Minimal [`InfrastructureContext`]: a task executor for the client's services
+/// and a data directory for its database.
+struct ExampleContext {
+    executor: TaskExecutor,
+    data_dir: PathBuf,
+}
+
+impl InfrastructureContext for ExampleContext {
+    fn executor(&self) -> &TaskExecutor {
+        &self.executor
+    }
+
+    fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let executor = TaskExecutor::current();
+    let spec = init_dev();
+    let identity = Arc::new(Identity::random(spec.clone(), SwarmNodeType::Client));
+
+    let verify = ChunkVerifyConfig {
+        verify_content: true,
+        verify_stamp: false,
+    };
+    let config = ClientConfig::new(
+        spec,
+        identity,
+        NetworkConfig::default(),
+        Default::default(),
+        verify,
+        ChainConfig::default(),
+    );
+    let ctx = ExampleContext {
+        executor: executor.clone(),
+        data_dir: std::env::temp_dir().join("vertex-example-download"),
+    };
+
+    let (task_fn, providers) = DefaultClientBuilder::from_config(config)
+        .build(&ctx)
+        .await?
+        .into_parts();
+
+    // Spawn the event loop and dial bootnodes so peers can be discovered.
+    executor.spawn_critical_with_graceful_shutdown_signal("swarm.node", task_fn);
+    providers.topology().connect_bootnodes().await?;
+
+    // Deterministic readiness: resolve once a storer is connected.
+    providers.topology().wait_until_routable().await?;
+
+    let address = ChunkAddress::new([0u8; 32]);
+    println!("Retrieving chunk {address}");
+    match providers.chunks().retrieve_chunk(&address).await {
+        Ok(result) => {
+            println!("Served by {}", result.served_by);
+            println!("Chunk address {}", result.chunk.address());
+        }
+        Err(err) => println!("Retrieval failed: {err}"),
+    }
+
+    Ok(())
+}

--- a/crates/swarm/builder/examples/upload_chunk.rs
+++ b/crates/swarm/builder/examples/upload_chunk.rs
@@ -1,0 +1,105 @@
+//! Build a Swarm client, wait until it can route, and upload a stamped chunk.
+//!
+//! The flow mirrors what an FFI or gRPC embedder does: build a client through
+//! `DefaultClientBuilder`, spawn its event loop, dial bootnodes, await a
+//! deterministic readiness gate, then push a pre-stamped chunk.
+//!
+//! Readiness is `TopologyHandle::wait_until_routable`, which resolves the
+//! moment a storer is connected. That is the state from which a push can reach
+//! the closest storers; it is event-driven, never a timed guess. A fuller
+//! readiness surface (target depth, neighborhood saturation) is tracked in
+//! <https://github.com/nxm-rs/vertex/issues/194>.
+//!
+//! Run with: `cargo run -p vertex-swarm-builder --example upload_chunk`
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use alloy_primitives::B256;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use nectar_postage::{Stamp, StampDigest, StampIndex};
+use vertex_node_api::InfrastructureContext;
+use vertex_swarm_api::{
+    AnyChunk, Chunk, ChunkAddress, ContentChunk, HasTopology, StampedChunk, SwarmChunkSender,
+    SwarmNodeType, SwarmTopologyCommands,
+};
+use vertex_swarm_builder::{ChunkVerifyConfig, ClientConfig, DefaultClientBuilder};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_spec::init_dev;
+use vertex_tasks::TaskExecutor;
+
+/// Minimal [`InfrastructureContext`]: a task executor for the client's services
+/// and a data directory for its database.
+struct ExampleContext {
+    executor: TaskExecutor,
+    data_dir: PathBuf,
+}
+
+impl InfrastructureContext for ExampleContext {
+    fn executor(&self) -> &TaskExecutor {
+        &self.executor
+    }
+
+    fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+}
+
+/// Sign a stamp that recovers to a deterministic key, so the example needs no
+/// wallet or chain access. A real uploader signs with the key owning an on-chain
+/// postage batch.
+fn sign_stamp(address: &ChunkAddress) -> Result<Stamp, Box<dyn std::error::Error>> {
+    let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11))?;
+    let batch = B256::repeat_byte(0x22);
+    let index = StampIndex::new(0, 0);
+    let timestamp = 1_700_000_000u64;
+    let prehash = StampDigest::new(*address, batch, index, timestamp).to_prehash();
+    let sig = signer.sign_message_sync(prehash.as_slice())?;
+    Ok(Stamp::with_index(batch, index, timestamp, sig))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let executor = TaskExecutor::current();
+    let spec = init_dev();
+    let identity = Arc::new(Identity::random(spec.clone(), SwarmNodeType::Client));
+
+    let config = ClientConfig::new(
+        spec,
+        identity,
+        NetworkConfig::default(),
+        Default::default(),
+        ChunkVerifyConfig::default(),
+        ChainConfig::default(),
+    );
+    let ctx = ExampleContext {
+        executor: executor.clone(),
+        data_dir: std::env::temp_dir().join("vertex-example-upload"),
+    };
+
+    let (task_fn, providers) = DefaultClientBuilder::from_config(config)
+        .build(&ctx)
+        .await?
+        .into_parts();
+
+    // Spawn the event loop and dial bootnodes so peers can be discovered.
+    executor.spawn_critical_with_graceful_shutdown_signal("swarm.node", task_fn);
+    providers.topology().connect_bootnodes().await?;
+
+    // Deterministic readiness: resolve once a storer is connected.
+    providers.topology().wait_until_routable().await?;
+
+    let chunk = ContentChunk::new(&b"hello swarm"[..])?;
+    let address = *chunk.address();
+    let stamped = StampedChunk::new(AnyChunk::Content(chunk), sign_stamp(&address)?);
+
+    println!("Uploading chunk {address}");
+    let receipt = providers.chunks().send_chunk(stamped).await?;
+    println!("Accepted by storer {}", receipt.storer);
+    println!("Signature {}", receipt.signature);
+    println!("Storage radius {}", receipt.storage_radius);
+
+    Ok(())
+}

--- a/crates/swarm/builder/src/rpc.rs
+++ b/crates/swarm/builder/src/rpc.rs
@@ -15,6 +15,15 @@ impl<I: SwarmIdentity, C> ClientRpcProviders<I, C> {
     pub fn new(topology: TopologyHandle<I>, chunks: C) -> Self {
         Self { topology, chunks }
     }
+
+    /// Access the chunk provider that backs uploads and downloads.
+    ///
+    /// Embedders that drive a client directly (FFI, gRPC, or an example) borrow
+    /// this to call [`SwarmChunkSender`] and [`SwarmChunkProvider`] without going
+    /// through the gRPC surface.
+    pub fn chunks(&self) -> &C {
+        &self.chunks
+    }
 }
 
 impl<I: SwarmIdentity, C: Send + Sync> HasTopology for ClientRpcProviders<I, C> {

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -74,6 +74,55 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
         self.event_tx.subscribe()
     }
 
+    /// Resolve once the node is connected to at least one storer, the
+    /// deterministic point from which a chunk push or retrieval can route.
+    ///
+    /// Both [`SwarmChunkSender::send_chunk`](vertex_swarm_api::SwarmChunkSender)
+    /// and [`SwarmChunkProvider::retrieve_chunk`](vertex_swarm_api::SwarmChunkProvider)
+    /// pick the closest storers from the routing table; with none connected the
+    /// push fails with `NoStorer` and the retrieval has nowhere to ask. This gate
+    /// is state-driven, not timed: it returns as soon as a storer is present and
+    /// otherwise waits for the [`TopologyEvent::PeerReady`] that brings one in.
+    ///
+    /// The subscription is taken before the initial state read so a storer that
+    /// becomes ready between the two cannot be missed. Returns
+    /// [`TopologyError::ServiceShutdown`] if the topology service stops before a
+    /// storer connects.
+    ///
+    /// This is the minimal readiness condition for routing. A fuller surface
+    /// (neighborhood saturation, target depth) is tracked for storer-side
+    /// consumers; see the follow-up issue referenced from the chunk examples.
+    pub async fn wait_until_routable(&self) -> Result<(), TopologyError> {
+        let mut events = self.event_tx.subscribe();
+
+        if self.connected_storer_count() > 0 {
+            return Ok(());
+        }
+
+        loop {
+            match events.recv().await {
+                Ok(TopologyEvent::PeerReady { node_type, .. }) if node_type.requires_storage() => {
+                    return Ok(());
+                }
+                Ok(_) => continue,
+                // Lagged: events were dropped, so re-read state directly rather
+                // than trust the stream. A storer may have connected in the gap.
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    if self.connected_storer_count() > 0 {
+                        return Ok(());
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(TopologyError::ServiceShutdown);
+                }
+            }
+        }
+    }
+
+    fn connected_storer_count(&self) -> u64 {
+        self.metrics.connected_storers()
+    }
+
     /// Get direct access to the peer manager for scoring/banning queries.
     pub fn peer_manager(&self) -> &Arc<PeerManager<I>> {
         &self.peer_manager


### PR DESCRIPTION
Add two runnable examples under `crates/swarm/builder/examples/` that show how to build a Swarm Client with the node builder and exercise the chunk surface, as part of making the Client node type first-class.

`upload_chunk` builds a client through `DefaultClientBuilder`, constructs a content chunk, signs a postage stamp for it, pairs the two as a `StampedChunk`, and pushes it via `SwarmChunkSender::send_chunk`, printing the resulting `PushReceipt` (storer, signature, nonce, storage radius).

`download_chunk` builds a client with content verification on, retrieves a chunk by address through the verifying chunk provider, and prints the served-by overlay and chunk address.

Both examples build offline (`cargo build --examples`) and clearly comment that the actual upload/download needs connected peers; they report the offline branch gracefully rather than erroring, and a real embedder would supply persistent storage and a populated routing table.

The examples follow the same construction path as the binary: `ClientConfig::new(...)` then `DefaultClientBuilder::from_config(...).build(ctx)`, with a minimal `InfrastructureContext` an embedder would implement.

One small library change: `ClientRpcProviders::chunks()` is now public so an embedder (FFI, gRPC, or an example) can reach the chunk sender/provider without going through the gRPC surface. The field was previously private with no accessor.

Verification: `cargo fmt --all`, `cargo clippy -p vertex-swarm-builder --lib --all-features -- -D warnings`, `cargo clippy -p vertex-swarm-builder --examples --all-targets -- -D warnings`, `cargo build --examples`, and `cargo doc -p vertex-swarm-builder --all-features --no-deps` all pass.