### PR TITLE
feat(swarm-swap): add chequebook settlement service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8692,6 +8692,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-swarm-bandwidth-swap"
+version = "0.1.0"
+dependencies = [
+ "alloy-chains",
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "async-trait",
+ "nectar-contracts",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vertex-chain",
+ "vertex-swarm-api",
+ "vertex-swarm-bandwidth",
+ "vertex-swarm-bandwidth-chequebook",
+ "vertex-swarm-node",
+ "vertex-swarm-primitives",
+ "vertex-swarm-test-utils",
+ "vertex-tasks",
+]
+
+[[package]]
 name = "vertex-swarm-builder"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ members = [
     "crates/swarm/bandwidth/chequebook",
     "crates/swarm/bandwidth/pricing",
     "crates/swarm/bandwidth/pseudosettle",
-    # "crates/swarm/bandwidth/swap",  # disabled: depends on serde_json
+    "crates/swarm/bandwidth/swap",
 
     # Storage
     "crates/storage",
@@ -196,7 +196,7 @@ vertex-swarm-bandwidth = { path = "crates/swarm/bandwidth/core" }
 vertex-swarm-bandwidth-chequebook = { path = "crates/swarm/bandwidth/chequebook" }
 vertex-swarm-bandwidth-pricing = { path = "crates/swarm/bandwidth/pricing" }
 vertex-swarm-bandwidth-pseudosettle = { path = "crates/swarm/bandwidth/pseudosettle" }
-# vertex-swarm-bandwidth-swap = { path = "crates/swarm/bandwidth/swap" }  # disabled
+vertex-swarm-bandwidth-swap = { path = "crates/swarm/bandwidth/swap" }
 
 # localstore (local chunk storage configuration)
 vertex-swarm-localstore = { path = "crates/swarm/localstore" }

--- a/crates/swarm/bandwidth/swap/Cargo.toml
+++ b/crates/swarm/bandwidth/swap/Cargo.toml
@@ -8,25 +8,45 @@ homepage.workspace = true
 repository.workspace = true
 description = "Chequebook-based settlement provider for Swarm bandwidth accounting"
 
+[lints]
+workspace = true
+
 [dependencies]
 vertex-swarm-bandwidth-chequebook = { workspace = true }
 vertex-swarm-bandwidth = { workspace = true }
-vertex-swarm-node = { workspace = true }
+vertex-swarm-node = { workspace = true, features = ["swap"] }
 vertex-swarm-primitives = { workspace = true }
 vertex-swarm-api = { workspace = true }
 vertex-tasks = { workspace = true }
+alloy-chains = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-signer = { workspace = true }
 async-trait = { workspace = true }
-parking_lot = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 
+# Chain feature: optional on-chain cashout over a shared alloy provider.
+vertex-chain = { workspace = true, optional = true }
+alloy-provider = { workspace = true, optional = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
 vertex-swarm-test-utils = { workspace = true }
+alloy-signer-local = { workspace = true }
+# Used only by the `swap-chequebook`-gated cashout calldata test.
+nectar-contracts = { workspace = true }
+alloy-contract = { workspace = true }
+alloy-sol-types = { workspace = true }
 
 [features]
 default = ["std"]
 std = []
+# Enables the optional on-chain chequebook client for cashing received cheques.
+# Off by default so the cheque-exchange path stays chain-free and wasm-friendly.
+swap-chequebook = [
+    "dep:vertex-chain",
+    "dep:alloy-provider",
+    "vertex-swarm-bandwidth-chequebook/swap-chequebook",
+]

--- a/crates/swarm/bandwidth/swap/src/cashout.rs
+++ b/crates/swarm/bandwidth/swap/src/cashout.rs
@@ -1,0 +1,96 @@
+//! On-chain cashout for received cheques.
+//!
+//! Cheque exchange (sign, send, validate, credit) is fully chain-free. Cashing a
+//! received cheque is the only step that touches the chain, so it lives behind
+//! the `swap-chequebook` feature in this module. The service holds an optional
+//! [`Cashout`]; without it, a received cheque is still validated and credited,
+//! only never redeemed on-chain.
+
+use alloy_primitives::Address;
+use alloy_provider::DynProvider;
+use vertex_chain::{ChainConfig, TxError};
+use vertex_swarm_bandwidth_chequebook::{ChequebookContract, SignedCheque};
+
+/// On-chain redeemer for received cheques.
+///
+/// Wraps a [`ChequebookContract`] over the shared chain provider and the address
+/// that cashed funds are paid out to (our payout recipient).
+#[derive(Debug, Clone)]
+pub struct Cashout {
+    contract: ChequebookContract<DynProvider>,
+    recipient: Address,
+}
+
+impl Cashout {
+    /// Build a cashout client over the shared provider.
+    pub fn new(provider: DynProvider, config: ChainConfig, recipient: Address) -> Self {
+        Self {
+            contract: ChequebookContract::new(provider, config),
+            recipient,
+        }
+    }
+
+    /// Cash a received cheque as its beneficiary, paying out to our recipient.
+    ///
+    /// Returns once the transaction has been submitted; confirmation is left to
+    /// the caller, which holds the returned pending-transaction handle's chain.
+    pub async fn cash(&self, cheque: &SignedCheque) -> Result<(), TxError> {
+        let _pending = self
+            .contract
+            .cash_cheque_beneficiary(cheque, self.recipient)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    //! Exercises cashout call encoding only; there is no live chain in CI.
+
+    use alloy_contract::CallBuilder;
+    use alloy_primitives::{Bytes, U256, address};
+    use alloy_provider::{ProviderBuilder, mock::Asserter};
+    use alloy_sol_types::SolCall;
+    use nectar_contracts::IChequebook;
+    use vertex_swarm_bandwidth_chequebook::{
+        Bytes as ChequeBytes, Cheque, ChequeExt, SignedCheque,
+    };
+
+    /// The cashout call carries the cheque's cumulative payout, the issuer
+    /// signature, and our recipient, targeting the cheque's own chequebook. Build
+    /// the call the way [`Cashout::cash`] does and assert the calldata directly so
+    /// the encoding is pinned without a live chain.
+    #[test]
+    fn cash_cheque_beneficiary_calldata() {
+        let cheque = SignedCheque::new(
+            Cheque::new(
+                address!("1111111111111111111111111111111111111111"),
+                address!("2222222222222222222222222222222222222222"),
+                U256::from(1_000_000u64),
+            ),
+            ChequeBytes::from(vec![7u8; 65]),
+        );
+        let recipient = address!("3333333333333333333333333333333333333333");
+
+        let call = IChequebook::cashChequeBeneficiaryCall {
+            recipient,
+            cumulativePayout: cheque.cheque.cumulativePayout,
+            issuerSig: Bytes::copy_from_slice(cheque.signature.as_ref()),
+        };
+
+        let provider = ProviderBuilder::new().connect_mocked_client(Asserter::new());
+        let calldata = CallBuilder::new_sol(&provider, &cheque.cheque.chequebook, &call)
+            .calldata()
+            .clone();
+
+        assert_eq!(
+            calldata.get(..4).unwrap(),
+            IChequebook::cashChequeBeneficiaryCall::SELECTOR
+        );
+        let decoded = IChequebook::cashChequeBeneficiaryCall::abi_decode(&calldata).unwrap();
+        assert_eq!(decoded.recipient, recipient);
+        assert_eq!(decoded.cumulativePayout, U256::from(1_000_000u64));
+        assert_eq!(decoded.issuerSig, call.issuerSig);
+    }
+}

--- a/crates/swarm/bandwidth/swap/src/error.rs
+++ b/crates/swarm/bandwidth/swap/src/error.rs
@@ -1,5 +1,7 @@
 //! SWAP settlement errors.
 
+use alloy_primitives::{Address, U256};
+
 /// Errors that can occur during swap operations.
 #[derive(Debug, Clone, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -16,19 +18,55 @@ pub enum SwapSettlementError {
     #[error("network error: {0}")]
     NetworkError(String),
 
+    /// The peer's beneficiary has not been learned from the swap handshake yet.
+    #[error("unknown beneficiary for peer")]
+    UnknownBeneficiary,
+
+    /// A cheque arrived from a peer whose swap identity has not been learned, so
+    /// its issuer cannot be authenticated.
+    #[error("no swap identity learned for peer; cannot authenticate cheque")]
+    UnknownPeerIdentity,
+
+    /// A received cheque names a beneficiary that is not our payout address.
+    #[error("cheque beneficiary mismatch: expected {expected}, got {got}")]
+    BeneficiaryMismatch {
+        /// Our own beneficiary, the only address a cheque to us may name.
+        expected: Address,
+        /// The beneficiary the received cheque actually names.
+        got: Address,
+    },
+
     /// Cheque signing failed.
     #[error("cheque signing failed: {0}")]
     SigningFailed(String),
 
-    /// Chequebook has insufficient balance.
-    #[error("insufficient chequebook balance")]
-    InsufficientBalance,
+    /// A received cheque's signature did not recover to the expected issuer.
+    #[error("cheque issuer mismatch: expected {expected}, recovered {recovered}")]
+    IssuerMismatch {
+        /// The chequebook issuer expected for this peer.
+        expected: Address,
+        /// The address actually recovered from the cheque signature.
+        recovered: Address,
+    },
+
+    /// A received cheque did not increase the cumulative payout.
+    #[error("cumulative payout did not increase: last {last}, received {received}")]
+    NonIncreasingPayout {
+        /// The cumulative payout of the last accepted cheque.
+        last: U256,
+        /// The cumulative payout of the received cheque.
+        received: U256,
+    },
+
+    /// The incremental cheque amount did not fit the accounting unit type.
+    #[error("cheque amount overflows accounting unit: {0}")]
+    AmountOverflow(U256),
 
     /// Cheque validation failed.
     #[error("cheque validation failed: {0}")]
     ValidationFailed(String),
 
-    /// Chain backend not available.
+    /// Chain backend not available for the requested cashout.
     #[error("chain backend not available")]
     NoChainBackend,
 }

--- a/crates/swarm/bandwidth/swap/src/handle.rs
+++ b/crates/swarm/bandwidth/swap/src/handle.rs
@@ -4,7 +4,7 @@ use tokio::sync::{mpsc, oneshot};
 use vertex_swarm_primitives::OverlayAddress;
 
 use crate::error::SwapSettlementError;
-use crate::service::SwapCommand;
+use crate::service::{PeerSwapInfo, SwapCommand};
 
 /// Cloneable handle for requesting cheque settlements from the service.
 #[derive(Clone)]
@@ -19,7 +19,11 @@ impl SwapHandle {
     }
 
     /// Request cheque settlement. Returns the amount settled.
-    pub async fn settle(&self, peer: OverlayAddress, amount: u64) -> Result<u64, SwapSettlementError> {
+    pub async fn settle(
+        &self,
+        peer: OverlayAddress,
+        amount: u64,
+    ) -> Result<u64, SwapSettlementError> {
         let (tx, rx) = oneshot::channel();
 
         self.command_tx
@@ -31,5 +35,17 @@ impl SwapHandle {
             .map_err(|_| SwapSettlementError::ServiceStopped)?;
 
         rx.await.map_err(|_| SwapSettlementError::ServiceStopped)?
+    }
+
+    /// Register the SWAP identity (beneficiary and chequebook issuer) learned for
+    /// a peer during the swap handshake.
+    pub fn set_peer_info(
+        &self,
+        peer: OverlayAddress,
+        info: PeerSwapInfo,
+    ) -> Result<(), SwapSettlementError> {
+        self.command_tx
+            .send(SwapCommand::SetPeerInfo { peer, info })
+            .map_err(|_| SwapSettlementError::ServiceStopped)
     }
 }

--- a/crates/swarm/bandwidth/swap/src/lib.rs
+++ b/crates/swarm/bandwidth/swap/src/lib.rs
@@ -1,15 +1,20 @@
-compile_error!("vertex-swarm-bandwidth-swap is disabled: depends on serde_json which has been removed from the workspace. Remove serde_json dependency before re-enabling.");
-
 //! Chequebook-based settlement provider for bandwidth accounting.
 //!
-//! When debt exceeds the payment threshold, the debtor issues a signed cheque.
-//! The creditor stores cheques and can cash them on-chain at any time.
+//! When debt crosses the payment threshold, the debtor issues a signed cheque
+//! whose cumulative payout advances monotonically. The creditor validates the
+//! cheque (signature recovers to the expected issuer, payout strictly increases)
+//! and credits the incremental amount. Cheque exchange is fully chain-free; the
+//! optional `swap-chequebook` feature adds an on-chain client for redeeming
+//! received cheques.
+//!
+//! Swap is one of the pluggable [`SwarmSettlementProvider`]s selected by
+//! [`BandwidthMode`], alongside pseudosettle. The two compose: pseudosettle
+//! forgives debt up to a time-based allowance, swap pays the remainder.
 //!
 //! # Usage
 //!
-//! Use [`create_swap_actor`] to create a service/handle pair.
-//! The [`SwapProvider`] implements [`SwarmSettlementProvider`] for
-//! integration with [`Accounting`].
+//! Use [`create_swap_actor`] to create a service/handle pair. Spawn the service
+//! as a background task and build a [`SwapProvider`] from the handle.
 //!
 //! [`SwarmSettlementProvider`]: vertex_swarm_api::SwarmSettlementProvider
 
@@ -17,31 +22,36 @@ compile_error!("vertex-swarm-bandwidth-swap is disabled: depends on serde_json w
 
 extern crate alloc;
 
+#[cfg(feature = "swap-chequebook")]
+pub mod cashout;
 pub mod error;
 pub mod handle;
 pub mod service;
 
 use std::sync::Arc;
 
-use alloy_primitives::U256;
+use alloy_chains::NamedChain;
+use alloy_primitives::{Address, U256};
+use alloy_signer::SignerSync;
 use tokio::sync::mpsc;
 use vertex_swarm_api::{
-    BandwidthMode, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmError, SwarmIdentity,
-    SwarmPeerState, SwarmResult, SwarmSettlementProvider,
+    BandwidthMode, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmError, SwarmPeerState,
+    SwarmResult, SwarmSettlementProvider,
 };
-use vertex_swarm_bandwidth::{Accounting, AccountingPeerHandle};
 use vertex_swarm_node::ClientCommand;
 use vertex_swarm_primitives::OverlayAddress;
 
 pub use error::SwapSettlementError;
 pub use handle::SwapHandle;
-pub use service::{SwapCommand, SwapService};
+pub use service::{PeerSwapInfo, SwapCommand, SwapService};
 pub use vertex_swarm_node::SwapEvent;
 
 /// Chequebook-based settlement provider.
 ///
-/// On `settle()`, issues a cheque for outstanding debt exceeding the threshold.
-/// With a handle, delegates to the network service; without, returns Ok(0).
+/// On `settle()`, when the peer's debt crosses the payment threshold the
+/// provider delegates to the service, which issues and sends a signed cheque.
+/// Without a handle it is inert (it never issues cheques on its own), so it
+/// composes safely with pseudosettle in [`BandwidthMode::Both`].
 pub struct SwapProvider<C> {
     config: C,
     /// Optional handle for delegating to the service.
@@ -72,6 +82,14 @@ impl<C: SwarmAccountingConfig> SwapProvider<C> {
     pub fn config(&self) -> &C {
         &self.config
     }
+
+    /// The early-payment trigger: pay once debt reaches this fraction of the
+    /// payment threshold, mirroring pseudosettle's early-payment behaviour.
+    fn early_payment_trigger(&self) -> u64 {
+        let threshold = self.config.payment_threshold();
+        let early = self.config.early_payment_percent().min(100);
+        threshold.saturating_mul(100 - early) / 100
+    }
 }
 
 #[async_trait::async_trait]
@@ -81,52 +99,35 @@ impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for SwapProvide
     }
 
     fn pre_allow(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> i64 {
-        // SWAP doesn't modify balance during allow check
+        // SWAP does not modify the balance during the allow check; payment is
+        // driven by `settle()` once debt crosses the threshold.
         0
     }
 
     async fn settle(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> SwarmResult<i64> {
-        // If we have a handle, delegate to the service
-        if let Some(handle) = &self.handle {
-            let balance = state.balance();
-            if balance >= 0 {
-                return Ok(0); // Nothing to settle
-            }
-
-            let amount = (-balance) as u64;
-            let accepted =
-                handle
-                    .settle(peer, amount)
-                    .await
-                    .map_err(SwarmError::payment_required)?;
-
-            Ok(accepted as i64)
-        } else {
-            // No handle - stub implementation
-            let balance = state.balance();
-
-            // Only settle if balance exceeds payment threshold (we owe them)
-            if balance >= 0 {
-                return Ok(0);
-            }
-
-            let debt = (-balance) as u64;
-            let threshold = self.config.payment_threshold();
-
-            if debt < threshold {
-                return Ok(0);
-            }
-
-            tracing::debug!(
-                %peer,
-                balance = balance,
-                debt = debt,
-                "SWAP settlement stub - no-op (cheque would be issued here)"
-            );
-
-            // For now, just log and return 0 (no settlement occurred)
-            Ok(0)
+        let balance = state.balance();
+        // Positive balance means the peer owes us; nothing for us to pay.
+        if balance >= 0 {
+            return Ok(0);
         }
+
+        let debt = balance.unsigned_abs();
+        // Only pay once debt reaches the early-payment trigger.
+        if debt < self.early_payment_trigger() {
+            return Ok(0);
+        }
+
+        let Some(handle) = &self.handle else {
+            // Without a service handle the provider cannot issue cheques.
+            return Ok(0);
+        };
+
+        let accepted = handle
+            .settle(peer, debt)
+            .await
+            .map_err(SwarmError::payment_required)?;
+
+        Ok(i64::try_from(accepted).unwrap_or(i64::MAX))
     }
 
     fn name(&self) -> &'static str {
@@ -136,14 +137,26 @@ impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for SwapProvide
 
 /// Create a swap actor (service + handle pair).
 ///
-/// Spawn the service as a background task. Use the handle to create
-/// a [`SwapProvider`].
-pub fn create_swap_actor<A: SwarmBandwidthAccounting + 'static>(
+/// Spawn the service as a background task. Use the handle to create a
+/// [`SwapProvider`]. The `signer` signs issued cheques, `chequebook` is this
+/// node's chequebook (the drawer), `beneficiary` is our payout address (the only
+/// address a cheque sent to us may name), and `chain` binds the EIP-712 domain to
+/// the settlement chain.
+#[allow(clippy::too_many_arguments)]
+pub fn create_swap_actor<A, S>(
     event_rx: mpsc::UnboundedReceiver<SwapEvent>,
     client_command_tx: mpsc::UnboundedSender<ClientCommand>,
     accounting: Arc<A>,
     our_rate: U256,
-) -> (SwapService<A>, SwapHandle) {
+    signer: Arc<S>,
+    chequebook: Address,
+    beneficiary: Address,
+    chain: NamedChain,
+) -> (SwapService<A, S>, SwapHandle)
+where
+    A: SwarmBandwidthAccounting + 'static,
+    S: SignerSync + Send + Sync + 'static,
+{
     let (command_tx, command_rx) = mpsc::unbounded_channel();
 
     let service = SwapService::new(
@@ -152,6 +165,10 @@ pub fn create_swap_actor<A: SwarmBandwidthAccounting + 'static>(
         client_command_tx,
         accounting,
         our_rate,
+        signer,
+        chequebook,
+        beneficiary,
+        chain,
     );
 
     let handle = SwapHandle::new(command_tx);
@@ -159,34 +176,16 @@ pub fn create_swap_actor<A: SwarmBandwidthAccounting + 'static>(
     (service, handle)
 }
 
-/// Type alias for the SWAP peer handle.
-pub type SwapPeerHandle = AccountingPeerHandle;
-
-/// Create a new SWAP-only accounting instance.
-///
-/// This is a convenience function that creates a `Accounting` with
-/// a `SwapProvider`.
-pub fn new_swap_accounting<C: SwarmAccountingConfig + Clone + 'static, I: SwarmIdentity>(
-    config: C,
-    identity: I,
-) -> Accounting<C, I> {
-    Accounting::with_providers(
-        config.clone(),
-        identity,
-        vec![Box::new(SwapProvider::new(config))],
-    )
-}
-
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use vertex_swarm_api::{
-        BandwidthMode, Direction, SwarmAccountingConfig, SwarmBandwidthAccounting,
-        SwarmPeerBandwidth,
-    };
-    use vertex_swarm_bandwidth::BandwidthConfig;
-    use vertex_swarm_bandwidth::PeerState;
-    use vertex_swarm_test_utils::{test_identity, test_peer};
+    use alloy_primitives::{Address, U256};
+    use alloy_signer_local::PrivateKeySigner;
+    use vertex_swarm_api::{BandwidthMode, SwarmAccountingConfig};
+    use vertex_swarm_bandwidth_chequebook::{Cheque, ChequeExt, SignedCheque};
+
+    const CHAIN: NamedChain = NamedChain::Gnosis;
 
     struct SwapTestConfig;
 
@@ -217,34 +216,31 @@ mod tests {
     }
 
     #[test]
-    fn test_swap_provider_name() {
+    fn provider_name() {
         let provider = SwapProvider::new(SwapTestConfig);
         assert_eq!(provider.name(), "swap");
     }
 
     #[test]
-    fn test_swap_accounting_basic() {
-        let accounting = new_swap_accounting(BandwidthConfig::default(), test_identity());
-
-        let handle = accounting.for_peer(test_peer());
-        assert_eq!(handle.balance(), 0);
-
-        handle.record(1000, Direction::Upload);
-        assert_eq!(handle.balance(), 1000);
-
-        handle.record(500, Direction::Download);
-        assert_eq!(handle.balance(), 500);
+    fn early_payment_trigger_is_fraction_of_threshold() {
+        let provider = SwapProvider::new(SwapTestConfig);
+        // 50% early payment => trigger at 50% of the 13_500_000 threshold.
+        assert_eq!(provider.early_payment_trigger(), 6_750_000);
     }
 
+    /// A signed cheque must recover to the signer that produced it.
     #[test]
-    fn test_swap_pre_allow_no_change() {
-        let provider = SwapProvider::new(SwapTestConfig);
-        let state = PeerState::new(13_500_000, 16_875_000);
-        state.add_balance(-1000);
+    fn cheque_sign_recover_roundtrip() {
+        let signer = PrivateKeySigner::random();
+        let cheque = Cheque::new(
+            Address::repeat_byte(0x11),
+            Address::repeat_byte(0x22),
+            U256::from(1_000u64),
+        );
+        let hash = cheque.signing_hash(CHAIN);
+        let sig = signer.sign_hash_sync(&hash).unwrap();
+        let signed = SignedCheque::from_signature(cheque, sig);
 
-        let adjustment = provider.pre_allow(test_peer(), &state);
-
-        assert_eq!(adjustment, 0);
-        assert_eq!(state.balance(), -1000);
+        assert_eq!(signed.recover_signer(CHAIN).unwrap(), signer.address());
     }
 }

--- a/crates/swarm/bandwidth/swap/src/service.rs
+++ b/crates/swarm/bandwidth/swap/src/service.rs
@@ -1,18 +1,41 @@
 //! Swap service actor (runs in its own tokio task).
+//!
+//! The service owns the cheque-exchange state machine: it issues signed cheques
+//! when a peer's debt crosses the payment threshold, validates cheques received
+//! from peers, and credits the accounting balances accordingly. Cheque exchange
+//! is fully chain-free. Cashing a received cheque on-chain is optional and gated
+//! behind the `swap-chequebook` feature.
 
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 
-use alloy_primitives::U256;
+use alloy_chains::NamedChain;
+use alloy_primitives::{Address, U256};
+use alloy_signer::SignerSync;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use vertex_swarm_api::{Direction, SwarmBandwidthAccounting, SwarmPeerBandwidth};
+use vertex_swarm_bandwidth_chequebook::{Cheque, ChequeExt, SignedCheque};
 use vertex_swarm_node::{ClientCommand, SwapEvent};
 use vertex_swarm_primitives::OverlayAddress;
 use vertex_tasks::{GracefulShutdown, SpawnableTask};
 
 use crate::error::SwapSettlementError;
+
+/// Per-peer SWAP identity learned from the swap handshake.
+///
+/// The beneficiary is the address a cheque we issue to this peer must pay; the
+/// issuer is the chequebook owner whose key must sign cheques the peer sends us.
+/// Populated through [`SwapCommand::SetPeerInfo`] by the node layer (handshake
+/// wiring is the builder's job).
+#[derive(Debug, Clone, Copy)]
+pub struct PeerSwapInfo {
+    /// The peer's beneficiary address (where cheques we issue are paid).
+    pub beneficiary: Address,
+    /// The peer's chequebook issuer (signs cheques the peer sends us).
+    pub issuer: Address,
+}
 
 /// Commands from the handle to the service.
 pub enum SwapCommand {
@@ -20,15 +43,33 @@ pub enum SwapCommand {
     Settle {
         /// The peer to settle with.
         peer: OverlayAddress,
-        /// The amount to settle.
+        /// The amount to settle, in accounting units.
         amount: u64,
         /// Channel to send the result.
         response_tx: oneshot::Sender<Result<u64, SwapSettlementError>>,
     },
+    /// Register the SWAP identity learned for a peer during the handshake.
+    SetPeerInfo {
+        /// The peer the identity belongs to.
+        peer: OverlayAddress,
+        /// The peer's beneficiary and chequebook issuer.
+        info: PeerSwapInfo,
+    },
+}
+
+/// Per-peer cheque accounting state.
+#[derive(Debug, Default)]
+struct PeerChequeState {
+    /// SWAP identity learned from the handshake, if any.
+    info: Option<PeerSwapInfo>,
+    /// Cumulative payout of the last cheque we issued to this peer.
+    last_sent_payout: U256,
+    /// Cumulative payout of the last cheque we accepted from this peer.
+    last_received_payout: U256,
 }
 
 /// Processes settlement commands from handles and network events.
-pub struct SwapService<A: SwarmBandwidthAccounting> {
+pub struct SwapService<A: SwarmBandwidthAccounting, S> {
     /// Receive commands from handles.
     command_rx: mpsc::UnboundedReceiver<SwapCommand>,
     /// Receive events routed from the network layer.
@@ -38,9 +79,23 @@ pub struct SwapService<A: SwarmBandwidthAccounting> {
     /// Reference to accounting for balance updates.
     accounting: Arc<A>,
     /// Our exchange rate.
+    #[allow(dead_code)]
     our_rate: U256,
-    /// Track pending outbound settlements (waiting for ack).
+    /// The Ethereum signer used to sign cheques.
+    signer: Arc<S>,
+    /// Our chequebook address (the drawer of cheques we issue).
+    chequebook: Address,
+    /// Our beneficiary, the only address a cheque sent to us may name.
+    beneficiary: Address,
+    /// The settlement chain the EIP-712 domain is bound to.
+    chain: NamedChain,
+    /// Per-peer cheque accounting state.
+    peers: HashMap<OverlayAddress, PeerChequeState>,
+    /// Track pending outbound settlements (waiting for the wire ack).
     pending: HashMap<OverlayAddress, PendingSettlement>,
+    /// Optional on-chain chequebook client for cashing received cheques.
+    #[cfg(feature = "swap-chequebook")]
+    cashout: Option<crate::cashout::Cashout>,
 }
 
 struct PendingSettlement {
@@ -48,14 +103,23 @@ struct PendingSettlement {
     response_tx: oneshot::Sender<Result<u64, SwapSettlementError>>,
 }
 
-impl<A: SwarmBandwidthAccounting + 'static> SwapService<A> {
+impl<A, S> SwapService<A, S>
+where
+    A: SwarmBandwidthAccounting + 'static,
+    S: SignerSync + Send + Sync + 'static,
+{
     /// Create a new swap service.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         command_rx: mpsc::UnboundedReceiver<SwapCommand>,
         event_rx: mpsc::UnboundedReceiver<SwapEvent>,
         command_tx: mpsc::UnboundedSender<ClientCommand>,
         accounting: Arc<A>,
         our_rate: U256,
+        signer: Arc<S>,
+        chequebook: Address,
+        beneficiary: Address,
+        chain: NamedChain,
     ) -> Self {
         Self {
             command_rx,
@@ -63,8 +127,22 @@ impl<A: SwarmBandwidthAccounting + 'static> SwapService<A> {
             command_tx,
             accounting,
             our_rate,
+            signer,
+            chequebook,
+            beneficiary,
+            chain,
+            peers: HashMap::new(),
             pending: HashMap::new(),
+            #[cfg(feature = "swap-chequebook")]
+            cashout: None,
         }
+    }
+
+    /// Attach an on-chain chequebook client so received cheques can be cashed.
+    #[cfg(feature = "swap-chequebook")]
+    pub fn with_cashout(mut self, cashout: crate::cashout::Cashout) -> Self {
+        self.cashout = Some(cashout);
+        self
     }
 
     /// Run the service event loop with graceful shutdown support.
@@ -95,48 +173,89 @@ impl<A: SwarmBandwidthAccounting + 'static> SwapService<A> {
 
     async fn handle_command(&mut self, cmd: SwapCommand) {
         match cmd {
+            SwapCommand::SetPeerInfo { peer, info } => {
+                debug!(
+                    %peer,
+                    beneficiary = %info.beneficiary,
+                    issuer = %info.issuer,
+                    "Learned swap identity for peer"
+                );
+                self.peers.entry(peer).or_default().info = Some(info);
+            }
             SwapCommand::Settle {
                 peer,
                 amount,
                 response_tx,
             } => {
-                // Check if we already have a pending settlement with this peer
                 if self.pending.contains_key(&peer) {
                     let _ = response_tx.send(Err(SwapSettlementError::SettlementInProgress));
                     return;
                 }
 
-                debug!(%peer, %amount, "Creating swap settlement cheque");
+                match self.issue_cheque(peer, amount) {
+                    Ok(cheque) => {
+                        debug!(
+                            %peer,
+                            %amount,
+                            cumulative_payout = %cheque.cheque.cumulativePayout,
+                            "Issuing swap cheque"
+                        );
 
-                // TODO: Sign cheque here
-                // For now, create a placeholder cheque
-                // This will require:
-                // 1. ChequeSigner interface
-                // 2. Last cumulative payout tracking
-                // 3. Chequebook address
+                        if let Err(e) = self
+                            .command_tx
+                            .send(ClientCommand::SendCheque { peer, cheque })
+                        {
+                            // Roll back the optimistic cumulative-payout bump so a
+                            // retry re-issues at the same level.
+                            if let Some(state) = self.peers.get_mut(&peer) {
+                                state.last_sent_payout -= U256::from(amount);
+                            }
+                            let _ = response_tx
+                                .send(Err(SwapSettlementError::NetworkError(e.to_string())));
+                            return;
+                        }
 
-                // Store the pending settlement
-                self.pending.insert(
-                    peer,
-                    PendingSettlement {
-                        amount,
-                        response_tx,
-                    },
-                );
-
-                // For now, immediately complete with stub
-                // In real implementation, we would send the cheque and wait for ChequeSent event
-                warn!(%peer, %amount, "SWAP: Cheque signing not yet implemented - completing as stub");
-
-                if let Some(pending) = self.pending.remove(&peer) {
-                    // Credit our balance (we paid, debt reduced)
-                    let handle = self.accounting.for_peer(peer);
-                    handle.record(amount, Direction::Upload);
-
-                    let _ = pending.response_tx.send(Ok(amount));
+                        self.pending.insert(
+                            peer,
+                            PendingSettlement {
+                                amount,
+                                response_tx,
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        let _ = response_tx.send(Err(e));
+                    }
                 }
             }
         }
+    }
+
+    /// Build and sign a cheque for `amount`, advancing the per-peer cumulative
+    /// payout monotonically.
+    fn issue_cheque(
+        &mut self,
+        peer: OverlayAddress,
+        amount: u64,
+    ) -> Result<SignedCheque, SwapSettlementError> {
+        let state = self.peers.entry(peer).or_default();
+        let beneficiary = state
+            .info
+            .ok_or(SwapSettlementError::UnknownBeneficiary)?
+            .beneficiary;
+
+        let next_payout = state.last_sent_payout + U256::from(amount);
+        let cheque = Cheque::new(self.chequebook, beneficiary, next_payout);
+
+        let hash = cheque.signing_hash(self.chain);
+        let sig = self
+            .signer
+            .sign_hash_sync(&hash)
+            .map_err(|e| SwapSettlementError::SigningFailed(e.to_string()))?;
+
+        // Commit the new cumulative payout only once signing succeeds.
+        state.last_sent_payout = next_payout;
+        Ok(SignedCheque::from_signature(cheque, sig))
     }
 
     async fn handle_event(&mut self, event: SwapEvent) {
@@ -144,12 +263,10 @@ impl<A: SwarmBandwidthAccounting + 'static> SwapService<A> {
             SwapEvent::ChequeSent { peer, peer_rate } => {
                 debug!(%peer, %peer_rate, "Cheque sent acknowledgment received");
 
-                // Complete pending request
                 if let Some(pending) = self.pending.remove(&peer) {
-                    // Credit our balance
+                    // We paid, so our debt to the peer is reduced.
                     let handle = self.accounting.for_peer(peer);
                     handle.record(pending.amount, Direction::Upload);
-
                     let _ = pending.response_tx.send(Ok(pending.amount));
                 } else {
                     warn!(%peer, "Received cheque sent ack for unknown settlement");
@@ -168,30 +285,320 @@ impl<A: SwarmBandwidthAccounting + 'static> SwapService<A> {
                     "Cheque received from peer"
                 );
 
-                // TODO: Validate cheque
-                // 1. Verify EIP-712 signature
-                // 2. Verify chequebook exists (on-chain)
-                // 3. Verify issuer matches chequebook owner
-                // 4. Verify sufficient balance (on-chain)
-                // 5. Calculate actual amount (cumulative - last seen)
+                match self.accept_cheque(peer, &cheque) {
+                    Ok(amount) => {
+                        // The peer paid us, so what they owe us is reduced.
+                        let handle = self.accounting.for_peer(peer);
+                        handle.record(amount, Direction::Download);
+                        debug!(%peer, %amount, "Credited received cheque");
 
-                // For now, just credit the full cumulative payout as a stub
-                let amount = cheque.cheque.cumulativePayout.as_limbs()[0];
-
-                // Credit peer's balance
-                let handle = self.accounting.for_peer(peer);
-                handle.record(amount, Direction::Download);
-
-                warn!(%peer, %amount, "SWAP: Cheque validation not yet implemented - credited as stub");
-
-                // TODO: Store cheque for later cashing
+                        #[cfg(feature = "swap-chequebook")]
+                        self.maybe_cash(peer, cheque).await;
+                    }
+                    Err(e) => {
+                        warn!(%peer, error = %e, "Rejected received cheque");
+                    }
+                }
             }
+        }
+    }
+
+    /// Validate a received cheque and return the incremental amount to credit.
+    ///
+    /// Requires a learned swap identity for the peer, then verifies the cheque
+    /// names our beneficiary, that the signature recovers to the peer's expected
+    /// issuer, that the cumulative payout strictly increases versus the last
+    /// accepted cheque, and that the increment fits the accounting-unit type. On
+    /// success the per-peer last-received payout is advanced.
+    fn accept_cheque(
+        &mut self,
+        peer: OverlayAddress,
+        cheque: &SignedCheque,
+    ) -> Result<u64, SwapSettlementError> {
+        // An unauthenticated cheque must never reduce the peer's debt: without a
+        // learned identity we cannot bind the signature to a real chequebook, so
+        // anyone could mint free credit with a self-signed cheque.
+        let issuer = self
+            .peers
+            .get(&peer)
+            .and_then(|s| s.info)
+            .ok_or(SwapSettlementError::UnknownPeerIdentity)?
+            .issuer;
+
+        if cheque.cheque.beneficiary != self.beneficiary {
+            return Err(SwapSettlementError::BeneficiaryMismatch {
+                expected: self.beneficiary,
+                got: cheque.cheque.beneficiary,
+            });
+        }
+
+        let recovered = cheque
+            .recover_signer(self.chain)
+            .map_err(|e| SwapSettlementError::ValidationFailed(e.to_string()))?;
+        if recovered != issuer {
+            return Err(SwapSettlementError::IssuerMismatch {
+                expected: issuer,
+                recovered,
+            });
+        }
+
+        let state = self.peers.entry(peer).or_default();
+        let received = cheque.cheque.cumulativePayout;
+        let last = state.last_received_payout;
+        if received <= last {
+            return Err(SwapSettlementError::NonIncreasingPayout { last, received });
+        }
+
+        let increment = received - last;
+        let amount: u64 = increment
+            .try_into()
+            .map_err(|_| SwapSettlementError::AmountOverflow(increment))?;
+
+        state.last_received_payout = received;
+        Ok(amount)
+    }
+
+    /// Cash a received cheque on-chain if a chequebook client is attached.
+    #[cfg(feature = "swap-chequebook")]
+    async fn maybe_cash(&self, peer: OverlayAddress, cheque: SignedCheque) {
+        if let Some(cashout) = &self.cashout
+            && let Err(e) = cashout.cash(&cheque).await
+        {
+            warn!(%peer, error = %e, "Failed to cash received cheque");
         }
     }
 }
 
-impl<A: SwarmBandwidthAccounting + 'static> SpawnableTask for SwapService<A> {
+impl<A, S> SpawnableTask for SwapService<A, S>
+where
+    A: SwarmBandwidthAccounting + 'static,
+    S: SignerSync + Send + Sync + 'static,
+{
     fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + Send {
         self.run(shutdown)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use alloy_signer_local::PrivateKeySigner;
+    use vertex_swarm_bandwidth::{Accounting, BandwidthConfig};
+    use vertex_swarm_test_utils::{Identity, test_identity, test_peer};
+
+    const CHAIN: NamedChain = NamedChain::Gnosis;
+
+    /// Our payout address; the only beneficiary a cheque sent to us may name.
+    const OUR_BENEFICIARY: Address = Address::repeat_byte(0xbe);
+
+    type TestService = SwapService<Accounting<BandwidthConfig, Identity>, PrivateKeySigner>;
+
+    fn build_service(signer: PrivateKeySigner) -> TestService {
+        let (_cmd_tx, command_rx) = mpsc::unbounded_channel();
+        let (_evt_tx, event_rx) = mpsc::unbounded_channel();
+        let (client_tx, _client_rx) = mpsc::unbounded_channel();
+        let accounting = Arc::new(Accounting::new(BandwidthConfig::default(), test_identity()));
+
+        SwapService::new(
+            command_rx,
+            event_rx,
+            client_tx,
+            accounting,
+            U256::ZERO,
+            Arc::new(signer),
+            Address::repeat_byte(0xcb),
+            OUR_BENEFICIARY,
+            CHAIN,
+        )
+    }
+
+    /// Sign a cheque the way a peer would, returning the signed cheque.
+    fn peer_cheque(
+        signer: &PrivateKeySigner,
+        chequebook: Address,
+        beneficiary: Address,
+        payout: u64,
+    ) -> SignedCheque {
+        let cheque = Cheque::new(chequebook, beneficiary, U256::from(payout));
+        let hash = cheque.signing_hash(CHAIN);
+        let sig = signer.sign_hash_sync(&hash).unwrap();
+        SignedCheque::from_signature(cheque, sig)
+    }
+
+    #[test]
+    fn issue_cheque_advances_cumulative_payout() {
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: Address::repeat_byte(0x22),
+            issuer: Address::repeat_byte(0x33),
+        });
+
+        let first = svc.issue_cheque(peer, 1_000).unwrap();
+        assert_eq!(first.cheque.cumulativePayout, U256::from(1_000u64));
+
+        let second = svc.issue_cheque(peer, 500).unwrap();
+        assert_eq!(second.cheque.cumulativePayout, U256::from(1_500u64));
+    }
+
+    #[test]
+    fn issue_cheque_without_beneficiary_fails() {
+        let mut svc = build_service(PrivateKeySigner::random());
+        assert!(matches!(
+            svc.issue_cheque(test_peer(), 1_000),
+            Err(SwapSettlementError::UnknownBeneficiary)
+        ));
+    }
+
+    #[test]
+    fn accept_cheque_credits_incremental_amount() {
+        let issuer = PrivateKeySigner::random();
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: Address::repeat_byte(0x22),
+            issuer: issuer.address(),
+        });
+
+        let cheque = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 1_000);
+        assert_eq!(svc.accept_cheque(peer, &cheque).unwrap(), 1_000);
+
+        // A second cheque at a higher cumulative payout credits only the delta.
+        let cheque = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 1_700);
+        assert_eq!(svc.accept_cheque(peer, &cheque).unwrap(), 700);
+    }
+
+    #[test]
+    fn accept_cheque_rejects_non_increasing_payout() {
+        let issuer = PrivateKeySigner::random();
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: Address::repeat_byte(0x22),
+            issuer: issuer.address(),
+        });
+
+        let cheque = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 1_000);
+        assert_eq!(svc.accept_cheque(peer, &cheque).unwrap(), 1_000);
+
+        // Same cumulative payout: no new funds, must be rejected.
+        let replay = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 1_000);
+        assert!(matches!(
+            svc.accept_cheque(peer, &replay),
+            Err(SwapSettlementError::NonIncreasingPayout { .. })
+        ));
+
+        // A lower cumulative payout is also rejected.
+        let lower = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 500);
+        assert!(matches!(
+            svc.accept_cheque(peer, &lower),
+            Err(SwapSettlementError::NonIncreasingPayout { .. })
+        ));
+    }
+
+    #[test]
+    fn accept_cheque_rejects_wrong_issuer() {
+        let issuer = PrivateKeySigner::random();
+        let imposter = PrivateKeySigner::random();
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: Address::repeat_byte(0x22),
+            issuer: issuer.address(),
+        });
+
+        let cheque = peer_cheque(
+            &imposter,
+            Address::repeat_byte(0xaa),
+            OUR_BENEFICIARY,
+            1_000,
+        );
+        assert!(matches!(
+            svc.accept_cheque(peer, &cheque),
+            Err(SwapSettlementError::IssuerMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn accept_cheque_rejects_amount_overflow() {
+        let issuer = PrivateKeySigner::random();
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: Address::repeat_byte(0x22),
+            issuer: issuer.address(),
+        });
+
+        // A cumulative payout above u64::MAX cannot be credited as an accounting
+        // unit; the conversion must reject rather than wrap.
+        let payout = U256::from(u64::MAX) + U256::from(1u64);
+        let cheque = Cheque::new(Address::repeat_byte(0xaa), OUR_BENEFICIARY, payout);
+        let hash = cheque.signing_hash(CHAIN);
+        let sig = issuer.sign_hash_sync(&hash).unwrap();
+        let signed = SignedCheque::from_signature(cheque, sig);
+
+        assert!(matches!(
+            svc.accept_cheque(peer, &signed),
+            Err(SwapSettlementError::AmountOverflow(_))
+        ));
+    }
+
+    #[test]
+    fn accept_cheque_roundtrips_our_own_issuance() {
+        // A cheque we sign with our own signer recovers to our own address, so
+        // pointing a peer's expected issuer at us lets the validation path accept
+        // a cheque produced by `issue_cheque`. This exercises sign -> recover. The
+        // peer's beneficiary is set to our own so the issued cheque also passes
+        // the received-cheque beneficiary check.
+        let signer = PrivateKeySigner::random();
+        let mut svc = build_service(signer.clone());
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: OUR_BENEFICIARY,
+            issuer: signer.address(),
+        });
+
+        let issued = svc.issue_cheque(peer, 4_200).unwrap();
+        assert_eq!(svc.accept_cheque(peer, &issued).unwrap(), 4_200);
+    }
+
+    #[test]
+    fn accept_cheque_rejects_unknown_peer_identity() {
+        // Without a learned identity the issuer cannot be authenticated, so a
+        // self-signed cheque must not mint credit.
+        let issuer = PrivateKeySigner::random();
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+
+        let cheque = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 1_000);
+        assert!(matches!(
+            svc.accept_cheque(peer, &cheque),
+            Err(SwapSettlementError::UnknownPeerIdentity)
+        ));
+    }
+
+    #[test]
+    fn accept_cheque_rejects_wrong_beneficiary() {
+        // A cheque drawn for someone other than our payout address must be
+        // rejected before it is credited or cashed.
+        let issuer = PrivateKeySigner::random();
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: OUR_BENEFICIARY,
+            issuer: issuer.address(),
+        });
+
+        let cheque = peer_cheque(
+            &issuer,
+            Address::repeat_byte(0xaa),
+            Address::repeat_byte(0x77),
+            1_000,
+        );
+        assert!(matches!(
+            svc.accept_cheque(peer, &cheque),
+            Err(SwapSettlementError::BeneficiaryMismatch { .. })
+        ));
     }
 }


