### PR TITLE
feat(swarm-api): add peer reporting, affordability, and lifecycle event types

### DIFF
--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -31,10 +31,32 @@ pub trait SwarmRoutingConfig {
 }
 
 /// Default ban threshold for peer scoring (-100.0).
+///
+/// Third tier of the score response: a peer whose score falls below this
+/// threshold receives a timed ban.
 pub const DEFAULT_PEER_BAN_THRESHOLD: f64 = -100.0;
 
+/// Default disconnect threshold for peer scoring (-75.0).
+///
+/// Second tier of the score response: a peer whose score falls below this
+/// threshold has its connection closed and is backed off before redial.
+/// The full mapping is warn ([`DEFAULT_PEER_WARN_THRESHOLD`]) -> excluded
+/// from selection, disconnect -> connection closed plus backoff, ban
+/// ([`DEFAULT_PEER_BAN_THRESHOLD`]) -> timed ban.
+pub const DEFAULT_PEER_DISCONNECT_THRESHOLD: f64 = -75.0;
+
 /// Default warn threshold for peer scoring (-50.0).
+///
+/// First tier of the score response: a peer whose score falls below this
+/// threshold stays connected but is excluded from peer selection.
 pub const DEFAULT_PEER_WARN_THRESHOLD: f64 = -50.0;
+
+// The three response tiers must stay strictly ordered.
+const _: () = {
+    assert!(DEFAULT_PEER_BAN_THRESHOLD < DEFAULT_PEER_DISCONNECT_THRESHOLD);
+    assert!(DEFAULT_PEER_DISCONNECT_THRESHOLD < DEFAULT_PEER_WARN_THRESHOLD);
+    assert!(DEFAULT_PEER_WARN_THRESHOLD < 0.0);
+};
 
 /// Default maximum peers per proximity bin in the index.
 pub const DEFAULT_PEER_MAX_PER_BIN: usize = 128;

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -28,6 +28,15 @@
 //!
 //! [`SwarmProtocol`] implements [`vertex_node_api::NodeProtocol`], bridging the
 //! Swarm domain with the generic node infrastructure.
+//!
+//! # Peer Reporting
+//!
+//! [`PeerReporter`] is the single sanctioned path for subsystems to affect a
+//! peer's score, with [`SwarmScoringEvent`] as the shared event vocabulary.
+//! [`PeerAffordability`] lets protocol handlers ask bandwidth accounting
+//! whether a peer can pay for a request, and [`PeerLifecycleEvent`] carries
+//! the resulting lifecycle decisions (warnings, disconnects, bans) to
+//! subscribers such as topology.
 
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -40,6 +49,7 @@ mod error;
 mod identity;
 mod protocol;
 mod providers;
+mod reporting;
 mod rpc;
 mod spec;
 mod swarm;
