### PR TITLE
refactor(swarm-builder): replace last_error accumulation with Result-based peer fallback

### DIFF
--- a/crates/swarm/api/src/error.rs
+++ b/crates/swarm/api/src/error.rs
@@ -23,6 +23,18 @@ pub enum SwarmError {
         chunk_address: ChunkAddress,
     },
 
+    /// Every candidate peer failed for a chunk operation.
+    #[error("all {attempts} candidate peers failed for chunk {address}")]
+    AllPeersFailed {
+        /// The chunk address the operation targeted.
+        address: ChunkAddress,
+        /// Number of peers attempted.
+        attempts: usize,
+        /// The error from the last attempt.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     /// Invalid postage stamp signature.
     #[error("invalid stamp signature for {chunk_address}: {reason}")]
     InvalidSignature {
@@ -160,6 +172,7 @@ impl SwarmError {
                 | Self::PeerUnavailable { .. }
                 | Self::Accounting { .. }
                 | Self::NoStorer { .. }
+                | Self::AllPeersFailed { .. }
         )
     }
 

--- a/crates/swarm/builder/src/providers.rs
+++ b/crates/swarm/builder/src/providers.rs
@@ -12,6 +12,9 @@ use vertex_swarm_topology::TopologyHandle;
 /// Number of closest peers to try when pushing a chunk before giving up.
 const PUSH_CANDIDATE_COUNT: usize = 5;
 
+/// Number of closest peers to try when retrieving a chunk before giving up.
+const RETRIEVE_CANDIDATE_COUNT: usize = 3;
+
 /// Chunk provider using ClientHandle for network retrieval.
 #[derive(Clone)]
 pub struct NetworkChunkProvider<I: SwarmIdentity> {
@@ -32,20 +35,18 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
 impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
     async fn retrieve_chunk(&self, address: &ChunkAddress) -> SwarmResult<ChunkRetrievalResult> {
         let chunk_address = SwarmAddress::new(address.0.into());
+        let closest_peers = self
+            .topology
+            .closest_to(&chunk_address, RETRIEVE_CANDIDATE_COUNT);
+        let attempts = closest_peers.len();
 
-        // Get the closest peers to the chunk address (up to 5 candidates)
-        let closest_peers = self.topology.closest_to(&chunk_address, 5);
-
-        if closest_peers.is_empty() {
-            return Err(SwarmError::network_msg(
-                "No connected peers available for retrieval",
-            ));
-        }
-
-        // Try each peer in order until one succeeds
-        let mut last_error = None;
-        for peer_overlay in closest_peers.into_iter().take(3) {
-            // Try to retrieve from this peer
+        // Try each closest peer in order and return the first success. The
+        // seed error covers the no-candidates case; each failed attempt
+        // replaces it, so the value after the loop is always the last failure.
+        let mut outcome = Err(SwarmError::network_msg(
+            "no connected peers available for retrieval",
+        ));
+        for peer_overlay in closest_peers {
             match self
                 .client_handle
                 .retrieve_chunk(peer_overlay, chunk_address)
@@ -58,17 +59,16 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
                     });
                 }
                 Err(e) => {
-                    last_error = Some(e);
-                    // Continue to next peer
+                    outcome = Err(SwarmError::AllPeersFailed {
+                        address: *address,
+                        attempts,
+                        source: Box::new(e),
+                    });
                 }
             }
         }
 
