### PR TITLE
refactor(swarm-builder): deduplicate launch and rpc registration paths

### DIFF
--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -13,23 +13,26 @@ use vertex_node_api::InfrastructureContext;
 use vertex_storage_redb::RedbDatabase;
 #[cfg(feature = "swap")]
 use vertex_swarm_api::SwarmClientAccounting;
-use vertex_swarm_api::{PeerConfigValues, SwarmLaunchConfig, SwarmPeerConfig, SwarmScoreStore};
+use vertex_swarm_api::{
+    PeerConfigValues, SwarmLaunchConfig, SwarmNodeType, SwarmPeerConfig, SwarmScoreStore,
+};
 use vertex_swarm_bandwidth::{
     Accounting, AccountingBuilder, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
 };
 use vertex_swarm_identity::Identity;
+use vertex_swarm_node::args::NetworkConfig;
 use vertex_swarm_node::{BootNode, ClientNode};
 use vertex_swarm_peer_manager::{DbPeerStore, StoredPeer};
 use vertex_swarm_peer_score::PeerScore;
 use vertex_swarm_spec::{Loggable, Spec};
-use vertex_swarm_topology::TopologyHandle;
+use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
 use vertex_tasks::{GracefulShutdown, NodeTaskFn};
 
 use crate::config::{BootnodeConfig, ClientConfig, StorerConfig};
 use crate::error::SwarmNodeError;
 use crate::providers::NetworkChunkProvider;
 use crate::rpc::{BootnodeRpcProviders, ClientRpcProviders, StorerRpcProviders};
-use crate::verify::VerifyingChunkProvider;
+use crate::verify::{ChunkVerifyConfig, VerifyingChunkProvider};
 
 /// Network chunk provider wrapped with config-gated download verification.
 type VerifiedChunkProvider = VerifyingChunkProvider<NetworkChunkProvider<Arc<Identity>>>;
@@ -37,9 +40,9 @@ type VerifiedChunkProvider = VerifyingChunkProvider<NetworkChunkProvider<Arc<Ide
 #[cfg(feature = "chain")]
 use vertex_swarm_api::{SwarmAccountingConfig, SwarmSpec};
 #[cfg(feature = "chain")]
-use vertex_swarm_node::SwarmNodeType;
-#[cfg(feature = "chain")]
 use vertex_swarm_node::args::ChainConfig;
+#[cfg(feature = "swap")]
+use vertex_swarm_node::args::SwapConfig;
 
 #[cfg(feature = "chain")]
 use crate::chain::SharedChainProvider;
@@ -50,12 +53,12 @@ type PeerScoreStore = Arc<dyn SwarmScoreStore<Score = PeerScore, Error = StoreEr
 /// Stats collection interval for database metrics.
 const DB_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 
