### PR TITLE
feat(swarm-builder): wire SWAP settlement into accounting and binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8750,6 +8750,7 @@ dependencies = [
  "vertex-swarm-bandwidth-chequebook",
  "vertex-swarm-bandwidth-pricing",
  "vertex-swarm-bandwidth-pseudosettle",
+ "vertex-swarm-bandwidth-swap",
  "vertex-swarm-identity",
  "vertex-swarm-localstore",
  "vertex-swarm-node",

--- a/bin/vertex/Cargo.toml
+++ b/bin/vertex/Cargo.toml
@@ -18,9 +18,14 @@ default = []
 # cone guard (`just check-cone`) enforces that the default cone never resolves
 # chain code.
 chain = ["vertex-swarm-builder/chain"]
-# Node role: a storer settles bandwidth over SWAP, so it turns the chain stack
-# and the on-chain chequebook client on. Equivalent to `chain` today; kept as a
-# distinct role feature so the storer build is selected by intent.
+# SWAP cheque-based settlement. Wires the chequebook settlement service into the
+# accounting and surfaces the `--swap` flags. Chain-free on its own (cheque
+# exchange needs no chain); combine with `chain` for on-chain cashout. Off by
+# default so the default binary stays swap-free and chain-free.
+swap = ["vertex-swarm-builder/swap"]
+# Node role: a storer settles bandwidth over SWAP, so it turns the chain stack,
+# the on-chain chequebook client, and the swap settlement service on. Selected by
+# intent for the storer build.
 storer = ["vertex-swarm-builder/storer"]
 jemalloc = ["tikv-jemallocator", "vertex-observability/jemalloc", "vertex-node-builder/jemalloc"]
 heap-profiling = ["jemalloc", "tikv-jemallocator/profiling", "vertex-observability/heap-profiling"]

--- a/bin/vertex/src/cli.rs
+++ b/bin/vertex/src/cli.rs
@@ -132,9 +132,10 @@ pub async fn run() -> Result<()> {
                     .bandwidth_config()
                     .map_err(|e| eyre::eyre!("bandwidth config error: {}", e))?;
                 let chain = config.protocol.chain_config();
+                let swap = config.protocol.swap_config();
 
                 let node_config =
-                    ClientConfig::new(spec, identity, network, bandwidth, verify, chain);
+                    ClientConfig::new(spec, identity, network, bandwidth, verify, chain, swap);
 
                 let (task_fn, rpc_providers) = DefaultClientBuilder::from_config(node_config)
                     .build(&launch_ctx)
@@ -159,6 +160,7 @@ pub async fn run() -> Result<()> {
                 let local_store = config.protocol.local_store_config();
                 let storage = config.protocol.storage_config();
                 let chain = config.protocol.chain_config();
+                let swap = config.protocol.swap_config();
 
                 let node_config = StorerConfig::new(
                     spec,
@@ -169,6 +171,7 @@ pub async fn run() -> Result<()> {
                     storage,
                     verify,
                     chain,
+                    swap,
                 );
 
                 let (task_fn, rpc_providers) = DefaultStorerBuilder::from_config(node_config)

--- a/crates/ffi/src/api/client.rs
+++ b/crates/ffi/src/api/client.rs
@@ -23,7 +23,7 @@ use vertex_swarm_builder::{
     NetworkChunkProvider, VerifyingChunkProvider,
 };
 use vertex_swarm_identity::Identity;
-use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
 use vertex_swarm_primitives::{Nonce, SwarmNodeType};
 use vertex_swarm_spec::{Spec, init_dev, init_mainnet, init_testnet};
 use vertex_tasks::{TaskExecutor, TaskManager};
@@ -88,6 +88,7 @@ impl VertexClient {
             Default::default(),
             ChunkVerifyConfig::default(),
             ChainConfig::default(),
+            SwapConfig::default(),
         );
 
         let launch = LaunchContext::new(executor.clone());

--- a/crates/swarm/builder/Cargo.toml
+++ b/crates/swarm/builder/Cargo.toml
@@ -25,10 +25,26 @@ chain = [
     "dep:alloy-network",
     "dep:alloy-signer-local",
     "dep:alloy-chains",
+    # When the swap service is also present, the chain unlocks on-chain cashout
+    # of received cheques. Without `swap` this is a no-op.
+    "vertex-swarm-bandwidth-swap?/swap-chequebook",
+]
+# SWAP cheque-based settlement. Wires the chequebook settlement service into
+# bandwidth accounting and routes the swap wire events. Chain-free on its own:
+# cheque exchange (sign, send, validate, credit) needs no chain. Combine with
+# `chain` to enable on-chain cashout of received cheques. Off by default so the
+# light, chain-free node stays the default cone.
+swap = [
+    "dep:vertex-swarm-bandwidth-swap",
+    "vertex-swarm-node/swap",
+    "dep:alloy-chains",
+    "dep:alloy-signer",
+    "dep:alloy-signer-local",
 ]
 # Node role: the storer settles bandwidth over SWAP, so it pulls in the chain
-# stack and the on-chain chequebook client. Light clients leave this off.
-storer = ["chain"]
+# stack, the on-chain chequebook client, and the swap settlement service. Light
+# clients leave this off.
+storer = ["chain", "swap"]
 
 [dependencies]
 # vertex - node infrastructure
@@ -62,6 +78,10 @@ vertex-chain = { workspace = true, optional = true }
 # `chain` feature enables `swap-chequebook` on it to construct the SWAP
 # settlement client.
 vertex-swarm-bandwidth-chequebook = { workspace = true, optional = true }
+# The chequebook settlement service (optional, behind the `swap` feature). Cheque
+# exchange is chain-free; `swap` + `chain` turns on the service's `swap-chequebook`
+# cashout path.
+vertex-swarm-bandwidth-swap = { workspace = true, optional = true }
 
 # nectar
 nectar-primitives.workspace = true
@@ -77,6 +97,7 @@ alloy-provider = { workspace = true, optional = true, features = [
     "reqwest-native-tls",
 ] }
 alloy-network = { workspace = true, optional = true }
+alloy-signer = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }
 alloy-chains = { workspace = true, optional = true }
 

--- a/crates/swarm/builder/examples/download_chunk.rs
+++ b/crates/swarm/builder/examples/download_chunk.rs
@@ -21,7 +21,7 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_builder::{ChunkVerifyConfig, ClientConfig, DefaultClientBuilder};
 use vertex_swarm_identity::Identity;
-use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
 use vertex_swarm_spec::init_dev;
 use vertex_tasks::TaskExecutor;
 
@@ -59,6 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Default::default(),
         verify,
         ChainConfig::default(),
+        SwapConfig::default(),
     );
     let ctx = ExampleContext {
         executor: executor.clone(),

--- a/crates/swarm/builder/examples/upload_chunk.rs
+++ b/crates/swarm/builder/examples/upload_chunk.rs
@@ -26,7 +26,7 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_builder::{ChunkVerifyConfig, ClientConfig, DefaultClientBuilder};
 use vertex_swarm_identity::Identity;
-use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
 use vertex_swarm_spec::init_dev;
 use vertex_tasks::TaskExecutor;
 
@@ -73,6 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Default::default(),
         ChunkVerifyConfig::default(),
         ChainConfig::default(),
+        SwapConfig::default(),
     );
     let ctx = ExampleContext {
         executor: executor.clone(),

--- a/crates/swarm/builder/src/config.rs
+++ b/crates/swarm/builder/src/config.rs
@@ -18,7 +18,7 @@ use vertex_swarm_api::SwarmProtocol;
 use vertex_swarm_bandwidth::DefaultBandwidthConfig;
 use vertex_swarm_identity::Identity;
 use vertex_swarm_localstore::LocalStoreConfig;
-use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
 use vertex_swarm_redistribution::StorageConfig;
 use vertex_swarm_spec::Spec;
 use vertex_swarm_topology::KademliaConfig;
@@ -91,6 +91,7 @@ pub struct ClientConfig {
     bandwidth: DefaultBandwidthConfig,
     verify: ChunkVerifyConfig,
     chain: ChainConfig,
+    swap: SwapConfig,
 }
 
 impl ClientConfig {
@@ -101,6 +102,7 @@ impl ClientConfig {
         bandwidth: DefaultBandwidthConfig,
         verify: ChunkVerifyConfig,
         chain: ChainConfig,
+        swap: SwapConfig,
     ) -> Self {
         Self {
             spec,
@@ -109,6 +111,7 @@ impl ClientConfig {
             bandwidth,
             verify,
             chain,
+            swap,
         }
     }
 
@@ -123,6 +126,11 @@ impl ClientConfig {
 
     pub fn chain(&self) -> &ChainConfig {
         &self.chain
+    }
+
+    /// SWAP settlement configuration (chequebook, beneficiary, deploy).
+    pub fn swap(&self) -> &SwapConfig {
+        &self.swap
     }
 }
 
@@ -140,6 +148,7 @@ pub struct StorerConfig {
     storage: StorageConfig,
     verify: ChunkVerifyConfig,
     chain: ChainConfig,
+    swap: SwapConfig,
 }
 
 impl StorerConfig {
@@ -156,6 +165,7 @@ impl StorerConfig {
         storage: StorageConfig,
         verify: ChunkVerifyConfig,
         chain: ChainConfig,
+        swap: SwapConfig,
     ) -> Self {
         Self {
             spec,
@@ -166,6 +176,7 @@ impl StorerConfig {
             storage,
             verify,
             chain,
+            swap,
         }
     }
 
@@ -188,6 +199,11 @@ impl StorerConfig {
 
     pub fn chain(&self) -> &ChainConfig {
         &self.chain
+    }
+
+    /// SWAP settlement configuration (chequebook, beneficiary, deploy).
+    pub fn swap(&self) -> &SwapConfig {
+        &self.swap
     }
 }
 

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -11,6 +11,8 @@ use vertex_net_peer_store::NetPeerStore;
 use vertex_net_peer_store::error::StoreError;
 use vertex_node_api::InfrastructureContext;
 use vertex_storage_redb::RedbDatabase;
+#[cfg(feature = "swap")]
+use vertex_swarm_api::SwarmClientAccounting;
 use vertex_swarm_api::{PeerConfigValues, SwarmLaunchConfig, SwarmPeerConfig, SwarmScoreStore};
 use vertex_swarm_bandwidth::{
     Accounting, AccountingBuilder, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
@@ -62,6 +64,7 @@ where
     }
 }
 
+#[cfg(not(feature = "swap"))]
 #[allow(clippy::type_complexity)]
 fn build_accounting<A>(
     spec: Arc<Spec>,
@@ -81,6 +84,36 @@ where
     AccountingBuilder::new(config)
         .with_pricer_from_config(spec)
         .build(identity)
+}
+
+/// Build client accounting, embedding the SWAP settlement provider when enabled.
+///
+/// Returns the accounting plus the swap wiring to spawn after the node command
+/// channel exists. When SWAP is not enabled the wiring is `None` and the
+/// accounting is identical to [`build_accounting`].
+#[cfg(feature = "swap")]
+#[allow(clippy::type_complexity)]
+fn build_accounting_with_swap(
+    spec: &Arc<Spec>,
+    identity: &Arc<Identity>,
+    config: &DefaultBandwidthConfig,
+    swap_config: &vertex_swarm_node::args::SwapConfig,
+) -> (
+    ClientAccounting<
+        Arc<vertex_swarm_bandwidth::Accounting<DefaultBandwidthConfig, Arc<Identity>>>,
+        FixedPricer<Spec>,
+    >,
+    Option<crate::swap::SwapWiring>,
+) {
+    let builder = AccountingBuilder::new(config.clone()).with_pricer_from_config(Arc::clone(spec));
+
+    match crate::swap::SwapWiring::prepare(spec, identity, config, swap_config) {
+        Some((provider, wiring)) => (
+            builder.with_settlement(provider).build(identity),
+            Some(wiring),
+        ),
+        None => (builder.build(identity), None),
+    }
 }
 
 /// Wrap a future factory as a NodeTaskFn with graceful shutdown support.
@@ -276,19 +309,31 @@ impl SwarmLaunchConfig for ClientConfig {
         let db = open_shared_database(ctx);
         let (peer_store, score_store) = create_peer_store(&db);
 
+        // Prepare SWAP settlement first: the provider must be embedded in the
+        // accounting, and the swap event sink must be routed at node build time.
+        #[cfg(feature = "swap")]
+        let (accounting, swap_wiring) =
+            build_accounting_with_swap(self.spec(), self.identity(), self.bandwidth(), self.swap());
+        #[cfg(not(feature = "swap"))]
         let accounting = build_accounting(
             self.spec().clone(),
             self.identity(),
             self.bandwidth().clone(),
         );
 
-        let (node, client_service, client_handle) = ClientNode::builder(self.identity().clone())
+        let node_builder = ClientNode::builder(self.identity().clone());
+        #[cfg(feature = "swap")]
+        let node_builder = match swap_wiring.as_ref() {
+            Some(wiring) => node_builder.with_swap_events(wiring.swap_event_sender()),
+            None => node_builder,
+        };
+        let (node, client_service, client_handle) = node_builder
             .build(self.network(), peer_store, score_store)
             .await
             .map_err(|e| SwarmNodeError::Build(e.into()))?;
 
         let topology = node.topology_handle().clone();
-        let chunk_provider = NetworkChunkProvider::new(client_handle, topology.clone());
+        let chunk_provider = NetworkChunkProvider::new(client_handle.clone(), topology.clone());
         let verified_provider = VerifyingChunkProvider::new(chunk_provider, self.verify());
         let providers = ClientRpcProviders::new(topology, verified_provider);
 
@@ -310,9 +355,22 @@ impl SwarmLaunchConfig for ClientConfig {
             .await?
         };
 
+        // Spawn the SWAP settlement service over the shared accounting instance,
+        // forwarding its cheque commands to the node and cashing received cheques
+        // on chain when a provider is present.
+        #[cfg(feature = "swap")]
+        if let Some(wiring) = swap_wiring {
+            wiring.spawn(
+                ctx,
+                accounting.bandwidth().clone(),
+                client_handle,
+                #[cfg(feature = "chain")]
+                chain_provider.as_ref(),
+            );
+        }
+
         // Return node task - accounting is moved into the closure to keep it
-        // alive. The chain provider is held alive the same way until the SWAP
-        // settlement service (a later PR) consumes it.
+        // alive. The chain provider is held alive the same way.
         let task = single_task(move |shutdown| async move {
             let _accounting = accounting;
             #[cfg(feature = "chain")]
@@ -342,6 +400,12 @@ impl SwarmLaunchConfig for StorerConfig {
         let db = open_shared_database(ctx);
         let (peer_store, score_store) = create_peer_store(&db);
 
+        // Prepare SWAP settlement first: the provider must be embedded in the
+        // accounting, and the swap event sink must be routed at node build time.
+        #[cfg(feature = "swap")]
+        let (accounting, swap_wiring) =
+            build_accounting_with_swap(self.spec(), self.identity(), self.bandwidth(), self.swap());
+        #[cfg(not(feature = "swap"))]
         let accounting = build_accounting(
             self.spec().clone(),
             self.identity(),
@@ -353,13 +417,19 @@ impl SwarmLaunchConfig for StorerConfig {
         let _ = self.storage();
 
         // Build as ClientNode for now (storer components not yet implemented)
-        let (node, client_service, client_handle) = ClientNode::builder(self.identity().clone())
+        let node_builder = ClientNode::builder(self.identity().clone());
+        #[cfg(feature = "swap")]
+        let node_builder = match swap_wiring.as_ref() {
+            Some(wiring) => node_builder.with_swap_events(wiring.swap_event_sender()),
+            None => node_builder,
+        };
+        let (node, client_service, client_handle) = node_builder
             .build(self.network(), peer_store, score_store)
             .await
             .map_err(|e| SwarmNodeError::Build(e.into()))?;
 
         let topology = node.topology_handle().clone();
-        let chunk_provider = NetworkChunkProvider::new(client_handle, topology.clone());
+        let chunk_provider = NetworkChunkProvider::new(client_handle.clone(), topology.clone());
         let verified_provider = VerifyingChunkProvider::new(chunk_provider, self.verify());
         let providers = StorerRpcProviders::new(topology, verified_provider);
 
@@ -381,9 +451,22 @@ impl SwarmLaunchConfig for StorerConfig {
             .await?
         };
 
+        // Spawn the SWAP settlement service over the shared accounting instance,
+        // forwarding its cheque commands to the node and cashing received cheques
+        // on chain when a provider is present.
+        #[cfg(feature = "swap")]
+        if let Some(wiring) = swap_wiring {
+            wiring.spawn(
+                ctx,
+                accounting.bandwidth().clone(),
+                client_handle,
+                #[cfg(feature = "chain")]
+                chain_provider.as_ref(),
+            );
+        }
+
         // Return node task - accounting is moved into the closure to keep it
-        // alive. The chain provider is held alive the same way until the SWAP
-        // settlement service (a later PR) consumes it.
+        // alive. The chain provider is held alive the same way.
         let task = single_task(move |shutdown| async move {
             let _accounting = accounting;
             #[cfg(feature = "chain")]

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -37,6 +37,8 @@ mod launch;
 mod node;
 mod providers;
 mod rpc;
+#[cfg(feature = "swap")]
+mod swap;
 pub mod verify;
 
 // Traits

--- a/crates/swarm/builder/src/node.rs
+++ b/crates/swarm/builder/src/node.rs
@@ -14,7 +14,7 @@ use vertex_swarm_api::{
 use vertex_swarm_bandwidth::DefaultBandwidthConfig;
 use vertex_swarm_identity::Identity;
 use vertex_swarm_localstore::LocalStoreConfig;
-use vertex_swarm_node::args::{ChainConfig, NetworkConfig};
+use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
 use vertex_swarm_redistribution::StorageConfig;
 use vertex_swarm_spec::Spec;
 use vertex_swarm_topology::KademliaConfig;
@@ -94,6 +94,7 @@ where
             accounting,
             verify: ChunkVerifyConfig::default(),
             chain: ChainConfig::default(),
+            swap: SwapConfig::default(),
         }
     }
 }
@@ -109,6 +110,7 @@ where
     accounting: A,
     verify: ChunkVerifyConfig,
     chain: ChainConfig,
+    swap: SwapConfig,
 }
 
 impl<I, N, A> BuilderExt for ClientNodeBuilder<I, N, A>
@@ -138,6 +140,12 @@ where
     /// Set the chain configuration (RPC endpoint and transaction tuning).
     pub fn with_chain(mut self, chain: ChainConfig) -> Self {
         self.chain = chain;
+        self
+    }
+
+    /// Set the SWAP settlement configuration (chequebook, beneficiary, deploy).
+    pub fn with_swap(mut self, swap: SwapConfig) -> Self {
+        self.swap = swap;
         self
     }
 
@@ -259,6 +267,7 @@ impl DefaultClientBuilder {
             config.verify(),
         )
         .with_chain(config.chain().clone())
+        .with_swap(config.swap().clone())
     }
 
     /// Convert to config for building.
@@ -270,6 +279,7 @@ impl DefaultClientBuilder {
             self.accounting,
             self.verify,
             self.chain,
+            self.swap,
         )
     }
 
@@ -302,6 +312,7 @@ impl DefaultStorerBuilder {
 
     pub fn from_config(config: StorerConfig) -> Self {
         let chain = config.chain().clone();
+        let swap = config.swap().clone();
         let mut builder = Self::from_parts(
             config.spec().clone(),
             config.identity().clone(),
@@ -311,7 +322,7 @@ impl DefaultStorerBuilder {
             config.storage().clone(),
             config.verify(),
         );
-        builder.client = builder.client.with_chain(chain);
+        builder.client = builder.client.with_chain(chain).with_swap(swap);
         builder
     }
 
@@ -326,6 +337,7 @@ impl DefaultStorerBuilder {
             self.storage,
             self.client.verify,
             self.client.chain,
+            self.client.swap,
         )
     }
 

--- a/crates/swarm/builder/src/swap.rs
+++ b/crates/swarm/builder/src/swap.rs
@@ -1,0 +1,233 @@
+//! SWAP settlement wiring for the client launch path.
+//!
+//! Ties three pieces together behind the `swap` feature: a [`SwapProvider`]
+//! registered with the accounting builder so [`BandwidthMode`] selection drives
+//! cheque issuance, the [`SwapService`] actor that owns the cheque-exchange state
+//! machine, and the wire plumbing that routes swap events from the node into the
+//! service and the service's `SendCheque` commands back to the node.
+//!
+//! The provider and the service share one accounting instance: the provider
+//! delegates outbound settlement to the service through a [`SwapHandle`], and the
+//! service credits received cheques against the same balances. Because the
+//! provider must be embedded in the accounting before it is built, the wiring is
+//! split: [`SwapWiring::prepare`] builds the handle and provider up front, then
+//! [`SwapWiring::spawn`] constructs and spawns the service once the accounting
+//! instance and the node command channel exist.
+//!
+//! Cheque exchange is chain-free. With the `chain` feature also enabled, a
+//! cashout client built over the shared provider redeems received cheques on
+//! chain.
+
+use std::sync::Arc;
+
+use alloy_chains::NamedChain;
+use alloy_primitives::{Address, U256};
+use alloy_signer_local::PrivateKeySigner;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+use vertex_node_api::InfrastructureContext;
+use vertex_swarm_api::{SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmIdentity, SwarmSpec};
+use vertex_swarm_bandwidth_swap::service::SwapCommand;
+use vertex_swarm_bandwidth_swap::{SwapEvent, SwapHandle, SwapProvider, SwapService};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_node::args::SwapConfig;
+use vertex_swarm_node::{ClientCommand, ClientHandle};
+use vertex_swarm_spec::Spec;
+
+#[cfg(feature = "chain")]
+use crate::chain::SharedChainProvider;
+
+/// Resolved swap settlement parameters and the channels that connect the
+/// provider, the service, and the node.
+///
+/// Produced by [`SwapWiring::prepare`] before the accounting is built; consumed
+/// by [`SwapWiring::spawn`] after the node command channel exists.
+pub(crate) struct SwapWiring {
+    command_rx: mpsc::UnboundedReceiver<SwapCommand>,
+    swap_event_tx: mpsc::UnboundedSender<SwapEvent>,
+    swap_event_rx: mpsc::UnboundedReceiver<SwapEvent>,
+    signer: Arc<PrivateKeySigner>,
+    our_rate: U256,
+    chequebook: Address,
+    beneficiary: Address,
+    chain: NamedChain,
+}
+
+impl SwapWiring {
+    /// Build the swap handle and provider when SWAP settlement is enabled.
+    ///
+    /// Returns `None` (and leaves accounting swap-free) when the bandwidth mode
+    /// does not enable SWAP, or when SWAP is requested but the required chequebook
+    /// address and settlement chain cannot be resolved. The returned provider is
+    /// registered with the accounting builder; the returned wiring is later handed
+    /// to [`SwapWiring::spawn`].
+    pub(crate) fn prepare<C>(
+        spec: &Arc<Spec>,
+        identity: &Arc<Identity>,
+        config: &C,
+        swap_config: &SwapConfig,
+    ) -> Option<(SwapProvider<C>, Self)>
+    where
+        C: SwarmAccountingConfig + Clone + 'static,
+    {
+        let mode = config.mode();
+        if !mode.swap_enabled() {
+            if swap_config.enable {
+                warn!(
+                    ?mode,
+                    "--swap set but bandwidth mode does not enable SWAP; settlement not wired"
+                );
+            }
+            return None;
+        }
+
+        let Some(chequebook) = swap_config.chequebook else {
+            warn!(
+                "SWAP enabled but no --swap.chequebook configured; settlement not wired (chequebook deploy not yet supported)"
+            );
+            return None;
+        };
+        if swap_config.deploy {
+            warn!("--swap.deploy is not yet supported; using the configured chequebook address");
+        }
+
+        let Some(chain) = spec.chain().named() else {
+            warn!(
+                "SWAP enabled but the network has no named settlement chain; settlement not wired"
+            );
+            return None;
+        };
+
+        // The beneficiary defaults to the node Ethereum address: the only payout
+        // address a cheque sent to us may name.
+        let beneficiary = swap_config
+            .beneficiary
+            .unwrap_or_else(|| identity.ethereum_address());
+
+        let (swap_event_tx, swap_event_rx) = mpsc::unbounded_channel();
+        // The handle backs the provider; its command channel is drained by the
+        // service spawned in `spawn`. The handle is created here so the provider
+        // can be embedded in the accounting before the accounting is built.
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let handle = SwapHandle::new(command_tx);
+        let provider = SwapProvider::with_handle(config.clone(), handle);
+
+        info!(%chequebook, %beneficiary, %chain, "SWAP settlement enabled");
+
+        let wiring = Self {
+            command_rx,
+            swap_event_tx,
+            swap_event_rx,
+            signer: identity.signer(),
+            our_rate: U256::from(config.refresh_rate()),
+            chequebook,
+            beneficiary,
+            chain,
+        };
+
+        Some((provider, wiring))
+    }
+
+    /// The sender the node behaviour routes swap wire events into.
+    pub(crate) fn swap_event_sender(&self) -> mpsc::UnboundedSender<SwapEvent> {
+        self.swap_event_tx.clone()
+    }
+
+    /// Construct, spawn, and wire the swap service.
+    ///
+    /// The service records cheque-driven balance changes against `accounting`
+    /// (the same instance the provider settles through), drains the provider's
+    /// command channel, and consumes routed swap wire events. Its `SendCheque`
+    /// commands are forwarded to the node through `client_handle`. With the
+    /// `chain` feature and a connected provider, received cheques are also cashed
+    /// on chain, paying out to our beneficiary.
+    pub(crate) fn spawn<A>(
+        self,
+        ctx: &dyn InfrastructureContext,
+        accounting: Arc<A>,
+        client_handle: ClientHandle,
+        #[cfg(feature = "chain")] chain_provider: Option<&SharedChainProvider>,
+    ) where
+        A: SwarmBandwidthAccounting + 'static,
+    {
+        // The service speaks unbounded `ClientCommand`; the node command channel
+        // is bounded and reached through `ClientHandle::send_command`. Bridge the
+        // two with a forwarding task so the service never blocks on a full queue.
+        let (client_command_tx, client_command_rx) = mpsc::unbounded_channel();
+        spawn_command_bridge(ctx, client_command_rx, client_handle);
+
+        let service = SwapService::new(
+            self.command_rx,
+            self.swap_event_rx,
+            client_command_tx,
+            accounting,
+            self.our_rate,
+            self.signer,
+            self.chequebook,
+            self.beneficiary,
+            self.chain,
+        );
+
+        #[cfg(feature = "chain")]
+        let service = attach_cashout(service, chain_provider, self.beneficiary);
+
+        ctx.executor().spawn_service("swarm.swap_service", service);
+    }
+}
+
+/// Forward the swap service's `ClientCommand`s to the node command channel.
+///
+/// The service emits commands on an unbounded channel; this task drains it and
+/// hands each command to the node through `ClientHandle::send_command`, which is
+/// non-blocking. The task ends when the service drops its sender or on shutdown.
+fn spawn_command_bridge(
+    ctx: &dyn InfrastructureContext,
+    mut client_command_rx: mpsc::UnboundedReceiver<ClientCommand>,
+    client_handle: ClientHandle,
+) {
+    ctx.executor().spawn_with_graceful_shutdown_signal(
+        "swarm.swap_command_bridge",
+        move |shutdown| async move {
+            let mut shutdown = std::pin::pin!(shutdown);
+            loop {
+                tokio::select! {
+                    guard = &mut shutdown => {
+                        drop(guard);
+                        break;
+                    }
+                    command = client_command_rx.recv() => {
+                        let Some(command) = command else { break };
+                        if let Err(e) = client_handle.send_command(command) {
+                            warn!(error = %e, "Failed to forward swap command to node");
+                        }
+                    }
+                }
+            }
+        },
+    );
+}
+
+/// Attach an on-chain cashout client to the swap service when a chain provider is
+/// present, so received cheques are redeemed paying out to our beneficiary.
+#[cfg(feature = "chain")]
+fn attach_cashout<A, S>(
+    service: SwapService<A, S>,
+    chain_provider: Option<&SharedChainProvider>,
+    beneficiary: Address,
+) -> SwapService<A, S>
+where
+    A: SwarmBandwidthAccounting + 'static,
+    S: alloy_signer::SignerSync + Send + Sync + 'static,
+{
+    use vertex_swarm_bandwidth_swap::cashout::Cashout;
+
+    let Some(provider) = chain_provider else {
+        return service;
+    };
+    let cashout = Cashout::new(
+        provider.provider().clone(),
+        *provider.addresses(),
+        beneficiary,
+    );
+    service.with_cashout(cashout)
+}

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -105,4 +105,5 @@ cli = [
     "dep:vertex-swarm-localstore",
     "dep:vertex-swarm-redistribution",
     "vertex-swarm-primitives/serde",
+    "alloy-primitives/serde",
 ]

--- a/crates/swarm/node/src/args/mod.rs
+++ b/crates/swarm/node/src/args/mod.rs
@@ -5,6 +5,7 @@ mod network;
 mod peer;
 mod retrieval;
 mod spec;
+mod swap;
 mod swarm;
 
 pub use chain::{ChainArgs, ChainConfig};
@@ -12,5 +13,6 @@ pub use network::{NetworkArgs, NetworkConfig};
 pub use peer::{PeerArgs, PeerConfig};
 pub use retrieval::RetrievalArgs;
 pub use spec::SwarmSpecArgs;
+pub use swap::{SwapArgs, SwapConfig};
 pub use swarm::{NodeTypeArg, ProtocolArgs};
 pub use vertex_swarm_topology::RoutingArgs;

--- a/crates/swarm/node/src/args/swap.rs
+++ b/crates/swarm/node/src/args/swap.rs
@@ -1,0 +1,108 @@
+//! SWAP settlement CLI arguments and validated configuration.
+//!
+//! These are plain knobs (a chequebook address, a beneficiary payout address, and
+//! a deploy toggle) that exist in every build. The arguments name no chain types,
+//! so the surface is identical whether or not the binary is compiled with the
+//! optional `swap` feature; a build without the feature simply ignores them. The
+//! builder reads these only under the `swap` feature, and only when the bandwidth
+//! mode enables SWAP. The settlement chain and contract addresses come from the
+//! network spec; the RPC endpoint is the shared `--chain.rpc-url`.
+
+use alloy_primitives::Address;
+use clap::Args;
+use serde::{Deserialize, Serialize};
+
+/// SWAP settlement CLI arguments.
+#[derive(Debug, Default, Args, Clone, Serialize, Deserialize)]
+#[command(next_help_heading = "Swap")]
+#[serde(default)]
+pub struct SwapArgs {
+    /// Enable SWAP settlement (chequebook payments). Equivalent to selecting a
+    /// SWAP-capable bandwidth mode. Has no effect unless the binary was built with
+    /// the `swap` feature.
+    #[arg(long = "swap")]
+    #[serde(default)]
+    pub enable: bool,
+
+    /// This node's chequebook contract address (the drawer of cheques we issue).
+    /// Required to issue cheques when SWAP is enabled and a chequebook is not
+    /// being deployed.
+    #[arg(long = "swap.chequebook")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chequebook: Option<Address>,
+
+    /// Payout address that cheques sent to this node must name (where received
+    /// funds are paid). Defaults to the node Ethereum address when unset.
+    #[arg(long = "swap.beneficiary")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub beneficiary: Option<Address>,
+
+    /// Deploy a new chequebook on startup instead of using an existing one.
+    #[arg(long = "swap.deploy")]
+    #[serde(default)]
+    pub deploy: bool,
+}
+
+impl SwapArgs {
+    /// Build the validated SWAP configuration.
+    pub fn swap_config(&self) -> SwapConfig {
+        SwapConfig {
+            enable: self.enable,
+            chequebook: self.chequebook,
+            beneficiary: self.beneficiary,
+            deploy: self.deploy,
+        }
+    }
+}
+
+/// Validated SWAP configuration carried on the node configs.
+///
+/// Plain data with no chain-crate types so it compiles in every build. The
+/// builder reads these fields only under the `swap` feature; without it they are
+/// inert.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SwapConfig {
+    /// Whether SWAP settlement is requested via the dedicated flag.
+    pub enable: bool,
+
+    /// This node's chequebook contract address, if configured.
+    pub chequebook: Option<Address>,
+
+    /// Payout address cheques sent to us must name. `None` falls back to the node
+    /// Ethereum address.
+    pub beneficiary: Option<Address>,
+
+    /// Whether to deploy a fresh chequebook on startup.
+    pub deploy: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_when_unset() {
+        let cfg = SwapArgs::default().swap_config();
+        assert!(!cfg.enable);
+        assert_eq!(cfg.chequebook, None);
+        assert_eq!(cfg.beneficiary, None);
+        assert!(!cfg.deploy);
+    }
+
+    #[test]
+    fn overrides_flow_through() {
+        let chequebook = Address::repeat_byte(0x11);
+        let beneficiary = Address::repeat_byte(0x22);
+        let args = SwapArgs {
+            enable: true,
+            chequebook: Some(chequebook),
+            beneficiary: Some(beneficiary),
+            deploy: true,
+        };
+        let cfg = args.swap_config();
+        assert!(cfg.enable);
+        assert_eq!(cfg.chequebook, Some(chequebook));
+        assert_eq!(cfg.beneficiary, Some(beneficiary));
+        assert!(cfg.deploy);
+    }
+}

--- a/crates/swarm/node/src/args/swarm.rs
+++ b/crates/swarm/node/src/args/swarm.rs
@@ -11,7 +11,7 @@ use vertex_swarm_localstore::LocalStoreArgs;
 use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_redistribution::RedistributionArgs;
 
-use super::{ChainArgs, NetworkArgs, RetrievalArgs, SwarmSpecArgs};
+use super::{ChainArgs, NetworkArgs, RetrievalArgs, SwapArgs, SwarmSpecArgs};
 
 /// CLI argument for node mode selection. Maps to [`SwarmNodeType`].
 #[derive(
@@ -92,4 +92,8 @@ pub struct ProtocolArgs {
     /// Ethereum chain connection (RPC endpoint and transaction tuning).
     #[command(flatten)]
     pub chain: ChainArgs,
+
+    /// SWAP settlement (chequebook, beneficiary, deploy).
+    #[command(flatten)]
+    pub swap: SwapArgs,
 }

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -16,7 +16,8 @@ use vertex_swarm_spec::Spec;
 use vertex_swarm_api::ConfigError;
 
 use crate::args::{
-    ChainArgs, ChainConfig, NetworkArgs, NetworkConfig, ProtocolArgs, RetrievalArgs,
+    ChainArgs, ChainConfig, NetworkArgs, NetworkConfig, ProtocolArgs, RetrievalArgs, SwapArgs,
+    SwapConfig,
 };
 
 /// Swarm protocol configuration (serializable Args layer).
@@ -35,6 +36,7 @@ pub struct ProtocolConfig {
     pub localstore: LocalStoreArgs,
     pub redistribution: RedistributionArgs,
     pub chain: ChainArgs,
+    pub swap: SwapArgs,
 }
 
 impl ProtocolConfig {
@@ -72,6 +74,11 @@ impl ProtocolConfig {
     pub fn chain_config(&self) -> ChainConfig {
         self.chain.chain_config()
     }
+
+    /// Create the validated SWAP configuration (chequebook, beneficiary, deploy).
+    pub fn swap_config(&self) -> SwapConfig {
+        self.swap.swap_config()
+    }
 }
 
 impl ProtocolConfig {
@@ -92,5 +99,6 @@ impl NodeProtocolConfig for ProtocolConfig {
         self.localstore = args.localstore.clone();
         self.redistribution = args.redistribution.clone();
         self.chain = args.chain.clone();
+        self.swap = args.swap.clone();
     }
 }

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -326,6 +326,8 @@ pub struct ClientNodeBuilder<I: SwarmIdentity + Clone> {
     infra: Option<BuiltInfrastructure<I>>,
     kademlia_config: Option<KademliaConfig>,
     pseudosettle_event_tx: Option<mpsc::UnboundedSender<PseudosettleEvent>>,
+    #[cfg(feature = "swap")]
+    swap_event_tx: Option<mpsc::UnboundedSender<crate::protocol::SwapEvent>>,
 }
 
 impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
@@ -335,6 +337,8 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
             infra: None,
             kademlia_config: None,
             pseudosettle_event_tx: None,
+            #[cfg(feature = "swap")]
+            swap_event_tx: None,
         }
     }
 
@@ -353,6 +357,20 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
         tx: mpsc::UnboundedSender<PseudosettleEvent>,
     ) -> Self {
         self.pseudosettle_event_tx = Some(tx);
+        self
+    }
+
+    /// Route swap wire events to the SWAP settlement service.
+    ///
+    /// When set, swap cheque events are forwarded to this channel so the
+    /// settlement service can validate and credit received cheques and complete
+    /// outbound settlements.
+    #[cfg(feature = "swap")]
+    pub fn with_swap_events(
+        mut self,
+        tx: mpsc::UnboundedSender<crate::protocol::SwapEvent>,
+    ) -> Self {
+        self.swap_event_tx = Some(tx);
         self
     }
 }
@@ -416,6 +434,11 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
                 .behaviour_mut()
                 .client
                 .set_pseudosettle_events(tx);
+        }
+
+        #[cfg(feature = "swap")]
+        if let Some(tx) = self.swap_event_tx {
+            base.swarm.behaviour_mut().client.route_swap_events(tx);
         }
 
         let executor = TaskExecutor::current();

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -111,6 +111,8 @@ pub struct StorerNodeBuilder<I: SwarmIdentity + Clone> {
     identity: I,
     kademlia_config: Option<KademliaConfig>,
     pseudosettle_event_tx: Option<mpsc::UnboundedSender<PseudosettleEvent>>,
+    #[cfg(feature = "swap")]
+    swap_event_tx: Option<mpsc::UnboundedSender<crate::protocol::SwapEvent>>,
 }
 
 impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
@@ -120,6 +122,8 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
             identity,
             kademlia_config: None,
             pseudosettle_event_tx: None,
+            #[cfg(feature = "swap")]
+            swap_event_tx: None,
         }
     }
 
@@ -135,6 +139,16 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
         tx: mpsc::UnboundedSender<PseudosettleEvent>,
     ) -> Self {
         self.pseudosettle_event_tx = Some(tx);
+        self
+    }
+
+    /// Set the sender for routing swap wire events to the settlement service.
+    #[cfg(feature = "swap")]
+    pub fn with_swap_events(
+        mut self,
+        tx: mpsc::UnboundedSender<crate::protocol::SwapEvent>,
+    ) -> Self {
+        self.swap_event_tx = Some(tx);
         self
     }
 }
@@ -172,6 +186,10 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
         }
         if let Some(tx) = self.pseudosettle_event_tx {
             client_builder = client_builder.with_pseudosettle_events(tx);
+        }
+        #[cfg(feature = "swap")]
+        if let Some(tx) = self.swap_event_tx {
+            client_builder = client_builder.with_swap_events(tx);
         }
 
         let (client, service, handle) = client_builder