-        // All peers failed
-        match last_error {
-            Some(e) => Err(SwarmError::network_msg(e.to_string())),
-            None => Err(SwarmError::ChunkNotFound { address: *address }),
-        }
+        outcome
     }
 
     fn has_chunk(&self, _address: &ChunkAddress) -> bool {
@@ -88,24 +88,28 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     async fn push_to_closest(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
         let address = *chunk.address();
         let closest = self.topology.closest_to(&address, PUSH_CANDIDATE_COUNT);
+        let attempts = closest.len();
 
-        if closest.is_empty() {
-            return Err(SwarmError::NoStorer {
-                chunk_address: address,
-            });
-        }
-
-        let mut last_error = None;
+        // Try each closest peer in order and return the first receipt. The
+        // seed error covers the no-candidates case; each failed attempt
+        // replaces it, so the value after the loop is always the last failure.
+        let mut outcome = Err(SwarmError::NoStorer {
+            chunk_address: address,
+        });
         for peer in closest {
             match self.client_handle.push_chunk(peer, chunk.clone()).await {
                 Ok(receipt) => return Ok(receipt),
-                Err(e) => last_error = Some(SwarmError::network_msg(e.to_string())),
+                Err(e) => {
+                    outcome = Err(SwarmError::AllPeersFailed {
+                        address,
+                        attempts,
+                        source: Box::new(e),
+                    });
+                }
             }
         }
 
-        Err(last_error.unwrap_or(SwarmError::NoStorer {
-            chunk_address: address,
-        }))
+        outcome
     }
 }
 

--- a/crates/swarm/node/src/swarm_client.rs
+++ b/crates/swarm/node/src/swarm_client.rs
@@ -87,12 +87,7 @@ where
             .components
             .topology()
             .closest_to(address, CLOSEST_PEER_COUNT);
-
-        if closest.is_empty() {
-            return Err(SwarmError::NoStorer {
-                chunk_address: *address,
-            });
-        }
+        let attempts = closest.len();
 
         // Walk the closest peers in order and return the first response. The
         // codec reconstructs the chunk against the requested address, so the
@@ -102,15 +97,26 @@ where
         // chunk address alone, so two in-flight requests for one address would
         // alias. Fanning out needs a per-request correlation id in the handle
         // and handler, tracked as a follow-up; until then this is sequential.
-        let mut last_error: Option<SwarmError> = None;
+        //
+        // The seed error covers the no-candidates case; each failed attempt
+        // replaces it, so the value after the loop is always the last failure.
+        let mut outcome = Err(SwarmError::NoStorer {
+            chunk_address: *address,
+        });
         for peer in closest {
             match self.client_handle.retrieve_chunk(peer, *address).await {
                 Ok(result) => return Ok(result.chunk.into_parts().0),
-                Err(e) => last_error = Some(SwarmError::network_msg(e.to_string())),
+                Err(e) => {
+                    outcome = Err(SwarmError::AllPeersFailed {
+                        address: *address,
+                        attempts,
+                        source: Box::new(e),
+                    });
+                }
             }
         }
 
-        Err(last_error.unwrap_or(SwarmError::ChunkNotFound { address: *address }))
+        outcome
     }
 
     async fn put(&self, chunk: StampedChunk) -> SwarmResult<()> {
@@ -211,6 +217,41 @@ mod tests {
 
     fn test_address() -> ChunkAddress {
         *test_stamped_chunk().address()
+    }
+
+    fn client_with_topology(topology: MockTopology) -> impl SwarmClient {
+        let bandwidth = Arc::new(Accounting::new(
+            DefaultBandwidthConfig::default(),
+            test_identity(),
+        ));
+        let pricer = FixedPricer::new(10_000, vertex_swarm_spec::init_mainnet());
+        let accounting = ClientAccounting::new(bandwidth, pricer);
+        Client::client(topology, accounting, create_test_handle())
+    }
+
+    #[tokio::test]
+    async fn get_fails_with_no_storer_without_candidates() {
+        let client = client_with_topology(MockTopology::default());
+
+        let err = client.get(&test_address()).await.unwrap_err();
+        assert!(matches!(err, SwarmError::NoStorer { .. }));
+    }
+
+    #[tokio::test]
+    async fn get_fails_with_all_peers_failed_when_every_peer_errors() {
+        let closest = vec![
+            OverlayAddress::from([1u8; 32]),
+            OverlayAddress::from([2u8; 32]),
+        ];
+        // The test handle's command channel is closed, so every retrieval
+        // attempt fails and the client must surface the all-peers-failed path.
+        let client = client_with_topology(MockTopology::default().with_closest(closest));
+
+        let err = client.get(&test_address()).await.unwrap_err();
+        assert!(matches!(
+            err,
+            SwarmError::AllPeersFailed { attempts: 2, .. }
+        ));
     }
 
     #[tokio::test]

--- a/crates/swarm/test-utils/src/topology.rs
+++ b/crates/swarm/test-utils/src/topology.rs
@@ -23,6 +23,7 @@ pub struct MockTopology {
     stored: usize,
     pending: usize,
     depth: u8,
+    closest: Vec<OverlayAddress>,
 }
 
 impl Default for MockTopology {
@@ -34,6 +35,7 @@ impl Default for MockTopology {
             stored: 0,
             pending: 0,
             depth: 0,
+            closest: Vec::new(),
         }
     }
 }
@@ -59,6 +61,7 @@ impl MockTopology {
             stored: 0,
             pending: 0,
             depth,
+            closest: Vec::new(),
         }
     }
 