-fn log_build_start<N>(node_type: &str, spec: &Spec, network: &N)
+fn log_build_start<N>(node_type: SwarmNodeType, spec: &Spec, network: &N)
 where
     N: SwarmPeerConfig,
     N::Peers: PeerConfigValues,
 {
-    info!("Building {} node...", node_type);
+    info!(%node_type, "Building node...");
     spec.log();
 
     match network.peers().store_path() {
@@ -97,7 +100,7 @@ fn build_accounting_with_swap(
     spec: &Arc<Spec>,
     identity: &Arc<Identity>,
     config: &DefaultBandwidthConfig,
-    swap_config: &vertex_swarm_node::args::SwapConfig,
+    swap_config: &SwapConfig,
 ) -> (
     ClientAccounting<
         Arc<vertex_swarm_bandwidth::Accounting<DefaultBandwidthConfig, Arc<Identity>>>,
@@ -232,7 +235,8 @@ fn create_peer_store(
 }
 
 macro_rules! define_launch_types {
-    ($name:ident) => {
+    ($(#[$attr:meta])* $name:ident) => {
+        $(#[$attr])*
         pub struct $name;
 
         impl vertex_swarm_api::SwarmPrimitives for $name {
@@ -244,8 +248,8 @@ macro_rules! define_launch_types {
             type Topology = TopologyHandle<Arc<Identity>>;
         }
     };
-    ($name:ident, with_client) => {
-        define_launch_types!($name);
+    ($(#[$attr:meta])* $name:ident, with_client) => {
+        define_launch_types!($(#[$attr])* $name);
 
         impl vertex_swarm_api::SwarmClientTypes for $name {
             type Accounting = ClientAccounting<
@@ -256,9 +260,143 @@ macro_rules! define_launch_types {
     };
 }
 
-define_launch_types!(BootnodeLaunchTypes);
-define_launch_types!(ClientLaunchTypes, with_client);
-define_launch_types!(StorerLaunchTypes, with_client);
+define_launch_types!(
+    /// Associated type set for the bootnode launch path: spec, identity, and
+    /// topology only, with no bandwidth accounting.
+    BootnodeLaunchTypes
+);
+define_launch_types!(
+    /// Associated type set for the client launch path: the bootnode types plus
+    /// the default bandwidth accounting stack.
+    ClientLaunchTypes,
+    with_client
+);
+define_launch_types!(
+    /// Associated type set for the storer launch path: the bootnode types plus
+    /// the default bandwidth accounting stack.
+    StorerLaunchTypes,
+    with_client
+);
+
+/// Borrowed inputs for [`build_client_backed_node`], gathered from a validated
+/// client or storer config.
+struct ClientNodeParams<'a> {
+    node_type: SwarmNodeType,
+    spec: &'a Arc<Spec>,
+    identity: &'a Arc<Identity>,
+    network: &'a NetworkConfig<KademliaConfig>,
+    bandwidth: &'a DefaultBandwidthConfig,
+    verify: ChunkVerifyConfig,
+    #[cfg(feature = "chain")]
+    chain: &'a ChainConfig,
+    #[cfg(feature = "swap")]
+    swap: &'a SwapConfig,
+}
+
+/// Outputs of [`build_client_backed_node`]: the long-running node task plus the
+/// handles the node-type-specific RPC providers wrap.
+struct ClientNodeParts {
+    task: NodeTaskFn,
+    topology: TopologyHandle<Arc<Identity>>,
+    chunks: VerifiedChunkProvider,
+}
+
+/// Shared launch path for the node types backed by a client node (client and
+/// storer).
+///
+/// Builds the bandwidth accounting (with SWAP settlement embedded when enabled),
+/// constructs the node and the verified chunk provider, spawns the client
+/// service and the SWAP settlement service, connects the chain provider when the
+/// node type requires one, and wraps the node run loop in a task that owns the
+/// accounting and chain handles for the node's lifetime.
+async fn build_client_backed_node(
+    ctx: &dyn InfrastructureContext,
+    params: ClientNodeParams<'_>,
+) -> Result<ClientNodeParts, SwarmNodeError> {
+    let node_type = params.node_type;
+    log_build_start(node_type, params.spec, params.network);
+
+    let db = open_shared_database(ctx);
+    let (peer_store, score_store) = create_peer_store(&db);
+
+    // Prepare SWAP settlement first: the provider must be embedded in the
+    // accounting, and the swap event sink must be routed at node build time.
+    #[cfg(feature = "swap")]
+    let (accounting, swap_wiring) =
+        build_accounting_with_swap(params.spec, params.identity, params.bandwidth, params.swap);
+    #[cfg(not(feature = "swap"))]
+    let accounting = build_accounting(
+        params.spec.clone(),
+        params.identity,
+        params.bandwidth.clone(),
+    );
+
+    let node_builder = ClientNode::builder(params.identity.clone());
+    #[cfg(feature = "swap")]
+    let node_builder = match swap_wiring.as_ref() {
+        Some(wiring) => node_builder.with_swap_events(wiring.swap_event_sender()),
+        None => node_builder,
+    };
+    let (node, client_service, client_handle) = node_builder
+        .build(params.network, peer_store, score_store)
+        .await
+        .map_err(|e| SwarmNodeError::Build(e.into()))?;
+
+    let topology = node.topology_handle().clone();
+    let chunk_provider = NetworkChunkProvider::new(client_handle.clone(), topology.clone());
+    let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
+
+    // Spawn client service as independent task with graceful shutdown
+    ctx.executor()
+        .spawn_service("swarm.client_service", client_service);
+
+    // A storer always needs a chain (staking, oracle, settlement); a client
+    // needs one only when SWAP settlement is enabled.
+    #[cfg(feature = "chain")]
+    let chain_provider = {
+        let swap_enabled = SwarmAccountingConfig::mode(params.bandwidth).swap_enabled();
+        build_node_chain_provider(
+            params.spec,
+            params.identity,
+            node_type,
+            swap_enabled,
+            params.chain,
+        )
+        .await?
+    };
+
+    // Spawn the SWAP settlement service over the shared accounting instance,
+    // forwarding its cheque commands to the node and cashing received cheques
+    // on chain when a provider is present.
+    #[cfg(feature = "swap")]
+    if let Some(wiring) = swap_wiring {
+        wiring.spawn(
+            ctx,
+            accounting.bandwidth().clone(),
+            client_handle,
+            #[cfg(feature = "chain")]
+            chain_provider.as_ref(),
+        );
+    }
+
+    // Return node task - accounting is moved into the closure to keep it
+    // alive. The chain provider is held alive the same way.
+    let task = single_task(move |shutdown| async move {
+        let _accounting = accounting;
+        #[cfg(feature = "chain")]
+        let _chain_provider = chain_provider;
+        if let Err(e) = node.start_and_run(shutdown).await {
+            tracing::error!(error = %e, %node_type, "Node error");
+        }
+    });
+
+    info!(%node_type, "Node built successfully");
+    Ok(ClientNodeParts {
+        task,
+        topology,
+        chunks,
+    })
+}
 
 #[async_trait]
 impl SwarmLaunchConfig for BootnodeConfig {
@@ -270,7 +408,7 @@ impl SwarmLaunchConfig for BootnodeConfig {
         self,
         ctx: &dyn InfrastructureContext,
     ) -> Result<(NodeTaskFn, Self::Providers), Self::Error> {
-        log_build_start("Bootnode", self.spec(), self.network());
+        log_build_start(SwarmNodeType::Bootnode, self.spec(), self.network());
 
         let db = open_shared_database(ctx);
         let (peer_store, score_store) = create_peer_store(&db);
@@ -304,84 +442,25 @@ impl SwarmLaunchConfig for ClientConfig {
         self,
         ctx: &dyn InfrastructureContext,
     ) -> Result<(NodeTaskFn, Self::Providers), Self::Error> {
-        log_build_start("Client", self.spec(), self.network());
-
-        let db = open_shared_database(ctx);
-        let (peer_store, score_store) = create_peer_store(&db);
-
-        // Prepare SWAP settlement first: the provider must be embedded in the
-        // accounting, and the swap event sink must be routed at node build time.
-        #[cfg(feature = "swap")]
-        let (accounting, swap_wiring) =
-            build_accounting_with_swap(self.spec(), self.identity(), self.bandwidth(), self.swap());
-        #[cfg(not(feature = "swap"))]
-        let accounting = build_accounting(
-            self.spec().clone(),
-            self.identity(),
-            self.bandwidth().clone(),
-        );
-
-        let node_builder = ClientNode::builder(self.identity().clone());
-        #[cfg(feature = "swap")]
-        let node_builder = match swap_wiring.as_ref() {
-            Some(wiring) => node_builder.with_swap_events(wiring.swap_event_sender()),
-            None => node_builder,
-        };
-        let (node, client_service, client_handle) = node_builder
-            .build(self.network(), peer_store, score_store)
-            .await
-            .map_err(|e| SwarmNodeError::Build(e.into()))?;
-
-        let topology = node.topology_handle().clone();
-        let chunk_provider = NetworkChunkProvider::new(client_handle.clone(), topology.clone());
-        let verified_provider = VerifyingChunkProvider::new(chunk_provider, self.verify());
-        let providers = ClientRpcProviders::new(topology, verified_provider);
-
-        // Spawn client service as independent task with graceful shutdown
-        ctx.executor()
-            .spawn_service("swarm.client_service", client_service);
-
-        // A client needs a chain only when SWAP settlement is enabled.
-        #[cfg(feature = "chain")]
-        let chain_provider = {
-            let swap_enabled = SwarmAccountingConfig::mode(self.bandwidth()).swap_enabled();
-            build_node_chain_provider(
-                self.spec(),
-                self.identity(),
-                SwarmNodeType::Client,
-                swap_enabled,
-                self.chain(),
-            )
-            .await?
-        };
-
-        // Spawn the SWAP settlement service over the shared accounting instance,
-        // forwarding its cheque commands to the node and cashing received cheques
-        // on chain when a provider is present.
-        #[cfg(feature = "swap")]
-        if let Some(wiring) = swap_wiring {
-            wiring.spawn(
-                ctx,
-                accounting.bandwidth().clone(),
-                client_handle,
+        let parts = build_client_backed_node(
+            ctx,
+            ClientNodeParams {
+                node_type: SwarmNodeType::Client,
+                spec: self.spec(),
+                identity: self.identity(),
+                network: self.network(),
+                bandwidth: self.bandwidth(),
+                verify: self.verify(),
                 #[cfg(feature = "chain")]
-                chain_provider.as_ref(),
-            );
-        }
+                chain: self.chain(),
+                #[cfg(feature = "swap")]
+                swap: self.swap(),
+            },
+        )
+        .await?;
 
-        // Return node task - accounting is moved into the closure to keep it
-        // alive. The chain provider is held alive the same way.
-        let task = single_task(move |shutdown| async move {
-            let _accounting = accounting;
-            #[cfg(feature = "chain")]
-            let _chain_provider = chain_provider;
-            if let Err(e) = node.start_and_run(shutdown).await {
-                tracing::error!(error = %e, "ClientNode error");
-            }
-        });
-
-        info!("Client node built successfully");
-        Ok((task, providers))
+        let providers = ClientRpcProviders::new(parts.topology, parts.chunks);
+        Ok((parts.task, providers))
     }
 }
 
@@ -395,88 +474,30 @@ impl SwarmLaunchConfig for StorerConfig {
         self,
         ctx: &dyn InfrastructureContext,
     ) -> Result<(NodeTaskFn, Self::Providers), Self::Error> {
-        log_build_start("Storer", self.spec(), self.network());
-
-        let db = open_shared_database(ctx);
-        let (peer_store, score_store) = create_peer_store(&db);
-
-        // Prepare SWAP settlement first: the provider must be embedded in the
-        // accounting, and the swap event sink must be routed at node build time.
-        #[cfg(feature = "swap")]
-        let (accounting, swap_wiring) =
-            build_accounting_with_swap(self.spec(), self.identity(), self.bandwidth(), self.swap());
-        #[cfg(not(feature = "swap"))]
-        let accounting = build_accounting(
-            self.spec().clone(),
-            self.identity(),
-            self.bandwidth().clone(),
-        );
-
         // TODO: build storer-specific components
         let _ = self.local_store();
         let _ = self.storage();
 
-        // Build as ClientNode for now (storer components not yet implemented)
-        let node_builder = ClientNode::builder(self.identity().clone());
-        #[cfg(feature = "swap")]
-        let node_builder = match swap_wiring.as_ref() {
-            Some(wiring) => node_builder.with_swap_events(wiring.swap_event_sender()),
-            None => node_builder,
-        };
-        let (node, client_service, client_handle) = node_builder
-            .build(self.network(), peer_store, score_store)
-            .await
-            .map_err(|e| SwarmNodeError::Build(e.into()))?;
-
-        let topology = node.topology_handle().clone();
-        let chunk_provider = NetworkChunkProvider::new(client_handle.clone(), topology.clone());
-        let verified_provider = VerifyingChunkProvider::new(chunk_provider, self.verify());
-        let providers = StorerRpcProviders::new(topology, verified_provider);
-
-        // Spawn client service as independent task with graceful shutdown
-        ctx.executor()
-            .spawn_service("swarm.client_service", client_service);
-
-        // A storer always needs a chain (staking, oracle, settlement).
-        #[cfg(feature = "chain")]
-        let chain_provider = {
-            let swap_enabled = SwarmAccountingConfig::mode(self.bandwidth()).swap_enabled();
-            build_node_chain_provider(
-                self.spec(),
-                self.identity(),
-                SwarmNodeType::Storer,
-                swap_enabled,
-                self.chain(),
-            )
-            .await?
-        };
-
-        // Spawn the SWAP settlement service over the shared accounting instance,
-        // forwarding its cheque commands to the node and cashing received cheques
-        // on chain when a provider is present.
-        #[cfg(feature = "swap")]
-        if let Some(wiring) = swap_wiring {
-            wiring.spawn(
-                ctx,
-                accounting.bandwidth().clone(),
-                client_handle,
+        // Built over the client launch path for now (storer components not yet
+        // implemented).
+        let parts = build_client_backed_node(
+            ctx,
+            ClientNodeParams {
+                node_type: SwarmNodeType::Storer,
+                spec: self.spec(),
+                identity: self.identity(),
+                network: self.network(),
+                bandwidth: self.bandwidth(),
+                verify: self.verify(),
                 #[cfg(feature = "chain")]
-                chain_provider.as_ref(),
-            );
-        }
+                chain: self.chain(),
+                #[cfg(feature = "swap")]
+                swap: self.swap(),
+            },
+        )
+        .await?;
 
-        // Return node task - accounting is moved into the closure to keep it
-        // alive. The chain provider is held alive the same way.
-        let task = single_task(move |shutdown| async move {
-            let _accounting = accounting;
-            #[cfg(feature = "chain")]
-            let _chain_provider = chain_provider;
-            if let Err(e) = node.start_and_run(shutdown).await {
-                tracing::error!(error = %e, "StorerNode error");
-            }
-        });
-
-        info!("Storer node built successfully");
-        Ok((task, providers))
+        let providers = StorerRpcProviders::new(parts.topology, parts.chunks);
+        Ok((parts.task, providers))
     }
 }

--- a/crates/swarm/builder/src/rpc.rs
+++ b/crates/swarm/builder/src/rpc.rs
@@ -5,6 +5,30 @@ use vertex_swarm_api::{HasTopology, SwarmChunkProvider, SwarmChunkSender, SwarmI
 use vertex_swarm_rpc::{ChunkService, NodeService, proto};
 use vertex_swarm_topology::TopologyHandle;
 
+/// Register the node status service and the reflection descriptor that every
+/// node type's gRPC surface shares.
+fn register_node_service<I: SwarmIdentity>(
+    registry: &mut GrpcRegistry,
+    topology: &TopologyHandle<I>,
+) {
+    let node_service = NodeService::new(topology.clone());
+    let node_server = proto::node::node_server::NodeServer::new(node_service);
+    registry.add_service(node_server);
+
+    registry.add_descriptor(proto::FILE_DESCRIPTOR_SET);
+}
+
+/// Register the chunk upload/download service that backs client and storer
+/// nodes.
+fn register_chunk_service<C>(registry: &mut GrpcRegistry, chunks: &C)
+where
+    C: SwarmChunkProvider + SwarmChunkSender + Clone,
+{
+    let chunk_service = ChunkService::new(chunks.clone());
+    let chunk_server = proto::chunk::chunk_server::ChunkServer::new(chunk_service);
+    registry.add_service(chunk_server);
+}
+
 /// RPC providers for client nodes (topology status + chunk retrieval).
 pub struct ClientRpcProviders<I: SwarmIdentity, C> {
     topology: TopologyHandle<I>,
@@ -12,6 +36,8 @@ pub struct ClientRpcProviders<I: SwarmIdentity, C> {
 }
 
 impl<I: SwarmIdentity, C> ClientRpcProviders<I, C> {
+    /// Create providers from the topology handle and chunk provider of a built
+    /// client node.
     pub fn new(topology: TopologyHandle<I>, chunks: C) -> Self {
         Self { topology, chunks }
     }
@@ -38,15 +64,8 @@ impl<I: SwarmIdentity, C: SwarmChunkProvider + SwarmChunkSender + Clone> Registe
     for ClientRpcProviders<I, C>
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
-        let node_service = NodeService::new(self.topology.clone());
-        let node_server = proto::node::node_server::NodeServer::new(node_service);
-        registry.add_service(node_server);
-
-        let chunk_service = ChunkService::new(self.chunks.clone());
-        let chunk_server = proto::chunk::chunk_server::ChunkServer::new(chunk_service);
-        registry.add_service(chunk_server);
-
-        registry.add_descriptor(proto::FILE_DESCRIPTOR_SET);
+        register_node_service(registry, &self.topology);
+        register_chunk_service(registry, &self.chunks);
     }
 }
 
@@ -56,6 +75,7 @@ pub struct BootnodeRpcProviders<I: SwarmIdentity> {
 }
 
 impl<I: SwarmIdentity> BootnodeRpcProviders<I> {
+    /// Create providers from the topology handle of a built bootnode.
     pub fn new(topology: TopologyHandle<I>) -> Self {
         Self { topology }
     }
@@ -71,11 +91,7 @@ impl<I: SwarmIdentity> HasTopology for BootnodeRpcProviders<I> {
 
 impl<I: SwarmIdentity> RegistersGrpcServices for BootnodeRpcProviders<I> {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
-        let node_service = NodeService::new(self.topology.clone());
-        let node_server = proto::node::node_server::NodeServer::new(node_service);
-        registry.add_service(node_server);
-
-        registry.add_descriptor(proto::FILE_DESCRIPTOR_SET);
+        register_node_service(registry, &self.topology);
     }
 }
 
@@ -86,6 +102,8 @@ pub struct StorerRpcProviders<I: SwarmIdentity, C> {
 }
 
 impl<I: SwarmIdentity, C> StorerRpcProviders<I, C> {
+    /// Create providers from the topology handle and chunk provider of a built
+    /// storer node.
     pub fn new(topology: TopologyHandle<I>, chunks: C) -> Self {
         Self { topology, chunks }
     }
@@ -103,16 +121,9 @@ impl<I: SwarmIdentity, C: SwarmChunkProvider + SwarmChunkSender + Clone> Registe
     for StorerRpcProviders<I, C>
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
-        let node_service = NodeService::new(self.topology.clone());
-        let node_server = proto::node::node_server::NodeServer::new(node_service);
-        registry.add_service(node_server);
-
-        let chunk_service = ChunkService::new(self.chunks.clone());
-        let chunk_server = proto::chunk::chunk_server::ChunkServer::new(chunk_service);
-        registry.add_service(chunk_server);
+        register_node_service(registry, &self.topology);
+        register_chunk_service(registry, &self.chunks);
 
         // TODO: Add storer-specific RPC services (storage, redistribution, etc.)
-
-        registry.add_descriptor(proto::FILE_DESCRIPTOR_SET);
     }
 }


### PR DESCRIPTION
Closes #60

## What

Extracts the duplicated client and storer launch paths in vertex-swarm-builder into one shared crate-private function and shares the common gRPC service registration in rpc.rs, per the re-scoping comment on the issue.

## launch.rs

The Client and Storer SwarmLaunchConfig::build impls each repeated the same sequence: open the shared database and peer stores, build bandwidth accounting with optional SWAP settlement embedded, wire the swap event sender into the node builder, build the client node, construct the verified chunk provider, spawn the client service, build the chain provider, spawn the SWAP settlement service, and wrap the node run loop in a task that owns the accounting and chain handles. That whole path now lives in build_client_backed_node, parameterised by SwarmNodeType and the borrowed config inputs (ClientNodeParams), returning the task plus the topology and chunk handles (ClientNodeParts) that each impl wraps in its own RpcProviders type. The two impls keep only their real differences: the node type, the provider type, and the storer's placeholder for storer-specific components.

The Bootnode impl deliberately stays on its own path. It has no accounting, no chain, no chunk provider, and a different node builder, so funnelling it through the shared helper would have made every step optional and the helper worse than the duplication.

## rpc.rs

The three RegistersGrpcServices impls shared the node-service plus reflection-descriptor registration, and Client and Storer additionally shared the chunk-service registration. These are now two crate-private free functions, register_node_service and register_chunk_service, called from each impl. I chose shared functions over a blanket impl bounded on HasTopology because Client and Storer need to register more than the node service and Storer will grow storer-specific services; with a blanket impl those would collide with the specialized impls since Rust has no specialization. The free functions keep each impl a readable two-liner while leaving room for per-type services.

## Rustdoc

define_launch_types! now forwards doc attributes, and the three marker types (BootnodeLaunchTypes, ClientLaunchTypes, StorerLaunchTypes) document their associated type sets. The RpcProviders constructors gained the rustdoc they were missing.

## Out of scope

Item 4 of the issue (config getter repetition) was already fixed by the impl_common_config_getters! macro in config.rs, so this PR does not touch it. The node.rs builder structs already carry rustdoc.

No behaviour change. Verified with cargo fmt, clippy with -D warnings across all-features, no-features, swap-only, and chain-only combinations of vertex-swarm-builder, and the crate's test suite.
