### PR TITLE
feat(swarm-node): wire swap protocol into client behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8883,6 +8883,7 @@ dependencies = [
  "vertex-swarm-net-pseudosettle",
  "vertex-swarm-net-pushsync",
  "vertex-swarm-net-retrieval",
+ "vertex-swarm-net-swap",
  "vertex-swarm-peer",
  "vertex-swarm-peer-manager",
  "vertex-swarm-peer-score",

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -29,6 +29,9 @@ vertex-swarm-peer.workspace = true
 vertex-swarm-net-pushsync.workspace = true
 vertex-swarm-net-retrieval.workspace = true
 
+## vertex - settlement (optional, feature-gated)
+vertex-swarm-net-swap = { workspace = true, optional = true }
+
 ## vertex - topology
 vertex-swarm-topology.workspace = true
 vertex-swarm-peer-manager.workspace = true
@@ -90,6 +93,10 @@ rand_08.workspace = true
 [features]
 default = ["std"]
 std = []
+# SWAP cheque-based settlement. Pulls the swap wire protocol and surfaces
+# `SwapEvent` plus the `ClientCommand::SendCheque` variant for a settlement
+# service to consume.
+swap = ["dep:vertex-swarm-net-swap"]
 cli = [
     "dep:clap",
     "dep:serde",

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -397,6 +397,27 @@ impl ClientService {
             ClientEvent::PseudosettleSent { peer, peer_id, ack } => {
                 debug!(%peer, %peer_id, amount = %ack.amount, timestamp = ack.timestamp, "Pseudosettle sent, received ack");
             }
+
+            #[cfg(feature = "swap")]
+            ClientEvent::SwapChequeReceived {
+                peer,
+                peer_id,
+                peer_rate,
+                ..
+            } => {
+                // The swap settlement service consumes cheques via the dedicated
+                // channel configured with `set_swap_events`.
+                debug!(%peer, %peer_id, %peer_rate, "Swap cheque received");
+            }
+
+            #[cfg(feature = "swap")]
+            ClientEvent::SwapChequeSent {
+                peer,
+                peer_id,
+                peer_rate,
+            } => {
+                debug!(%peer, %peer_id, %peer_rate, "Swap cheque sent");
+            }
         }
     }
 }

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -406,7 +406,7 @@ impl ClientService {
                 ..
             } => {
                 // The swap settlement service consumes cheques via the dedicated
-                // channel configured with `set_swap_events`.
+                // channel configured with `route_swap_events`.
                 debug!(%peer, %peer_id, %peer_rate, "Swap cheque received");
             }
 

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -27,6 +27,8 @@ pub use node::{
 pub use vertex_swarm_api::SwarmNodeType;
 
 pub use client_service::{ClientHandle, ClientService, RetrievalError, RetrievalResult};
+#[cfg(feature = "swap")]
+pub use protocol::SwapEvent;
 pub use protocol::{ClientCommand, ClientEvent, PseudosettleEvent};
 
 pub use swarm_client::{BootnodeClient, Client, FullClient};

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -107,15 +107,15 @@ impl ClientBehaviour {
         self.pseudosettle_event_tx = Some(tx);
     }
 
-    /// Set the sender for swap events.
+    /// Route swap events to the given sink.
     ///
-    /// When set, swap-related events will be sent to this channel in addition
+    /// Once routed, swap-related events will be sent to this channel in addition
     /// to being emitted as [`ClientEvent`]. The node wires this up when a swap
     /// settlement service is present.
     #[cfg(feature = "swap")]
     // Wired by the node builder when the swap settlement service is present.
     #[allow(dead_code)]
-    pub(crate) fn set_swap_events(&mut self, tx: mpsc::UnboundedSender<SwapEvent>) {
+    pub(crate) fn route_swap_events(&mut self, tx: mpsc::UnboundedSender<SwapEvent>) {
         self.swap_event_tx = Some(tx);
     }
 

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -21,6 +21,8 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 use vertex_swarm_primitives::OverlayAddress;
 
+#[cfg(feature = "swap")]
+use super::SwapEvent;
 use super::{
     ClientCommand, ClientEvent, PseudosettleEvent,
     handler::{ClientHandler, Config as HandlerConfig, HandlerCommand, HandlerEvent},
@@ -78,6 +80,9 @@ pub(crate) struct ClientBehaviour {
     pending_events: VecDeque<ToSwarm<ClientEvent, HandlerCommand>>,
     /// Optional sender for pseudosettle events.
     pseudosettle_event_tx: Option<mpsc::UnboundedSender<PseudosettleEvent>>,
+    /// Optional sender for swap events.
+    #[cfg(feature = "swap")]
+    swap_event_tx: Option<mpsc::UnboundedSender<SwapEvent>>,
 }
 
 impl ClientBehaviour {
@@ -89,6 +94,8 @@ impl ClientBehaviour {
             overlay_peers: HashMap::new(),
             pending_events: VecDeque::new(),
             pseudosettle_event_tx: None,
+            #[cfg(feature = "swap")]
+            swap_event_tx: None,
         }
     }
 
@@ -98,6 +105,18 @@ impl ClientBehaviour {
     /// in addition to being emitted as [`ClientEvent`].
     pub(crate) fn set_pseudosettle_events(&mut self, tx: mpsc::UnboundedSender<PseudosettleEvent>) {
         self.pseudosettle_event_tx = Some(tx);
+    }
+
+    /// Set the sender for swap events.
+    ///
+    /// When set, swap-related events will be sent to this channel in addition
+    /// to being emitted as [`ClientEvent`]. The node wires this up when a swap
+    /// settlement service is present.
+    #[cfg(feature = "swap")]
+    // Wired by the node builder when the swap settlement service is present.
+    #[allow(dead_code)]
+    pub(crate) fn set_swap_events(&mut self, tx: mpsc::UnboundedSender<SwapEvent>) {
+        self.swap_event_tx = Some(tx);
     }
 
     /// Push an event if the queue isn't full, otherwise drop with a metric.
@@ -235,6 +254,19 @@ impl ClientBehaviour {
                     });
                 } else {
                     debug!(%peer, "Unknown peer for pseudosettle ack");
+                }
+            }
+            #[cfg(feature = "swap")]
+            ClientCommand::SendCheque { peer, cheque } => {
+                if let Some(&peer_id) = self.overlay_peers.get(&peer) {
+                    debug!(%peer_id, %peer, "Sending swap cheque");
+                    self.push_event(ToSwarm::NotifyHandler {
+                        peer_id,
+                        handler: libp2p::swarm::NotifyHandler::Any,
+                        event: HandlerCommand::SendCheque { cheque },
+                    });
+                } else {
+                    debug!(%peer, "Unknown peer for swap cheque");
                 }
             }
             ClientCommand::DisconnectPeer { peer, reason } => {
@@ -380,6 +412,50 @@ impl ClientBehaviour {
                     peer: overlay,
                     peer_id,
                     ack,
+                }));
+            }
+            #[cfg(feature = "swap")]
+            HandlerEvent::SwapChequeReceived {
+                overlay,
+                cheque,
+                peer_rate,
+            } => {
+                // Route to swap service if configured
+                if let Some(tx) = &self.swap_event_tx
+                    && tx
+                        .send(SwapEvent::ChequeReceived {
+                            peer: overlay,
+                            cheque: cheque.clone(),
+                            peer_rate,
+                        })
+                        .is_err()
+                {
+                    warn!(%overlay, "Swap event channel closed");
+                }
+                self.push_event(ToSwarm::GenerateEvent(ClientEvent::SwapChequeReceived {
+                    peer: overlay,
+                    peer_id,
+                    cheque,
+                    peer_rate,
+                }));
+            }
+            #[cfg(feature = "swap")]
+            HandlerEvent::SwapChequeSent { overlay, peer_rate } => {
+                // Route to swap service if configured
+                if let Some(tx) = &self.swap_event_tx
+                    && tx
+                        .send(SwapEvent::ChequeSent {
+                            peer: overlay,
+                            peer_rate,
+                        })
+                        .is_err()
+                {
+                    warn!(%overlay, "Swap event channel closed");
+                }
+                self.push_event(ToSwarm::GenerateEvent(ClientEvent::SwapChequeSent {
+                    peer: overlay,
+                    peer_id,
+                    peer_rate,
                 }));
             }
         }