@@ -104,6 +107,13 @@ impl MockTopology {
         self
     }
 
+    /// Set the peers returned by [`SwarmTopologyRouting::closest_to`].
+    #[must_use]
+    pub fn with_closest(mut self, closest: Vec<OverlayAddress>) -> Self {
+        self.closest = closest;
+        self
+    }
+
     /// Get the overlay address as SwarmAddress.
     pub fn overlay(&self) -> SwarmAddress {
         self.identity.overlay_address()
@@ -134,8 +144,8 @@ impl SwarmTopologyState for MockTopology {
 }
 
 impl SwarmTopologyRouting for MockTopology {
-    fn closest_to(&self, _address: &ChunkAddress, _count: usize) -> Vec<OverlayAddress> {
-        Vec::new()
+    fn closest_to(&self, _address: &ChunkAddress, count: usize) -> Vec<OverlayAddress> {
+        self.closest.iter().take(count).copied().collect()
     }
 
     fn neighbors(&self, _depth: NeighborhoodDepth) -> Vec<OverlayAddress> {


### PR DESCRIPTION
## Summary

Closes #125

The pseudosettle crate no longer carries a `last_error` field; `refresh_allowance` and `settle` were already refactored to Result-based flow in earlier work, so the remaining Go-style `last_error: Option<...>` accumulation lived in the try-each-peer fallback loops: `retrieve_chunk` and `push_to_closest` in `vertex-swarm-builder`, and the closest-peer loop in `get` in `vertex-swarm-node`. See the re-scoping comment on the issue.

## Changes

- Replace the mutable `Option<Error>` sentinel plus post-loop `unwrap_or` fallback in all three loops with a single `Result` binding: the seed error covers the no-candidates case, each failed attempt replaces it, and the value after the loop is always the last failure.
- Add a `SwarmError::AllPeersFailed` variant carrying the chunk address, the number of attempted peers, and the last failure as a boxed `source`, replacing the stringly `network_msg(e.to_string())` escape hatch. The variant is classified as retryable.
- `retrieve_chunk` in `vertex-swarm-builder` previously fetched 5 candidates and tried only the first 3; it now requests exactly `RETRIEVE_CANDIDATE_COUNT = 3`, preserving observable behaviour.
- Extend `MockTopology` in `vertex-swarm-test-utils` with a `with_closest` builder so `closest_to` can return configured peers in tests.
- Add client tests covering both error paths: `NoStorer` when there are no candidates, and `AllPeersFailed { attempts: 2 }` when every peer errors.

A grep for `last_error` across the workspace now returns nothing.

## Testing

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` clean across the workspace; the touched crates are also clean under `--all-features`
- `cargo test -p vertex-swarm-api -p vertex-swarm-builder -p vertex-swarm-node -p vertex-swarm-test-utils` all green
