### PR TITLE
fix(clippy): drop redundant test lint expectations

### DIFF
--- a/crates/swarm/bandwidth/chequebook/src/chain.rs
+++ b/crates/swarm/bandwidth/chequebook/src/chain.rs
@@ -159,7 +159,6 @@ impl<P: Provider> ChequebookContract<P> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     //! These tests exercise call and transaction *encoding* only.
     //!

--- a/crates/swarm/builder/src/chain.rs
+++ b/crates/swarm/builder/src/chain.rs
@@ -100,7 +100,6 @@ pub async fn build_chain_provider(
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "tests")]
 mod tests {
     use super::*;
     use alloy_signer_local::PrivateKeySigner;


### PR DESCRIPTION
The MSRV 1.92 bump (#189) added a `clippy.toml` with `allow-unwrap-in-tests` and `allow-expect-in-tests`, and the Clippy (tests) CI job already passes `-A clippy::unwrap_used -A clippy::expect_used -A clippy::indexing_slicing`.

With those allows in effect the `#[expect(clippy::expect_used)]` / `#[expect(clippy::unwrap_used)]` attributes on the chain test modules in `vertex-swarm-builder` and `vertex-swarm-bandwidth-chequebook` never fire, so they are reported as unfulfilled lint expectations under `-D warnings`. That is currently failing the Clippy (tests) job on `main`.

Removing the two now-redundant attributes restores a green `main`. The allow-in-tests config continues to permit `unwrap`/`expect` in test code.