--- a/crates/swarm/node/src/protocol/events.rs
+++ b/crates/swarm/node/src/protocol/events.rs
@@ -19,6 +19,8 @@ use alloy_primitives::{Signature, U256};
 use libp2p::PeerId;
 use nectar_primitives::{ChunkAddress, Nonce};
 use vertex_swarm_net_pseudosettle::PaymentAck;
+#[cfg(feature = "swap")]
+use vertex_swarm_net_swap::SignedCheque;
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk, StorageRadius, SwarmNodeType};
 
 /// Events emitted by the client behaviour.
@@ -153,6 +155,30 @@ pub enum ClientEvent {
         ack: PaymentAck,
     },
 
+    /// Received a swap cheque from a peer.
+    #[cfg(feature = "swap")]
+    SwapChequeReceived {
+        /// The peer that sent the cheque.
+        peer: OverlayAddress,
+        /// The libp2p peer ID.
+        peer_id: PeerId,
+        /// The signed cheque received.
+        cheque: SignedCheque,
+        /// The peer's advertised exchange rate, from the headers exchange.
+        peer_rate: U256,
+    },
+
+    /// Successfully sent a swap cheque to a peer.
+    #[cfg(feature = "swap")]
+    SwapChequeSent {
+        /// The peer we sent the cheque to.
+        peer: OverlayAddress,
+        /// The libp2p peer ID.
+        peer_id: PeerId,
+        /// The peer's advertised exchange rate, from the headers exchange.
+        peer_rate: U256,
+    },
+
     /// A peer's handler has been activated.
     ///
     /// This is emitted after the ActivatePeer command is processed.
