### PR TITLE
refactor(swarm-peer-score): ScoreOutcome apply path; decay and recovery primitives

### DIFF
--- a/crates/net/peer/score/src/lib.rs
+++ b/crates/net/peer/score/src/lib.rs
@@ -48,7 +48,10 @@ impl PeerScore {
     }
 
     /// Atomically adjust score, clamped to bounds.
-    pub fn add_score(&self, delta: f64) {
+    ///
+    /// Returns `(old, new)` from the successful update so callers can detect
+    /// threshold crossings without racing a separate load.
+    pub fn add_score(&self, delta: f64) -> (f64, f64) {
         loop {
             let current = self.score.load(Ordering::Acquire);
             let new_val = (current + delta).clamp(MIN_SCORE, MAX_SCORE);
@@ -57,7 +60,43 @@ impl PeerScore {
                 .compare_exchange_weak(current, new_val, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
             {
-                break;
+                return (current, new_val);
+            }
+        }
+    }
+
+    /// Exponentially decay the score toward zero.
+    ///
+    /// After one half-life the score magnitude halves; both positive and
+    /// negative scores decay, so reputation is recency-weighted in either
+    /// direction. The crate holds no clock: callers measure `elapsed_secs`
+    /// themselves and drive decay from their own heartbeat.
+    ///
+    /// Accelerated recovery for connected peers needs no second method: decay
+    /// is scale-free in `elapsed_secs / half_life_secs`, so passing half the
+    /// configured half-life (or equivalently doubling the elapsed time)
+    /// decays a connected peer's negative score twice as fast.
+    ///
+    /// A `half_life_secs` of zero is treated as infinitely fast decay and
+    /// resets the score to zero.
+    pub fn decay(&self, half_life_secs: u64, elapsed_secs: u64) {
+        if elapsed_secs == 0 {
+            return;
+        }
+        if half_life_secs == 0 {
+            self.score.store(0.0, Ordering::Release);
+            return;
+        }
+        let factor = 0.5_f64.powf(elapsed_secs as f64 / half_life_secs as f64);
+        loop {
+            let current = self.score.load(Ordering::Acquire);
+            let new_val = current * factor;
+            if self
+                .score
+                .compare_exchange_weak(current, new_val, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return;
             }
         }
     }
@@ -203,6 +242,96 @@ mod tests {
         }
 
         assert!((score.score() - MAX_SCORE).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_add_score_returns_old_and_new() {
+        let score = PeerScore::new();
+
+        let (old, new) = score.add_score(10.0);
+        assert_eq!(old, 0.0);
+        assert!((new - 10.0).abs() < 0.001);
+
+        let (old, new) = score.add_score(-200.0);
+        assert!((old - 10.0).abs() < 0.001);
+        assert!((new - MIN_SCORE).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_decay_halves_over_one_half_life() {
+        let score = PeerScore::new();
+        score.set_score(80.0);
+        score.decay(600, 600);
+        assert!((score.score() - 40.0).abs() < 0.001);
+
+        // Negative scores decay toward zero too.
+        score.set_score(-80.0);
+        score.decay(600, 600);
+        assert!((score.score() + 40.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_decay_converges_to_zero() {
+        let score = PeerScore::new();
+        score.set_score(MAX_SCORE);
+        for _ in 0..100 {
+            score.decay(60, 60);
+        }
+        assert!(score.score().abs() < 1e-9);
+
+        score.set_score(MIN_SCORE);
+        for _ in 0..100 {
+            score.decay(60, 60);
+        }
+        assert!(score.score().abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_decay_edge_cases() {
+        let score = PeerScore::new();
+        score.set_score(50.0);
+
+        // Zero elapsed time is a no-op.
+        score.decay(600, 0);
+        assert!((score.score() - 50.0).abs() < 0.001);
+
+        // Halved half-life decays faster (accelerated recovery pattern).
+        let connected = PeerScore::new();
+        connected.set_score(-40.0);
+        connected.decay(300, 600);
+        assert!((connected.score() + 10.0).abs() < 0.001);
+
+        // Zero half-life resets to zero.
+        score.decay(0, 1);
+        assert_eq!(score.score(), 0.0);
+    }
+
+    #[test]
+    fn test_concurrent_add_and_decay() {
+        let score = Arc::new(PeerScore::new());
+        let mut handles = vec![];
+
+        for i in 0..8 {
+            let score = Arc::clone(&score);
+            handles.push(thread::spawn(move || {
+                for _ in 0..1000 {
+                    if i % 2 == 0 {
+                        score.add_score(1.0);
+                    } else {
+                        score.decay(60, 60);
+                    }
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // No torn reads or panics; final value stays within clamp bounds.
+        let final_score = score.score();
+        assert!(final_score.is_finite());
+        assert!((MIN_SCORE..=MAX_SCORE).contains(&final_score));
     }
 
     #[test]

--- a/crates/swarm/peers/peer-score/src/config.rs
+++ b/crates/swarm/peers/peer-score/src/config.rs
@@ -2,7 +2,9 @@
 
 use std::time::Duration;
 
-use vertex_swarm_api::{DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_WARN_THRESHOLD};
+use vertex_swarm_api::{
+    DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_WARN_THRESHOLD,
+};
 
 // The scoring event vocabulary is defined in `vertex-swarm-api`; this crate
 // re-exports it so existing import paths keep working.
@@ -33,6 +35,7 @@ scoring_events! {
 
     ban_threshold = DEFAULT_PEER_BAN_THRESHOLD,
     warn_threshold = DEFAULT_PEER_WARN_THRESHOLD,
+    disconnect_threshold = DEFAULT_PEER_DISCONNECT_THRESHOLD,
 }
 
 impl SwarmScoringConfig {
@@ -76,15 +79,27 @@ impl SwarmScoringConfig {
             .build()
     }
 
+    /// True if score is at or below the ban threshold.
+    ///
+    /// Inclusive because scores clamp at the scale minimum: with the default
+    /// ban threshold equal to that minimum, a strict comparison could never
+    /// fire.
     #[must_use]
     pub fn should_ban(&self, score: f64) -> bool {
-        score < self.ban_threshold
+        score <= self.ban_threshold
+    }
+
+    /// True if score is at or below the disconnect threshold but above the
+    /// ban threshold.
+    #[must_use]
+    pub fn should_disconnect(&self, score: f64) -> bool {
+        score <= self.disconnect_threshold && !self.should_ban(score)
     }
 
     /// True if score is below warning threshold but above ban threshold.
     #[must_use]
     pub fn should_warn(&self, score: f64) -> bool {
-        score < self.warn_threshold && score >= self.ban_threshold
+        score < self.warn_threshold && !self.should_ban(score)
     }
 }
 
@@ -151,6 +166,8 @@ mod tests {
         let config = SwarmScoringConfig::default();
         assert!(!config.should_ban(0.0));
         assert!(!config.should_ban(-50.0));
+        // Inclusive: the score scale clamps at the default ban threshold.
+        assert!(config.should_ban(-100.0));
         assert!(config.should_ban(-101.0));
     }
 
@@ -159,7 +176,19 @@ mod tests {
         let config = SwarmScoringConfig::default();
         assert!(!config.should_warn(0.0));
         assert!(config.should_warn(-60.0));
+        assert!(!config.should_warn(-100.0));
         assert!(!config.should_warn(-101.0));
+    }
+
+    #[test]
+    fn test_should_disconnect() {
+        let config = SwarmScoringConfig::default();
+        assert!(!config.should_disconnect(0.0));
+        assert!(!config.should_disconnect(-60.0));
+        assert!(config.should_disconnect(-75.0));
+        assert!(config.should_disconnect(-80.0));
+        // At or below the ban threshold, ban takes over.
+        assert!(!config.should_disconnect(-100.0));
     }
 
     #[test]

--- a/crates/swarm/peers/peer-score/src/lib.rs
+++ b/crates/swarm/peers/peer-score/src/lib.rs
@@ -1,4 +1,10 @@
 //! Swarm-specific peer scoring with configurable policies and callbacks.
+//!
+//! [`SwarmPeerScore::record_event`] applies the configured weight and returns
+//! a [`ScoreOutcome`] computed from the warn, disconnect, and ban thresholds
+//! so the caller owns the resulting action. The closure-based
+//! [`ScoreCallbacks`] remain as a transitional shim until the peer manager's
+//! single report path consumes the returned outcome directly.
 
 #[macro_use]
 mod macros;
@@ -7,8 +13,10 @@ mod score;
 
 pub use config::{SwarmScoringConfig, SwarmScoringConfigBuilder, SwarmScoringEvent};
 pub use score::{
-    ScoreCallbacks, ScoreChangedFn, ScoreWarningFn, SevereEventFn, ShouldBanFn, SwarmPeerScore,
+    ScoreCallbacks, ScoreChangedFn, ScoreOutcome, ScoreWarningFn, SevereEventFn, ShouldBanFn,
+    SwarmPeerScore,
 };
+pub use vertex_swarm_api::DEFAULT_PEER_DISCONNECT_THRESHOLD;
 
 // Re-export base scoring types
 pub use vertex_net_peer_score::PeerScore;

--- a/crates/swarm/peers/peer-score/src/score.rs
+++ b/crates/swarm/peers/peer-score/src/score.rs
@@ -21,7 +21,35 @@ pub type ShouldBanFn = Box<dyn Fn(&OverlayAddress, f64, &str) + Send + Sync>;
 /// Called on severe scoring events: `(overlay, event)`.
 pub type SevereEventFn = Box<dyn Fn(&OverlayAddress, &SwarmScoringEvent) + Send + Sync>;
 
+/// Action implied by a peer's score after recording an event.
+///
+/// Returned by [`SwarmPeerScore::record_event`] so the caller can act on
+/// threshold crossings through its own report path instead of wiring
+/// closures. `Warn` and `Disconnect` are edge-triggered: they are returned
+/// when the score crosses the threshold, not on every event below it. `Ban`
+/// is level-triggered: it is returned whenever the score is at or below the
+/// ban threshold, so severe events that drive the score straight past it
+/// surface immediately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreOutcome {
+    /// No threshold crossed; no action needed.
+    Ok,
+    /// Score crossed the warning threshold (emitted once per descent).
+    Warn,
+    /// Score crossed the disconnect threshold; the peer should be dropped.
+    Disconnect,
+    /// Score is at or below the ban threshold; the peer should be banned.
+    Ban,
+}
+
 /// Closure-based callbacks invoked on peer score changes.
+///
+/// Transitional surface: the successor is a single report path on the peer
+/// manager that consumes the [`ScoreOutcome`] returned by
+/// [`SwarmPeerScore::record_event`] and maps it to warn, disconnect, or ban
+/// actions itself. New consumers should branch on the returned outcome
+/// rather than registering callbacks; this type remains only until existing
+/// wiring migrates.
 pub struct ScoreCallbacks {
     pub on_score_changed: ScoreChangedFn,
     pub on_score_warning: ScoreWarningFn,
@@ -92,8 +120,13 @@ impl SwarmPeerScore {
     }
 
     /// Apply configured weight, update latency tracking, and notify observer.
-    pub fn record_event(&self, event: SwarmScoringEvent) {
-        let old_score = self.score.score();
+    ///
+    /// Returns the [`ScoreOutcome`] implied by the resulting score so the
+    /// caller can warn, disconnect, or ban without registering callbacks.
+    /// Threshold logic lives in one place here: warn and disconnect are
+    /// edge-triggered on the crossing, ban is level-triggered at or below
+    /// the ban threshold.
+    pub fn record_event(&self, event: SwarmScoringEvent) -> ScoreOutcome {
         let weight = self.config.weight_for(&event);
 
         // Record latency if present
@@ -102,10 +135,9 @@ impl SwarmPeerScore {
                 .record_latency(latency.as_nanos().min(u64::MAX as u128) as u64);
         }
 
-        // Apply weight
-        self.score.add_score(weight);
-
-        let new_score = self.score.score();
+        // Apply weight; old and new come from the same atomic update so
+        // threshold crossings are race-free under concurrent recording.
+        let (old_score, new_score) = self.score.add_score(weight);
 
         // Notify observer
         (self.callbacks.on_score_changed)(&self.overlay, old_score, new_score, &event);
@@ -116,7 +148,20 @@ impl SwarmPeerScore {
         }
 
         // Check thresholds
-        self.check_thresholds(new_score, &event);
+        self.check_thresholds(old_score, new_score, &event)
+    }
+
+    /// Exponentially decay the score toward zero.
+    ///
+    /// Delegates to [`PeerScore::decay`]; callers pass elapsed time from
+    /// their own heartbeat. Resets the one-shot warning state when the
+    /// decayed score has recovered above the warning threshold so a later
+    /// descent warns again.
+    pub fn decay(&self, half_life_secs: u64, elapsed_secs: u64) {
+        self.score.decay(half_life_secs, elapsed_secs);
+        if !self.config.should_warn(self.score.score()) {
+            self.warned.store(false, Ordering::Release);
+        }
     }
 
     /// Record latency without affecting score.
@@ -139,26 +184,45 @@ impl SwarmPeerScore {
         (*self.score).clone()
     }
 
-    fn check_thresholds(&self, score: f64, event: &SwarmScoringEvent) {
-        if self.config.should_ban(score) {
-            let reason = format!("score {:+.1} below threshold after {:?}", score, event);
-            (self.callbacks.on_should_ban)(&self.overlay, score, &reason);
-            return;
+    fn check_thresholds(
+        &self,
+        old_score: f64,
+        new_score: f64,
+        event: &SwarmScoringEvent,
+    ) -> ScoreOutcome {
+        if self.config.should_ban(new_score) {
+            let reason = format!("score {:+.1} below threshold after {:?}", new_score, event);
+            (self.callbacks.on_should_ban)(&self.overlay, new_score, &reason);
+            return ScoreOutcome::Ban;
         }
 
-        if self.config.should_warn(score) {
-            // Only warn once (CAS: false → true)
+        let mut warned_now = false;
+        if self.config.should_warn(new_score) {
+            // Only warn once (CAS: false -> true)
             if self
                 .warned
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
                 .is_ok()
             {
-                (self.callbacks.on_score_warning)(&self.overlay, score);
+                (self.callbacks.on_score_warning)(&self.overlay, new_score);
+                warned_now = true;
             }
         } else {
             // Reset warning flag if score recovered
             self.warned.store(false, Ordering::Release);
         }
+
+        // Edge-triggered on the downward crossing only, so a recovery event
+        // climbing out of the ban range never reads as a fresh disconnect.
+        // Disconnect outranks warn when one event crosses both thresholds.
+        let disconnect_threshold = self.config.disconnect_threshold();
+        if old_score > disconnect_threshold && new_score <= disconnect_threshold {
+            return ScoreOutcome::Disconnect;
+        }
+        if warned_now {
+            return ScoreOutcome::Warn;
+        }
+        ScoreOutcome::Ok
     }
 }
 
@@ -345,6 +409,188 @@ mod tests {
 
         assert!(bans.load(Ordering::Relaxed) >= 1);
         assert!(score.should_ban());
+    }
+
+    #[test]
+    fn test_outcome_warn_is_one_shot_until_recovery() {
+        let config = SwarmScoringConfig::builder().warn_threshold(-10.0).build();
+        let score = SwarmPeerScore::new(
+            test_overlay(1),
+            PeerScore::new(),
+            Arc::new(config),
+            ScoreCallbacks::noop(),
+        );
+
+        // Six timeouts (-1.5 each) stay above -10: all Ok.
+        for _ in 0..6 {
+            assert_eq!(
+                score.record_event(SwarmScoringEvent::ConnectionTimeout),
+                ScoreOutcome::Ok
+            );
+        }
+
+        // Seventh crosses -10: Warn exactly once.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ConnectionTimeout),
+            ScoreOutcome::Warn
+        );
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ConnectionTimeout),
+            ScoreOutcome::Ok
+        );
+
+        // Recover above the warn threshold, then descend again: warns again.
+        for _ in 0..3 {
+            score.record_event(SwarmScoringEvent::ConnectionSuccess { latency: None });
+        }
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ConnectionTimeout),
+            ScoreOutcome::Warn
+        );
+    }
+
+    #[test]
+    fn test_outcome_disconnect_is_edge_triggered() {
+        let score = SwarmPeerScore::with_defaults(test_overlay(1));
+
+        // 0 -> -50: at the warn threshold but not below it.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::MaliciousBehavior),
+            ScoreOutcome::Ok
+        );
+        // -50 -> -70: warn crossing.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::AccountingViolation),
+            ScoreOutcome::Warn
+        );
+        // -70 -> -72: still above disconnect.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::RetrievalFailure),
+            ScoreOutcome::Ok
+        );
+        // -72 -> -82: crosses -75 once.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::InvalidData),
+            ScoreOutcome::Disconnect
+        );
+        // -82 -> -84: already below; edge-triggered means Ok.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::RetrievalFailure),
+            ScoreOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn test_outcome_ban_is_level_triggered() {
+        let score = SwarmPeerScore::with_defaults(test_overlay(1));
+
+        score.record_event(SwarmScoringEvent::InvalidData); // -10
+        for _ in 0..4 {
+            score.record_event(SwarmScoringEvent::AccountingViolation); // -90
+        }
+        // -90 -> -100 (clamped at the scale minimum): Ban.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::AccountingViolation),
+            ScoreOutcome::Ban
+        );
+        // Still at the ban threshold: Ban on every event, not just the edge.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ConnectionTimeout),
+            ScoreOutcome::Ban
+        );
+        assert!(score.should_ban());
+    }
+
+    #[test]
+    fn test_outcome_recovery_from_ban_range_is_not_disconnect() {
+        let score = SwarmPeerScore::with_defaults(test_overlay(1));
+
+        // Drive the score to the ban threshold.
+        score.record_event(SwarmScoringEvent::MaliciousBehavior);
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::MaliciousBehavior),
+            ScoreOutcome::Ban
+        );
+
+        // A positive event climbing out of the ban range must not read as a
+        // fresh downward disconnect crossing. The peer was never warned (the
+        // descent jumped straight past the warn band into the ban branch),
+        // so the one-shot warning fires here instead.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ConnectionSuccess { latency: None }),
+            ScoreOutcome::Warn
+        );
+        // Subsequent events inside the warn band are quiet.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ConnectionSuccess { latency: None }),
+            ScoreOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn test_decay_resets_warning_state() {
+        let score = SwarmPeerScore::with_defaults(test_overlay(1));
+
+        // Cross the warn threshold (-50) once.
+        score.record_event(SwarmScoringEvent::MaliciousBehavior); // -50
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ProtocolError), // -53
+            ScoreOutcome::Warn
+        );
+
+        // Decay well above the warn threshold, then descend again: a fresh
+        // warning fires because decay reset the one-shot state.
+        score.decay(60, 600); // -53 * 2^-10, near zero
+        assert!(score.score() > -1.0);
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::AccountingViolation), // about -20
+            ScoreOutcome::Ok
+        );
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::AccountingViolation), // about -40
+            ScoreOutcome::Ok
+        );
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::AccountingViolation), // about -60
+            ScoreOutcome::Warn
+        );
+    }
+
+    #[test]
+    fn test_outcome_severe_fast_path() {
+        let (cb, _, _, bans, severe) = counting_callbacks();
+        let config = Arc::new(SwarmScoringConfig::default());
+        let score = SwarmPeerScore::new(test_overlay(1), PeerScore::new(), config, cb);
+
+        // Two severe events drive the score straight to the ban threshold.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::MaliciousBehavior),
+            ScoreOutcome::Ok
+        );
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::MaliciousBehavior),
+            ScoreOutcome::Ban
+        );
+        assert_eq!(severe.load(Ordering::Relaxed), 2);
+        assert_eq!(bans.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_outcome_disconnect_outranks_warn_on_double_crossing() {
+        let (cb, _, warnings, _, _) = counting_callbacks();
+        let config = Arc::new(SwarmScoringConfig::default());
+        let score = SwarmPeerScore::new(test_overlay(1), PeerScore::new(), config, cb);
+
+        // 0 -> -30: above both thresholds.
+        score.record_event(SwarmScoringEvent::AccountingViolation);
+        score.record_event(SwarmScoringEvent::InvalidData);
+        // -30 -> -80 crosses warn (-50) and disconnect (-75) in one event:
+        // the outcome is Disconnect, but the warn callback shim still fires.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::MaliciousBehavior),
+            ScoreOutcome::Disconnect
+        );
+        assert_eq!(warnings.load(Ordering::Relaxed), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prepares the scoring crates for the peer manager's single report path: the event-recording path now returns the action implied by the score instead of only dispatching through closures.

`SwarmPeerScore::record_event` returns a new `ScoreOutcome` enum (`Ok`, `Warn`, `Disconnect`, `Ban`) computed from threshold crossings in one place. Warn stays one-shot per descent at the existing warn threshold (-50). Disconnect is a new edge-triggered threshold, added as a `disconnect_threshold` field on `SwarmScoringConfig` defaulting to -75.0, returned only on the downward crossing so a recovery event climbing out of the ban range never reads as a fresh disconnect. Ban is level-triggered at or below the ban threshold (-100), which keeps the immediate-ban semantics for severe events. `should_ban` is now inclusive because scores clamp at the scale minimum: with the default threshold equal to that minimum, a strict comparison could never fire.

`ScoreCallbacks` keep firing exactly as before and are documented as a transitional shim until the peer manager's single report path consumes the returned outcome directly. No call-site changes were needed in `vertex-swarm-peer-manager`.

`vertex-net-peer-score` gains pure, timer-free decay primitives. `PeerScore::add_score` now returns the `(old, new)` pair from the successful CAS so threshold crossings are race-free under concurrent recording. `PeerScore::decay(half_life_secs, elapsed_secs)` exponentially decays the score toward zero (both signs, recency-weighted reputation) via the existing CAS-loop style; callers pass elapsed time, so the crate stays wasm-clean with no clock, timer, or tokio dependency. Accelerated recovery for connected peers is expressed by passing a smaller half-life (the operation is scale-free in `elapsed/half_life`), documented on the method instead of adding a second one. `SwarmPeerScore::decay` delegates and resets the one-shot warning state once the decayed score recovers above the warn threshold.

## Tests

Threshold-crossing matrix: warn one-shot until recovery, disconnect edge-triggered (and not on ban-range recovery), ban level-triggered, severe fast path, disconnect outranking warn on a double crossing, and decay resetting the warning state. Decay halving over one half-life, convergence to zero from both signs, edge cases (zero elapsed, zero half-life, halved half-life), and a multi-thread add/decay smoke test.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p vertex-net-peer-score -p vertex-swarm-peer-score -p vertex-swarm-peer-manager`, and a full `cargo check --all-features` are green.