### PR TITLE
docs: align node type terminology with SwarmNodeType variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ members = [
     # Redistribution (storage incentives)
     "crates/swarm/redistribution",
 
-    # Storer (full node storage)
+    # Storer (chunk storage and staking)
     "crates/swarm/storer",
 
     # RPC
@@ -204,7 +204,7 @@ vertex-swarm-localstore = { path = "crates/swarm/localstore" }
 # redistribution (storage incentives)
 vertex-swarm-redistribution = { path = "crates/swarm/redistribution" }
 
-# storer (full node storage)
+# storer (chunk storage and staking)
 vertex-swarm-storer = { path = "crates/swarm/storer" }
 
 # rpc

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -97,7 +97,7 @@ pub struct InfraArgs {
     pub observability: ObservabilityArgs,
 }
 
-/// Full node infrastructure arguments including logging and tracing.
+/// Complete set of node infrastructure arguments including logging and tracing.
 ///
 /// This struct combines all generic infrastructure CLI arguments including
 /// logging and tracing. Use [`InfraArgs`] if logging/tracing are handled

--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -317,7 +317,7 @@ pub trait SwarmLaunchConfig: Send + Sync + 'static {
     ) -> Result<(NodeTaskFn, Self::Providers), Self::Error>;
 }
 
-/// Launch config for client (light) nodes.
+/// Launch config for Client nodes.
 ///
 /// Client nodes can retrieve and upload chunks but don't store them locally.
 /// This is the default node type for most users.

--- a/crates/swarm/api/src/identity.rs
+++ b/crates/swarm/api/src/identity.rs
@@ -45,9 +45,11 @@ pub trait SwarmIdentity: Send + Sync + 'static {
         self.signer().address()
     }
 
-    /// Whether this node sets the wire-level full node flag in the
-    /// handshake. The flag is set for Storers, which store chunks.
-    fn is_full_node(&self) -> bool {
+    /// Whether this node is a Storer (stores chunks).
+    ///
+    /// Storers announce the storer flag in the handshake and are the only
+    /// node type gossiped network-wide.
+    fn is_storer(&self) -> bool {
         self.node_type().requires_storage()
     }
 

--- a/crates/swarm/api/src/identity.rs
+++ b/crates/swarm/api/src/identity.rs
@@ -45,7 +45,8 @@ pub trait SwarmIdentity: Send + Sync + 'static {
         self.signer().address()
     }
 
-    /// Whether this node operates as a full node (stores chunks).
+    /// Whether this node sets the wire-level full node flag in the
+    /// handshake. The flag is set for Storers, which store chunks.
     fn is_full_node(&self) -> bool {
         self.node_type().requires_storage()
     }

--- a/crates/swarm/api/src/providers.rs
+++ b/crates/swarm/api/src/providers.rs
@@ -26,7 +26,7 @@ pub trait SwarmChunkProvider: Send + Sync + 'static {
 
     /// Check if a chunk exists locally.
     ///
-    /// Returns false for light nodes that don't have local storage.
+    /// Returns false for Clients, which have no local storage.
     fn has_chunk(&self, address: &ChunkAddress) -> bool;
 }
 

--- a/crates/swarm/api/src/spec.rs
+++ b/crates/swarm/api/src/spec.rs
@@ -113,9 +113,9 @@ pub trait SwarmSpec: Send + Sync + 'static {
         Self::ChunkSet::BODY_SIZE
     }
 
-    /// Returns the reserve capacity in number of chunks for full nodes.
+    /// Returns the reserve capacity in number of chunks for Storers.
     ///
-    /// This is the target number of chunks a full storage node should hold.
+    /// This is the target number of chunks a Storer should hold.
     /// Standard networks use 2^22 = 4,194,304 chunks.
     fn reserve_capacity(&self) -> u64;
 

--- a/crates/swarm/bandwidth/chequebook/Cargo.toml
+++ b/crates/swarm/bandwidth/chequebook/Cargo.toml
@@ -12,7 +12,7 @@ description = "Chequebook types and signing for SWAP settlement"
 workspace = true
 
 [features]
-# Default is a pure, wasm-safe cheque codec with no RPC stack, so light clients
+# Default is a pure, wasm-safe cheque codec with no RPC stack, so client nodes
 # compile without an Ethereum provider.
 default = []
 # `swap-chequebook` adds the native on-chain chequebook client over a shared