@@ -274,6 +300,15 @@ pub enum ClientCommand {
         ack: PaymentAck,
     },
 
+    /// Send a swap cheque to a peer.
+    #[cfg(feature = "swap")]
+    SendCheque {
+        /// The peer to send the cheque to.
+        peer: OverlayAddress,
+        /// The signed cheque to send.
+        cheque: SignedCheque,
+    },
+
     /// Disconnect from a peer.
     ///
     /// Used when a peer fails validation (e.g., threshold too low).
@@ -306,5 +341,32 @@ pub enum PseudosettleEvent {
         amount: U256,
         /// Request ID for sending ack.
         request_id: u64,
+    },
+}
+
+/// Events routed to the swap settlement service.
+///
+/// These events are extracted from [`ClientEvent`] and sent to the swap
+/// service via a dedicated channel for type-safe handling. They carry strong
+/// types ([`SignedCheque`], typed peer, typed rate) so the service never sees
+/// raw wire bytes.
+#[cfg(feature = "swap")]
+#[derive(Debug, Clone)]
+pub enum SwapEvent {
+    /// We sent a cheque and the headers exchange completed.
+    ChequeSent {
+        /// The peer we sent the cheque to.
+        peer: OverlayAddress,
+        /// The peer's advertised exchange rate, from the headers exchange.
+        peer_rate: U256,
+    },
+    /// A peer sent us a cheque.
+    ChequeReceived {
+        /// The peer that sent the cheque.
+        peer: OverlayAddress,
+        /// The signed cheque received.
+        cheque: SignedCheque,
+        /// The peer's advertised exchange rate, from the headers exchange.
+        peer_rate: U256,
     },
 }

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -36,6 +36,8 @@ use libp2p::swarm::{
 use nectar_primitives::{ChunkAddress, Nonce};
 use tracing::{debug, warn};
 use vertex_swarm_net_pseudosettle::PaymentAck;
+#[cfg(feature = "swap")]
+use vertex_swarm_net_swap::SignedCheque;
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk, StorageRadius, SwarmNodeType};
 
 use super::upgrade::{
@@ -68,6 +70,11 @@ pub(crate) struct Config {
     /// Bootnodes only speak pricing (listen-only) so the rest of the
     /// client surface is inert.
     pub(crate) local_role: SwarmNodeType,
+    /// Our advertised swap exchange rate, sent in the swap headers exchange.
+    /// Rate negotiation is owned by the settlement service; the handler only
+    /// carries the value onto the wire.
+    #[cfg(feature = "swap")]
+    pub(crate) swap_exchange_rate: U256,
 }
 
 impl Default for Config {
@@ -77,6 +84,8 @@ impl Default for Config {
             max_pending_commands: DEFAULT_MAX_PENDING_COMMANDS,
             max_pending_events: DEFAULT_MAX_PENDING_EVENTS,
             local_role: SwarmNodeType::Client,
+            #[cfg(feature = "swap")]
+            swap_exchange_rate: U256::ZERO,
         }
     }
 }