### PR DESCRIPTION
Completes the Client + SWAP batch by wiring the chequebook settlement service into the client and storer launch paths, behind a new `swap` cargo feature on `vertex-swarm-builder` and `vertex`.

## What this does

When the bandwidth mode enables SWAP, the launch path embeds a `SwapProvider` in the accounting so `BandwidthMode` selection drives cheque issuance (composing with pseudosettle for `Both`), spawns the `SwapService` over the same accounting instance, routes swap wire events into the service via the node behaviour's `route_swap_events`, and forwards the service's `ClientCommand::SendCheque` back to the node through a small bridge task that adapts the unbounded service channel to the node's bounded command channel.

With the `chain` feature also enabled, a `ChequebookContract` built over a clone of the `SharedChainProvider`'s `DynProvider` cashes received cheques on chain, paying out to our beneficiary. Cheque exchange itself is chain-free, so `swap` works without `chain`.

## Builder and binary surface

The node `ClientNodeBuilder` and `StorerNodeBuilder` gain a `with_swap_events` method behind the node `swap` feature, mirroring the existing `with_pseudosettle_events`, so the builder can drive the `pub(crate)` `route_swap_events`. New `--swap`, `--swap.chequebook`, `--swap.beneficiary`, and `--swap.deploy` flags (strongly typed `Address` knobs in the node args crate, present in every build like the `--chain.*` flags) carry the operator config. The settlement chain comes from the spec swarm, and the RPC endpoint reuses `--chain.rpc-url`.

## Default cone stays swap-free and chain-free

The swap service crate and the chain crates never resolve in the default build. Verified with `cargo tree -e features` on the default `vertex` target.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test -p vertex-swarm-builder` all pass.

Feature matrix builds pass: `vertex` default, `--features swap`, `--features "swap chain"`, `--features storer`; and `vertex-swarm-builder --features swap` and `--features "swap chain"`.

## Follow-up

Exposing chequebook balance/status over gRPC is left as a follow-up: it needs a new proto service and provider plumbing, which is beyond the small addition this unit targeted.