--- a/crates/swarm/bandwidth/chequebook/src/lib.rs
+++ b/crates/swarm/bandwidth/chequebook/src/lib.rs
@@ -5,8 +5,8 @@
 //! - [`Cheque`] - An unsigned cheque commitment (EIP-712 typed data)
 //! - [`SignedCheque`] - A signed cheque ready for transmission or cashing
 //!
-//! By default this is a pure, wasm-safe codec with no RPC stack, so light
-//! clients compile without an Ethereum provider. The optional `swap-chequebook`
+//! By default this is a pure, wasm-safe codec with no RPC stack, so client
+//! nodes compile without an Ethereum provider. The optional `swap-chequebook`
 //! feature adds [`chain::ChequebookContract`], the native on-chain client that
 //! deploys, cashes, and reads chequebooks over a shared
 //! `alloy_provider::Provider`. A node role that settles over SWAP (the storer)

--- a/crates/swarm/bandwidth/core/src/accounting/mod.rs
+++ b/crates/swarm/bandwidth/core/src/accounting/mod.rs
@@ -150,8 +150,9 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             .clone()
     }
 
-    /// Get or create peer state for a light node.
-    pub fn get_or_create_light_peer(&self, peer: OverlayAddress) -> Arc<PeerState> {
+    /// Get or create peer state for a Client peer, with thresholds scaled
+    /// by the client-only factor.
+    pub fn get_or_create_client_peer(&self, peer: OverlayAddress) -> Arc<PeerState> {
         if let Some(state) = self.peers.read().get(&peer) {
             return Arc::clone(state);
         }

--- a/crates/swarm/builder/Cargo.toml
+++ b/crates/swarm/builder/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 # Construct a shared Ethereum alloy provider for chain-needing node types
 # (storer, and a client with SWAP enabled). Native-only: pulls the alloy RPC
 # stack (HTTP transport via reqwest) and the on-chain chequebook client. Off by
-# default so the light node and the wasm build stay completely chain-free; the
+# default so the client node and the wasm build stay completely chain-free; the
 # cone guard (`just check-cone`) enforces this.
 chain = [
     "dep:vertex-chain",
@@ -33,7 +33,7 @@ chain = [
 # bandwidth accounting and routes the swap wire events. Chain-free on its own:
 # cheque exchange (sign, send, validate, credit) needs no chain. Combine with
 # `chain` to enable on-chain cashout of received cheques. Off by default so the
-# light, chain-free node stays the default cone.
+# chain-free client node stays the default cone.
 swap = [
     "dep:vertex-swarm-bandwidth-swap",
     "vertex-swarm-node/swap",
@@ -42,8 +42,8 @@ swap = [
     "dep:alloy-signer-local",
 ]
 # Node role: the storer settles bandwidth over SWAP, so it pulls in the chain
-# stack, the on-chain chequebook client, and the swap settlement service. Light
-# clients leave this off.
+# stack, the on-chain chequebook client, and the swap settlement service.
+# Client nodes leave this off.
 storer = ["chain", "swap"]
 
 [dependencies]

--- a/crates/swarm/builder/src/config.rs
+++ b/crates/swarm/builder/src/config.rs
@@ -82,7 +82,7 @@ impl BootnodeConfig {
 impl_common_config_getters!(BootnodeConfig);
 impl_builds_protocol!(BootnodeConfig, "Swarm Bootnode");
 
-/// Validated configuration for client (light) node with bandwidth accounting.
+/// Validated configuration for a Client node with bandwidth accounting.
 #[derive(Clone)]
 pub struct ClientConfig {
     spec: Arc<Spec>,

--- a/crates/swarm/identity/src/lib.rs
+++ b/crates/swarm/identity/src/lib.rs
@@ -158,7 +158,7 @@ mod tests {
 
         assert!(!identity.ethereum_address().is_zero());
         assert!(!identity.overlay_address().is_zero());
-        assert!(identity.is_full_node());
+        assert!(identity.is_storer());
     }
 
     #[test]

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -100,7 +100,7 @@ fn prepare_local_peer<I: SwarmIdentity>(
     if ephemeral_fallback && identity.is_full_node() {
         warn!(
             observed = %observed_addr,
-            "full node has no reachable address; advertising an ephemeral address that peers \
+            "storer has no reachable address; advertising an ephemeral address that peers \
              cannot dial. Configure --network.nat-addr or enable AutoNAT v2 / UPnP."
         );
     }
@@ -435,7 +435,7 @@ mod tests {
     fn uses_observed_only_as_last_resort() {
         // With nothing real to advertise, the observed address keeps the record
         // non-empty so the handshake completes (a zero-multiaddr record is
-        // rejected). The fallback flag is set so a full node can warn; the entry
+        // rejected). The fallback flag is set so a storer can warn; the entry
         // is transient until AutoNAT v2 / UPnP confirms a real address.
         let observed = addr("/ip4/203.0.113.7/tcp/54321");
         let (out, fallback) = select_local_addrs(&[], &observed);

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -91,13 +91,13 @@ fn prepare_local_peer<I: SwarmIdentity>(
 ) -> Result<SwarmPeer, HandshakeError> {
     let (addrs, ephemeral_fallback) = select_local_addrs(&[], observed_addr);
 
-    // A full (storer) node's record is gossiped network-wide, so it must carry a
-    // real reachable address. Falling back to the ephemeral observed address
+    // A storer's record is gossiped network-wide, so it must carry a real
+    // reachable address. Falling back to the ephemeral observed address
     // means this storer is unreachable and is about to advertise an address no
-    // peer can dial. A light (client) node is never gossiped, so its fallback is
+    // peer can dial. A client node is never gossiped, so its fallback is
     // harmless and silent. The fallback self-heals once AutoNAT v2 / UPnP / a
     // static NAT address provides a real one.
-    if ephemeral_fallback && identity.is_full_node() {
+    if ephemeral_fallback && identity.is_storer() {
         warn!(
             observed = %observed_addr,
             "storer has no reachable address; advertising an ephemeral address that peers \

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! - [`BootNode`] - Topology only (bootnode servers)
 //! - [`ClientNode`] - Topology + client protocols (chunk read/write)
-//! - [`StorerNode`] - Client + storage protocols (full node)
+//! - [`StorerNode`] - Client + storage protocols (chunk storage and staking)
 
 mod base;
 #[allow(unreachable_pub)]

--- a/crates/swarm/node/src/protocol/events.rs
+++ b/crates/swarm/node/src/protocol/events.rs
@@ -228,7 +228,8 @@ pub enum ClientCommand {
 
     /// Announce our payment threshold to a peer.
     ///
-    /// The threshold value depends on peer type (full vs light) and configuration.
+    /// The threshold value depends on the peer's node type (Storer vs Client)
+    /// and configuration.
     AnnouncePricing {
         /// The peer to announce to.
         peer: OverlayAddress,

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -44,7 +44,7 @@
 //! the node sends an `ActivatePeer` command which transitions the handler to
 //! active state with:
 //! - Peer's overlay address
-//! - Node type (full or light)
+//! - Node type (`SwarmNodeType`)
 //!
 //! # Event/Command Interface
 //!

--- a/crates/swarm/node/src/protocol/upgrade.rs
+++ b/crates/swarm/node/src/protocol/upgrade.rs
@@ -8,8 +8,8 @@
 //! The client handler needs to accept multiple inbound protocols:
 //! - Pricing: Payment threshold exchange (symmetric - both peers announce)
 //! - Pseudosettle: Bandwidth settlement (symmetric)
-//! - Retrieval: Chunk request/response (full nodes only)
-//! - Pushsync: Chunk push with receipt (full nodes only)
+//! - Retrieval: Chunk request/response (Storers only)
+//! - Pushsync: Chunk push with receipt (Storers only)
 //!
 //! We use a custom `ClientInboundUpgrade` that implements `UpgradeInfo`
 //! with all protocol names and dispatches based on the negotiated protocol.

--- a/crates/swarm/spec/src/constants.rs
+++ b/crates/swarm/spec/src/constants.rs
@@ -14,7 +14,7 @@
 //!
 //! # Storage Capacity Constants
 //!
-//! - [`DEFAULT_RESERVE_CAPACITY`]: Default number of chunks for a full node (2^22)
+//! - [`DEFAULT_RESERVE_CAPACITY`]: Default number of chunks for a Storer (2^22)
 //!
 //! # Contract Addresses
 //!
@@ -57,9 +57,9 @@ pub const DEFAULT_CHUNK_SIZE: usize = 1 << DEFAULT_CHUNK_SIZE_LOG2;
 /// This is the canonical definition. `DEFAULT_RESERVE_CAPACITY = 2^DEFAULT_RESERVE_CAPACITY_LOG2`
 pub const DEFAULT_RESERVE_CAPACITY_LOG2: u32 = 22;
 
-/// Default reserve capacity in number of chunks for a full node.
+/// Default reserve capacity in number of chunks for a Storer.
 ///
-/// This is the target number of chunks a full storage node should hold.
+/// This is the target number of chunks a Storer should hold.
 /// When the node's reserve exceeds this capacity, it may trigger radius
 /// adjustments to maintain the target.
 ///
@@ -69,13 +69,13 @@ pub const DEFAULT_RESERVE_CAPACITY_LOG2: u32 = 22;
 /// (not including metadata and indexing overhead).
 pub const DEFAULT_RESERVE_CAPACITY: u64 = 1 << DEFAULT_RESERVE_CAPACITY_LOG2;
 
-/// Default cache capacity for light nodes as a power of 2 exponent.
+/// Default cache capacity for Clients as a power of 2 exponent.
 ///
 /// This is the canonical definition for memory-constrained devices.
 /// `DEFAULT_CACHE_CAPACITY = 2^DEFAULT_CACHE_CAPACITY_LOG2`
 pub const DEFAULT_CACHE_CAPACITY_LOG2: u32 = 16;
 
-/// Default cache capacity in number of chunks for light nodes.
+/// Default cache capacity in number of chunks for Clients.
 ///
 /// In-memory cache for retrieval/pushsync on non-storage nodes.
 /// Suitable for memory-constrained devices.

--- a/crates/swarm/spec/src/lib.rs
+++ b/crates/swarm/spec/src/lib.rs
@@ -13,8 +13,8 @@
 //!
 //! What a spec deliberately excludes is node-level policy: how much storage to allocate,
 //! bandwidth pricing, cache strategies. These vary per operator and belong in node
-//! configuration, not network specification. This separation allows light clients and
-//! full nodes to share the same spec while differing in operational parameters.
+//! configuration, not network specification. This separation allows Clients and
+//! Storers to share the same spec while differing in operational parameters.
 //!
 //! # Core Types
 //!

--- a/crates/swarm/spec/src/spec.rs
+++ b/crates/swarm/spec/src/spec.rs
@@ -73,7 +73,7 @@ pub struct Spec {
     #[serde(default)]
     pub genesis_timestamp: u64,
 
-    /// Reserve capacity in number of chunks for full nodes (typically 2^22)
+    /// Reserve capacity in number of chunks for Storers (typically 2^22)
     #[serde(default = "default_reserve_capacity")]
     pub reserve_capacity: u64,
 }

--- a/crates/swarm/topology/src/kademlia/limits.rs
+++ b/crates/swarm/topology/src/kademlia/limits.rs
@@ -420,9 +420,9 @@ mod tests {
 
     #[test]
     fn test_various_total_targets() {
-        // Light client
-        let light = DepthAwareLimits::new(32, 2);
-        assert!(light.target(b(7), d(8)) < 10);
+        // Client with a small connection budget
+        let client = DepthAwareLimits::new(32, 2);
+        assert!(client.target(b(7), d(8)) < 10);
 
         // Robust retrieval
         let robust = DepthAwareLimits::new(256, 4);

--- a/docs/design/chain-service.md
+++ b/docs/design/chain-service.md
@@ -34,7 +34,7 @@ There is one chain crate, not two. An earlier split into a wasm-safe trait crate
 | Node type | Chain access |
 |---|---|
 | Bootnode | None. No provider. |
-| Client, light (default) | None. No provider. |
+| Client (default) | None. No provider. |
 | Client, wasm | Optional. Same alloy provider over a wasm-compatible transport when enabled. |
 | Storer | Required. A provider injected by the storer builder. |
 | Client with SWAP | Required. A provider injected for the settlement service. |

--- a/docs/networking/peer-management.md
+++ b/docs/networking/peer-management.md
@@ -64,9 +64,9 @@ Any type implementing `Clone + Eq + Hash + Send + Sync + Debug + Serialize + Des
 
 Per-peer state with atomic hot paths and per-peer locked cold paths.
 
-**Atomic fields (hot path):** score, connection state, latency, connection counters, last-seen timestamp, full-node flag.
+**Atomic fields (hot path):** score, connection state, latency, connection counters, last-seen timestamp.
 
-**Locked fields (cold path):** multiaddrs, ban metadata.
+**Locked fields (cold path):** peer record (multiaddrs, node type), ban metadata.
 
 ### ConnectionState
 

--- a/docs/observability/design.md
+++ b/docs/observability/design.md
@@ -95,7 +95,7 @@ Labels add dimensions but must have **bounded cardinality**:
 |-------|----------------|-------------|
 | `direction` | `inbound`, `outbound` | 2 |
 | `outcome` | `success`, `failure` | 2 |
-| `peer_type` | `full`, `light` | 2 |
+| `peer_type` | `storer`, `client` | 2 |
 | `reason` | Error enum variants | ~10-20 |
 | `protocol` | Protocol names | ~10 |
 

--- a/docs/swarm/api.md
+++ b/docs/swarm/api.md
@@ -53,7 +53,7 @@ Extends `SwarmNetworkTypes` with bandwidth accounting for data transfer operatio
 
 ### SwarmStorerTypes
 
-Full storage node capabilities with local chunk persistence.
+Storer capabilities with local chunk persistence.
 
 | Associated Type | Bound | Purpose |
 |----------------|-------|---------|
@@ -119,7 +119,7 @@ Accounting uses overlay addresses (not `PeerId`) because:
 | Payment threshold | 13,500,000 AU |
 | Tolerance | 25% |
 | Early payment | 50% |
-| Light factor | 10 |
+| Client-only factor | 10 |
 
 ## See Also
 

--- a/docs/swarm/differences-from-bee.md
+++ b/docs/swarm/differences-from-bee.md
@@ -19,7 +19,7 @@ Vertex introduces a `SwarmSpec` trait that defines network identity and protocol
 - Bandwidth pricing
 - Cache strategies
 
-This separation allows light clients and full nodes to share the same spec while differing in operational parameters.
+This separation allows Clients and Storers to share the same spec while differing in operational parameters.
 
 ### Hardfork Support
 

--- a/docs/swarm/hive-gossip.md
+++ b/docs/swarm/hive-gossip.md
@@ -25,9 +25,9 @@ Distant peers receive a targeted bootstrap set:
 1. **Close peers**: peers near the recipient's overlay address (help find their neighbourhood)
 2. **Diverse sample**: one peer from each bin for routing diversity
 
-### Light Nodes
+### Clients
 
-Light nodes are invisible to gossip:
+Clients are invisible to gossip:
 - Never gossiped about (they do not store chunks)
 - Receive no peer lists (they connect to storers directly)
 
@@ -35,7 +35,7 @@ Light nodes are invisible to gossip:
 
 | Event | Action |
 |-------|--------|
-| Full node connects | Gossip based on neighbour/distant rules |
+| Storer connects | Gossip based on neighbour/distant rules |
 | Depth decreases | Notify newly-promoted neighbours |
 | Periodic tick | Refresh stale neighbourhood peers |
 


### PR DESCRIPTION
Closes #61

Replaces leftover "full node" and "light node" wording with the SwarmNodeType variants (Bootnode, Client, Storer) across rustdoc, code comments, Cargo.toml comments, and docs pages: vertex-swarm-api (identity, providers, spec, launch config), vertex-swarm-spec (constants, crate docs, spec struct), vertex-swarm-node (node type list, protocol upgrade and event docs), vertex-swarm-bandwidth (accounting), vertex-swarm-bandwidth-chequebook and vertex-swarm-builder (feature comments), vertex-node-core (infra args rustdoc), the workspace Cargo.toml comments, and the docs pages for hive gossip, peer management, observability label values, chain service, and the swarm API.

Two accessors are renamed. get_or_create_light_peer becomes get_or_create_client_peer in vertex-swarm-bandwidth, consistent with the existing new_client_only and client_only_factor naming. is_full_node becomes is_storer on SwarmIdentity: protobuf wire compatibility keys on field numbers and types, not names, and the handshake proto field is already named storer, so no wire bytes change. Neither accessor has callers outside this workspace.

Exclusions, and why:

- The handshake wire encoding is unchanged: proto field numbers and the bool semantics (storer flag set only for Storers, who are the only gossiped node type) are exactly as before.
- docs/networking/address-management.md keeps its wording where it deliberately describes bee behaviour.
- docs/agents/ and docs/swarm/reference/ are agent guidance and reference material and are out of scope.
- FullNodeConfig in vertex-node-core is not renamed: "full" there means the complete infra-plus-protocol configuration set, not the Swarm node type. The adjacent rustdoc that read "Full node infrastructure arguments" is reworded to "Complete set of node infrastructure arguments" to avoid the collision.