@@ -117,6 +126,12 @@ pub(crate) enum HandlerCommand {
         request_id: u64,
         /// The ack to send.
         ack: PaymentAck,
+    },
+    /// Send a swap cheque to the peer.
+    #[cfg(feature = "swap")]
+    SendCheque {
+        /// The signed cheque to send.
+        cheque: SignedCheque,
     },
     /// Serve a chunk to a peer (respond to retrieval request).
     ServeChunk {
@@ -226,6 +241,24 @@ pub(crate) enum HandlerEvent {
         overlay: OverlayAddress,
         /// The ack received.
         ack: PaymentAck,
+    },
+    /// Received a swap cheque from peer.
+    #[cfg(feature = "swap")]
+    SwapChequeReceived {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// The signed cheque received.
+        cheque: SignedCheque,
+        /// The peer's advertised exchange rate, from the headers exchange.
+        peer_rate: U256,
+    },
+    /// Successfully sent a swap cheque.
+    #[cfg(feature = "swap")]
+    SwapChequeSent {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// The peer's advertised exchange rate, from the headers exchange.
+        peer_rate: U256,
     },
 }
 
@@ -508,7 +541,12 @@ impl ConnectionHandler for ClientHandler {
 
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         let upgrade = match &self.state {
-            State::Active { .. } => ClientInboundUpgrade::active_for(self.config.local_role),
+            State::Active { .. } => {
+                let upgrade = ClientInboundUpgrade::active_for(self.config.local_role);
+                #[cfg(feature = "swap")]
+                let upgrade = upgrade.with_swap_rate(self.config.swap_exchange_rate);
+                upgrade
+            }
             State::Dormant => ClientInboundUpgrade::new(),
         };
         SubstreamProtocol::new(upgrade, ()).with_timeout(self.config.timeout)
@@ -605,6 +643,15 @@ impl ConnectionHandler for ClientHandler {
                             ClientOutboundInfo::Pseudosettle { amount },
                         )
                         .with_timeout(self.config.timeout),
+                    });
+                }
+                #[cfg(feature = "swap")]
+                HandlerCommand::SendCheque { cheque } => {
+                    let upgrade =
+                        ClientOutboundUpgrade::swap(cheque, self.config.swap_exchange_rate);
+                    return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
+                        protocol: SubstreamProtocol::new(upgrade, ClientOutboundInfo::Swap)
+                            .with_timeout(self.config.timeout),
                     });
                 }
                 HandlerCommand::AckPseudosettle { request_id, ack } => {
@@ -731,6 +778,8 @@ impl ConnectionHandler for ClientHandler {
                     ClientOutboundInfo::Retrieval { .. } => "retrieval",
                     ClientOutboundInfo::Pushsync { .. } => "pushsync",
                     ClientOutboundInfo::Pseudosettle { .. } => "pseudosettle",
+                    #[cfg(feature = "swap")]
+                    ClientOutboundInfo::Swap => "swap",
                 };
                 warn!(protocol, error = %e.error, "Client dial upgrade error");
                 self.push_event(HandlerEvent::Error {
@@ -780,6 +829,17 @@ impl ClientHandler {
                     self.store_response(request_id, PendingResponse::Pseudosettle(result));
                 }
             }
+            #[cfg(feature = "swap")]
+            ClientInboundOutput::Swap(cheque, headers) => {
+                if let Some(overlay) = self.overlay() {
+                    debug!(%overlay, peer_rate = %headers.exchange_rate, "Received swap cheque");
+                    self.push_event(HandlerEvent::SwapChequeReceived {
+                        overlay,
+                        cheque,
+                        peer_rate: headers.exchange_rate,
+                    });
+                }
+            }
         }
     }
 
