### PR TITLE
refactor(topology): consolidate gossip tuning constants into GossipConfig

### DIFF
--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -46,7 +46,7 @@ use crate::composed::ProtocolBehaviours;
 use crate::error::TopologyError;
 use crate::events::TopologyEvent;
 use crate::extract_peer_id;
-use crate::gossip::{GossipHandle, spawn_gossip_task};
+use crate::gossip::{GossipConfig, GossipHandle, spawn_gossip_task};
 use crate::handle::TopologyHandle;
 use crate::kademlia::{
     KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting,
@@ -129,6 +129,8 @@ impl DialTarget {
 #[derive(Debug, Clone)]
 pub struct TopologyConfig {
     pub kademlia: KademliaConfig,
+    /// Tuning knobs for gossip peer exchange and verification.
+    pub gossip: GossipConfig,
     pub dial_interval: Duration,
     pub early_disconnect_threshold: Duration,
     pub peer_save_interval: Duration,
@@ -138,6 +140,7 @@ impl Default for TopologyConfig {
     fn default() -> Self {
         Self {
             kademlia: KademliaConfig::default(),
+            gossip: GossipConfig::default(),
             dial_interval: DEFAULT_DIAL_INTERVAL,
             early_disconnect_threshold: DEFAULT_EARLY_DISCONNECT_THRESHOLD,
             peer_save_interval: DEFAULT_PEER_SAVE_INTERVAL,
@@ -152,6 +155,12 @@ impl TopologyConfig {
 
     pub fn with_kademlia(mut self, config: KademliaConfig) -> Self {
         self.kademlia = config;
+        self
+    }
+
+    /// Override the gossip tuning knobs.
+    pub fn with_gossip(mut self, config: GossipConfig) -> Self {
+        self.gossip = config;
         self
     }
 
@@ -369,6 +378,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         let spec = <I as HasSpec>::spec(&*identity).clone();
         let gossip = spawn_gossip_task(
             spec,
+            config.gossip.clone(),
             local_overlay,
             peer_manager.clone(),
             connection_registry.clone(),

--- a/crates/swarm/topology/src/gossip/config.rs
+++ b/crates/swarm/topology/src/gossip/config.rs
@@ -1,0 +1,170 @@
+//! Tuning knobs for the gossip subsystem.
+
+use std::time::Duration;
+
+/// Tuning knobs for gossip peer exchange and verification.
+///
+/// None of these values are fixed by the Swarm protocol; they trade
+/// responsiveness against memory, dial load, and abuse resistance.
+/// [`GossipConfig::default`] is the production tuning. Tests tighten
+/// individual fields with struct-update syntax for deterministic timing,
+/// for example `GossipConfig { max_total_pending: 8, ..Default::default() }`.
+///
+/// See the `gossip` module docs for how the limits relate to each other.
+#[derive(Debug, Clone)]
+pub struct GossipConfig {
+    /// Interval between neighborhood refresh broadcasts to connected
+    /// neighbors.
+    ///
+    /// Also bounds memory indirectly: last-broadcast timestamps older than
+    /// twice this interval are evicted, so the broadcast bookkeeping never
+    /// outlives two refresh cycles. Shorter intervals push redundant peer
+    /// lists onto stable neighbors; longer intervals slow discovery of
+    /// neighborhood changes.
+    pub refresh_interval: Duration,
+
+    /// Delay before exchanging gossip with a peer we dialed for gossip
+    /// purposes.
+    ///
+    /// A freshly dialed peer may drop the connection immediately if its bin
+    /// is saturated; waiting avoids wasting an exchange on a connection that
+    /// is about to close. Exchanges scheduled behind this delay are cancelled
+    /// if the connection closes first.
+    pub health_check_delay: Duration,
+
+    /// Idle connection timeout for the ephemeral verification swarm.
+    ///
+    /// Verification connections are short-lived by design: handshake, then
+    /// disconnect. This timeout reclaims connections that stall after the
+    /// transport opens, bounding the file descriptors the verifier can hold.
+    pub verification_idle_timeout: Duration,
+
+    /// Maximum unverified peers a single gossiper may have queued for
+    /// verification at once.
+    ///
+    /// Per-source rate limit: one malicious or buggy gossiper cannot fill
+    /// the global verification queue by itself. With the default global cap
+    /// (`max_total_pending` 1024) and this per-source cap (64), it takes at
+    /// least 16 distinct gossipers at their limit to saturate the queue.
+    pub max_pending_per_gossiper: usize,
+
+    /// Maximum unverified peers queued for verification across all
+    /// gossipers.
+    ///
+    /// Global memory bound on the verification queue: each entry holds a
+    /// full unverified peer record. The default (1024) is sized for roughly
+    /// 32 simultaneously gossiping connections sending a typical gossip
+    /// message of about 30 peers each. Note this is deliberately smaller
+    /// than `max_concurrent_verifications * max_pending_per_gossiper`
+    /// (32 * 64 = 2048): the global cap binds first under broad load, the
+    /// per-gossiper cap binds first under a single abusive source.
+    pub max_total_pending: usize,
+
+    /// Time a queued or in-flight verification may live before it expires.
+    ///
+    /// Expiry frees queue slots held by peers that never become dialable,
+    /// so a burst of bad gossip cannot pin the queue at `max_total_pending`
+    /// forever. Also serves as the in-flight dial timeout.
+    pub pending_expiry: Duration,
+
+    /// Maximum concurrent verification dials.
+    ///
+    /// Bounds the outbound connection load the verifier adds on top of
+    /// regular topology dialing. Queued entries beyond this drain as
+    /// in-flight verifications resolve.
+    pub max_concurrent_verifications: usize,
+
+    /// LRU capacity of the per-gossiper pending counters.
+    ///
+    /// Memory bound on rate-limit bookkeeping. Must be at least the
+    /// expected number of concurrently gossiping peers, otherwise counter
+    /// eviction lets a gossiper restart its `max_pending_per_gossiper`
+    /// budget early.
+    pub max_tracked_gossipers: usize,
+
+    /// Interval between cleanup passes that evict expired queue entries.
+    ///
+    /// Sets how stale the queue can get between passes; it only needs to be
+    /// comfortably below `pending_expiry` to keep expiry timely.
+    pub cleanup_interval: Duration,
+
+    /// LRU capacity of the backoff cache for unreachable gossiped peers.
+    ///
+    /// Memory bound on backoff bookkeeping. Sized to match
+    /// `max_total_pending` so every queued peer that fails can be tracked.
+    pub backoff_capacity: usize,
+
+    /// Backoff applied after the first failed verification dial of a peer.
+    ///
+    /// Grows exponentially per consecutive failure, capped at
+    /// `backoff_max`. Stops the verifier from redialing a dead address every
+    /// time a gossiper repeats it.
+    pub backoff_base: Duration,
+
+    /// Cap on the exponential backoff growth.
+    pub backoff_max: Duration,
+
+    /// LRU capacity of the ban cache for repeatedly unreachable peers.
+    ///
+    /// Memory bound on ban bookkeeping. Larger than `backoff_capacity`
+    /// because bans live much longer (`ban_ttl`) than backoff entries.
+    pub ban_capacity: usize,
+
+    /// Consecutive failed verification dials before a peer is banned from
+    /// re-verification.
+    pub ban_after_failures: u32,
+
+    /// Time a ban lasts before the peer may be verified again.
+    ///
+    /// A successful verification clears backoff and ban state early.
+    pub ban_ttl: Duration,
+}
+
+impl Default for GossipConfig {
+    fn default() -> Self {
+        Self {
+            refresh_interval: Duration::from_secs(600),
+            health_check_delay: Duration::from_millis(500),
+            verification_idle_timeout: Duration::from_secs(10),
+            max_pending_per_gossiper: 64,
+            max_total_pending: 1024,
+            pending_expiry: Duration::from_secs(60),
+            max_concurrent_verifications: 32,
+            max_tracked_gossipers: 1024,
+            cleanup_interval: Duration::from_secs(10),
+            backoff_capacity: 1024,
+            backoff_base: Duration::from_secs(5),
+            backoff_max: Duration::from_secs(20),
+            ban_capacity: 8192,
+            ban_after_failures: 3,
+            ban_ttl: Duration::from_secs(3600),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The defaults are the production tuning; this pins them so a default
+    /// change is a deliberate diff, not an accident.
+    #[test]
+    fn defaults_match_production_tuning() {
+        let config = GossipConfig::default();
+        assert_eq!(config.refresh_interval, Duration::from_secs(600));
+        assert_eq!(config.health_check_delay, Duration::from_millis(500));
+        assert_eq!(config.verification_idle_timeout, Duration::from_secs(10));
+        assert_eq!(config.max_pending_per_gossiper, 64);
+        assert_eq!(config.max_total_pending, 1024);
+        assert_eq!(config.pending_expiry, Duration::from_secs(60));
+        assert_eq!(config.max_concurrent_verifications, 32);
+        assert_eq!(config.max_tracked_gossipers, 1024);
+        assert_eq!(config.cleanup_interval, Duration::from_secs(10));
+        assert_eq!(config.backoff_capacity, 1024);
+        assert_eq!(config.backoff_base, Duration::from_secs(5));
+        assert_eq!(config.backoff_max, Duration::from_secs(20));
+        assert_eq!(config.ban_capacity, 8192);
+        assert_eq!(config.ban_after_failures, 3);
+        assert_eq!(config.ban_ttl, Duration::from_secs(3600));
+    }
+}

--- a/crates/swarm/topology/src/gossip/mod.rs
+++ b/crates/swarm/topology/src/gossip/mod.rs
@@ -1,5 +1,32 @@
 //! Gossip coordination for peer discovery and verification.
+//!
+//! Peers learned through gossip are untrusted until a verification handshake
+//! confirms them, so the subsystem is bounded at every stage. All bounds are
+//! collected in [`GossipConfig`]; its defaults are the production tuning and
+//! tests tighten individual fields for deterministic timing.
+//!
+//! The limits relate to each other in layers:
+//!
+//! - Admission: `max_pending_per_gossiper` caps what one source can queue;
+//!   `max_total_pending` caps the queue overall. The global cap is sized for
+//!   broad load from many gossipers (roughly 32 sources sending about 30
+//!   peers each), so it binds before the per-source caps could in aggregate.
+//!   `max_tracked_gossipers` bounds the rate-limit bookkeeping itself and
+//!   must cover the expected number of concurrent gossipers for the
+//!   per-source cap to hold.
+//! - Draining: `max_concurrent_verifications` bounds simultaneous
+//!   verification dials, and `pending_expiry` (swept every
+//!   `cleanup_interval`) evicts entries that never get dialed, so a full
+//!   queue always recovers.
+//! - Failure damping: unreachable peers back off exponentially from
+//!   `backoff_base` to `backoff_max`, and after `ban_after_failures`
+//!   consecutive failures they are banned for `ban_ttl`. The caches behind
+//!   these are LRU-bounded by `backoff_capacity` and `ban_capacity`.
+//! - Exchange cadence: `refresh_interval` paces neighborhood broadcasts and
+//!   `health_check_delay` defers exchanges on fresh gossip dials until the
+//!   connection proves stable.
 
+mod config;
 mod error;
 mod events;
 mod filter;
@@ -8,6 +35,7 @@ mod verifier;
 
 use tokio::sync::mpsc;
 
+pub use config::GossipConfig;
 pub(crate) use events::{GossipAction, GossipInput};
 pub(crate) use tasks::spawn_gossip_task;
 

--- a/crates/swarm/topology/src/gossip/tasks.rs
+++ b/crates/swarm/topology/src/gossip/tasks.rs
@@ -22,32 +22,23 @@ use vertex_swarm_peer_manager::PeerManager;
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
 use vertex_swarm_spec::Spec;
 
-use super::GossipInput;
 use super::events::{GossipAction, GossipCheckOk, VerificationResult};
 use super::filter::{
     RecipientProfile, detect_depth_decrease, filter_peers_for_recipient, scoring_event_for,
     select_peers_for_distant,
 };
 use super::verifier::{GossipVerifier, Verification};
+use super::{GossipConfig, GossipInput};
 use crate::kademlia::RoutingEvaluatorHandle;
 use crate::kademlia::peer_selection;
 
 use crate::behaviour::ConnectionRegistry;
-
-/// Interval for refreshing neighborhood peers.
-const GOSSIP_REFRESH_INTERVAL: Duration = Duration::from_secs(600);
-
-/// Default delay before exchanging gossip with gossip-dial peers.
-const DEFAULT_HEALTH_CHECK_DELAY: Duration = Duration::from_millis(500);
 
 /// Channel capacity for gossip inputs.
 const INPUT_CHANNEL_CAPACITY: usize = 128;
 
 /// Channel capacity for gossip broadcast actions.
 const OUTPUT_CHANNEL_CAPACITY: usize = 128;
-
-/// Idle connection timeout for verification swarm.
-const VERIFICATION_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Lightweight behaviour for verification handshakes + identify push.
 #[derive(NetworkBehaviour)]
@@ -106,6 +97,7 @@ struct GossipTask<I: SwarmIdentity> {
     /// `PeerActivated` (connection succeeded) or `ConnectionClosed` (connection dropped).
     gossip_dial_peers: HashSet<PeerId>,
     health_check_delay: Duration,
+    refresh_interval: Duration,
     gossip_interval: Interval,
 
     // Delayed gossip exchange
@@ -488,15 +480,15 @@ impl<I: SwarmIdentity> GossipTask<I> {
         // Periodic cleanup: remove cancelled_exchanges entries with no pending future.
         // When pending_exchanges is empty, all futures have resolved so no cancellation
         // tokens are needed. Otherwise, retain only entries that could still match a
-        // pending future (conservatively keep all — they are removed on resolution).
+        // pending future (conservatively keep all; they are removed on resolution).
         if self.pending_exchanges.is_empty() {
             self.cancelled_exchanges.clear();
         }
 
         // Periodic cleanup: evict stale last_broadcast entries.
-        // Entries older than 2x the refresh interval are unlikely to be useful —
+        // Entries older than 2x the refresh interval are unlikely to be useful;
         // the peer has either disconnected or will be refreshed on the next tick.
-        let broadcast_expiry = GOSSIP_REFRESH_INTERVAL * 2;
+        let broadcast_expiry = self.refresh_interval * 2;
         self.last_broadcast
             .retain(|_, ts| now.duration_since(*ts) <= broadcast_expiry);
 
@@ -506,7 +498,7 @@ impl<I: SwarmIdentity> GossipTask<I> {
         let has_stale = neighbors.iter().any(|neighbor| {
             self.last_broadcast
                 .get(neighbor)
-                .map(|t| now.duration_since(*t) > GOSSIP_REFRESH_INTERVAL)
+                .map(|t| now.duration_since(*t) > self.refresh_interval)
                 .unwrap_or(true)
         });
 
@@ -521,7 +513,7 @@ impl<I: SwarmIdentity> GossipTask<I> {
             let is_stale = self
                 .last_broadcast
                 .get(&neighbor)
-                .map(|t| now.duration_since(*t) > GOSSIP_REFRESH_INTERVAL)
+                .map(|t| now.duration_since(*t) > self.refresh_interval)
                 .unwrap_or(true);
 
             if is_stale {
@@ -660,8 +652,10 @@ impl<I: SwarmIdentity> GossipTask<I> {
 }
 
 /// Spawn the gossip task. Returns a handle for sending inputs and receiving outputs.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
     spec: Arc<Spec>,
+    config: GossipConfig,
     local_overlay: OverlayAddress,
     peer_manager: Arc<PeerManager<I>>,
     connection_registry: Arc<ConnectionRegistry>,
@@ -707,10 +701,10 @@ pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
             })
         })
         .map_err(|e| format!("Behaviour: {e}"))?
-        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(VERIFICATION_IDLE_TIMEOUT))
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(config.verification_idle_timeout))
         .build();
 
-    let verifier = GossipVerifier::new();
+    let verifier = GossipVerifier::new(&config);
 
     let task = GossipTask {
         input_rx,
@@ -725,8 +719,9 @@ pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
         last_depth: 0,
         last_broadcast: HashMap::new(),
         gossip_dial_peers: HashSet::new(),
-        health_check_delay: DEFAULT_HEALTH_CHECK_DELAY,
-        gossip_interval: tokio::time::interval(GOSSIP_REFRESH_INTERVAL),
+        health_check_delay: config.health_check_delay,
+        refresh_interval: config.refresh_interval,
+        gossip_interval: tokio::time::interval(config.refresh_interval),
         pending_exchanges: FuturesUnordered::new(),
         cancelled_exchanges: HashSet::new(),
         evaluator_handle,

--- a/crates/swarm/topology/src/gossip/verifier.rs
+++ b/crates/swarm/topology/src/gossip/verifier.rs
@@ -4,7 +4,7 @@
 //! being stored in the peer manager. This prevents storage exhaustion attacks
 //! and ensures only cryptographically valid peers enter our peer store.
 
-use std::{sync::LazyLock, time::Duration};
+use std::sync::LazyLock;
 
 use hashlink::LruCache;
 use libp2p::PeerId;
@@ -13,6 +13,7 @@ use tracing::{debug, warn};
 use vertex_net_dialer::{DialRequest, DialTracker, DialTrackerConfig, EnqueueError};
 use vertex_swarm_peer::{SwarmAddress, SwarmPeer};
 
+use super::config::GossipConfig;
 use super::error::{GossipCheckError, VerificationFailure};
 use super::events::{GossipCheckOk, VerificationResult};
 use crate::extract_peer_id;
@@ -20,27 +21,10 @@ use crate::extract_peer_id;
 type OverlayAddress = SwarmAddress;
 
 /// Fallback dial address used when the gossiped peer has no multiaddrs.
-/// This should never happen — `check_gossip` validates non-empty addrs.
+/// This should never happen; `check_gossip` validates non-empty addrs.
 #[allow(clippy::unwrap_used)]
 static FALLBACK_ADDR: LazyLock<libp2p::Multiaddr> =
     LazyLock::new(|| "/ip4/0.0.0.0/tcp/0".parse().unwrap());
-
-const MAX_PENDING_PER_GOSSIPER: usize = 64;
-/// ~32 concurrent connections x ~30 gossiped peers each = 960, rounded to 1024.
-const MAX_TOTAL_PENDING: usize = 1024;
-const PENDING_EXPIRY: Duration = Duration::from_secs(60);
-const MAX_CONCURRENT_VERIFICATIONS: usize = 32;
-const MAX_TRACKED_GOSSIPERS: usize = 1024;
-/// Interval between expired entry cleanup runs.
-const CLEANUP_INTERVAL: Duration = Duration::from_secs(10);
-
-/// Backoff/ban configuration for unreachable gossiped peers.
-const BACKOFF_CAPACITY: usize = 1024;
-const BACKOFF_BASE_SECS: u64 = 5;
-const BACKOFF_MAX_SECS: u64 = 20;
-const BAN_CAPACITY: usize = 8192;
-const BAN_AFTER_FAILURES: u32 = 3;
-const BAN_TTL_SECS: u64 = 3600;
 
 /// Data carried with each verification dial request.
 #[derive(Debug)]
@@ -77,28 +61,31 @@ pub(super) enum Verification {
 pub(super) struct GossipVerifier {
     /// Per-gossiper pending count for rate limiting (LRU-bounded).
     per_gossiper_count: LruCache<OverlayAddress, usize>,
+    /// Maximum pending verifications a single gossiper may hold.
+    max_pending_per_gossiper: usize,
     dial_tracker: DialTracker<OverlayAddress, VerificationData>,
 }
 
 impl GossipVerifier {
-    pub(super) fn new() -> Self {
-        let config = DialTrackerConfig {
-            max_pending: MAX_TOTAL_PENDING,
-            max_in_flight: MAX_CONCURRENT_VERIFICATIONS,
-            pending_ttl: PENDING_EXPIRY,
-            in_flight_timeout: PENDING_EXPIRY,
-            cleanup_interval: CLEANUP_INTERVAL,
+    pub(super) fn new(config: &GossipConfig) -> Self {
+        let tracker_config = DialTrackerConfig {
+            max_pending: config.max_total_pending,
+            max_in_flight: config.max_concurrent_verifications,
+            pending_ttl: config.pending_expiry,
+            in_flight_timeout: config.pending_expiry,
+            cleanup_interval: config.cleanup_interval,
             metrics_label: Some("gossip"),
-            backoff_capacity: BACKOFF_CAPACITY,
-            backoff_base_secs: BACKOFF_BASE_SECS,
-            backoff_max_secs: BACKOFF_MAX_SECS,
-            ban_capacity: BAN_CAPACITY,
-            ban_after_failures: BAN_AFTER_FAILURES,
-            ban_ttl_secs: BAN_TTL_SECS,
+            backoff_capacity: config.backoff_capacity,
+            backoff_base_secs: config.backoff_base.as_secs(),
+            backoff_max_secs: config.backoff_max.as_secs(),
+            ban_capacity: config.ban_capacity,
+            ban_after_failures: config.ban_after_failures,
+            ban_ttl_secs: config.ban_ttl.as_secs(),
         };
         Self {
-            per_gossiper_count: LruCache::new(MAX_TRACKED_GOSSIPERS),
-            dial_tracker: DialTracker::new(config),
+            per_gossiper_count: LruCache::new(config.max_tracked_gossipers),
+            max_pending_per_gossiper: config.max_pending_per_gossiper,
+            dial_tracker: DialTracker::new(tracker_config),
         }
     }
 
@@ -132,7 +119,7 @@ impl GossipVerifier {
         }
 
         let gossiper_count = self.per_gossiper_count.get(gossiper).copied().unwrap_or(0);
-        if gossiper_count >= MAX_PENDING_PER_GOSSIPER {
+        if gossiper_count >= self.max_pending_per_gossiper {
             return Err(GossipCheckError::GossiperRateLimited);
         }
 
@@ -194,7 +181,7 @@ impl GossipVerifier {
                 .addrs
                 .into_iter()
                 .next()
-                // Should never happen — check_gossip validates non-empty multiaddrs
+                // Should never happen; check_gossip validates non-empty multiaddrs
                 .unwrap_or_else(|| FALLBACK_ADDR.clone()),
         })
     }
@@ -357,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_rejects_no_peer_id() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         // Multiaddr without /p2p/ component
         let peer = mock_swarm_peer_no_p2p([2u8; 32], "/ip4/1.2.3.4/tcp/1634");
@@ -369,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_already_known_with_matching_signature() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let peer = mock_swarm_peer_with_peer_id([2u8; 32], "/ip4/1.2.3.4/tcp/1634", peer_id);
@@ -382,7 +369,7 @@ mod tests {
 
     #[test]
     fn test_needs_verification_for_new_peer() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let peer = mock_swarm_peer_with_peer_id([2u8; 32], "/ip4/1.2.3.4/tcp/1634", peer_id);
@@ -395,11 +382,18 @@ mod tests {
 
     #[test]
     fn test_rate_limit_per_gossiper() {
-        let mut verifier = GossipVerifier::new();
+        // Tightened config: a small per-gossiper cap keeps the test fast and
+        // proves the limit is config-driven rather than hardcoded.
+        let max_pending_per_gossiper = 4;
+        let config = GossipConfig {
+            max_pending_per_gossiper,
+            ..Default::default()
+        };
+        let mut verifier = GossipVerifier::new(&config);
         let gossiper = OverlayAddress::from(B256::from([3u8; 32]));
 
-        // Add MAX_PENDING_PER_GOSSIPER peers
-        for i in 0..MAX_PENDING_PER_GOSSIPER {
+        // Fill the per-gossiper budget
+        for i in 0..max_pending_per_gossiper {
             let peer_id = test_peer_id((i + 10) as u8);
             let mut overlay_bytes = [0u8; 32];
             overlay_bytes[0] = (i + 10) as u8;
@@ -418,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_verification_success() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let peer = mock_swarm_peer_with_peer_id([2u8; 32], "/ip4/1.2.3.4/tcp/1634", peer_id);
@@ -445,7 +439,7 @@ mod tests {
 
     #[test]
     fn test_verification_identity_updated() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         // Gossiped peer with signature (1, 2)
@@ -477,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_verification_different_peer_at_address() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let gossiped_peer =
@@ -517,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_is_in_flight() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let peer = mock_swarm_peer_with_peer_id([2u8; 32], "/ip4/1.2.3.4/tcp/1634", peer_id);
@@ -538,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_resolve_in_flight_on_dial_failure() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let peer = mock_swarm_peer_with_peer_id([2u8; 32], "/ip4/1.2.3.4/tcp/1634", peer_id);
@@ -561,11 +555,18 @@ mod tests {
 
     #[test]
     fn test_total_pending_limit() {
-        let mut verifier = GossipVerifier::new();
+        // Tightened config: a small global cap exercises the limit without
+        // enqueueing the production-sized queue.
+        let max_total_pending = 8;
+        let config = GossipConfig {
+            max_total_pending,
+            ..Default::default()
+        };
+        let mut verifier = GossipVerifier::new(&config);
 
         // Use many gossipers to avoid per-gossiper rate limit.
         // PeerId::random() ensures unique peer IDs beyond the u8 limit of test_peer_id.
-        for i in 0..MAX_TOTAL_PENDING {
+        for i in 0..max_total_pending {
             let peer_id = PeerId::random();
             let mut overlay_bytes = [0u8; 32];
             overlay_bytes[0] = (i % 256) as u8;
@@ -590,7 +591,7 @@ mod tests {
             );
         }
 
-        assert_eq!(verifier.dial_tracker.pending_count(), MAX_TOTAL_PENDING);
+        assert_eq!(verifier.dial_tracker.pending_count(), max_total_pending);
 
         // Next should be rejected with QueueFull
         let peer_id = PeerId::random();
@@ -605,7 +606,7 @@ mod tests {
 
     #[test]
     fn test_multiple_gossipers_tracked() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         // Track multiple gossipers to verify LRU doesn't break rate limiting
         for g in 0..10 {
@@ -629,10 +630,16 @@ mod tests {
 
     #[test]
     fn test_concurrent_verifications_limit() {
-        let mut verifier = GossipVerifier::new();
+        // Tightened config: a small in-flight cap exercises the limit quickly.
+        let max_concurrent_verifications = 4;
+        let config = GossipConfig {
+            max_concurrent_verifications,
+            ..Default::default()
+        };
+        let mut verifier = GossipVerifier::new(&config);
 
-        // Add more peers than MAX_CONCURRENT_VERIFICATIONS
-        for i in 0..MAX_CONCURRENT_VERIFICATIONS + 5 {
+        // Add more peers than the concurrency limit
+        for i in 0..max_concurrent_verifications + 5 {
             let peer_id = test_peer_id((i + 10) as u8);
             let mut overlay_bytes = [0u8; 32];
             overlay_bytes[0] = (i + 10) as u8;
@@ -642,8 +649,8 @@ mod tests {
             verifier.check_gossip(&peer, &gossiper, None).unwrap();
         }
 
-        // Start MAX_CONCURRENT_VERIFICATIONS dials
-        for _ in 0..MAX_CONCURRENT_VERIFICATIONS {
+        // Start dials up to the concurrency limit
+        for _ in 0..max_concurrent_verifications {
             assert!(verifier.next_verification_dial().is_some());
         }
 
@@ -653,7 +660,7 @@ mod tests {
 
     #[test]
     fn test_verification_batch() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         // Add 10 peers
         for i in 0..10 {
@@ -689,7 +696,7 @@ mod tests {
 
     #[test]
     fn test_backoff_rejects_different_gossiper() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let overlay_bytes = [2u8; 32];
@@ -711,7 +718,7 @@ mod tests {
 
     #[test]
     fn test_clear_backoff_allows_re_verification() {
-        let mut verifier = GossipVerifier::new();
+        let mut verifier = GossipVerifier::new(&GossipConfig::default());
 
         let peer_id = test_peer_id(2);
         let overlay_bytes = [2u8; 32];

--- a/crates/swarm/topology/src/lib.rs
+++ b/crates/swarm/topology/src/lib.rs
@@ -25,6 +25,10 @@
 //! - The dialer tracks at most 256 in-flight dials, each bounded by the
 //!   handshake timeout; the per-bin routing targets, not this cap, are the real
 //!   gate on how many become connections.
+//! - Gossip exchange and verification tuning (refresh cadence, queue bounds,
+//!   backoff and ban policy) lives in [`GossipConfig`], overridable through
+//!   [`TopologyConfig::with_gossip`]. The `gossip` module docs explain how the
+//!   limits relate.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
@@ -52,6 +56,7 @@ pub(crate) mod test_support;
 pub use behaviour::{DEFAULT_DIAL_INTERVAL, TopologyBehaviour, TopologyConfig};
 pub use error::{DialError, DisconnectReason, RejectionReason, TopologyError, TopologyResult};
 pub use events::{ConnectionDirection, DialReason, TopologyCommand, TopologyEvent};
+pub use gossip::GossipConfig;
 pub use handle::{BinStats, RoutingStats, TopologyHandle};
 
 pub use kademlia::{KademliaConfig, RoutingArgs};


### PR DESCRIPTION
Closes #120

Consolidates the gossip tuning constants scattered across `gossip/tasks.rs` and `gossip/verifier.rs` into a documented `GossipConfig` in `crates/swarm/topology/src/gossip/config.rs`. Every field carries rustdoc stating what it protects against and how it interacts with its neighbours, and the `gossip` module docs explain the limit relationships in layers (admission, draining, failure damping, exchange cadence).

`GossipConfig::default()` reproduces the previous constants exactly, and a pinning test asserts every default so a tuning change is always a deliberate diff. While documenting the relationships I verified the queue sizing claim from the issue: `max_total_pending` (1024) is deliberately smaller than `max_concurrent_verifications * max_pending_per_gossiper` (32 * 64 = 2048); the global cap derives from roughly 32 gossiping connections sending about 30 peers each, so it binds first under broad load while the per-gossiper cap binds first under a single abusive source. The field docs record this instead of the equality the issue hypothesised.

The config threads through `TopologyConfig` (new `gossip` field plus `with_gossip`, matching the existing `with_kademlia` construction style), `spawn_gossip_task`, and `GossipVerifier::new`, so tests can override individual timings. The verifier tests for per-gossiper rate limiting, the global queue cap, and the concurrency limit now run against tightened configs, proving the limits are config-driven rather than hardcoded.

Deliberately left as consts: `INPUT_CHANNEL_CAPACITY` and `OUTPUT_CHANNEL_CAPACITY` are structural backpressure boundaries between the behaviour and the task, not behavioural tuning knobs, and `FALLBACK_ADDR` is an internal invariant guard (`check_gossip` rejects empty multiaddrs before it can ever be used), so none of them belong in an operator-facing config.

Issue #119 (TopologyBehaviour builder) is handled separately; this change funnels through `TopologyConfig` as on main.