### PR TITLE
chore(swarm-swap): remove dead our_rate field from settlement service

### DIFF
--- a/crates/swarm/bandwidth/swap/src/lib.rs
+++ b/crates/swarm/bandwidth/swap/src/lib.rs
@@ -31,7 +31,7 @@ pub mod service;
 use std::sync::Arc;
 
 use alloy_chains::NamedChain;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use tokio::sync::mpsc;
 use vertex_swarm_api::{
@@ -142,12 +142,10 @@ impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for SwapProvide
 /// node's chequebook (the drawer), `beneficiary` is our payout address (the only
 /// address a cheque sent to us may name), and `chain` binds the EIP-712 domain to
 /// the settlement chain.
-#[allow(clippy::too_many_arguments)]
 pub fn create_swap_actor<A, S>(
     event_rx: mpsc::UnboundedReceiver<SwapEvent>,
     client_command_tx: mpsc::UnboundedSender<ClientCommand>,
     accounting: Arc<A>,
-    our_rate: U256,
     signer: Arc<S>,
     chequebook: Address,
     beneficiary: Address,
@@ -164,7 +162,6 @@ where
         event_rx,
         client_command_tx,
         accounting,
-        our_rate,
         signer,
         chequebook,
         beneficiary,

--- a/crates/swarm/bandwidth/swap/src/service.rs
+++ b/crates/swarm/bandwidth/swap/src/service.rs
@@ -78,9 +78,6 @@ pub struct SwapService<A: SwarmBandwidthAccounting, S> {
     command_tx: mpsc::UnboundedSender<ClientCommand>,
     /// Reference to accounting for balance updates.
     accounting: Arc<A>,
-    /// Our exchange rate.
-    #[allow(dead_code)]
-    our_rate: U256,
     /// The Ethereum signer used to sign cheques.
     signer: Arc<S>,
     /// Our chequebook address (the drawer of cheques we issue).
@@ -115,7 +112,6 @@ where
         event_rx: mpsc::UnboundedReceiver<SwapEvent>,
         command_tx: mpsc::UnboundedSender<ClientCommand>,
         accounting: Arc<A>,
-        our_rate: U256,
         signer: Arc<S>,
         chequebook: Address,
         beneficiary: Address,
@@ -126,7 +122,6 @@ where
             event_rx,
             command_tx,
             accounting,
-            our_rate,
             signer,
             chequebook,
             beneficiary,
@@ -405,7 +400,6 @@ mod tests {
             event_rx,
             client_tx,
             accounting,
-            U256::ZERO,
             Arc::new(signer),
             Address::repeat_byte(0xcb),
             OUR_BENEFICIARY,

--- a/crates/swarm/builder/src/swap.rs
+++ b/crates/swarm/builder/src/swap.rs
@@ -21,7 +21,7 @@
 use std::sync::Arc;
 
 use alloy_chains::NamedChain;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
@@ -47,7 +47,6 @@ pub(crate) struct SwapWiring {
     swap_event_tx: mpsc::UnboundedSender<SwapEvent>,
     swap_event_rx: mpsc::UnboundedReceiver<SwapEvent>,
     signer: Arc<PrivateKeySigner>,
-    our_rate: U256,
     chequebook: Address,
     beneficiary: Address,
     chain: NamedChain,
@@ -119,7 +118,6 @@ impl SwapWiring {
             swap_event_tx,
             swap_event_rx,
             signer: identity.signer(),
-            our_rate: U256::from(config.refresh_rate()),
             chequebook,
             beneficiary,
             chain,
@@ -161,7 +159,6 @@ impl SwapWiring {
             self.swap_event_rx,
             client_command_tx,
             accounting,
-            self.our_rate,
             self.signer,
             self.chequebook,
             self.beneficiary,


### PR DESCRIPTION
Closes #36

Issue #36 listed three suppressed dead fields in the bandwidth services. Two of them are already in active use after the SWAP settlement wiring in #196 and #197: `refresh_rate` in the pseudosettle service caps the time-based settlement allowance, and `command_tx` in the swap service sends `SendCheque` commands to the node layer. The only remaining suppressed dead code was `our_rate` in `SwapService`.

This PR removes the field rather than wiring it. Two reasons. First, exchange-rate handling already lives at the wire layer: the protocol handler advertises our rate in the swap settlement headers and the peer's rate flows back through `SwapEvent`, so the settlement service copy was a duplicate that nothing read. Second, the builder filled the field with `config.refresh_rate()`, the pseudosettle refresh rate, which is not an exchange rate at all; wiring that value into received-cheque validation would have entrenched a semantically wrong comparison. When rate validation lands it should be fed from a real rate source (oracle or config) at the wire layer where the peer rate is already known.

The change removes the field, its assignment, the `#[allow(dead_code)]`, the corresponding constructor and factory parameters, and the now-unneeded `too_many_arguments` allow on `create_swap_actor`. No behaviour change; existing cheque issue and accept tests cover the touched paths.