@@ -822,6 +882,16 @@ impl ClientHandler {
                     debug!(%overlay, %amount, ack_amount = %ack.amount, "Pseudosettle sent");
                     self.pending_events
                         .push_back(HandlerEvent::PseudosettleSent { overlay, ack });
+                }
+            }
+            #[cfg(feature = "swap")]
+            (ClientOutboundOutput::Swap(headers), ClientOutboundInfo::Swap) => {
+                if let Some(overlay) = self.overlay() {
+                    debug!(%overlay, peer_rate = %headers.exchange_rate, "Swap cheque sent");
+                    self.push_event(HandlerEvent::SwapChequeSent {
+                        overlay,
+                        peer_rate: headers.exchange_rate,
+                    });
                 }
             }
             (output, info) => {

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -7,6 +7,7 @@
 //! - **Retrieval**: Chunk request/response
 //! - **PushSync**: Chunk push with receipt
 //! - **Pseudosettle**: Bandwidth accounting settlement
+//! - **Swap**: Cheque-based settlement wire plumbing (behind the `swap` feature)
 //!
 //! # Architecture
 //!
@@ -17,6 +18,24 @@
 //!
 //! Business logic (peer selection, threshold validation, settlement decisions)
 //! lives in the trait implementations (client/core, bandwidth crates).
+//!
+//! # Swap layering
+//!
+//! The swap integration here is the **wire plumbing only**. It composes the
+//! `/swarm/swap` protocol into the handler and upgrade, emits a cheque on
+//! [`ClientCommand::SendCheque`], and surfaces a received cheque as
+//! [`SwapEvent::ChequeReceived`] (and an outbound completion as
+//! [`SwapEvent::ChequeSent`]) with strong types: typed peer, the full
+//! `SignedCheque`, and the peer's exchange rate from the headers exchange.
+//!
+//! The settlement **policy** lives downstream, mirroring how pseudosettle is
+//! layered. When to issue a cheque (debt crossing the payment threshold), when
+//! to expect a cheque, and when to disconnect a peer that exceeds the
+//! disconnect threshold without paying are decided by the swap
+//! `SwarmSettlementProvider` in the `vertex-swarm-bandwidth-swap` crate, driven
+//! by the per-peer balance state, and connected to this wire layer by the node
+//! builder's accounting wiring. This crate carries no thresholds and makes no
+//! settlement decisions.
 //!
 //! # Handler Lifecycle
 //!

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -49,4 +49,6 @@ mod handler;
 pub(crate) mod upgrade;
 
 pub(crate) use behaviour::{ClientBehaviour, Config as BehaviourConfig};
+#[cfg(feature = "swap")]
+pub use events::SwapEvent;
 pub use events::{ClientCommand, ClientEvent, PseudosettleEvent};

--- a/crates/swarm/node/src/protocol/upgrade.rs
+++ b/crates/swarm/node/src/protocol/upgrade.rs
@@ -36,6 +36,11 @@ use vertex_swarm_net_retrieval::{
     Request as RetrievalRequest, RetrievalInboundProtocol, RetrievalOutboundProtocol,
     RetrievalResponder,
 };
+#[cfg(feature = "swap")]
+use vertex_swarm_net_swap::{
+    PROTOCOL_NAME as SWAP_PROTOCOL, SettlementHeaders, SignedCheque, SwapInboundProtocol,
+    SwapOutboundProtocol,
+};
 /// Errors from client protocol upgrades.
 #[derive(Debug, Error)]
 pub(crate) enum ClientUpgradeError {
@@ -55,6 +60,11 @@ pub(crate) enum ClientUpgradeError {
     #[error("pseudosettle error: {0}")]
     Pseudosettle(#[source] ProtocolError),
 
+    /// Swap protocol error.
+    #[cfg(feature = "swap")]
+    #[error("swap error: {0}")]
+    Swap(#[source] ProtocolError),
+
     /// Unknown protocol negotiated.
     #[error("unknown protocol: {0}")]
     UnknownProtocol(String),
@@ -70,6 +80,9 @@ pub(crate) enum ClientInboundOutput {
     Pushsync(PushsyncDelivery, PushsyncResponder),
     /// Received pseudosettle payment (with responder to send ack).
     Pseudosettle(PseudosettleInboundResult),
+    /// Received a swap cheque with the peer's negotiated headers.
+    #[cfg(feature = "swap")]
+    Swap(SignedCheque, SettlementHeaders),
 }
 
 impl std::fmt::Debug for ClientInboundOutput {
@@ -91,6 +104,10 @@ impl std::fmt::Debug for ClientInboundOutput {
                 .field(&result.payment)
                 .field(&"<responder>")
                 .finish(),
+            #[cfg(feature = "swap")]
+            Self::Swap(cheque, headers) => {
+                f.debug_tuple("Swap").field(cheque).field(headers).finish()
+            }
         }
     }
 }
@@ -112,6 +129,9 @@ impl std::fmt::Debug for ClientInboundOutput {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ClientInboundUpgrade {
     advertised: ProtocolSet,
+    /// Our advertised swap exchange rate, sent in the headers exchange.
+    #[cfg(feature = "swap")]
+    swap_rate: U256,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -121,7 +141,7 @@ enum ProtocolSet {
     None,
     /// Bootnode-active: pricing only.
     PricingOnly,
-    /// Client/storer-active: pricing + retrieval + pushsync + pseudosettle.
+    /// Client/storer-active: pricing + retrieval + pushsync + pseudosettle (+ swap).
     Full,
 }
 
@@ -130,6 +150,8 @@ impl ClientInboundUpgrade {
     pub(crate) fn new() -> Self {
         Self {
             advertised: ProtocolSet::None,
+            #[cfg(feature = "swap")]
+            swap_rate: U256::ZERO,
         }
     }
 
@@ -142,7 +164,18 @@ impl ClientInboundUpgrade {
             vertex_swarm_primitives::SwarmNodeType::Client
             | vertex_swarm_primitives::SwarmNodeType::Storer => ProtocolSet::Full,
         };
-        Self { advertised }
+        Self {
+            advertised,
+            #[cfg(feature = "swap")]
+            swap_rate: U256::ZERO,
+        }
+    }
+
+    /// Set the swap exchange rate advertised in the headers exchange.
+    #[cfg(feature = "swap")]
+    pub(crate) fn with_swap_rate(mut self, rate: U256) -> Self {
+        self.swap_rate = rate;
+        self
     }
 }
 
@@ -154,13 +187,17 @@ impl UpgradeInfo for ClientInboundUpgrade {
         match self.advertised {
             ProtocolSet::None => Vec::new().into_iter(),
             ProtocolSet::PricingOnly => vec![PRICING_PROTOCOL].into_iter(),
-            ProtocolSet::Full => vec![
-                PRICING_PROTOCOL,
-                RETRIEVAL_PROTOCOL,
-                PUSHSYNC_PROTOCOL,
-                PSEUDOSETTLE_PROTOCOL,
-            ]
-            .into_iter(),
+            ProtocolSet::Full => {
+                let protocols = vec![
+                    PRICING_PROTOCOL,
+                    RETRIEVAL_PROTOCOL,
+                    PUSHSYNC_PROTOCOL,
+                    PSEUDOSETTLE_PROTOCOL,
+                    #[cfg(feature = "swap")]
+                    SWAP_PROTOCOL,
+                ];
+                protocols.into_iter()
+            }
         }
     }
 }
@@ -171,6 +208,8 @@ impl InboundUpgrade<Stream> for ClientInboundUpgrade {
     type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, socket: Stream, info: Self::Info) -> Self::Future {
+        #[cfg(feature = "swap")]
+        let swap_rate = self.swap_rate;
         Box::pin(async move {
             match info {
                 PRICING_PROTOCOL => {
@@ -205,6 +244,15 @@ impl InboundUpgrade<Stream> for ClientInboundUpgrade {
                         .map_err(ClientUpgradeError::Pseudosettle)?;
                     Ok(ClientInboundOutput::Pseudosettle(result))
                 }
+                #[cfg(feature = "swap")]
+                SWAP_PROTOCOL => {
+                    let protocol: SwapInboundProtocol = vertex_swarm_net_swap::inbound(swap_rate);
+                    let (cheque, headers) = protocol
+                        .upgrade_inbound(socket, info)
+                        .await
+                        .map_err(ClientUpgradeError::Swap)?;
+                    Ok(ClientInboundOutput::Swap(cheque, headers))
+                }
                 other => Err(ClientUpgradeError::UnknownProtocol(other.to_string())),
             }
         })
@@ -222,6 +270,9 @@ pub(crate) enum ClientOutboundRequest {
     Pushsync(PushsyncDelivery),
     /// Send pseudosettle payment.
     Pseudosettle(Payment),
+    /// Send a swap cheque with our advertised exchange rate.
+    #[cfg(feature = "swap")]
+    Swap(SignedCheque, U256),
 }
 
 /// Output from a client outbound upgrade.
@@ -235,6 +286,9 @@ pub(crate) enum ClientOutboundOutput {
     Pushsync(PushsyncReceipt),
     /// Received pseudosettle ack.
     Pseudosettle(PaymentAck),
+    /// Cheque sent; carries the peer's negotiated headers.
+    #[cfg(feature = "swap")]
+    Swap(SettlementHeaders),
 }
 
 /// Combined outbound upgrade for client protocols.
@@ -274,6 +328,14 @@ impl ClientOutboundUpgrade {
         }
     }
 
+    /// Create a new swap outbound upgrade that emits a cheque.
+    #[cfg(feature = "swap")]
+    pub(crate) fn swap(cheque: SignedCheque, our_rate: U256) -> Self {
+        Self {
+            request: ClientOutboundRequest::Swap(cheque, our_rate),
+        }
+    }
+
     /// Get the protocol name for this request.
     fn protocol_name(&self) -> &'static str {
         match &self.request {
@@ -281,6 +343,8 @@ impl ClientOutboundUpgrade {
             ClientOutboundRequest::Retrieval(_) => RETRIEVAL_PROTOCOL,
             ClientOutboundRequest::Pushsync(_) => PUSHSYNC_PROTOCOL,
             ClientOutboundRequest::Pseudosettle(_) => PSEUDOSETTLE_PROTOCOL,
+            #[cfg(feature = "swap")]
+            ClientOutboundRequest::Swap(..) => SWAP_PROTOCOL,
         }
     }
 }
@@ -337,6 +401,16 @@ impl OutboundUpgrade<Stream> for ClientOutboundUpgrade {
                         .map_err(ClientUpgradeError::Pseudosettle)?;
                     Ok(ClientOutboundOutput::Pseudosettle(ack))
                 }
+                #[cfg(feature = "swap")]
+                ClientOutboundRequest::Swap(cheque, our_rate) => {
+                    let protocol: SwapOutboundProtocol =
+                        vertex_swarm_net_swap::outbound(cheque, our_rate);
+                    let headers = protocol
+                        .upgrade_outbound(socket, info)
+                        .await
+                        .map_err(ClientUpgradeError::Swap)?;
+                    Ok(ClientOutboundOutput::Swap(headers))
+                }
             }
         })
     }
