### PR TITLE
feat(ffi): add embeddable client FFI surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Per-area `AGENTS.md` files apply when you edit code in that directory.
 | `crates/storage/AGENTS.md` | Storage abstraction and redb backend. |
 | `crates/node/AGENTS.md` | Protocol-agnostic node infrastructure. |
 | `crates/observability/AGENTS.md` | Logging, tracing, metrics infra. |
+| `crates/ffi/AGENTS.md` | Native FFI surface for embedding a client. |
 
 ## Doc map
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "allo-isolate"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449e356a4864c017286dbbec0e12767ea07efba29e3b7d984194c2a7ff3c4550"
+dependencies = [
+ "anyhow",
+ "atomic 0.5.3",
+ "backtrace",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,7 +391,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 6.2.1",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -658,6 +669,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter 0.1.4",
+ "log",
 ]
 
 [[package]]
@@ -1055,6 +1083,12 @@ dependencies = [
 
 [[package]]
 name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
@@ -1415,6 +1449,12 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "build-target"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
 
 [[package]]
 name = "bumpalo"
@@ -1852,6 +1892,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2227,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dart-sys"
+version = "4.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57967e4b200d767d091b961d6ab42cc7d0cc14fe9e052e75d0d3cf9eb732d895"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2295,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid 1.23.2",
+]
+
+[[package]]
+name = "delegate-attr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2559,6 +2642,16 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
@@ -2586,7 +2679,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "env_filter",
+ "env_filter 1.0.1",
  "log",
 ]
 
@@ -2708,7 +2801,7 @@ version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
- "atomic",
+ "atomic 0.6.1",
  "pear",
  "serde",
  "toml 0.8.23",
