### PR TITLE
refactor: rename wiring and config set_ methods to verb-based names

### DIFF
--- a/bin/vertex/src/cli.rs
+++ b/bin/vertex/src/cli.rs
@@ -88,7 +88,7 @@ pub async fn run() -> Result<()> {
             None
         })?;
         config.apply_args(&args.infra, &args.protocol);
-        config.protocol.set_node_type(node_type);
+        config.protocol.override_node_type(node_type);
 
         // Build metrics config from CLI args
         let metrics_config = args.infra.observability.metrics.metrics_config();

--- a/crates/ffi/src/api/client.rs
+++ b/crates/ffi/src/api/client.rs
@@ -255,7 +255,7 @@ fn build_network(bootnodes: Vec<String>) -> NetworkConfig {
             .filter_map(|addr| addr.parse().ok())
             .collect();
         if !parsed.is_empty() {
-            network.set_bootnodes(parsed);
+            network.override_bootnodes(parsed);
         }
     }
     network

--- a/crates/swarm/bandwidth/swap/src/handle.rs
+++ b/crates/swarm/bandwidth/swap/src/handle.rs
@@ -39,13 +39,13 @@ impl SwapHandle {
 
     /// Register the SWAP identity (beneficiary and chequebook issuer) learned for
     /// a peer during the swap handshake.
-    pub fn set_peer_info(
+    pub fn register_peer_info(
         &self,
         peer: OverlayAddress,
         info: PeerSwapInfo,
     ) -> Result<(), SwapSettlementError> {
         self.command_tx
-            .send(SwapCommand::SetPeerInfo { peer, info })
+            .send(SwapCommand::RegisterPeerInfo { peer, info })
             .map_err(|_| SwapSettlementError::ServiceStopped)
     }
 }

--- a/crates/swarm/bandwidth/swap/src/service.rs
+++ b/crates/swarm/bandwidth/swap/src/service.rs
@@ -27,7 +27,7 @@ use crate::error::SwapSettlementError;
 ///
 /// The beneficiary is the address a cheque we issue to this peer must pay; the
 /// issuer is the chequebook owner whose key must sign cheques the peer sends us.
-/// Populated through [`SwapCommand::SetPeerInfo`] by the node layer (handshake
+/// Populated through [`SwapCommand::RegisterPeerInfo`] by the node layer (handshake
 /// wiring is the builder's job).
 #[derive(Debug, Clone, Copy)]
 pub struct PeerSwapInfo {
@@ -49,7 +49,7 @@ pub enum SwapCommand {
         response_tx: oneshot::Sender<Result<u64, SwapSettlementError>>,
     },
     /// Register the SWAP identity learned for a peer during the handshake.
-    SetPeerInfo {
+    RegisterPeerInfo {
         /// The peer the identity belongs to.
         peer: OverlayAddress,
         /// The peer's beneficiary and chequebook issuer.
@@ -173,7 +173,7 @@ where
 
     async fn handle_command(&mut self, cmd: SwapCommand) {
         match cmd {
-            SwapCommand::SetPeerInfo { peer, info } => {
+            SwapCommand::RegisterPeerInfo { peer, info } => {
                 debug!(
                     %peer,
                     beneficiary = %info.beneficiary,

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -200,7 +200,7 @@ impl NetworkArgs {
                     })
                 })
                 .collect();
-            config.set_bootnodes(parsed?);
+            config.override_bootnodes(parsed?);
         }
 
         Ok(config)
@@ -260,14 +260,16 @@ impl<R> NetworkConfig<R> {
         }
     }
 
-    /// Set bootnodes (for spec fallback).
-    pub fn set_bootnodes(&mut self, bootnodes: Vec<Multiaddr>) {
+    /// Replace the configured bootnodes with a list from a higher-precedence
+    /// source (spec defaults when the CLI gave none, or host-supplied
+    /// multiaddrs at the FFI boundary).
+    pub fn override_bootnodes(&mut self, bootnodes: Vec<Multiaddr>) {
         self.bootnodes = bootnodes;
     }
 
-    /// Set default peer store path if not already configured via CLI.
-    pub fn set_default_peer_store_path(&mut self, path: std::path::PathBuf) {
-        self.peer.set_default_store_path(path);
+    /// Fill in the default peer store path if none was configured via CLI.
+    pub fn apply_default_peer_store_path(&mut self, path: std::path::PathBuf) {
+        self.peer.apply_default_store_path(path);
     }
 }
 

--- a/crates/swarm/node/src/args/peer.rs
+++ b/crates/swarm/node/src/args/peer.rs
@@ -45,8 +45,8 @@ impl From<&PeerArgs> for PeerConfig {
 }
 
 impl PeerConfig {
-    /// Set the store path if not already set.
-    pub fn set_default_store_path(&mut self, path: PathBuf) {
+    /// Fill in the default store path if none was configured.
+    pub fn apply_default_store_path(&mut self, path: PathBuf) {
         if self.store_path.is_none() {
             self.store_path = Some(path);
         }

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -82,8 +82,9 @@ impl ProtocolConfig {
 }
 
 impl ProtocolConfig {
-    /// Set the node type.
-    pub fn set_node_type(&mut self, node_type: SwarmNodeType) {
+    /// Override the node type with the CLI-selected value, taking precedence
+    /// over whatever the loaded config file carried.
+    pub fn override_node_type(&mut self, node_type: SwarmNodeType) {
         self.node_type = node_type;
     }
 }

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -351,11 +351,11 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
         )
         .await?;
 
-        // Set local PeerId for address advertisement in handshakes
+        // Register the local PeerId for address advertisement in handshakes
         base.swarm
             .behaviour()
             .topology
-            .set_local_peer_id(*base.swarm.local_peer_id());
+            .register_local_peer_id(*base.swarm.local_peer_id());
 
         Ok(BootNode { base })
     }

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -164,7 +164,7 @@ impl<C: SwarmRoutingConfig> SwarmRoutingConfig for ConfigWithBootnodes<'_, C> {
 ///
 /// The `behaviour_fn` receives the libp2p public key and the topology behaviour,
 /// and must return both the composed NetworkBehaviour and a reference to its
-/// topology so we can call `set_local_peer_id`.
+/// topology so we can call `register_local_peer_id`.
 pub(crate) async fn build_base_node<I, B, C, F>(
     mut infra: BuiltInfrastructure<I>,
     network_config: &C,

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -423,17 +423,17 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
         )
         .await?;
 
-        // Set local PeerId for address advertisement in handshakes
+        // Register the local PeerId for address advertisement in handshakes
         base.swarm
             .behaviour()
             .topology
-            .set_local_peer_id(*base.swarm.local_peer_id());
+            .register_local_peer_id(*base.swarm.local_peer_id());
 
         if let Some(tx) = self.pseudosettle_event_tx {
             base.swarm
                 .behaviour_mut()
                 .client
-                .set_pseudosettle_events(tx);
+                .route_pseudosettle_events(tx);
         }
 
         #[cfg(feature = "swap")]

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -68,7 +68,7 @@ impl Config {
 /// # Event Routing
 ///
 /// Settlement events can be routed directly to settlement services via optional
-/// event senders. Use [`set_pseudosettle_events`](Self::set_pseudosettle_events)
+/// event senders. Use [`route_pseudosettle_events`](Self::route_pseudosettle_events)
 /// to configure routing. Events are still emitted as [`ClientEvent`] for other consumers.
 pub(crate) struct ClientBehaviour {
     config: Config,
@@ -99,11 +99,14 @@ impl ClientBehaviour {
         }
     }
 
-    /// Set the sender for pseudosettle events.
+    /// Route pseudosettle events to the given sink.
     ///
-    /// When set, pseudosettle-related events will be sent to this channel
+    /// Once routed, pseudosettle-related events will be sent to this channel
     /// in addition to being emitted as [`ClientEvent`].
-    pub(crate) fn set_pseudosettle_events(&mut self, tx: mpsc::UnboundedSender<PseudosettleEvent>) {
+    pub(crate) fn route_pseudosettle_events(
+        &mut self,
+        tx: mpsc::UnboundedSender<PseudosettleEvent>,
+    ) {
         self.pseudosettle_event_tx = Some(tx);
     }
 

--- a/crates/swarm/peers/peer-manager/src/entry.rs
+++ b/crates/swarm/peers/peer-manager/src/entry.rs
@@ -273,8 +273,8 @@ impl PeerEntry {
         self.mark_dirty();
     }
 
-    pub(crate) fn set_latency(&self, rtt: Duration) {
-        self.scoring.set_latency(rtt);
+    pub(crate) fn record_latency(&self, rtt: Duration) {
+        self.scoring.record_latency(rtt);
         self.mark_dirty();
     }
 

--- a/crates/swarm/peers/peer-manager/src/scoring.rs
+++ b/crates/swarm/peers/peer-manager/src/scoring.rs
@@ -13,7 +13,7 @@ use crate::manager::PeerManager;
 impl<I: SwarmIdentity> PeerManager<I> {
     pub fn record_latency(&self, overlay: &OverlayAddress, rtt: Duration) {
         if let Some(entry) = self.peers.get(overlay) {
-            entry.set_latency(rtt);
+            entry.record_latency(rtt);
             trace!(?overlay, ?rtt, "recorded latency");
         }
     }

--- a/crates/swarm/peers/peer-score/src/score.rs
+++ b/crates/swarm/peers/peer-score/src/score.rs
@@ -120,7 +120,7 @@ impl SwarmPeerScore {
     }
 
     /// Record latency without affecting score.
-    pub fn set_latency(&self, rtt: Duration) {
+    pub fn record_latency(&self, rtt: Duration) {
         self.score.record_latency(rtt.as_nanos() as u64);
     }
 

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -421,12 +421,12 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
     // Public methods
 
-    /// Set the local PeerId for address advertisement in handshakes.
+    /// Register the local PeerId for address advertisement in handshakes.
     ///
     /// Must be called after the libp2p Swarm is built. All multiaddrs
     /// advertised to peers will include `/p2p/{peer_id}`.
-    pub fn set_local_peer_id(&self, peer_id: PeerId) {
-        self.nat_discovery.set_local_peer_id(peer_id);
+    pub fn register_local_peer_id(&self, peer_id: PeerId) {
+        self.nat_discovery.register_local_peer_id(peer_id);
     }
 
     /// Record an observed address reported by a peer.

--- a/crates/swarm/topology/src/nat_discovery.rs
+++ b/crates/swarm/topology/src/nat_discovery.rs
@@ -93,10 +93,10 @@ impl LocalAddressManager {
         self.reachability.on_autonat_peer_confirmed(peer);
     }
 
-    /// Set the local PeerId for appending /p2p/ to advertised addresses.
+    /// Register the local PeerId for appending /p2p/ to advertised addresses.
     ///
-    /// Must be called after the libp2p Swarm is built. Can only be set once.
-    pub fn set_local_peer_id(&self, peer_id: PeerId) {
+    /// Must be called after the libp2p Swarm is built. Can only be registered once.
+    pub fn register_local_peer_id(&self, peer_id: PeerId) {
         if self.local_peer_id.set(peer_id).is_err() {
             warn!("local_peer_id already set, ignoring duplicate call");
         } else {
@@ -548,7 +548,7 @@ mod tests {
     fn test_with_peer_id_appends() {
         let manager = create_manager(vec![]);
         let peer_id = PeerId::random();
-        manager.set_local_peer_id(peer_id);
+        manager.register_local_peer_id(peer_id);
 
         let addr = parse_addr("/ip4/8.8.8.8/tcp/1634");
         let with_peer_id = manager.with_peer_id(vec![addr]);

--- a/crates/swarm/topology/src/reachability.rs
+++ b/crates/swarm/topology/src/reachability.rs
@@ -136,7 +136,7 @@ impl PeerReachabilityRecord {
 
 /// Thread-safe per-peer reachability tracker.
 ///
-/// Cheap to clone; internally an `Arc<RwLock<...>>`. Never panics —
+/// Cheap to clone; internally an `Arc<RwLock<...>>`. Never panics:
 /// `parking_lot::RwLock` does not poison and all map accesses go through
 /// `entry`/`get`.
 #[derive(Debug, Clone, Default)]
@@ -197,7 +197,7 @@ impl ReachabilityTracker {
     /// accepts inbound connections on that address, so we promote it to
     /// [`PeerReachability::Reachable`].
     pub fn on_autonat_peer_confirmed(&self, peer: PeerId) {
-        self.set_reachable(peer, "autonat");
+        self.record_reachable(peer, "autonat");
     }
 
     /// Record that a peer is reachable because *we* dialed it outbound at a
@@ -208,7 +208,7 @@ impl ReachabilityTracker {
     /// address must not be routed here (it only proves local reachability); the
     /// topology behaviour gates on the dialed address scope.
     pub fn on_outbound_reachable(&self, peer: PeerId) {
-        self.set_reachable(peer, "outbound");
+        self.record_reachable(peer, "outbound");
     }
 
     /// Update from a `libp2p::ping` round-trip outcome.
@@ -240,7 +240,7 @@ impl ReachabilityTracker {
     // Internal helpers
     // ---------------------------------------------------------------------
 
-    fn set_reachable(&self, peer: PeerId, source: &'static str) {
+    fn record_reachable(&self, peer: PeerId, source: &'static str) {
         let mut guard = self.inner.write();
         let entry = guard
             .entry(peer)


### PR DESCRIPTION
Closes #195

Audits every `fn set_*` in `bin/` and `crates/` and renames the ones that are not plain field setters to verb-based names. Definitions, call sites, enum variants, rustdoc, and doc comments are updated together; `grep -rn 'fn set_'` now returns only genuine setters, and no stale old-name references remain in code or docs.

## Renamed

| Old | New | Location | Rationale |
|---|---|---|---|
| `set_pseudosettle_events` | `route_pseudosettle_events` | `crates/swarm/node/src/protocol/behaviour.rs` | Event routing, mirrors the existing `route_swap_events` from #191 |
| `set_bootnodes` | `override_bootnodes` | `crates/swarm/node/src/args/network.rs` | Replaces configured bootnodes from a higher-precedence source (spec fallback, FFI host) |
| `set_node_type` | `override_node_type` | `crates/swarm/node/src/config.rs` | CLI-selected value takes precedence over the loaded config file |
| `set_default_peer_store_path` | `apply_default_peer_store_path` | `crates/swarm/node/src/args/network.rs` | Conditional default fill, delegates to the peer config |
| `set_default_store_path` | `apply_default_store_path` | `crates/swarm/node/src/args/peer.rs` | Fills the store path only when none was configured |
| `set_local_peer_id` | `register_local_peer_id` | `crates/swarm/topology/src/behaviour.rs`, `crates/swarm/topology/src/nat_discovery.rs` | Once-only post-Swarm-build wiring into a `OnceLock`, kept consistent across both |
| `set_peer_info` | `register_peer_info` | `crates/swarm/bandwidth/swap/src/handle.rs` | Its rustdoc already said "Register"; the matching `SwapCommand::SetPeerInfo` variant is renamed to `RegisterPeerInfo` |
| `set_reachable` | `record_reachable` | `crates/swarm/topology/src/reachability.rs` | Records an observed reachability fact with a source label |
| `set_latency` | `record_latency` | `crates/swarm/peers/peer-score/src/score.rs`, `crates/swarm/peers/peer-manager/src/entry.rs` | Listed as a probable keep in the issue, but the code says otherwise: it feeds a latency EWMA recorder through `&self` rather than setting a field, its rustdoc already says "Record latency", and the public `PeerManager::record_latency` entry point already used the verb |

## Kept (genuine field/state setters)

| Method | Location |
|---|---|
| `set_score` | `crates/net/peer/score/src/lib.rs` |
| `set_balance` | `crates/swarm/bandwidth/core/src/accounting/peer.rs` |
| `set_last_refresh` | `crates/swarm/bandwidth/core/src/accounting/peer.rs` and the trait method in `crates/swarm/api/src/components/bandwidth.rs` |
| `set_outbound_pending` | `crates/swarm/net/handler-core/src/lib.rs` |
| `set_status` | `crates/swarm/topology/src/reachability.rs` |
| `set_status`, `set_serving`, `set_not_serving` | `crates/rpc/server/src/health.rs` |
| `set_panic_hook` | `bin/swarm-wasm-lib/src/utils.rs` (wasm ecosystem convention) |

Gates: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings` clean, and `cargo test` green for all touched crates (`vertex`, `vertex-ffi`, `vertex-swarm-bandwidth-swap`, `vertex-swarm-node`, `vertex-swarm-peer-manager`, `vertex-swarm-peer-score`, `vertex-swarm-topology`).