@@ -353,6 +427,9 @@ pub(crate) enum ClientOutboundInfo {
     Pushsync { address: ChunkAddress },
     /// Pseudosettle payment with amount.
     Pseudosettle { amount: U256 },
+    /// Swap cheque emission.
+    #[cfg(feature = "swap")]
+    Swap,
 }
 
 #[cfg(test)]
@@ -385,6 +462,8 @@ mod tests {
                 RETRIEVAL_PROTOCOL,
                 PUSHSYNC_PROTOCOL,
                 PSEUDOSETTLE_PROTOCOL,
+                #[cfg(feature = "swap")]
+                SWAP_PROTOCOL,
             ]
         );
     }
@@ -400,7 +479,17 @@ mod tests {
                 RETRIEVAL_PROTOCOL,
                 PUSHSYNC_PROTOCOL,
                 PSEUDOSETTLE_PROTOCOL,
+                #[cfg(feature = "swap")]
+                SWAP_PROTOCOL,
             ]
         );
+    }
+
+    #[cfg(feature = "swap")]
+    #[test]
+    fn full_set_includes_swap_when_enabled() {
+        let upgrade = ClientInboundUpgrade::active_for(SwarmNodeType::Client);
+        let protocols: Vec<_> = upgrade.protocol_info().collect();
+        assert!(protocols.contains(&SWAP_PROTOCOL));
     }
 }