@@ -2766,6 +2859,48 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flutter_rust_bridge"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0884853aae8a6517b5b58cf36f55da487f2fe110e1686938eb29b6640aae4a5"
+dependencies = [
+ "allo-isolate",
+ "android_logger",
+ "anyhow",
+ "build-target",
+ "bytemuck",
+ "byteorder",
+ "console_error_panic_hook",
+ "dart-sys",
+ "delegate-attr",
+ "flutter_rust_bridge_macros",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "oslog",
+ "portable-atomic",
+ "threadpool",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "flutter_rust_bridge_macros"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5ce32f35f710ced8c5aa557f023f1a624e737b5460cee2b70fcd3a8df09e1b"
+dependencies = [
+ "hex",
+ "md-5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4487,6 +4622,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,6 +5318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
+dependencies = [
+ "cc",
+ "dashmap 5.5.3",
+ "log",
 ]
 
 [[package]]
@@ -8138,6 +8294,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-ffi"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer-local",
+ "flutter_rust_bridge",
+ "nectar-postage",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "vertex-node-api",
+ "vertex-swarm-api",
+ "vertex-swarm-builder",
+ "vertex-swarm-identity",
+ "vertex-swarm-node",
+ "vertex-swarm-primitives",
+ "vertex-swarm-spec",
+ "vertex-tasks",
+]
+
+[[package]]
 name = "vertex-metrics"
 version = "0.1.0"
 dependencies = [
@@ -8928,7 +9105,7 @@ name = "vertex-swarm-peer-manager"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "dashmap",
+ "dashmap 6.2.1",
  "hashlink 0.10.0",
  "libp2p",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,9 @@ members = [
     # Chain (Ethereum RPC access)
     "crates/chain",
 
+    # FFI (native embedding surface)
+    "crates/ffi",
+
     # Data
     # "crates/file",
     # "crates/manifest",
@@ -211,6 +214,9 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 # chain (Ethereum RPC access)
 vertex-chain = { path = "crates/chain" }
 
+# ffi (native embedding surface)
+vertex-ffi = { path = "crates/ffi" }
+
 ## alloy
 alloy-eip2124 = { version = "0.2", default-features = false }
 alloy-primitives = { version = "1.6", default-features = false }
@@ -268,6 +274,9 @@ walkdir = "2.5.0"
 ## tokio
 tokio = { version = "1", default-features = false }
 tokio-stream = "0.1"
+
+## ffi (native embedding bindings)
+flutter_rust_bridge = "2.12"
 
 ## grpc
 tonic = "0.12"

--- a/crates/ffi/AGENTS.md
+++ b/crates/ffi/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS: crates/ffi/
+
+The native FFI surface. This crate (`vertex-ffi`) is the primary public API for embedding Vertex into a native host: Dart and Flutter, Swift, Kotlin and JNI, C++, and other native runtimes. It exposes an embeddable Swarm client that joins a network and uploads and downloads chunks.
+
+Root-level rules in `/AGENTS.md` apply here too, plus `docs/agents/api-surface.md` (FFI is the primary surface) and `docs/agents/wasm.md` (native-only gating). The notes below are the area-specific overlay.
+
+## Shape
+
+- `src/api/`: the public surface. Every reachable item is a binding-generation candidate. `client.rs` holds `VertexClient` (the opaque handle) and its build, upload, and download methods; `types.rs` holds the flat input and output shapes.
+- `src/error.rs`: `FfiError`, a flat `thiserror` enum with `strum::IntoStaticStr`. It carries pre-formatted strings so a host never needs a vertex-internal error type.
+- `src/frb_generated.rs`: the flutter_rust_bridge generated glue. Committed as an empty placeholder so a plain `cargo build -p vertex-ffi` succeeds without the codegen binary. The codegen overwrites it.
+- `flutter_rust_bridge.yaml`: codegen config. `src/api` is the input; the generated Rust and the per-language bindings (Dart, C header) are the output.
+- `build.rs`: registers the `frb_expand` cfg the `#[frb]` macro emits, keeping the workspace `unexpected_cfgs` lint clean.
+
+## Dos
+
+- Keep the API thin. The crate is a boundary, not a place for logic. Build the client through the highest-level builder entry point (`vertex_swarm_builder::DefaultClientBuilder`); drive chunks through `SwarmChunkSender` and `SwarmChunkProvider`.
+- Reconstruct strong types (`StampedChunk`, `ChunkAddress`, `Stamp`) immediately on entry. Raw bytes and strings live only in the `api::types` shapes; never let them flow into internal logic.
+- Generate the C ABI from the Rust `api` module via flutter_rust_bridge. There is no hand-maintained parallel C header.
+- Annotate exported items with `#[frb(...)]` so codegen sees the right shape. `#[frb(opaque)]` for handles, `#[frb(non_opaque)]` for plain data.
+- Gate runtime-bearing dependencies (the native tokio runtime) to non-wasm targets. The browser path is wasm-bindgen, a separate surface.
+
+## Donts
+
+- No `serde_json`, `serde_yaml`, or any text-format serde backend. No `reqwest`, `axum`, `hyper`, or HTTP handler framework. This is the FFI cone; HTTP+JSON is forbidden here.
+- Do not hand-edit `src/frb_generated.rs` beyond the placeholder. Edit `src/api` and regenerate.
+- Do not move domain logic here. Chunk, stamp, and address primitives live in `nectar`; node assembly lives in `vertex-swarm-builder`.
+- Do not block the calling thread on a runtime the host owns. The client owns its own native runtime and blocks on it internally.
+
+## Regenerating bindings
+
+Run the flutter_rust_bridge codegen against `flutter_rust_bridge.yaml` (the binary is `flutter_rust_bridge_codegen`; on this host reach it with `nix-shell -p flutter_rust_bridge_codegen --run "..."`). The crate compiles without this step, so CI does not run it.
+
+## Tests
+
+- `cargo test -p vertex-ffi`. The unit tests cover the boundary reconstruction and identity-building helpers without standing up a network.

--- a/crates/ffi/CLAUDE.md
+++ b/crates/ffi/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "vertex-ffi"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Native FFI surface for embedding a Vertex Swarm client"
+
+[lints]
+workspace = true
+
+# The C ABI lives in the cdylib; the rlib lets the workspace and tests link the
+# same API as a normal Rust dependency.
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+# Enable on-chain SWAP settlement for the embedded client. Forwards to the
+# builder's chain feature; native-only and off by default so the FFI client
+# stays chain-free unless the host opts in.
+chain = ["vertex-swarm-builder/chain"]
+
+[dependencies]
+# vertex - node infrastructure and the client builder
+vertex-swarm-builder.workspace = true
+vertex-swarm-api.workspace = true
+vertex-swarm-identity.workspace = true
+vertex-swarm-primitives.workspace = true
+vertex-swarm-spec.workspace = true
+vertex-swarm-node.workspace = true
+vertex-node-api.workspace = true
+vertex-tasks.workspace = true
+
+# nectar primitives (chunk and stamp types reconstructed at the boundary)
+nectar-postage.workspace = true
+
+# signing for client identity construction
+alloy-primitives.workspace = true
+alloy-signer-local.workspace = true
+
+# bridge codegen runtime
+flutter_rust_bridge.workspace = true
+
+thiserror.workspace = true
+strum.workspace = true
+
+# Native runtime owned by the client handle. The FFI cdylib is native-only, so
+# the multi-thread tokio runtime is unconditional here.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/ffi/build.rs
+++ b/crates/ffi/build.rs
@@ -1,0 +1,10 @@
+//! Build script for the Vertex client FFI crate.
+//!
+//! Registers the `frb_expand` cfg that the flutter_rust_bridge `#[frb]` macro
+//! emits, so the workspace `unexpected_cfgs` lint stays clean without disabling
+//! it crate-wide. The codegen sets this cfg when it expands the API for binding
+//! generation; a normal build never sets it.
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(frb_expand)");
+}

--- a/crates/ffi/flutter_rust_bridge.yaml
+++ b/crates/ffi/flutter_rust_bridge.yaml
@@ -1,0 +1,16 @@
+# flutter_rust_bridge codegen configuration for the Vertex client FFI surface.
+#
+# The Rust API under `src/api/` is the single source of truth. Running
+# `flutter_rust_bridge_codegen generate` from this directory regenerates
+# `src/frb_generated.rs` (the C ABI dispatch and wire codecs) and the per-language
+# host bindings. The crate compiles without this step; regenerate only when a
+# host needs to call the latest bindings.
+rust_input: crate::api
+rust_root: .
+rust_output: src/frb_generated.rs
+# Host binding output. The Dart path is the canonical target; Swift and Kotlin
+# bindings follow the same generated surface for their respective hosts.
+dart_output: bindings/dart/vertex_ffi.dart
+# Emit the C header alongside the generated Rust so native (non-Dart) hosts have
+# a generated, never hand-maintained, ABI declaration.
+c_output: bindings/c/vertex_ffi.h

--- a/crates/ffi/src/api/client.rs
+++ b/crates/ffi/src/api/client.rs
@@ -1,0 +1,379 @@
+//! The embedded client handle and its upload/download surface.
+//!
+//! [`VertexClient`] owns a native tokio runtime, the running client node task,
+//! and the chunk provider that drives uploads and downloads. The host builds one
+//! with [`VertexClient::build`], then calls [`VertexClient::upload_chunk`] and
+//! [`VertexClient::download_chunk`]. Dropping the handle fires graceful shutdown
+//! and tears the node down.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_primitives::B256;
+use alloy_signer_local::PrivateKeySigner;
+use flutter_rust_bridge::frb;
+use nectar_postage::Stamp;
+use tokio::runtime::Runtime;
+use vertex_node_api::InfrastructureContext;
+use vertex_swarm_api::{
+    ChunkAddress, Multiaddr, PushReceipt, StampedChunk, SwarmChunkProvider, SwarmChunkSender,
+};
+use vertex_swarm_builder::{
+    ChunkVerifyConfig, ClientConfig, ClientRpcProviders, DefaultClientBuilder,
+    NetworkChunkProvider, VerifyingChunkProvider,
+};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_primitives::{Nonce, SwarmNodeType};
+use vertex_swarm_spec::{Spec, init_dev, init_mainnet, init_testnet};
+use vertex_tasks::{TaskExecutor, TaskManager};
+
+use crate::api::types::{
+    VertexChunkDownload, VertexChunkUpload, VertexClientConfig, VertexNetwork, VertexPushReceipt,
+};
+use crate::error::{FfiError, FfiResult};
+
+/// How long [`VertexClient`] waits for in-flight tasks during shutdown.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Network chunk provider wrapped with config-gated download verification, the
+/// concrete provider the client builder produces for a client node.
+type ClientChunks = VerifyingChunkProvider<NetworkChunkProvider<Arc<Identity>>>;
+
+/// A running embedded Swarm client.
+///
+/// Opaque to the host: it is constructed and used only through the methods in
+/// this module. It owns the runtime that drives the node so the host does not
+/// have to manage one.
+#[frb(opaque)]
+pub struct VertexClient {
+    chunks: ClientChunks,
+    runtime: Runtime,
+    // Held so the global executor and the node task stay alive for the lifetime
+    // of the client. Taken on drop to fire graceful shutdown.
+    task_manager: Option<TaskManager>,
+}
+
+impl VertexClient {
+    /// Build and start an embedded client for `config`.
+    ///
+    /// Spins up a native multi-thread runtime, constructs the client node on it,
+    /// and spawns the node's event loop as a background task. Returns once the
+    /// node is built and running; the client begins discovering peers
+    /// immediately.
+    ///
+    /// One client per process. The node internals resolve their task executor
+    /// from a process-global slot that the first built client populates, so a
+    /// second concurrent client would spawn its node tasks onto the first
+    /// client's runtime. Build a single client, hold it for the process
+    /// lifetime, and drop it to shut the node down.
+    pub fn build(config: VertexClientConfig) -> FfiResult<VertexClient> {
+        let runtime = Runtime::new().map_err(|e| FfiError::Build {
+            reason: format!("runtime: {e}"),
+        })?;
+
+        // The task manager registers the global executor against the runtime
+        // handle and owns the shutdown signal the node task observes.
+        let task_manager = TaskManager::new(runtime.handle().clone());
+        let executor = task_manager.executor();
+
+        let spec = network_spec(config.network);
+        let identity = build_identity(&spec, config.private_key.as_deref())?;
+        let network = build_network(config.bootnodes);
+
+        let node_config = ClientConfig::new(
+            spec,
+            identity,
+            network,
+            Default::default(),
+            ChunkVerifyConfig::default(),
+            ChainConfig::default(),
+        );
+
+        let launch = LaunchContext::new(executor.clone());
+
+        let (task_fn, providers) = runtime
+            .block_on(DefaultClientBuilder::from_config(node_config).build(&launch))
+            .map_err(|e| FfiError::Build {
+                reason: e.to_string(),
+            })?
+            .into_parts();
+
+        let chunks = chunks_from(providers);
+        executor.spawn_critical_with_graceful_shutdown_signal("vertex.ffi.node", task_fn);
+
+        Ok(VertexClient {
+            chunks,
+            runtime,
+            task_manager: Some(task_manager),
+        })
+    }
+
+    /// Upload a pre-stamped chunk to the storers closest to its address.
+    ///
+    /// The chunk, its address, and its postage stamp are reconstructed into a
+    /// strong [`StampedChunk`] before any network call. Returns the first
+    /// storer's receipt.
+    pub fn upload_chunk(&self, chunk: VertexChunkUpload) -> FfiResult<VertexPushReceipt> {
+        let stamped = reconstruct_upload(&chunk)?;
+        let validate = chunk.validate;
+
+        let receipt = self.runtime.block_on(async {
+            if validate {
+                self.chunks.send_chunk(stamped).await
+            } else {
+                self.chunks.send_chunk_unchecked(stamped).await
+            }
+        });
+
+        receipt.map(receipt_into_ffi).map_err(|e| FfiError::Upload {
+            reason: e.to_string(),
+        })
+    }
+
+    /// Download the chunk at `address` from the network.
+    ///
+    /// `address` is the chunk's 32-byte address. `verify_stamp` opts into postage
+    /// stamp signer recovery; chunk content integrity is always enforced by the
+    /// retrieval path.
+    pub fn download_chunk(
+        &self,
+        address: Vec<u8>,
+        verify_stamp: bool,
+    ) -> FfiResult<VertexChunkDownload> {
+        let address = parse_address(&address)?;
+
+        let result = self
+            .runtime
+            .block_on(self.chunks.retrieve_chunk(&address))
+            .map_err(|e| FfiError::Download {
+                reason: e.to_string(),
+            })?;
+
+        let served_by = result.served_by.to_string();
+        let (chunk, stamp) = result.chunk.into_parts();
+
+        if verify_stamp {
+            stamp
+                .recover_signer(&address)
+                .map_err(|e| FfiError::Download {
+                    reason: format!("stamp signature: {e}"),
+                })?;
+        }
+
+        Ok(VertexChunkDownload {
+            data: chunk.into_bytes().to_vec(),
+            stamp: stamp.to_bytes().to_vec(),
+            served_by,
+        })
+    }
+}
+
+impl Drop for VertexClient {
+    fn drop(&mut self) {
+        if let Some(manager) = self.task_manager.take() {
+            manager.graceful_shutdown_with_timeout(SHUTDOWN_TIMEOUT);
+        }
+    }
+}
+
+/// Minimal infrastructure context for building the client outside the CLI.
+///
+/// The launch path needs an executor and a data directory. The FFI client runs
+/// without persistent on-disk state, so the data directory is a temporary path
+/// derived from the system temp dir; the peer store falls back to ephemeral when
+/// the database cannot be opened there.
+struct LaunchContext {
+    executor: TaskExecutor,
+    data_dir: std::path::PathBuf,
+}
+
+impl LaunchContext {
+    fn new(executor: TaskExecutor) -> Self {
+        Self {
+            executor,
+            data_dir: std::env::temp_dir().join("vertex-ffi-client"),
+        }
+    }
+}
+
+impl InfrastructureContext for LaunchContext {
+    fn executor(&self) -> &TaskExecutor {
+        &self.executor
+    }
+
+    fn data_dir(&self) -> &std::path::Path {
+        &self.data_dir
+    }
+}
+
+/// Resolve the spec for the requested network.
+fn network_spec(network: VertexNetwork) -> Arc<Spec> {
+    match network {
+        VertexNetwork::Mainnet => init_mainnet(),
+        VertexNetwork::Testnet => init_testnet(),
+        VertexNetwork::Dev => init_dev(),
+    }
+}
+
+/// Build a client identity from an optional private key.
+///
+/// A present key must be exactly 32 bytes. An absent key yields a random
+/// ephemeral identity.
+fn build_identity(spec: &Arc<Spec>, private_key: Option<&[u8]>) -> FfiResult<Arc<Identity>> {
+    let Some(key) = private_key else {
+        return Ok(Arc::new(Identity::random(
+            spec.clone(),
+            SwarmNodeType::Client,
+        )));
+    };
+
+    if key.len() != 32 {
+        return Err(FfiError::InvalidPrivateKey { len: key.len() });
+    }
+
+    let signer =
+        PrivateKeySigner::from_bytes(&B256::from_slice(key)).map_err(|e| FfiError::Build {
+            reason: format!("private key: {e}"),
+        })?;
+
+    Ok(Arc::new(Identity::new(
+        signer,
+        Nonce::random(),
+        spec.clone(),
+        SwarmNodeType::Client,
+    )))
+}
+
+/// Build the network config, overriding bootnodes when the host supplies them.
+fn build_network(bootnodes: Vec<String>) -> NetworkConfig {
+    let mut network = NetworkConfig::default();
+    if !bootnodes.is_empty() {
+        let parsed: Vec<Multiaddr> = bootnodes
+            .iter()
+            .filter_map(|addr| addr.parse().ok())
+            .collect();
+        if !parsed.is_empty() {
+            network.set_bootnodes(parsed);
+        }
+    }
+    network
+}
+
+/// Reconstruct a strong [`StampedChunk`] from the raw upload payload.
+fn reconstruct_upload(chunk: &VertexChunkUpload) -> FfiResult<StampedChunk> {
+    let address = parse_address(&chunk.address)?;
+    let stamp = parse_stamp(&chunk.stamp)?;
+    StampedChunk::reconstruct(address, chunk.data.clone().into(), stamp).map_err(|e| {
+        FfiError::ChunkMismatch {
+            reason: e.to_string(),
+        }
+    })
+}
+
+/// Parse a 32-byte chunk address.
+fn parse_address(bytes: &[u8]) -> FfiResult<ChunkAddress> {
+    ChunkAddress::from_slice(bytes).map_err(|_| FfiError::InvalidAddress { len: bytes.len() })
+}
+
+/// Parse a wire-encoded postage stamp.
+fn parse_stamp(bytes: &[u8]) -> FfiResult<Stamp> {
+    Stamp::try_from_slice(bytes).map_err(|e| FfiError::InvalidStamp {
+        reason: e.to_string(),
+    })
+}
+
+/// Map a [`PushReceipt`] to the flat boundary shape.
+fn receipt_into_ffi(receipt: PushReceipt) -> VertexPushReceipt {
+    let PushReceipt {
+        storer,
+        signature,
+        nonce,
+        storage_radius,
+    } = receipt;
+    VertexPushReceipt {
+        storer: storer.to_string(),
+        signature: signature.as_bytes().to_vec(),
+        nonce: nonce.as_slice().to_vec(),
+        storage_radius: u32::from(storage_radius.get()),
+    }
+}
+
+/// Extract the chunk provider from the built client's providers.
+fn chunks_from(providers: ClientRpcProviders<Arc<Identity>, ClientChunks>) -> ClientChunks {
+    providers.chunks().clone()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use vertex_swarm_api::{AnyChunk, Chunk, ContentChunk};
+
+    use super::*;
+
+    /// Build a content chunk from raw data and return its wire encoding alongside
+    /// its address, matching the upload payload the boundary expects.
+    fn content_wire(data: &[u8]) -> (Vec<u8>, Vec<u8>) {
+        let chunk: ContentChunk = ContentChunk::new(data.to_vec()).unwrap();
+        let address = chunk.address().as_bytes().to_vec();
+        let wire = AnyChunk::Content(chunk).into_bytes().to_vec();
+        (wire, address)
+    }
+
+    fn upload(data: Vec<u8>, address: Vec<u8>, stamp: Vec<u8>) -> VertexChunkUpload {
+        VertexChunkUpload {
+            address,
+            data,
+            stamp,
+            validate: false,
+        }
+    }
+
+    #[test]
+    fn reconstruct_accepts_matching_address() {
+        let (wire, address) = content_wire(b"reconstruct me");
+        let stamped = reconstruct_upload(&upload(wire, address.clone(), vec![0u8; 113])).unwrap();
+        assert_eq!(stamped.address().as_bytes(), address.as_slice());
+        assert!(stamped.chunk().is_content());
+    }
+
+    #[test]
+    fn reconstruct_rejects_short_address() {
+        let (wire, _) = content_wire(b"payload");
+        let err = reconstruct_upload(&upload(wire, vec![0u8; 4], vec![0u8; 113])).unwrap_err();
+        assert!(matches!(err, FfiError::InvalidAddress { len: 4 }));
+    }
+
+    #[test]
+    fn reconstruct_rejects_short_stamp() {
+        let (wire, address) = content_wire(b"payload");
+        let err = reconstruct_upload(&upload(wire, address, vec![0u8; 10])).unwrap_err();
+        assert!(matches!(err, FfiError::InvalidStamp { .. }));
+    }
+
+    #[test]
+    fn reconstruct_rejects_address_mismatch() {
+        let (wire, _) = content_wire(b"payload");
+        let wrong = vec![0xabu8; 32];
+        let err = reconstruct_upload(&upload(wire, wrong, vec![0u8; 113])).unwrap_err();
+        assert!(matches!(err, FfiError::ChunkMismatch { .. }));
+    }
+
+    #[test]
+    fn build_identity_rejects_wrong_key_length() {
+        let spec = init_dev();
+        let result = build_identity(&spec, Some(&[0u8; 16]));
+        assert!(matches!(
+            result,
+            Err(FfiError::InvalidPrivateKey { len: 16 })
+        ));
+    }
+
+    #[test]
+    fn build_identity_without_key_is_ephemeral() {
+        use vertex_swarm_api::SwarmIdentity;
+        let spec = init_dev();
+        let identity = build_identity(&spec, None).expect("ephemeral identity builds");
+        assert_eq!(identity.node_type(), SwarmNodeType::Client);
+    }
+}

--- a/crates/ffi/src/api/mod.rs
+++ b/crates/ffi/src/api/mod.rs
@@ -1,0 +1,9 @@
+//! The public FFI surface.
+//!
+//! Every item reachable from here is a candidate for binding generation by
+//! flutter_rust_bridge. The module is the single source of truth for the C ABI:
+//! the generated bindings (Dart, Swift, Kotlin, and the C header) are produced
+//! from these signatures, never hand-maintained alongside them.
+
+pub mod client;
+pub mod types;

--- a/crates/ffi/src/api/types.rs
+++ b/crates/ffi/src/api/types.rs
@@ -1,0 +1,85 @@
+//! Plain data shapes that cross the FFI boundary.
+//!
+//! These are the language-neutral inputs and outputs the bindings expose to a
+//! host (Dart, Swift, Kotlin, C++). They carry raw bytes and primitives only;
+//! the strong domain types (`StampedChunk`, `ChunkAddress`, `PushReceipt`) are
+//! reconstructed immediately inside Rust and never leak across the boundary.
+
+use flutter_rust_bridge::frb;
+
+/// Which network the embedded client joins.
+#[frb(non_opaque)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VertexNetwork {
+    /// The Swarm mainnet.
+    #[default]
+    Mainnet,
+    /// The Swarm testnet.
+    Testnet,
+    /// An isolated development network.
+    Dev,
+}
+
+/// Configuration for building an embedded client.
+///
+/// The host supplies an optional signing key and the target network. An absent
+/// key yields a random ephemeral identity, which is appropriate for a short
+/// lived client that only uploads and downloads.
+#[frb(non_opaque)]
+#[derive(Debug, Clone, Default)]
+pub struct VertexClientConfig {
+    /// The network to join.
+    pub network: VertexNetwork,
+    /// Optional 32-byte secp256k1 private key. When `None`, the client runs with
+    /// a random ephemeral identity.
+    pub private_key: Option<Vec<u8>>,
+    /// Optional multiaddrs of bootnodes to dial on startup. When empty, the
+    /// network spec's defaults are used.
+    pub bootnodes: Vec<String>,
+}
+
+/// A pre-stamped chunk to upload.
+///
+/// `address` and `stamp` are the chunk's 32-byte address and its 113-byte wire
+/// stamp. `data` is the chunk's wire encoding (span plus payload). The chunk type
+/// is inferred from `data` and `address` during reconstruction, so the host does
+/// not pass it separately: an address that does not match the bytes is rejected.
+#[frb(non_opaque)]
+#[derive(Debug, Clone)]
+pub struct VertexChunkUpload {
+    /// The chunk's 32-byte address.
+    pub address: Vec<u8>,
+    /// The chunk's wire-encoded bytes (span plus payload).
+    pub data: Vec<u8>,
+    /// The chunk's 113-byte postage stamp.
+    pub stamp: Vec<u8>,
+    /// When true, the stamp signature is recovered before the chunk is pushed.
+    /// When false, the chunk is pushed without stamp validation.
+    pub validate: bool,
+}
+
+/// Proof that a storer accepted an uploaded chunk.
+#[frb(non_opaque)]
+#[derive(Debug, Clone)]
+pub struct VertexPushReceipt {
+    /// Overlay address of the accepting storer, hex-encoded.
+    pub storer: String,
+    /// The storer's signature over the receipt (65 bytes).
+    pub signature: Vec<u8>,
+    /// The nonce the storer used when signing (32 bytes).
+    pub nonce: Vec<u8>,
+    /// The storer's storage radius at the time of acceptance.
+    pub storage_radius: u32,
+}
+
+/// A downloaded chunk and its postage stamp.
+#[frb(non_opaque)]
+#[derive(Debug, Clone)]
+pub struct VertexChunkDownload {
+    /// The chunk's wire-encoded bytes (span plus payload).
+    pub data: Vec<u8>,
+    /// The chunk's 113-byte postage stamp.
+    pub stamp: Vec<u8>,
+    /// Overlay address of the peer that served the chunk, hex-encoded.
+    pub served_by: String,
+}

--- a/crates/ffi/src/error.rs
+++ b/crates/ffi/src/error.rs
@@ -1,0 +1,66 @@
+//! Error type for the FFI surface.
+
+use flutter_rust_bridge::frb;
+
+/// Failure modes an embedding host can observe across the FFI boundary.
+///
+/// Each variant maps a stage of the embedded client lifecycle (build, upload,
+/// download) to a flat, language-neutral error. The wrapped strings are already
+/// formatted so the host does not need to understand any vertex-internal error
+/// type.
+#[frb(non_opaque)]
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum FfiError {
+    /// The supplied private key was not a 32-byte value.
+    #[error("invalid private key: expected 32 bytes, got {len}")]
+    InvalidPrivateKey {
+        /// Length of the rejected key in bytes.
+        len: usize,
+    },
+
+    /// The supplied chunk address was not a 32-byte value.
+    #[error("invalid chunk address: expected 32 bytes, got {len}")]
+    InvalidAddress {
+        /// Length of the rejected address in bytes.
+        len: usize,
+    },
+
+    /// The postage stamp bytes did not decode to a valid stamp.
+    #[error("invalid postage stamp: {reason}")]
+    InvalidStamp {
+        /// Why the stamp failed to decode.
+        reason: String,
+    },
+
+    /// The chunk bytes did not reconstruct to the supplied address.
+    #[error("chunk does not match the supplied address: {reason}")]
+    ChunkMismatch {
+        /// Why reconstruction failed.
+        reason: String,
+    },
+
+    /// Building the embedded client node failed.
+    #[error("failed to build client: {reason}")]
+    Build {
+        /// Why the build failed.
+        reason: String,
+    },
+
+    /// A network upload failed.
+    #[error("upload failed: {reason}")]
+    Upload {
+        /// Why the upload failed.
+        reason: String,
+    },
+
+    /// A network download failed.
+    #[error("download failed: {reason}")]
+    Download {
+        /// Why the download failed.
+        reason: String,
+    },
+}
+
+/// Convenience alias for results crossing the FFI boundary.
+pub type FfiResult<T> = Result<T, FfiError>;

--- a/crates/ffi/src/frb_generated.rs
+++ b/crates/ffi/src/frb_generated.rs
@@ -1,0 +1,11 @@
+//! Generated flutter_rust_bridge glue.
+//!
+//! This file is normally produced by the flutter_rust_bridge codegen from the
+//! signatures under [`crate::api`]. It is committed as an empty placeholder so a
+//! plain `cargo build -p vertex-ffi` succeeds without running the external
+//! codegen binary. Running the codegen (see `flutter_rust_bridge.yaml`)
+//! overwrites this file with the real C ABI dispatch table and the wire codecs
+//! the host bindings call into.
+//!
+//! Do not hand-edit the regenerated contents; edit the API under [`crate::api`]
+//! and regenerate.

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,0 +1,39 @@
+//! Native FFI surface for embedding a Vertex Swarm client.
+//!
+//! This crate is the primary public surface for embedding Vertex into a native
+//! host: Dart and Flutter, Swift, Kotlin and JNI, C++, and other native
+//! runtimes. It exposes a single embeddable client that can join a Swarm
+//! network and upload and download chunks, with no HTTP or JSON anywhere on the
+//! path.
+//!
+//! # Surface
+//!
+//! The public API lives entirely under [`api`]. [`api::client::VertexClient`] is
+//! the embeddable handle; the host builds one from an [`api::types`] config,
+//! then drives uploads and downloads through it. Inputs and outputs cross the
+//! boundary as flat byte vectors, strings, and primitives; the strong domain
+//! types are reconstructed immediately inside Rust and never leak outward.
+//!
+//! # Bindings
+//!
+//! The C ABI and the per-language bindings (Dart, Swift, Kotlin) are generated
+//! from the [`api`] module by flutter_rust_bridge; the [`frb_generated`] module
+//! holds the generated glue. The signatures in [`api`] are the single source of
+//! truth: there is no hand-maintained parallel C header. Regenerate with the
+//! flutter_rust_bridge codegen against `flutter_rust_bridge.yaml`. The crate
+//! compiles without running the codegen step, so a checkout builds and tests on
+//! its own; only a host that actually invokes the bindings needs the regenerated
+//! glue.
+//!
+//! # Native only
+//!
+//! The cdylib is a native artifact. The browser embedding path is wasm-bindgen,
+//! a separate surface, so this crate's runtime-bearing pieces are gated to
+//! non-wasm targets and the wasm cone never pulls them in.
+
+pub mod api;
+pub mod error;
+
+mod frb_generated;
+
+pub use error::{FfiError, FfiResult};


### PR DESCRIPTION
Add the `vertex-ffi` crate, the primary public API for embedding a Vertex Swarm client into a native host (Dart and Flutter, Swift, Kotlin and JNI, C++).

`VertexClient` owns a native multi-thread runtime and a running client node built through the highest-level builder entry point (`DefaultClientBuilder::from_config(...).build(ctx)`). The host builds one from a flat config, then uploads pre-stamped chunks and downloads chunks by address. Uploads reconstruct a `StampedChunk` from address plus wire bytes plus stamp (the address disambiguates the chunk variant), and downloads return the chunk's wire bytes, its stamp, and the serving peer.

Inputs and outputs cross the boundary as byte vectors, strings, and primitives only. The strong domain types (`StampedChunk`, `ChunkAddress`, `Stamp`, `PushReceipt`) are reconstructed immediately inside Rust and never leak across the boundary, mirroring the gRPC chunk service.

The C ABI and the per-language bindings are generated from the `api` module by flutter_rust_bridge via `flutter_rust_bridge.yaml`. There is no hand-maintained parallel C header. A placeholder `frb_generated` module keeps `cargo build -p vertex-ffi` self-contained, so a checkout builds and tests on its own and CI never runs the codegen binary; only a host that actually invokes the bindings regenerates the glue. A small `build.rs` registers the `frb_expand` cfg the `#[frb]` macro emits so the workspace `unexpected_cfgs` lint stays clean.

The crate is native-only: the runtime-bearing dependency is gated to non-wasm targets, since the browser embedding path is wasm-bindgen, a separate surface. No `serde_json`, `reqwest`, `axum`, or `hyper` anywhere in the cone.

The errors are a flat `thiserror` enum with `strum::IntoStaticStr` carrying pre-formatted strings, so a host never needs a vertex-internal error type.

One supporting change in the builder: a `chunks()` accessor on `ClientRpcProviders` so the embedding host can drive the client's chunk provider directly without standing up the gRPC server.

Documented limitation: one client per process. The node internals resolve their task executor from a process-global slot the first built client populates, so a second concurrent client would spawn its node tasks onto the first client's runtime. This matches the single-node assumption of the CLI; lifting it is a node-infrastructure change outside this crate.

Verification: `cargo fmt --all --check`, `cargo clippy -p vertex-ffi --all-targets -- -D warnings` (also with `--features chain`), `cargo build` workspace-wide, and `cargo test -p vertex-ffi` all pass.