@@ -55,12 +65,12 @@ pub use self::components::{
     SwarmTopologyStats,
 };
 pub use self::config::{
-    DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN, DEFAULT_PEER_WARN_THRESHOLD,
-    DefaultPeerConfig, DefaultStorageConfig, METADATA_OVERHEAD_FACTOR, NodeTask, NodeTaskFn,
-    PeerConfigValues, SwarmBootnodeConfig, SwarmClientConfig, SwarmClientLaunchConfig,
-    SwarmIdentityConfig, SwarmLaunchConfig, SwarmNetworkConfig, SwarmPeerConfig,
-    SwarmRoutingConfig, SwarmStorageConfig, SwarmStorerConfig, SwarmStorerLaunchConfig,
-    estimate_chunks_for_bytes, estimate_storage_bytes,
+    DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN,
+    DEFAULT_PEER_WARN_THRESHOLD, DefaultPeerConfig, DefaultStorageConfig, METADATA_OVERHEAD_FACTOR,
+    NodeTask, NodeTaskFn, PeerConfigValues, SwarmBootnodeConfig, SwarmClientConfig,
+    SwarmClientLaunchConfig, SwarmIdentityConfig, SwarmLaunchConfig, SwarmNetworkConfig,
+    SwarmPeerConfig, SwarmRoutingConfig, SwarmStorageConfig, SwarmStorerConfig,
+    SwarmStorerLaunchConfig, estimate_chunks_for_bytes, estimate_storage_bytes,
 };
 pub use self::error::{
     ConfigAddressKind, ConfigError, ConfigResult, IdentityError, SwarmError, SwarmResult,
@@ -69,6 +79,10 @@ pub use self::identity::SwarmIdentity;
 pub use self::protocol::SwarmProtocol;
 pub use self::providers::{
     ChunkRetrievalResult, PushReceipt, SwarmChunkProvider, SwarmChunkSender,
+};
+pub use self::reporting::{
+    BanCause, DisconnectCause, PeerAffordability, PeerLifecycleEvent, PeerReporter, ReportSource,
+    SwarmScoringEvent,
 };
 pub use self::rpc::RpcProviders;
 pub use self::spec::{

--- a/crates/swarm/api/src/reporting.rs
+++ b/crates/swarm/api/src/reporting.rs
@@ -1,0 +1,448 @@
+//! Peer reporting, affordability, and lifecycle event types.
+//!
+//! These types are the shared vocabulary between the peer manager and the
+//! subsystems that observe or judge peers:
+//!
+//! - [`PeerReporter`] is the single sanctioned path for scoring input. The
+//!   peer manager implements it via its handle; topology, gossip
+//!   verification, handshake, protocol handlers, bandwidth accounting, and
+//!   the RPC surface all report through it instead of mutating scores
+//!   directly.
+//! - [`PeerAffordability`] is implemented by bandwidth accounting so that
+//!   protocol handlers can check whether a peer can pay for a request
+//!   before doing the work.
+//! - [`PeerLifecycleEvent`] is emitted by the peer manager; topology
+//!   subscribes to it and executes the resulting disconnects and dial
+//!   policy changes.
+
+use core::time::Duration;
+
+use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
+
+/// Peer scoring events reported by subsystems.
+///
+/// Each event carries an implicit weight (see [`default_weight`]) that is
+/// applied to the peer's score by the scoring engine. Concrete weight
+/// configuration lives with the scoring implementation; this enum only
+/// names the observable behaviours.
+///
+/// [`default_weight`]: SwarmScoringEvent::default_weight
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum SwarmScoringEvent {
+    /// Successful connection with optional latency.
+    ConnectionSuccess {
+        /// Time taken to establish the connection, if measured.
+        latency: Option<Duration>,
+    },
+    /// Connection attempt timed out.
+    ConnectionTimeout,
+    /// Connection was refused by peer.
+    ConnectionRefused,
+    /// Handshake protocol failed.
+    HandshakeFailure,
+    /// Protocol-level error during communication.
+    ProtocolError,
+    /// Peer disconnected shortly after completing handshake (connection instability).
+    EarlyDisconnect {
+        /// How long the connection lasted before the peer disconnected.
+        duration: Duration,
+    },
+    /// Successful chunk retrieval.
+    RetrievalSuccess {
+        /// Time taken to retrieve the chunk.
+        latency: Duration,
+    },
+    /// Chunk retrieval failed.
+    RetrievalFailure,
+    /// Successful chunk push.
+    PushSuccess {
+        /// Time taken to push the chunk.
+        latency: Duration,
+    },
+    /// Chunk push failed.
+    PushFailure,
+    /// Peer provided invalid data (chunk, signature, etc.).
+    InvalidData,
+    /// Peer is behaving maliciously.
+    MaliciousBehavior,
+    /// Bandwidth accounting violation.
+    AccountingViolation,
+    /// Peer exceeded rate limits.
+    RateLimitExceeded,
+    /// Successful ping/pong.
+    PingSuccess {
+        /// Round-trip time of the ping.
+        latency: Duration,
+    },
+    /// Ping timed out.
+    PingTimeout,
+    /// Hive gossip received useful peers.
+    GossipUseful,
+    /// Hive gossip contained stale/invalid peers.
+    GossipStale,
+    /// Gossiped peer was verified via handshake (signature, overlay, multiaddr all match).
+    GossipVerified,
+    /// Gossiped peer failed verification (overlay, signature, or multiaddr mismatch).
+    GossipInvalid,
+    /// Gossiped peer could not be reached for verification.
+    GossipUnreachable,
+}
+
+impl SwarmScoringEvent {
+    /// Get the default weight for this event.
+    ///
+    /// Positive weights improve score, negative weights decrease it. These
+    /// are default values; scoring implementations may apply configured
+    /// overrides instead.
+    #[must_use]
+    pub fn default_weight(&self) -> f64 {
+        match self {
+            Self::ConnectionSuccess { .. } => 1.0,
+            Self::ConnectionTimeout => -1.5,
+            Self::ConnectionRefused => -1.0,
+            Self::HandshakeFailure => -5.0,
+            Self::ProtocolError => -3.0,
+            Self::EarlyDisconnect { .. } => -3.0,
+            Self::RetrievalSuccess { .. } => 0.5,
+            Self::RetrievalFailure => -2.0,
+            Self::PushSuccess { .. } => 0.5,
+            Self::PushFailure => -2.0,
+            Self::InvalidData => -10.0,
+            Self::MaliciousBehavior => -50.0,
+            Self::AccountingViolation => -20.0,
+            Self::RateLimitExceeded => -5.0,
+            Self::PingSuccess { .. } => 0.1,
+            Self::PingTimeout => -0.5,
+            Self::GossipUseful => 0.2,
+            Self::GossipStale => -0.1,
+            Self::GossipVerified => 1.0,
+            Self::GossipInvalid => -15.0,
+            Self::GossipUnreachable => -0.5,
+        }
+    }
+
+    /// Extract latency if this event includes timing information.
+    #[must_use]
+    pub fn latency(&self) -> Option<Duration> {
+        match self {
+            Self::ConnectionSuccess { latency } => *latency,
+            Self::RetrievalSuccess { latency }
+            | Self::PushSuccess { latency }
+            | Self::PingSuccess { latency } => Some(*latency),
+            _ => None,
+        }
+    }
+
+    /// True for successful connection events.
+    #[must_use]
+    pub fn is_connection_success(&self) -> bool {
+        matches!(self, Self::ConnectionSuccess { .. })
+    }
+
+    /// True for connection timeout events.
+    #[must_use]
+    pub fn is_connection_timeout(&self) -> bool {
+        matches!(self, Self::ConnectionTimeout)
+    }
+
+    /// True for protocol error events.
+    #[must_use]
+    pub fn is_protocol_error(&self) -> bool {
+        matches!(self, Self::ProtocolError)
+    }
+
+    /// True for events that should trigger an immediate ban check.
+    #[must_use]
+    pub fn is_severe(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidData
+                | Self::MaliciousBehavior
+                | Self::AccountingViolation
+                | Self::GossipInvalid
+        )
+    }
+}
+
+/// Subsystem that originated a peer report.
+///
+/// Carried alongside every [`SwarmScoringEvent`] so the peer manager can
+/// attribute score changes in logs and metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum ReportSource {
+    /// Topology management (dialing, connection lifecycle, kademlia).
+    Topology,
+    /// Hive gossip verification.
+    Gossip,
+    /// Handshake protocol.
+    Handshake,
+    /// A wire protocol handler, identified by protocol name.
+    Protocol(&'static str),
+    /// Bandwidth accounting.
+    Accounting,
+    /// Operator action over the RPC surface.
+    Rpc,
+}
+
+/// Report peer behaviour to the authority that owns peer records.
+///
+/// This is the single sanctioned path for any subsystem to affect a peer's
+/// score. The peer manager implements it via its handle; scoring, threshold
+/// checks, and the resulting [`PeerLifecycleEvent`]s all happen behind this
+/// trait.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait PeerReporter: Send + Sync {
+    /// Report a scoring event for the peer identified by `overlay`.
+    fn report_peer(&self, overlay: &OverlayAddress, event: SwarmScoringEvent, source: ReportSource);
+}
+
+/// Query whether a peer can pay for service.
+///
+/// Implemented by bandwidth accounting; protocol handlers consult it before
+/// serving a request so that work is never done for a peer that cannot
+/// settle it. Prices and allowances are in accounting units (AU).
+#[auto_impl::auto_impl(&, Arc)]
+pub trait PeerAffordability: Send + Sync {
+    /// True if the peer can afford a request of the given price in AU.
+    fn can_afford(&self, overlay: &OverlayAddress, price: u64) -> bool;
+
+    /// Remaining allowance for the peer in AU.
+    fn allowance_remaining(&self, overlay: &OverlayAddress) -> u64;
+}
+
+/// Why a peer's connection should be closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum DisconnectCause {
+    /// Score fell below the disconnect threshold.
+    LowScore,
+    /// A protocol handler reported a violation.
+    ProtocolViolation,
+    /// The peer exhausted its bandwidth allowance.
+    AllowanceExceeded,
+    /// Disconnect requested by an operator over the RPC surface.
+    Requested,
+    /// The connection slot was reclaimed by topology pruning.
+    Pruned,
+    /// The node is shutting down.
+    ShuttingDown,
+}
+
+/// Why a peer was banned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum BanCause {
+    /// Score fell below the ban threshold.
+    LowScore,
+    /// The peer provided data that failed validation.
+    InvalidData,
+    /// The peer behaved maliciously.
+    Malicious,
+    /// Ban requested by an operator over the RPC surface.
+    Requested,
+}
+
+/// Lifecycle events emitted by the authority that owns peer records.
+///
+/// Topology subscribes to this stream and executes the network-side
+/// consequences: closing connections for [`DisconnectRequested`], applying
+/// dial backoff, and refusing dials to banned peers.
+///
+/// [`DisconnectRequested`]: PeerLifecycleEvent::DisconnectRequested
+#[derive(Debug, Clone)]
+pub enum PeerLifecycleEvent {
+    /// A peer completed the handshake and is connected.
+    Connected {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// The node type the peer advertised.
+        node_type: SwarmNodeType,
+    },
+    /// A peer disconnected.
+    Disconnected {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+    },
+    /// A peer's score crossed the warn threshold; exclude it from selection.
+    ScoreWarning {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// The score at the time the threshold was crossed.
+        score: f64,
+    },
+    /// The peer's connection should be closed and the peer backed off.
+    DisconnectRequested {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// Why the disconnect was requested.
+        reason: DisconnectCause,
+    },
+    /// The peer was banned.
+    Banned {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// Unix timestamp in seconds at which the ban expires.
+        until: u64,
+        /// Why the peer was banned.
+        reason: BanCause,
+    },
+    /// A previously banned peer had its ban lifted.
+    Unbanned {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    // Compile-time check: both traits must stay object safe.
+    fn _assert_object_safe(_: &dyn PeerReporter, _: &dyn PeerAffordability) {}
+
+    #[derive(Default)]
+    struct RecordingReporter {
+        reports: Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
+    }
+
+    impl PeerReporter for RecordingReporter {
+        fn report_peer(
+            &self,
+            overlay: &OverlayAddress,
+            event: SwarmScoringEvent,
+            source: ReportSource,
+        ) {
+            self.reports.lock().unwrap().push((*overlay, event, source));
+        }
+    }
+
+    struct FixedAffordability(u64);
+
+    impl PeerAffordability for FixedAffordability {
+        fn can_afford(&self, _overlay: &OverlayAddress, price: u64) -> bool {
+            price <= self.0
+        }
+
+        fn allowance_remaining(&self, _overlay: &OverlayAddress) -> u64 {
+            self.0
+        }
+    }
+
+    #[test]
+    fn report_peer_via_arc_auto_impl() {
+        let reporter = Arc::new(RecordingReporter::default());
+        let overlay = OverlayAddress::zero();
+
+        fn report_all(reporter: impl PeerReporter, overlay: &OverlayAddress) {
+            reporter.report_peer(
+                overlay,
+                SwarmScoringEvent::HandshakeFailure,
+                ReportSource::Handshake,
+            );
+            reporter.report_peer(
+                overlay,
+                SwarmScoringEvent::RetrievalFailure,
+                ReportSource::Protocol("retrieval"),
+            );
+        }
+        report_all(Arc::clone(&reporter), &overlay);
+
+        let reports = reporter.reports.lock().unwrap();
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0].1, SwarmScoringEvent::HandshakeFailure);
+        assert_eq!(reports[0].2, ReportSource::Handshake);
+        assert_eq!(reports[1].2, ReportSource::Protocol("retrieval"));
+    }
+
+    #[test]
+    fn affordability_via_arc_auto_impl() {
+        let accounting: Arc<dyn PeerAffordability> = Arc::new(FixedAffordability(100));
+        let overlay = OverlayAddress::zero();
+        assert!(accounting.can_afford(&overlay, 100));
+        assert!(!accounting.can_afford(&overlay, 101));
+        assert_eq!(accounting.allowance_remaining(&overlay), 100);
+    }
+
+    #[test]
+    fn scoring_event_default_weights() {
+        assert!(SwarmScoringEvent::ConnectionSuccess { latency: None }.default_weight() > 0.0);
+        assert!(
+            SwarmScoringEvent::RetrievalSuccess {
+                latency: Duration::ZERO
+            }
+            .default_weight()
+                > 0.0
+        );
+        assert!(SwarmScoringEvent::GossipUseful.default_weight() > 0.0);
+
+        assert!(SwarmScoringEvent::ConnectionTimeout.default_weight() < 0.0);
+        assert!(SwarmScoringEvent::HandshakeFailure.default_weight() < 0.0);
+        assert!(SwarmScoringEvent::MaliciousBehavior.default_weight() < -10.0);
+    }
+
+    #[test]
+    fn scoring_event_latency_extraction() {
+        let event = SwarmScoringEvent::ConnectionSuccess {
+            latency: Some(Duration::from_millis(50)),
+        };
+        assert_eq!(event.latency(), Some(Duration::from_millis(50)));
+
+        let event = SwarmScoringEvent::ConnectionTimeout;
+        assert_eq!(event.latency(), None);
+    }
+
+    #[test]
+    fn scoring_event_severity() {
+        assert!(SwarmScoringEvent::MaliciousBehavior.is_severe());
+        assert!(SwarmScoringEvent::InvalidData.is_severe());
+        assert!(SwarmScoringEvent::AccountingViolation.is_severe());
+        assert!(SwarmScoringEvent::GossipInvalid.is_severe());
+        assert!(!SwarmScoringEvent::ConnectionTimeout.is_severe());
+    }
+
+    #[test]
+    fn scoring_event_derives() {
+        let event = SwarmScoringEvent::PingSuccess {
+            latency: Duration::from_millis(5),
+        };
+        let copy = event;
+        assert_eq!(event, copy);
+
+        let label: &'static str = SwarmScoringEvent::GossipInvalid.into();
+        assert_eq!(label, "gossip_invalid");
+    }
+
+    #[test]
+    fn cause_labels_are_snake_case() {
+        let label: &'static str = DisconnectCause::LowScore.into();
+        assert_eq!(label, "low_score");
+        assert_eq!(
+            DisconnectCause::AllowanceExceeded.to_string(),
+            "allowance_exceeded"
+        );
+
+        let label: &'static str = BanCause::InvalidData.into();
+        assert_eq!(label, "invalid_data");
+    }
+
+    #[test]
+    fn lifecycle_event_is_cloneable() {
+        let event = PeerLifecycleEvent::Banned {
+            overlay: OverlayAddress::zero(),
+            until: 1_750_000_000,
+            reason: BanCause::LowScore,
+        };
+        let cloned = event.clone();
+        assert!(matches!(
+            cloned,
+            PeerLifecycleEvent::Banned {
+                reason: BanCause::LowScore,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/swarm/peers/peer-score/src/config.rs
+++ b/crates/swarm/peers/peer-score/src/config.rs
@@ -1,113 +1,38 @@
-//! Scoring events, configurable weights, and builder.
+//! Configurable scoring weights and builder.
 
 use std::time::Duration;
 
 use vertex_swarm_api::{DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_WARN_THRESHOLD};
 
+// The scoring event vocabulary is defined in `vertex-swarm-api`; this crate
+// re-exports it so existing import paths keep working.
+pub use vertex_swarm_api::SwarmScoringEvent;
+
 scoring_events! {
-    /// Successful connection with optional latency.
-    ConnectionSuccess { latency: Option<Duration> }
-        => connection_success = 1.0,
-    /// Connection attempt timed out.
-    ConnectionTimeout
-        => connection_timeout = -1.5,
-    /// Connection was refused by peer.
-    ConnectionRefused
-        => connection_refused = -1.0,
-    /// Handshake protocol failed.
-    HandshakeFailure
-        => handshake_failure = -5.0,
-    /// Protocol-level error during communication.
-    ProtocolError
-        => protocol_error = -3.0,
-    /// Peer disconnected shortly after completing handshake (connection instability).
-    EarlyDisconnect { duration: Duration }
-        => early_disconnect = -3.0,
-    /// Successful chunk retrieval.
-    RetrievalSuccess { latency: Duration }
-        => retrieval_success = 0.5,
-    /// Chunk retrieval failed.
-    RetrievalFailure
-        => retrieval_failure = -2.0,
-    /// Successful chunk push.
-    PushSuccess { latency: Duration }
-        => push_success = 0.5,
-    /// Chunk push failed.
-    PushFailure
-        => push_failure = -2.0,
-    /// Peer provided invalid data (chunk, signature, etc.).
-    InvalidData
-        => invalid_data = -10.0,
-    /// Peer is behaving maliciously.
-    MaliciousBehavior
-        => malicious_behavior = -50.0,
-    /// Bandwidth accounting violation.
-    AccountingViolation
-        => accounting_violation = -20.0,
-    /// Peer exceeded rate limits.
-    RateLimitExceeded
-        => rate_limit_exceeded = -5.0,
-    /// Successful ping/pong.
-    PingSuccess { latency: Duration }
-        => ping_success = 0.1,
-    /// Ping timed out.
-    PingTimeout
-        => ping_timeout = -0.5,
-    /// Hive gossip received useful peers.
-    GossipUseful
-        => gossip_useful = 0.2,
-    /// Hive gossip contained stale/invalid peers.
-    GossipStale
-        => gossip_stale = -0.1,
-    /// Gossiped peer was verified via handshake (signature, overlay, multiaddr all match).
-    GossipVerified
-        => gossip_verified = 1.0,
-    /// Gossiped peer failed verification (overlay, signature, or multiaddr mismatch).
-    GossipInvalid
-        => gossip_invalid = -15.0,
-    /// Gossiped peer could not be reached for verification.
-    GossipUnreachable
-        => gossip_unreachable = -0.5;
+    ConnectionSuccess { latency: Option<Duration> } => connection_success,
+    ConnectionTimeout => connection_timeout,
+    ConnectionRefused => connection_refused,
+    HandshakeFailure => handshake_failure,
+    ProtocolError => protocol_error,
+    EarlyDisconnect { duration: Duration } => early_disconnect,
+    RetrievalSuccess { latency: Duration } => retrieval_success,
+    RetrievalFailure => retrieval_failure,
+    PushSuccess { latency: Duration } => push_success,
+    PushFailure => push_failure,
+    InvalidData => invalid_data,
+    MaliciousBehavior => malicious_behavior,
+    AccountingViolation => accounting_violation,
+    RateLimitExceeded => rate_limit_exceeded,
+    PingSuccess { latency: Duration } => ping_success,
+    PingTimeout => ping_timeout,
+    GossipUseful => gossip_useful,
+    GossipStale => gossip_stale,
+    GossipVerified => gossip_verified,
+    GossipInvalid => gossip_invalid,
+    GossipUnreachable => gossip_unreachable;
 
     ban_threshold = DEFAULT_PEER_BAN_THRESHOLD,
     warn_threshold = DEFAULT_PEER_WARN_THRESHOLD,
-}
-
-impl SwarmScoringEvent {
-    /// Extract latency if this event includes timing information.
-    #[must_use]
-    pub fn latency(&self) -> Option<Duration> {
-        match self {
-            Self::ConnectionSuccess { latency } => *latency,
-            Self::RetrievalSuccess { latency }
-            | Self::PushSuccess { latency }
-            | Self::PingSuccess { latency } => Some(*latency),
-            _ => None,
-        }
-    }
-
-    pub fn is_connection_success(&self) -> bool {
-        matches!(self, Self::ConnectionSuccess { .. })
-    }
-
-    pub fn is_connection_timeout(&self) -> bool {
-        matches!(self, Self::ConnectionTimeout)
-    }
-
-    pub fn is_protocol_error(&self) -> bool {
-        matches!(self, Self::ProtocolError)
-    }
-
-    /// True for events that should trigger an immediate ban check.
-    pub fn is_severe(&self) -> bool {
-        matches!(
-            self,
-            Self::InvalidData
-                | Self::MaliciousBehavior
-                | Self::AccountingViolation
-                | Self::GossipInvalid
-        )
-    }
 }
 
 impl SwarmScoringConfig {
@@ -176,6 +101,30 @@ mod tests {
     }
 
     #[test]
+    fn test_default_weights_match_events() {
+        let config = SwarmScoringConfig::default();
+        let events = [
+            SwarmScoringEvent::ConnectionSuccess { latency: None },
+            SwarmScoringEvent::ConnectionTimeout,
+            SwarmScoringEvent::HandshakeFailure,
+            SwarmScoringEvent::EarlyDisconnect {
+                duration: Duration::ZERO,
+            },
+            SwarmScoringEvent::RetrievalSuccess {
+                latency: Duration::ZERO,
+            },
+            SwarmScoringEvent::MaliciousBehavior,
+            SwarmScoringEvent::GossipUnreachable,
+        ];
+        for event in events {
+            assert!(
+                (config.weight_for(&event) - event.default_weight()).abs() < f64::EPSILON,
+                "default config weight diverges from default_weight for {event:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_builder() {
         let config = SwarmScoringConfig::builder()
             .connection_success(2.0)
@@ -219,41 +168,5 @@ mod tests {
         let bytes = postcard::to_allocvec(&config).unwrap();
         let restored: SwarmScoringConfig = postcard::from_bytes(&bytes).unwrap();
         assert!((config.connection_success() - restored.connection_success()).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_event_weights() {
-        assert!(SwarmScoringEvent::ConnectionSuccess { latency: None }.default_weight() > 0.0);
-        assert!(
-            SwarmScoringEvent::RetrievalSuccess {
-                latency: Duration::ZERO
-            }
-            .default_weight()
-                > 0.0
-        );
-        assert!(SwarmScoringEvent::GossipUseful.default_weight() > 0.0);
-
-        assert!(SwarmScoringEvent::ConnectionTimeout.default_weight() < 0.0);
-        assert!(SwarmScoringEvent::HandshakeFailure.default_weight() < 0.0);
-        assert!(SwarmScoringEvent::MaliciousBehavior.default_weight() < -10.0);
-    }
-
-    #[test]
-    fn test_latency_extraction() {
-        let event = SwarmScoringEvent::ConnectionSuccess {
-            latency: Some(Duration::from_millis(50)),
-        };
-        assert_eq!(event.latency(), Some(Duration::from_millis(50)));
-
-        let event = SwarmScoringEvent::ConnectionTimeout;
-        assert_eq!(event.latency(), None);
-    }
-
-    #[test]
-    fn test_severe_events() {
-        assert!(SwarmScoringEvent::MaliciousBehavior.is_severe());
-        assert!(SwarmScoringEvent::InvalidData.is_severe());
-        assert!(SwarmScoringEvent::AccountingViolation.is_severe());
-        assert!(!SwarmScoringEvent::ConnectionTimeout.is_severe());
     }
 }

--- a/crates/swarm/peers/peer-score/src/macros.rs
+++ b/crates/swarm/peers/peer-score/src/macros.rs
@@ -1,38 +1,19 @@
-//! Internal macro for generating scoring events and config.
+//! Internal macro for generating the scoring config from the event table.
 
-/// Generates `SwarmScoringEvent`, `SwarmScoringConfig`, and `SwarmScoringConfigBuilder`
-/// from a single declaration table mapping event variants to config fields and defaults.
+/// Generates `SwarmScoringConfig`, `SwarmScoringConfigBuilder`, and the
+/// per-event `record_*` convenience methods from a declaration table mapping
+/// `SwarmScoringEvent` variants to config fields.
+///
+/// Default weights come from [`SwarmScoringEvent::default_weight`], so the
+/// event vocabulary and its defaults are declared once in `vertex-swarm-api`.
 macro_rules! scoring_events {
     (
         $(
-            $(#[doc = $doc:expr])*
-            $variant:ident $({ $($field:ident : $fty:ty),* $(,)? })?
-                => $config_field:ident = $default:expr
+            $variant:ident $({ $($field:ident : $fty:ty),* $(,)? })? => $config_field:ident
         ),* $(,)?
         ;
         $( $extra_field:ident = $extra_default:expr ),* $(,)?
     ) => {
-        /// Swarm-specific peer scoring events.
-        #[derive(Debug)]
-        pub enum SwarmScoringEvent {
-            $(
-                $(#[doc = $doc])*
-                $variant $({ $($field: $fty),* })?,
-            )*
-        }
-
-        impl SwarmScoringEvent {
-            /// Get the default weight for this event.
-            ///
-            /// Positive weights improve score, negative weights decrease it.
-            /// These are default values; use [`SwarmScoringConfig`] for customization.
-            pub fn default_weight(&self) -> f64 {
-                match self {
-                    $( Self::$variant $({ $($field: _),* })? => $default, )*
-                }
-            }
-        }
-
         /// Configuration for Swarm peer scoring weights.
         ///
         /// All weights can be customized. Positive values improve score,
@@ -47,7 +28,11 @@ macro_rules! scoring_events {
         impl Default for SwarmScoringConfig {
             fn default() -> Self {
                 Self {
-                    $( $config_field: $default, )*
+                    $(
+                        $config_field: SwarmScoringEvent::$variant
+                            $({ $($field: Default::default()),* })?
+                            .default_weight(),
+                    )*
                     $( $extra_field: $extra_default, )*
                 }
             }
@@ -55,10 +40,12 @@ macro_rules! scoring_events {
 
         impl SwarmScoringConfig {
             $(
+                #[doc = concat!("Weight applied for [`SwarmScoringEvent::", stringify!($variant), "`].")]
                 #[must_use]
                 pub fn $config_field(&self) -> f64 { self.$config_field }
             )*
             $(
+                #[doc = concat!("The configured `", stringify!($extra_field), "` value.")]
                 #[must_use]
                 pub fn $extra_field(&self) -> f64 { self.$extra_field }
             )*
@@ -94,6 +81,7 @@ macro_rules! scoring_events {
             pub fn build(self) -> SwarmScoringConfig { self.config }
 
             $(
+                #[doc = concat!("Set the weight for [`SwarmScoringEvent::", stringify!($variant), "`].")]
                 #[must_use]
                 pub fn $config_field(mut self, value: f64) -> Self {
                     self.config.$config_field = value;
@@ -101,6 +89,7 @@ macro_rules! scoring_events {
                 }
             )*
             $(
+                #[doc = concat!("Set the `", stringify!($extra_field), "` value.")]
                 #[must_use]
                 pub fn $extra_field(mut self, value: f64) -> Self {
                     self.config.$extra_field = value;
@@ -113,7 +102,7 @@ macro_rules! scoring_events {
         paste::paste! {
             impl crate::score::SwarmPeerScore {
                 $(
-                    $(#[doc = $doc])*
+                    #[doc = concat!("Record a [`SwarmScoringEvent::", stringify!($variant), "`] event.")]
                     pub fn [<record_ $config_field>](&self $(, $($field: $fty),*)?) {
                         self.record_event(SwarmScoringEvent::$variant $({ $($field),* })?);
                     }


### PR DESCRIPTION
## Summary

This PR adds the shared peer-reporting vocabulary to `vertex-swarm-api` so that scoring, accounting, topology, and protocol handlers can plug into the peer manager through one sanctioned surface. It is purely additive: no behaviour changes, and no consumers are wired yet.

- Move `SwarmScoringEvent` from `vertex-swarm-peer-score` into `vertex-swarm-api`, next to the scoring threshold constants it pairs with. The enum stays dependency-free (`core::time::Duration` only) and gains `Clone`, `Copy`, `PartialEq`, `Eq`, and `strum::IntoStaticStr` for metric labels. `vertex-swarm-peer-score` re-exports it from its existing path, so all current consumers compile unchanged.
- Keep `SwarmScoringConfig` and its builder in `vertex-swarm-peer-score`. The `scoring_events!` macro no longer defines the enum; config defaults now come from `SwarmScoringEvent::default_weight`, so each weight is declared exactly once, and a new test asserts the default config matches the event defaults.
- Add `PeerReporter` (with `ReportSource`) as the single sanctioned path for any subsystem to affect a peer's score. The peer manager implements it via its handle in a later PR.
- Add `PeerAffordability` so bandwidth accounting can answer affordability queries from protocol handlers, in accounting units (AU).
- Add `PeerLifecycleEvent` with `DisconnectCause` and `BanCause` so topology can subscribe to lifecycle decisions (warnings, disconnect requests, bans) and execute the network-side consequences.
- Add `DEFAULT_PEER_DISCONNECT_THRESHOLD` (-75.0) between the existing warn (-50.0) and ban (-100.0) thresholds, with rustdoc for the three-tier mapping: warn excludes the peer from selection, disconnect closes the connection and backs the peer off, ban applies a timed ban. A const assertion keeps the tiers strictly ordered.

This provides groundwork for #175 and #176; those issues are closed by later PRs that wire the consumers.

## Testing

- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` (workspace, green)
- `cargo test -p vertex-swarm-api -p vertex-swarm-peer-score`
- `cargo check -p vertex-swarm-peer-manager -p vertex-swarm-topology` to confirm the re-export keeps dependents compiling unchanged