### PR DESCRIPTION
Wire the SWAP cheque-based settlement wire protocol into the client behaviour, behind an optional `swap` cargo feature, mirroring the existing pseudosettle plumbing.

## What this does

Adds a `swap = ["dep:vertex-swarm-net-swap"]` feature to `vertex-swarm-node` that pulls `vertex-swarm-net-swap` as an optional dependency and composes the `/swarm/swap/1.0.0/swap` protocol into the client handler and combined upgrade.

The handler advertises swap in the active full protocol set (clients and storers, not bootnodes), emits a cheque on `ClientCommand::SendCheque`, and surfaces a received cheque as `SwapEvent::ChequeReceived`. Exchange-rate negotiation rides the headers exchange already implemented in the wire crate; the node carries the rate value onto the wire and reports the peer rate back, leaving rate policy to the settlement service.

A dedicated event channel set via `ClientBehaviour::set_swap_events` routes swap events to a settlement service with strong types (`SignedCheque`, typed peer, typed `U256` rate), never raw wire bytes. Events are still emitted as `ClientEvent::SwapChequeReceived` / `SwapChequeSent` for other consumers, matching how pseudosettle surfaces both paths.

The `SwapEvent` shape (`ChequeSent { peer, peer_rate }`, `ChequeReceived { peer, cheque, peer_rate }`) matches the contract the future `vertex-swarm-bandwidth-swap` settlement service consumes.

## Scope

Touches only the node crate. No settlement service, no builder wiring, no accounting; those land in separate units. All swap types and wiring live behind `#[cfg(feature = "swap")]`.

## Verification

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings`, and `cargo test -p vertex-swarm-node` (default and `--features swap`) all pass. The node crate builds in both feature configurations.