### PR TITLE
refactor(topology): introduce TopologyBehaviourBuilder and split construction from task spawning

### DIFF
--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -16,7 +16,9 @@ use vertex_swarm_api::{
 use vertex_swarm_peer_manager::StoredPeer;
 use vertex_swarm_peer_score::PeerScore;
 use vertex_swarm_spec::HasSpec;
-use vertex_swarm_topology::{KademliaConfig, TopologyBehaviour, TopologyConfig, TopologyHandle};
+use vertex_swarm_topology::{
+    KademliaConfig, TopologyBehaviour, TopologyBehaviourBuilder, TopologyConfig, TopologyHandle,
+};
 
 use super::base::BaseNode;
 use super::error::NodeBuildError;
@@ -69,14 +71,20 @@ impl<I: SwarmIdentity + Clone> BuiltInfrastructure<I> {
             bootnodes,
         };
 
-        let (topology_behaviour, topology_handle) = TopologyBehaviour::new(
-            identity.clone(),
-            topology_config,
-            &config_with_bootnodes,
-            peer_store,
-            score_store,
-        )
-        .wrap_err("failed to create topology behaviour")?;
+        let mut builder = TopologyBehaviourBuilder::new(identity.clone(), &config_with_bootnodes)
+            .with_config(topology_config);
+        if let Some(store) = peer_store {
+            builder = builder.with_peer_store(store);
+        }
+        if let Some(store) = score_store {
+            builder = builder.with_score_store(store);
+        }
+        let (mut topology_behaviour, topology_handle) = builder
+            .try_build()
+            .wrap_err("failed to create topology behaviour")?;
+        topology_behaviour
+            .spawn_tasks()
+            .wrap_err("failed to spawn topology background tasks")?;
 
         Ok(Self {
             identity,

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -21,42 +21,32 @@ use libp2p::{
     },
 };
 use tracing::{debug, info};
-use vertex_net_local::{AddressScope, LocalCapabilities, classify_multiaddr, same_subnet};
+use vertex_net_local::{AddressScope, classify_multiaddr, same_subnet};
 use vertex_net_peer_store::NetPeerStore;
-use vertex_net_peer_store::error::StoreError;
-use vertex_swarm_api::SwarmScoreStore;
-use vertex_swarm_api::{PeerConfigValues, SwarmBootnodeConfig, SwarmIdentity};
-use vertex_swarm_net_handshake::HANDSHAKE_TIMEOUT;
+use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_net_hive::MAX_BATCH_SIZE;
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::{PeerManager, StoredPeer};
-use vertex_swarm_peer_score::PeerScore;
-use vertex_swarm_peer_score::SwarmScoringConfig;
 use vertex_swarm_primitives::{Bin, OverlayAddress, SwarmNodeType, all_bins};
-use vertex_swarm_spec::HasSpec;
 
 use crate::DialReason;
-use vertex_net_dialer::{DialTracker, DialTrackerConfig};
+use vertex_net_dialer::DialTracker;
 use vertex_net_peer_registry::PeerRegistry;
 
 pub(crate) type ConnectionRegistry = PeerRegistry<OverlayAddress, Option<DialReason>>;
 use crate::TopologyCommand;
+use crate::builder::PendingTopologyTasks;
 use crate::composed::ProtocolBehaviours;
-use crate::error::TopologyError;
 use crate::events::TopologyEvent;
 use crate::extract_peer_id;
-use crate::gossip::{GossipConfig, GossipHandle, spawn_gossip_task};
-use crate::handle::TopologyHandle;
-use crate::kademlia::{
-    KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting,
-    kademlia_admission_control,
-};
+use crate::gossip::{GossipConfig, GossipHandle};
+use crate::kademlia::{KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting};
 use crate::metrics::{TopologyMetrics, po_label};
 use crate::nat_discovery::LocalAddressManager;
 
 /// Type-erased peer store supporting both file-based and database-backed storage.
-type PeerStore = Arc<dyn NetPeerStore<StoredPeer>>;
+pub(crate) type PeerStore = Arc<dyn NetPeerStore<StoredPeer>>;
 
 /// Default interval between connection-evaluation rounds.
 ///
@@ -76,10 +66,38 @@ const DEFAULT_EARLY_DISCONNECT_THRESHOLD: Duration = Duration::from_secs(30);
 const DEFAULT_PEER_SAVE_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Event broadcast buffer (256 allows burst without blocking poll loop).
-const EVENT_CHANNEL_CAPACITY: usize = 256;
+pub(crate) const EVENT_CHANNEL_CAPACITY: usize = 256;
 
 /// Command buffer (64 is sufficient for typical dial/disconnect rate).
-const COMMAND_CHANNEL_CAPACITY: usize = 64;
+pub(crate) const COMMAND_CHANNEL_CAPACITY: usize = 64;
+
+/// Periodic interval whose underlying timer is created on first poll.
+///
+/// `tokio::time::interval` requires a running runtime, so deferring creation
+/// to the first [`Self::poll_tick`] (always inside the behaviour's poll loop)
+/// lets the behaviour be constructed without one. The first tick still
+/// completes immediately, matching an interval created at construction time.
+pub(crate) struct LazyInterval {
+    period: Duration,
+    interval: Option<Interval>,
+}
+
+impl LazyInterval {
+    /// Create a lazy interval with the given period.
+    pub(crate) fn new(period: Duration) -> Self {
+        Self {
+            period,
+            interval: None,
+        }
+    }
+
+    /// Poll for the next tick, creating the interval on first use.
+    pub(crate) fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<tokio::time::Instant> {
+        self.interval
+            .get_or_insert_with(|| tokio::time::interval(self.period))
+            .poll_tick(cx)
+    }
+}
 
 /// Target for dialing a peer (internal).
 ///
@@ -214,10 +232,10 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
     pub(crate) gossip: GossipHandle,
 
     // Periodic dial interval
-    pub(crate) dial_interval: Pin<Box<Interval>>,
+    pub(crate) dial_interval: LazyInterval,
 
     // Periodic peer save interval (only ticks when peer_store is Some)
-    pub(crate) peer_save_interval: Pin<Box<Interval>>,
+    pub(crate) peer_save_interval: LazyInterval,
 
     // Pending dnsaddr resolution for bootnodes (resolved_bootnodes, resolved_trusted)
     #[allow(clippy::type_complexity)]
@@ -270,165 +288,14 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
 
     // Metrics
     pub(crate) metrics: Arc<TopologyMetrics>,
+
+    /// Background-task inputs captured by [`crate::TopologyBehaviourBuilder`]
+    /// and consumed by [`TopologyBehaviour::spawn_tasks`]. `None` once the
+    /// tasks are running.
+    pub(crate) pending_tasks: Option<PendingTopologyTasks>,
 }
 
 impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
-    // Constructor
-
-    /// Create topology behaviour and handle.
-    pub fn new(
-        identity: I,
-        config: TopologyConfig,
-        network_config: &impl SwarmBootnodeConfig,
-        peer_store: Option<Arc<dyn NetPeerStore<StoredPeer>>>,
-        score_store: Option<Arc<dyn SwarmScoreStore<Score = PeerScore, Error = StoreError>>>,
-    ) -> Result<(Self, TopologyHandle<I>), TopologyError>
-    where
-        I: HasSpec,
-    {
-        let bootnodes = network_config.bootnodes().to_vec();
-        let trusted_peers = network_config.trusted_peers().to_vec();
-        let nat_addrs = network_config.nat_addrs().to_vec();
-        let trust_local_peers = network_config.trust_local_peers();
-
-        let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
-        let (command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
-
-        let peer_config = network_config.peers();
-        let scoring_config = SwarmScoringConfig::builder()
-            .ban_threshold(peer_config.ban_threshold())
-            .warn_threshold(peer_config.warn_threshold())
-            .build();
-        let peer_manager = if let Some(ref store) = peer_store {
-            PeerManager::with_store(
-                &identity,
-                store.clone(),
-                score_store,
-                scoring_config,
-                peer_config.max_per_bin(),
-            )
-        } else {
-            PeerManager::with_config(&identity, scoring_config, peer_config.max_per_bin())
-        };
-
-        let local_overlay = identity.overlay_address();
-
-        let connection_registry = Arc::new(ConnectionRegistry::new());
-        let agent_versions = identify::new_agent_versions();
-
-        let ban_rx = peer_manager.subscribe_bans();
-
-        let routing = KademliaRouting::new(
-            identity.clone(),
-            config.kademlia.clone(),
-            peer_manager.clone(),
-        );
-
-        let local_capabilities = Arc::new(LocalCapabilities::new());
-
-        // LocalAddressManager handles NAT address advertisement
-        // Note: We no longer track peer-observed addresses - they contain
-        // ephemeral NAT ports that only work for the specific peer connection.
-        let nat_discovery = Arc::new(if !nat_addrs.is_empty() {
-            info!(count = nat_addrs.len(), "NAT addresses configured");
-            LocalAddressManager::new(local_capabilities.clone(), nat_addrs)
-        } else {
-            LocalAddressManager::disabled(local_capabilities.clone())
-        });
-
-        let identity = Arc::new(identity);
-
-        // Wire kademlia routing as the handshake admission gate so the
-        // routing layer can veto a peer before the local side commits
-        // to its final exchange message.
-        let admission_control = kademlia_admission_control(routing.clone());
-
-        // Create composed protocol behaviours
-        let protocols =
-            ProtocolBehaviours::new(identity.clone(), nat_discovery.clone(), admission_control);
-
-        let metrics = Arc::new(TopologyMetrics::new());
-
-        let handle = TopologyHandle::new(
-            identity.clone(),
-            routing.clone(),
-            connection_registry.clone(),
-            peer_manager.clone(),
-            command_tx,
-            event_tx.clone(),
-            agent_versions.clone(),
-            metrics.clone(),
-        );
-
-        let dial_interval = config.dial_interval;
-
-        // Queue static NAT addresses to emit as external addresses on first poll
-        let pending_nat_external_addrs = nat_discovery.nat_addrs().to_vec();
-
-        let executor = vertex_tasks::TaskExecutor::try_current()
-            .map_err(|e| TopologyError::TaskSpawn(e.to_string()))?;
-
-        // Spawn background connection evaluator
-        let evaluator_handle = crate::kademlia::spawn_evaluator(routing.clone(), &executor);
-
-        // Spawn interface watcher for push-based subnet discovery.
-        crate::tasks::spawn_interface_watcher(&executor);
-
-        // Spawn the gossip task (merged peer exchange + verification).
-        let spec = <I as HasSpec>::spec(&*identity).clone();
-        let gossip = spawn_gossip_task(
-            spec,
-            config.gossip.clone(),
-            local_overlay,
-            peer_manager.clone(),
-            connection_registry.clone(),
-            evaluator_handle.clone(),
-            local_capabilities.clone(),
-            &executor,
-        )
-        .map_err(|e| TopologyError::TaskSpawn(e.to_string()))?;
-
-        let behaviour = Self {
-            identity,
-            protocols,
-            routing,
-            peer_manager,
-            connection_registry,
-            nat_discovery,
-            bootnodes,
-            trusted_peers,
-            command_rx,
-            event_tx,
-            pending_actions: VecDeque::new(),
-            gossip,
-            dial_interval: Box::pin(tokio::time::interval(dial_interval)),
-            peer_save_interval: Box::pin(tokio::time::interval(config.peer_save_interval)),
-            pending_bootnode_resolution: None,
-            evaluator_handle,
-            dial_tracker: DialTracker::new(DialTrackerConfig {
-                max_pending: 0,     // not used as a queue, only for direct in-flight tracking
-                max_in_flight: 256, // generous limit; routing capacity is the real gate
-                pending_ttl: HANDSHAKE_TIMEOUT,
-                in_flight_timeout: HANDSHAKE_TIMEOUT,
-                cleanup_interval: Duration::from_secs(30),
-                metrics_label: Some("topology"),
-                ..Default::default()
-            }),
-            early_disconnect_threshold: config.early_disconnect_threshold,
-            pending_evictions: HashSet::new(),
-            outbound_public_dials: HashSet::new(),
-            connected_node_types: HashMap::new(),
-            ban_rx,
-            peer_store,
-            agent_versions,
-            trust_local_peers,
-            pending_nat_external_addrs,
-            metrics,
-        };
-
-        Ok((behaviour, handle))
-    }
-
     // Public methods
 
     /// Register the local PeerId for address advertisement in handshakes.
@@ -869,13 +736,13 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
         }
 
         // Check for periodic dial candidate evaluation
-        if self.dial_interval.as_mut().poll_tick(cx).is_ready() {
+        if self.dial_interval.poll_tick(cx).is_ready() {
             self.cleanup_stale_pending();
             self.evaluator_handle.trigger_evaluation();
         }
 
         // Periodic peer save (safety net against crashes)
-        if self.peer_store.is_some() && self.peer_save_interval.as_mut().poll_tick(cx).is_ready() {
+        if self.peer_store.is_some() && self.peer_save_interval.poll_tick(cx).is_ready() {
             self.save_peers();
         }
 

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -1,0 +1,419 @@
+//! Builder for [`TopologyBehaviour`], separating construction from task spawning.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    sync::Arc,
+    time::Duration,
+};
+
+use libp2p::Multiaddr;
+use tokio::sync::{broadcast, mpsc};
+use tracing::info;
+use vertex_net_dialer::{DialTracker, DialTrackerConfig};
+use vertex_net_local::LocalCapabilities;
+use vertex_net_peer_store::NetPeerStore;
+use vertex_net_peer_store::error::StoreError;
+use vertex_swarm_api::{PeerConfigValues, SwarmBootnodeConfig, SwarmIdentity, SwarmScoreStore};
+use vertex_swarm_net_handshake::HANDSHAKE_TIMEOUT;
+use vertex_swarm_net_identify as identify;
+use vertex_swarm_peer_manager::{PeerManager, StoredPeer};
+use vertex_swarm_peer_score::{PeerScore, SwarmScoringConfig};
+use vertex_swarm_spec::{HasSpec, Spec};
+
+use crate::behaviour::{
+    COMMAND_CHANNEL_CAPACITY, ConnectionRegistry, EVENT_CHANNEL_CAPACITY, LazyInterval, PeerStore,
+    TopologyBehaviour, TopologyConfig,
+};
+use crate::composed::ProtocolBehaviours;
+use crate::error::TopologyError;
+use crate::gossip::{GossipChannels, GossipConfig, gossip_channel, spawn_gossip_task};
+use crate::handle::TopologyHandle;
+use crate::kademlia::{
+    KademliaRouting, RoutingEvaluatorHandle, kademlia_admission_control, spawn_evaluator,
+};
+use crate::metrics::TopologyMetrics;
+use crate::nat_discovery::LocalAddressManager;
+
+/// Type-erased peer score store.
+type ScoreStore = Arc<dyn SwarmScoreStore<Score = PeerScore, Error = StoreError>>;
+
+/// Inputs the background tasks need, captured at build time so that
+/// [`TopologyBehaviour::spawn_tasks`] can start them later without re-deriving
+/// state from the behaviour.
+pub(crate) struct PendingTopologyTasks {
+    /// Network spec for the gossip task's ephemeral verifier identity.
+    spec: Arc<Spec>,
+    /// Tuning knobs for the gossip task and its verifier.
+    gossip_config: GossipConfig,
+    /// Shared local capability tracker, also held by the address manager.
+    local_capabilities: Arc<LocalCapabilities>,
+    /// Task-side gossip channel endpoints.
+    gossip_channels: GossipChannels,
+}
+
+/// Builder for [`TopologyBehaviour`] and its [`TopologyHandle`].
+///
+/// Captures the values it needs from the network configuration at
+/// construction, takes the optional stores through fluent `with_*` methods,
+/// and constructs the behaviour in [`Self::try_build`] without spawning any
+/// background tasks. Spawning is a separate, explicit step
+/// ([`TopologyBehaviour::spawn_tasks`]), so unit tests can construct a
+/// behaviour without a tokio runtime.
+pub struct TopologyBehaviourBuilder<I: SwarmIdentity + Clone> {
+    identity: I,
+    config: TopologyConfig,
+    bootnodes: Vec<Multiaddr>,
+    trusted_peers: Vec<Multiaddr>,
+    nat_addrs: Vec<Multiaddr>,
+    trust_local_peers: bool,
+    scoring_config: SwarmScoringConfig,
+    max_per_bin: usize,
+    peer_store: Option<PeerStore>,
+    score_store: Option<ScoreStore>,
+}
+
+impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
+    /// Create a builder from the node identity and network configuration.
+    ///
+    /// Copies the multiaddrs and peer-management values out of
+    /// `network_config` so the builder owns everything it needs.
+    pub fn new(identity: I, network_config: &impl SwarmBootnodeConfig) -> Self {
+        let peer_config = network_config.peers();
+        Self {
+            identity,
+            config: TopologyConfig::default(),
+            bootnodes: network_config.bootnodes().to_vec(),
+            trusted_peers: network_config.trusted_peers().to_vec(),
+            nat_addrs: network_config.nat_addrs().to_vec(),
+            trust_local_peers: network_config.trust_local_peers(),
+            scoring_config: SwarmScoringConfig::builder()
+                .ban_threshold(peer_config.ban_threshold())
+                .warn_threshold(peer_config.warn_threshold())
+                .build(),
+            max_per_bin: peer_config.max_per_bin(),
+            peer_store: None,
+            score_store: None,
+        }
+    }
+
+    /// Set the topology configuration (kademlia, dial cadence, save interval).
+    pub fn with_config(mut self, config: TopologyConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Set the persistent peer store.
+    ///
+    /// Without one the node runs ephemeral: peers learned in this session are
+    /// lost on shutdown.
+    pub fn with_peer_store(mut self, store: Arc<dyn NetPeerStore<StoredPeer>>) -> Self {
+        self.peer_store = Some(store);
+        self
+    }
+
+    /// Set the persistent score store.
+    ///
+    /// Only consulted when a peer store is also set; scores are loaded lazily
+    /// as peers are promoted into the hot cache.
+    pub fn with_score_store(
+        mut self,
+        store: Arc<dyn SwarmScoreStore<Score = PeerScore, Error = StoreError>>,
+    ) -> Self {
+        self.score_store = Some(store);
+        self
+    }
+
+    /// Build the behaviour and its handle without spawning background tasks.
+    ///
+    /// The returned behaviour carries the captured task inputs; call
+    /// [`TopologyBehaviour::spawn_tasks`] from within a tokio runtime to start
+    /// the connection evaluator, interface watcher, and gossip tasks.
+    /// Construction itself needs no runtime.
+    pub fn try_build(self) -> Result<(TopologyBehaviour<I>, TopologyHandle<I>), TopologyError>
+    where
+        I: HasSpec,
+    {
+        let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        let (command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
+
+        let peer_manager = if let Some(ref store) = self.peer_store {
+            PeerManager::with_store(
+                &self.identity,
+                store.clone(),
+                self.score_store,
+                self.scoring_config,
+                self.max_per_bin,
+            )
+        } else {
+            PeerManager::with_config(&self.identity, self.scoring_config, self.max_per_bin)
+        };
+
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        let agent_versions = identify::new_agent_versions();
+
+        let ban_rx = peer_manager.subscribe_bans();
+
+        let routing = KademliaRouting::new(
+            self.identity.clone(),
+            self.config.kademlia.clone(),
+            peer_manager.clone(),
+        );
+
+        let local_capabilities = Arc::new(LocalCapabilities::new());
+
+        // LocalAddressManager handles NAT address advertisement
+        // Note: We no longer track peer-observed addresses - they contain
+        // ephemeral NAT ports that only work for the specific peer connection.
+        let nat_discovery = Arc::new(if !self.nat_addrs.is_empty() {
+            info!(count = self.nat_addrs.len(), "NAT addresses configured");
+            LocalAddressManager::new(local_capabilities.clone(), self.nat_addrs)
+        } else {
+            LocalAddressManager::disabled(local_capabilities.clone())
+        });
+
+        let spec = <I as HasSpec>::spec(&self.identity).clone();
+        let identity = Arc::new(self.identity);
+
+        // Wire kademlia routing as the handshake admission gate so the
+        // routing layer can veto a peer before the local side commits
+        // to its final exchange message.
+        let admission_control = kademlia_admission_control(routing.clone());
+
+        // Create composed protocol behaviours
+        let protocols =
+            ProtocolBehaviours::new(identity.clone(), nat_discovery.clone(), admission_control);
+
+        let metrics = Arc::new(TopologyMetrics::new());
+
+        let handle = TopologyHandle::new(
+            identity.clone(),
+            routing.clone(),
+            connection_registry.clone(),
+            peer_manager.clone(),
+            command_tx,
+            event_tx.clone(),
+            agent_versions.clone(),
+            metrics.clone(),
+        );
+
+        // Queue static NAT addresses to emit as external addresses on first poll
+        let pending_nat_external_addrs = nat_discovery.nat_addrs().to_vec();
+
+        // Handles wired here; the tasks behind them start in `spawn_tasks`.
+        let evaluator_handle = RoutingEvaluatorHandle::new();
+        let (gossip, gossip_channels) = gossip_channel();
+        let gossip_config = self.config.gossip.clone();
+
+        let behaviour = TopologyBehaviour {
+            identity,
+            protocols,
+            routing,
+            peer_manager,
+            connection_registry,
+            nat_discovery,
+            bootnodes: self.bootnodes,
+            trusted_peers: self.trusted_peers,
+            command_rx,
+            event_tx,
+            pending_actions: VecDeque::new(),
+            gossip,
+            dial_interval: LazyInterval::new(self.config.dial_interval),
+            peer_save_interval: LazyInterval::new(self.config.peer_save_interval),
+            pending_bootnode_resolution: None,
+            evaluator_handle,
+            dial_tracker: DialTracker::new(DialTrackerConfig {
+                max_pending: 0,     // not used as a queue, only for direct in-flight tracking
+                max_in_flight: 256, // generous limit; routing capacity is the real gate
+                pending_ttl: HANDSHAKE_TIMEOUT,
+                in_flight_timeout: HANDSHAKE_TIMEOUT,
+                cleanup_interval: Duration::from_secs(30),
+                metrics_label: Some("topology"),
+                ..Default::default()
+            }),
+            early_disconnect_threshold: self.config.early_disconnect_threshold,
+            pending_evictions: HashSet::new(),
+            outbound_public_dials: HashSet::new(),
+            connected_node_types: HashMap::new(),
+            ban_rx,
+            peer_store: self.peer_store,
+            agent_versions,
+            trust_local_peers: self.trust_local_peers,
+            pending_nat_external_addrs,
+            metrics,
+            pending_tasks: Some(PendingTopologyTasks {
+                spec,
+                gossip_config,
+                local_capabilities,
+                gossip_channels,
+            }),
+        };
+
+        Ok((behaviour, handle))
+    }
+}
+
+impl<I: SwarmIdentity + Clone + 'static> TopologyBehaviour<I> {
+    /// Spawn the background tasks that drive this behaviour: the kademlia
+    /// connection evaluator, the network interface watcher, and the gossip
+    /// task (peer exchange and verification).
+    ///
+    /// Requires a [`vertex_tasks::TaskExecutor`] reachable through
+    /// [`vertex_tasks::TaskExecutor::try_current`]. The captured task inputs
+    /// are consumed on the first successful call; a second call returns
+    /// [`TopologyError::TasksAlreadySpawned`]. If no executor is available the
+    /// inputs are preserved so the call can be retried.
+    pub fn spawn_tasks(&mut self) -> Result<(), TopologyError> {
+        if self.pending_tasks.is_none() {
+            return Err(TopologyError::TasksAlreadySpawned);
+        }
+        let executor = vertex_tasks::TaskExecutor::try_current()
+            .map_err(|e| TopologyError::TaskSpawn(e.to_string()))?;
+        let Some(pending) = self.pending_tasks.take() else {
+            return Err(TopologyError::TasksAlreadySpawned);
+        };
+
+        // Spawn background connection evaluator
+        spawn_evaluator(self.routing.clone(), &self.evaluator_handle, &executor);
+
+        // Spawn interface watcher for push-based subnet discovery.
+        crate::tasks::spawn_interface_watcher(&executor);
+
+        // Spawn the gossip task (merged peer exchange + verification).
+        spawn_gossip_task(
+            pending.spec,
+            pending.gossip_config,
+            self.identity.overlay_address(),
+            self.peer_manager.clone(),
+            self.connection_registry.clone(),
+            self.evaluator_handle.clone(),
+            pending.local_capabilities,
+            pending.gossip_channels,
+            &executor,
+        )
+        .map_err(|e| TopologyError::TaskSpawn(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use vertex_swarm_api::{
+        DefaultPeerConfig, SwarmNetworkConfig, SwarmNodeType, SwarmPeerConfig, SwarmRoutingConfig,
+    };
+    use vertex_swarm_identity::Identity;
+
+    use crate::kademlia::KademliaConfig;
+
+    /// Minimal network configuration for exercising the builder.
+    struct TestConfig {
+        peers: DefaultPeerConfig,
+        routing: KademliaConfig,
+        bootnodes: Vec<Multiaddr>,
+        empty_addrs: Vec<Multiaddr>,
+    }
+
+    impl TestConfig {
+        fn new() -> Self {
+            Self {
+                peers: DefaultPeerConfig::default(),
+                routing: KademliaConfig::default(),
+                bootnodes: vec!["/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr")],
+                empty_addrs: Vec::new(),
+            }
+        }
+    }
+
+    impl SwarmNetworkConfig for TestConfig {
+        fn listen_addrs(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn bootnodes(&self) -> &[Multiaddr] {
+            &self.bootnodes
+        }
+        fn discovery_enabled(&self) -> bool {
+            true
+        }
+        fn max_peers(&self) -> usize {
+            32
+        }
+        fn idle_timeout(&self) -> Duration {
+            Duration::from_secs(60)
+        }
+    }
+
+    impl SwarmPeerConfig for TestConfig {
+        type Peers = DefaultPeerConfig;
+        fn peers(&self) -> &Self::Peers {
+            &self.peers
+        }
+    }
+
+    impl SwarmRoutingConfig for TestConfig {
+        type Routing = KademliaConfig;
+        fn routing(&self) -> &Self::Routing {
+            &self.routing
+        }
+    }
+
+    fn test_identity() -> Identity {
+        Identity::random(vertex_swarm_spec::init_testnet(), SwarmNodeType::Client)
+    }
+
+    /// The builder constructs a behaviour and handle without a tokio runtime
+    /// and without spawning any background tasks.
+    #[test]
+    fn try_build_without_runtime_does_not_spawn_tasks() {
+        let config = TestConfig::new();
+        let (behaviour, _handle) = TopologyBehaviourBuilder::new(test_identity(), &config)
+            .with_config(TopologyConfig::default().with_dial_interval(Duration::from_secs(7)))
+            .try_build()
+            .expect("build without runtime");
+
+        assert!(
+            behaviour.pending_tasks.is_some(),
+            "task inputs must be captured, not spawned, at build time"
+        );
+        assert_eq!(behaviour.bootnodes, config.bootnodes);
+        assert!(behaviour.trust_local_peers);
+    }
+
+    /// Without a global task executor, spawning fails and preserves the
+    /// captured inputs so the call can be retried.
+    #[test]
+    fn spawn_tasks_without_executor_is_retryable() {
+        let config = TestConfig::new();
+        let (mut behaviour, _handle) = TopologyBehaviourBuilder::new(test_identity(), &config)
+            .try_build()
+            .expect("build without runtime");
+
+        let err = behaviour
+            .spawn_tasks()
+            .expect_err("no task executor in unit tests");
+        assert!(matches!(err, TopologyError::TaskSpawn(_)));
+        assert!(
+            behaviour.pending_tasks.is_some(),
+            "missing executor must not consume the task inputs"
+        );
+    }
+
+    /// A second spawn attempt reports the tasks as already spawned.
+    #[test]
+    fn spawn_tasks_twice_reports_already_spawned() {
+        let config = TestConfig::new();
+        let (mut behaviour, _handle) = TopologyBehaviourBuilder::new(test_identity(), &config)
+            .try_build()
+            .expect("build without runtime");
+
+        // Simulate a successful first spawn.
+        behaviour.pending_tasks = None;
+        assert!(matches!(
+            behaviour.spawn_tasks(),
+            Err(TopologyError::TasksAlreadySpawned)
+        ));
+    }
+}

--- a/crates/swarm/topology/src/error.rs
+++ b/crates/swarm/topology/src/error.rs
@@ -98,6 +98,10 @@ pub enum TopologyError {
     /// Failed to spawn a background task.
     #[error("failed to spawn task: {0}")]
     TaskSpawn(String),
+
+    /// Background tasks were already spawned for this behaviour.
+    #[error("background tasks already spawned")]
+    TasksAlreadySpawned,
 }
 
 impl TopologyError {

--- a/crates/swarm/topology/src/gossip/mod.rs
+++ b/crates/swarm/topology/src/gossip/mod.rs
@@ -37,7 +37,7 @@ use tokio::sync::mpsc;
 
 pub use config::GossipConfig;
 pub(crate) use events::{GossipAction, GossipInput};
-pub(crate) use tasks::spawn_gossip_task;
+pub(crate) use tasks::{GossipChannels, gossip_channel, spawn_gossip_task};
 
 /// Handle for communicating with the gossip task.
 pub(crate) struct GossipHandle {

--- a/crates/swarm/topology/src/gossip/tasks.rs
+++ b/crates/swarm/topology/src/gossip/tasks.rs
@@ -651,7 +651,33 @@ impl<I: SwarmIdentity> GossipTask<I> {
     }
 }
 
-/// Spawn the gossip task. Returns a handle for sending inputs and receiving outputs.
+/// Task-side endpoints of the gossip channels, created by [`gossip_channel`]
+/// and consumed when the task is spawned.
+pub(crate) struct GossipChannels {
+    input_rx: mpsc::Receiver<GossipInput>,
+    output_tx: mpsc::Sender<GossipAction>,
+}
+
+/// Create the gossip handle and task channel pair without spawning the task.
+///
+/// Inputs sent through the handle before the task starts are buffered up to
+/// the channel capacity.
+pub(crate) fn gossip_channel() -> (super::GossipHandle, GossipChannels) {
+    let (input_tx, input_rx) = mpsc::channel(INPUT_CHANNEL_CAPACITY);
+    let (output_tx, output_rx) = mpsc::channel(OUTPUT_CHANNEL_CAPACITY);
+    (
+        super::GossipHandle {
+            input_tx,
+            output_rx,
+        },
+        GossipChannels {
+            input_rx,
+            output_tx,
+        },
+    )
+}
+
+/// Spawn the gossip task on the channel endpoints created by [`gossip_channel`].
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
     spec: Arc<Spec>,
@@ -661,10 +687,13 @@ pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
     connection_registry: Arc<ConnectionRegistry>,
     evaluator_handle: RoutingEvaluatorHandle,
     local_capabilities: Arc<vertex_net_local::LocalCapabilities>,
+    channels: GossipChannels,
     executor: &vertex_tasks::TaskExecutor,
-) -> Result<super::GossipHandle, Box<dyn std::error::Error + Send + Sync>> {
-    let (input_tx, input_rx) = mpsc::channel(INPUT_CHANNEL_CAPACITY);
-    let (output_tx, output_rx) = mpsc::channel(OUTPUT_CHANNEL_CAPACITY);
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let GossipChannels {
+        input_rx,
+        output_tx,
+    } = channels;
 
     // Build ephemeral identity for the verification swarm
     let verifier_identity = Arc::new(
@@ -739,10 +768,7 @@ pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
         },
     );
 
-    Ok(super::GossipHandle {
-        input_tx,
-        output_rx,
-    })
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/swarm/topology/src/kademlia/task.rs
+++ b/crates/swarm/topology/src/kademlia/task.rs
@@ -17,6 +17,16 @@ pub(crate) struct RoutingEvaluatorHandle {
 }
 
 impl RoutingEvaluatorHandle {
+    /// Create a handle whose evaluator task has not started yet.
+    ///
+    /// The shared [`Notify`] stores a single permit, so a trigger issued
+    /// before [`spawn_evaluator`] wires the task is observed on startup.
+    pub(crate) fn new() -> Self {
+        Self {
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
     /// Signal the evaluator task to run an evaluation cycle.
     pub(crate) fn trigger_evaluation(&self) {
         self.notify.notify_one();
@@ -52,21 +62,18 @@ impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
     }
 }
 
-/// Spawn the routing evaluator task. Returns a handle for triggering evaluation.
+/// Spawn the routing evaluator task driven by the given handle's trigger.
 pub(crate) fn spawn_evaluator<I: SwarmIdentity + 'static>(
     routing: Arc<KademliaRouting<I>>,
+    handle: &RoutingEvaluatorHandle,
     executor: &TaskExecutor,
-) -> RoutingEvaluatorHandle {
-    let notify = Arc::new(Notify::new());
-    let handle = RoutingEvaluatorHandle {
-        notify: notify.clone(),
+) {
+    let task = RoutingEvaluatorTask {
+        routing,
+        notify: Arc::clone(&handle.notify),
     };
-
-    let task = RoutingEvaluatorTask { routing, notify };
 
     executor.spawn_critical_with_graceful_shutdown_signal("topology.evaluator", move |shutdown| {
         task.run(shutdown)
     });
-
-    handle
 }

--- a/crates/swarm/topology/src/lib.rs
+++ b/crates/swarm/topology/src/lib.rs
@@ -3,6 +3,11 @@
 //! Provides libp2p behaviour, handlers, and Kademlia routing for Swarm peer
 //! discovery and connection management.
 //!
+//! Construction goes through [`TopologyBehaviourBuilder`], which builds the
+//! behaviour and its [`TopologyHandle`] without spawning background tasks;
+//! [`TopologyBehaviour::spawn_tasks`] starts the connection evaluator,
+//! interface watcher, and gossip tasks once a runtime is available.
+//!
 //! # Timing and capacity assumptions
 //!
 //! These defaults are not specified by the Book of Swarm; they trade
@@ -35,6 +40,7 @@
 pub(crate) use vertex_net_utils::extract_peer_id;
 
 mod behaviour;
+mod builder;
 mod connection_handlers;
 mod dialing;
 mod events;
@@ -54,6 +60,7 @@ mod tasks;
 pub(crate) mod test_support;
 
 pub use behaviour::{DEFAULT_DIAL_INTERVAL, TopologyBehaviour, TopologyConfig};
+pub use builder::TopologyBehaviourBuilder;
 pub use error::{DialError, DisconnectReason, RejectionReason, TopologyError, TopologyResult};
 pub use events::{ConnectionDirection, DialReason, TopologyCommand, TopologyEvent};
 pub use gossip::GossipConfig;


### PR DESCRIPTION
## Summary

Closes #119

`TopologyBehaviour::new` took five Arc/Option-wrapped arguments, constructed roughly 27 fields, and spawned the gossip task, connection evaluator, and interface watcher inside the constructor, so a behaviour could not be built without a tokio runtime. This PR replaces it with `TopologyBehaviourBuilder` and splits construction from task spawning.

## Changes

- New `crates/swarm/topology/src/builder.rs`: `TopologyBehaviourBuilder::new(identity, network_config)` captures the bootnodes, trusted peers, NAT multiaddrs, and peer-management values; fluent `with_config`, `with_peer_store`, and `with_score_store` set the optional pieces; `try_build` returns `Result<(TopologyBehaviour, TopologyHandle), TopologyError>` without spawning anything. The existing `TopologyConfig` with_* chain is kept and funnels in through `with_config`.
- `TopologyBehaviour::spawn_tasks` is the explicit second step: it resolves the `vertex_tasks::TaskExecutor` and starts the connection evaluator, interface watcher, and gossip task from inputs captured at build time. A missing executor preserves the inputs so the call is retryable; a second call after success returns the new `TopologyError::TasksAlreadySpawned`.
- `dial_interval` and `peer_save_interval` become `LazyInterval`, which defers `tokio::time::interval` creation to the first poll inside the behaviour's poll loop, so construction needs no runtime. The first tick still completes immediately, matching the previous behaviour.
- `gossip_channel` creates the `GossipHandle` and task-side channel endpoints up front; `spawn_gossip_task` now consumes those endpoints instead of creating them. `RoutingEvaluatorHandle::new` similarly creates the trigger handle before `spawn_evaluator` wires the task; a trigger issued pre-spawn is observed on startup via the stored `Notify` permit.
- `TopologyBehaviour::new` is removed; the single call site in `crates/swarm/node/src/node/builder.rs` uses the builder followed by `spawn_tasks`.
- Unit tests in `builder.rs` prove a behaviour and handle can be built without a tokio runtime and without spawning tasks, and exercise the retryable-spawn and already-spawned error paths.

## Notes

Expected merge conflict with #202 (`refactor/120-gossip-config`): that branch threads a `GossipConfig` through `spawn_gossip_task` and `GossipVerifier`, and this branch changes the `spawn_gossip_task` signature for the channel split. The conflict is anticipated and will be resolved at merge time; this branch deliberately stays scoped to the builder and construction-vs-spawning split against current main.

## Testing

- `cargo test -p vertex-swarm-topology` (144 tests) and `cargo test -p vertex-swarm-node` (including the `three_node_convergence` integration test) pass.
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.