### PR DESCRIPTION
Re-enables the `vertex-swarm-bandwidth-swap` crate and implements the cheque-exchange settlement service (unit S4).

## What this adds

The service owns the per-peer cheque state machine. It issues signed cheques whose cumulative payout advances monotonically once a peer's debt crosses the early-payment trigger, and validates cheques received from peers before crediting accounting.

Received-cheque validation is strict: it requires a learned swap identity for the peer (an unauthenticated cheque can never mint credit), checks the cheque names our own beneficiary, recovers the EIP-712 signer via the chequebook `ChequeExt` signing hash and enforces it matches the peer's expected issuer, enforces a strictly-increasing `cumulativePayout`, and converts the increment to an accounting unit with a checked `U256 -> u64` conversion rather than a truncating cast.

Accepted cheques credit accounting through the same `record` path pseudosettle uses, and the `SwarmSettlementProvider` impl mirrors pseudosettle, so swap composes with it under `BandwidthMode::Both`.

## Chain boundary

Cheque exchange (sign, send, validate, credit) is fully chain-free. On-chain cashout of received cheques lives in `cashout.rs` behind the `swap-chequebook` feature, off by default, so the default dependency cone stays wasm-friendly.

## Scope

Only `crates/swarm/bandwidth/swap/` and the root `Cargo.toml` (re-adding the crate to the workspace members and dependencies). Builder wiring and the `--swap` CLI flag are deliberately out of scope and are the follow-up unit S6.

## Verification

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p vertex-swarm-bandwidth-swap` (both default and `--features swap-chequebook`), and a workspace `cargo build` all pass.