### PR TITLE
fix(topology): make PeerManager the single authority for peer node type

### DIFF
--- a/crates/swarm/peers/peer-manager/src/entry.rs
+++ b/crates/swarm/peers/peer-manager/src/entry.rs
@@ -1,12 +1,13 @@
 //! Per-peer state with lock-free scoring and persistence types.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use metrics::gauge;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 use vertex_net_local::IpCapability;
 use vertex_net_peer_backoff::PeerBackoff;
 use vertex_net_peer_store::NetRecord;
@@ -134,8 +135,62 @@ pub(crate) fn jitter_seed_from_overlay(overlay: &OverlayAddress) -> u64 {
     u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
 }
 
+/// A [`SwarmNodeType`] plus a confirmed bit, packed into one atomic byte.
+///
+/// A peer's node type flows in from two sources with different trust levels:
+/// hive gossip (provisional, unverified) and the handshake (asserted by the
+/// peer itself). Gossip may set or refresh the provisional value only while
+/// the cell is unconfirmed. A completed handshake confirms the value; from
+/// then on provisional writes are ignored. A later handshake may re-confirm
+/// a different value, since a node can legitimately change its type between
+/// sessions (for example upgrading from client to storer).
+///
+/// The confirmed bit is process-local: records restored from the peer store
+/// start unconfirmed until the next handshake.
+#[derive(Debug)]
+pub(crate) struct NodeTypeCell(AtomicU8);
+
+/// High bit marks the node type as handshake-confirmed; the low bits hold
+/// the [`SwarmNodeType`] discriminant.
+const CONFIRMED_BIT: u8 = 0x80;
+
+impl NodeTypeCell {
+    pub(crate) fn provisional(node_type: SwarmNodeType) -> Self {
+        Self(AtomicU8::new(node_type as u8))
+    }
+
+    pub(crate) fn get(&self) -> SwarmNodeType {
+        SwarmNodeType::from_repr(self.0.load(Ordering::Acquire) & !CONFIRMED_BIT)
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_confirmed(&self) -> bool {
+        self.0.load(Ordering::Acquire) & CONFIRMED_BIT != 0
+    }
+
+    /// Set the provisional value (gossip path).
+    ///
+    /// Returns `false` and leaves the cell untouched once the value has been
+    /// handshake-confirmed.
+    pub(crate) fn set_provisional(&self, node_type: SwarmNodeType) -> bool {
+        self.0
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current & CONFIRMED_BIT == 0).then_some(node_type as u8)
+            })
+            .is_ok()
+    }
+
+    /// Store the asserted value and mark the cell confirmed (handshake path).
+    pub(crate) fn confirm(&self, node_type: SwarmNodeType) {
+        self.0
+            .store(node_type as u8 | CONFIRMED_BIT, Ordering::Release);
+    }
+}
+
 pub(crate) struct PeerEntry {
-    identity: RwLock<(SwarmPeer, SwarmNodeType)>,
+    peer: RwLock<SwarmPeer>,
+    node_type: NodeTypeCell,
     scoring: SwarmPeerScore,
     first_seen: AtomicU64,
     last_seen: AtomicU64,
@@ -155,7 +210,8 @@ impl PeerEntry {
     ) -> Self {
         let now = unix_timestamp_secs();
         Self {
-            identity: RwLock::new((peer, node_type)),
+            peer: RwLock::new(peer),
+            node_type: NodeTypeCell::provisional(node_type),
             scoring: SwarmPeerScore::new(overlay, PeerScore::new(), config, callbacks),
             first_seen: AtomicU64::new(now),
             last_seen: AtomicU64::new(now),
@@ -174,7 +230,8 @@ impl PeerEntry {
     ) -> Self {
         let overlay = OverlayAddress::from(*record.peer.overlay());
         Self {
-            identity: RwLock::new((record.peer, record.node_type)),
+            node_type: NodeTypeCell::provisional(record.node_type),
+            peer: RwLock::new(record.peer),
             scoring: SwarmPeerScore::new(overlay, scoring.unwrap_or_default(), config, callbacks),
             first_seen: AtomicU64::new(record.first_seen),
             last_seen: AtomicU64::new(record.last_seen),
@@ -198,20 +255,20 @@ impl PeerEntry {
     }
 
     pub(crate) fn swarm_peer(&self) -> SwarmPeer {
-        self.identity.read().0.clone()
+        self.peer.read().clone()
     }
 
     /// Signed wall-clock timestamp of the currently held peer record.
     pub(crate) fn timestamp(&self) -> vertex_swarm_peer::Timestamp {
-        self.identity.read().0.timestamp()
+        self.peer.read().timestamp()
     }
 
     pub(crate) fn ip_capability(&self) -> IpCapability {
-        self.identity.read().0.ip_capability()
+        self.peer.read().ip_capability()
     }
 
     pub(crate) fn node_type(&self) -> SwarmNodeType {
-        self.identity.read().1
+        self.node_type.get()
     }
 
     pub(crate) fn score(&self) -> f64 {
@@ -230,34 +287,45 @@ impl PeerEntry {
         self.backoff.consecutive_failures()
     }
 
-    /// Update the peer identity and node type.
+    /// Update peer addresses without changing the node type.
+    ///
+    /// Used by gossip discovery to refresh multiaddrs for already-known peers
+    /// without overwriting the handshake-confirmed node type.
     ///
     /// Only refreshes `last_seen` if the peer has no active failures.
-    /// This prevents gossip re-verification from keeping permanently unreachable
-    /// peers alive — only successful connections (`record_success`) should reset
-    /// the staleness clock for failed peers.
-    pub(crate) fn update_peer(&self, peer: SwarmPeer, node_type: SwarmNodeType) {
-        let mut guard = self.identity.write();
-        guard.0 = peer;
-        guard.1 = node_type;
-        drop(guard);
+    /// This prevents gossip re-verification from keeping permanently
+    /// unreachable peers alive; only successful connections
+    /// (`record_success`) should reset the staleness clock for failed peers.
+    pub(crate) fn update_addresses(&self, peer: SwarmPeer) {
+        *self.peer.write() = peer;
         if self.consecutive_failures() == 0 {
             self.touch();
         }
         self.mark_dirty();
     }
 
-    /// Update peer addresses without changing the node type.
+    /// Refresh the provisional node type (gossip path).
     ///
-    /// Used by gossip discovery to refresh multiaddrs for already-known peers
-    /// without overwriting the handshake-confirmed node type.
-    pub(crate) fn update_addresses(&self, peer: SwarmPeer) {
-        let mut guard = self.identity.write();
-        guard.0 = peer;
-        drop(guard);
-        if self.consecutive_failures() == 0 {
-            self.touch();
+    /// Ignored once a handshake has confirmed the node type; a differing
+    /// proposal is debug-logged and dropped.
+    pub(crate) fn set_provisional_node_type(&self, node_type: SwarmNodeType) {
+        if self.node_type.set_provisional(node_type) {
+            self.mark_dirty();
+        } else if self.node_type.get() != node_type {
+            debug!(
+                proposed = %node_type,
+                confirmed = %self.node_type.get(),
+                "ignoring provisional node type for handshake-confirmed peer"
+            );
         }
+    }
+
+    /// Confirm the peer-asserted node type (handshake path).
+    ///
+    /// May re-confirm a different value on reconnect: a node can change its
+    /// type between sessions. Gossip can never change a confirmed value.
+    pub(crate) fn confirm_node_type(&self, node_type: SwarmNodeType) {
+        self.node_type.confirm(node_type);
         self.mark_dirty();
     }
 
@@ -350,10 +418,9 @@ impl PeerEntry {
 
 impl From<&PeerEntry> for StoredPeer {
     fn from(entry: &PeerEntry) -> Self {
-        let (ref peer, node_type) = *entry.identity.read();
         Self {
-            peer: peer.clone(),
-            node_type,
+            peer: entry.peer.read().clone(),
+            node_type: entry.node_type.get(),
             ban_info: entry.ban_info.read().clone(),
             first_seen: entry.first_seen(),
             last_seen: entry.last_seen(),
@@ -520,6 +587,67 @@ mod tests {
 
         // Node type must remain Storer
         assert_eq!(entry.node_type(), SwarmNodeType::Storer);
+    }
+
+    #[test]
+    fn test_node_type_cell_gossip_then_handshake() {
+        let cell = NodeTypeCell::provisional(SwarmNodeType::Client);
+        assert!(!cell.is_confirmed());
+        assert_eq!(cell.get(), SwarmNodeType::Client);
+
+        // Gossip may refresh the provisional value while unconfirmed.
+        assert!(cell.set_provisional(SwarmNodeType::Bootnode));
+        assert_eq!(cell.get(), SwarmNodeType::Bootnode);
+        assert!(!cell.is_confirmed());
+
+        // The handshake confirms the asserted value.
+        cell.confirm(SwarmNodeType::Storer);
+        assert!(cell.is_confirmed());
+        assert_eq!(cell.get(), SwarmNodeType::Storer);
+    }
+
+    #[test]
+    fn test_node_type_cell_gossip_ignored_after_confirm() {
+        let cell = NodeTypeCell::provisional(SwarmNodeType::Client);
+        cell.confirm(SwarmNodeType::Storer);
+
+        assert!(!cell.set_provisional(SwarmNodeType::Client));
+        assert_eq!(cell.get(), SwarmNodeType::Storer);
+        assert!(cell.is_confirmed());
+    }
+
+    #[test]
+    fn test_node_type_cell_reconfirm_on_reconnect() {
+        let cell = NodeTypeCell::provisional(SwarmNodeType::Client);
+        cell.confirm(SwarmNodeType::Client);
+
+        // The peer reconnects asserting a different type: the handshake path
+        // re-confirms (a node can upgrade from client to storer between
+        // sessions).
+        cell.confirm(SwarmNodeType::Storer);
+        assert_eq!(cell.get(), SwarmNodeType::Storer);
+
+        // Gossip still cannot change the confirmed value.
+        assert!(!cell.set_provisional(SwarmNodeType::Client));
+        assert_eq!(cell.get(), SwarmNodeType::Storer);
+    }
+
+    #[test]
+    fn test_entry_provisional_node_type_ignored_after_confirm() {
+        let entry = test_entry(1, SwarmNodeType::Client);
+
+        // Unconfirmed: gossip may refresh the provisional value.
+        entry.set_provisional_node_type(SwarmNodeType::Bootnode);
+        assert_eq!(entry.node_type(), SwarmNodeType::Bootnode);
+
+        // Handshake confirms; later gossip proposals are dropped.
+        entry.confirm_node_type(SwarmNodeType::Storer);
+        entry.set_provisional_node_type(SwarmNodeType::Client);
+        assert_eq!(entry.node_type(), SwarmNodeType::Storer);
+
+        // A reconnect handshake may still re-confirm a different type.
+        entry.confirm_node_type(SwarmNodeType::Client);
+        assert_eq!(entry.node_type(), SwarmNodeType::Client);
     }
 
     #[test]

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -524,20 +524,31 @@ impl<I: SwarmIdentity> PeerManager<I> {
                     let existing = self
                         .store
                         .as_ref()
-                        .and_then(|s| s.get(&overlay).ok().flatten())
-                        .map(|r| r.peer.timestamp());
-                    if self.reject_stale_gossip(&overlay, swarm_peer.timestamp(), existing) {
+                        .and_then(|s| s.get(&overlay).ok().flatten());
+                    if self.reject_stale_gossip(
+                        &overlay,
+                        swarm_peer.timestamp(),
+                        existing.as_ref().map(|r| r.peer.timestamp()),
+                    ) {
                         return overlay;
                     }
-                    let record = StoredPeer::new_discovered(swarm_peer);
+                    let mut record = StoredPeer::new_discovered(swarm_peer);
+                    if let Some(existing) = existing {
+                        // Gossip refreshes addresses; it never changes a
+                        // previously stored node type.
+                        record.node_type = existing.node_type;
+                    }
                     if self.write_buffer.push(record) {
                         self.flush_write_buffer();
                     }
                 }
             }
         } else {
-            // No store - insert into DashMap (backward compat)
-            self.insert_peer(overlay, swarm_peer, SwarmNodeType::Client);
+            // No store - insert into DashMap (backward compat). The
+            // provisional refresh is dropped if a concurrent handshake has
+            // already confirmed the node type.
+            let entry = self.insert_peer(overlay, swarm_peer, SwarmNodeType::Client);
+            entry.set_provisional_node_type(SwarmNodeType::Client);
         }
         overlay
     }
@@ -596,16 +607,18 @@ impl<I: SwarmIdentity> PeerManager<I> {
     }
 
     /// Called when a peer completes handshake. Always inserts into hot cache.
+    ///
+    /// Confirms the handshake-asserted node type: from here on gossip cannot
+    /// change it, and only a later handshake may re-confirm a different value.
     pub fn on_peer_ready(&self, swarm_peer: SwarmPeer, node_type: SwarmNodeType) {
         let overlay = OverlayAddress::from(*swarm_peer.overlay());
         debug!(?overlay, ?node_type, "storing peer");
 
-        self.insert_peer(overlay, swarm_peer, node_type);
-        if let Some(entry) = self.peers.get(&overlay) {
-            let old_state = entry.health_state();
-            entry.record_success(Duration::ZERO);
-            on_health_changed(old_state, entry.health_state());
-        }
+        let entry = self.insert_peer(overlay, swarm_peer, node_type);
+        entry.confirm_node_type(node_type);
+        let old_state = entry.health_state();
+        entry.record_success(Duration::ZERO);
+        on_health_changed(old_state, entry.health_state());
     }
 
     /// Total peers persisted in the backing store (or hot cache size if no store).
@@ -671,14 +684,26 @@ impl<I: SwarmIdentity> PeerManager<I> {
         record.is_dialable()
     }
 
-    /// Insert or update a peer in the hot cache.
-    fn insert_peer(&self, overlay: OverlayAddress, peer: SwarmPeer, node_type: SwarmNodeType) {
+    /// Insert or update a peer in the hot cache, returning the entry.
+    ///
+    /// `node_type` only seeds new entries (as a provisional value); existing
+    /// entries get their addresses refreshed and keep their node type.
+    /// Callers apply the source-appropriate node type write on the returned
+    /// entry: `confirm_node_type` for handshakes, `set_provisional_node_type`
+    /// for gossip.
+    fn insert_peer(
+        &self,
+        overlay: OverlayAddress,
+        peer: SwarmPeer,
+        node_type: SwarmNodeType,
+    ) -> Arc<PeerEntry> {
         use dashmap::mapref::entry::Entry;
 
         match self.peers.entry(overlay) {
             Entry::Occupied(e) => {
-                e.get().update_peer(peer, node_type);
+                e.get().update_addresses(peer);
                 self.index.touch(&overlay);
+                Arc::clone(e.get())
             }
             Entry::Vacant(e) => {
                 let entry = Arc::new(PeerEntry::with_config(
@@ -689,6 +714,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
                     Arc::clone(&self.callbacks),
                 ));
                 let initial_score = entry.score();
+                let cloned = Arc::clone(&entry);
                 e.insert(entry);
                 if self.index.add(overlay).is_ok() {
                     gauge!("peer_manager_total_peers").increment(1.0);
@@ -696,6 +722,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
                 gauge!("peer_manager_hot_peers").set(self.peers.len() as f64);
                 self.score_distribution.on_peer_added(initial_score);
                 on_health_added(HealthState::Healthy);
+                cloned
             }
         }
     }
@@ -1102,6 +1129,27 @@ mod tests {
         assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Storer));
 
         pm.store_discovered_peer(swarm_peer);
+        assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Storer));
+    }
+
+    #[test]
+    fn test_reconnect_handshake_reconfirms_node_type() {
+        let pm = PeerManager::new(&mock_identity(), PeerManagerConfig::default());
+        let overlay = test_overlay(1);
+
+        pm.on_peer_ready(test_swarm_peer(1), SwarmNodeType::Client);
+        assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Client));
+
+        // Gossip cannot change the confirmed type.
+        pm.store_discovered_peer(test_swarm_peer(1));
+        assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Client));
+
+        // The node upgraded between sessions; the new handshake re-confirms.
+        pm.on_peer_ready(test_swarm_peer(1), SwarmNodeType::Storer);
+        assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Storer));
+
+        // Gossip still cannot change it afterwards.
+        pm.store_discovered_peer(test_swarm_peer(1));
         assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Storer));
     }
 

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -1,7 +1,7 @@
 //! Network topology behaviour managing peer connections via handshake, hive, and ping.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -28,7 +28,7 @@ use vertex_swarm_net_hive::MAX_BATCH_SIZE;
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::{PeerManager, StoredPeer};
-use vertex_swarm_primitives::{Bin, OverlayAddress, SwarmNodeType, all_bins};
+use vertex_swarm_primitives::{Bin, OverlayAddress, all_bins};
 
 use crate::DialReason;
 use vertex_net_dialer::DialTracker;
@@ -265,12 +265,6 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
     /// address). Populated at `ConnectionEstablished`, consumed at handshake
     /// completion, and cleared at `ConnectionClosed`.
     pub(crate) outbound_public_dials: HashSet<ConnectionId>,
-
-    /// Node type recorded at PeerReady time for symmetric metric decrement on disconnect.
-    ///
-    /// Without this, gossip re-verification can overwrite the handshake-confirmed
-    /// node_type in PeerManager, causing the disconnect to decrement the wrong counter.
-    pub(crate) connected_node_types: HashMap<OverlayAddress, SwarmNodeType>,
 
     /// Receiver for peer ban notifications from PeerManager.
     pub(crate) ban_rx: broadcast::Receiver<OverlayAddress>,

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -1,7 +1,7 @@
 //! Builder for [`TopologyBehaviour`], separating construction from task spawning.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     sync::Arc,
     time::Duration,
 };
@@ -232,7 +232,6 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             early_disconnect_threshold: self.config.early_disconnect_threshold,
             pending_evictions: HashSet::new(),
             outbound_public_dials: HashSet::new(),
-            connected_node_types: HashMap::new(),
             ban_rx,
             peer_store: self.peer_store,
             agent_versions,

--- a/crates/swarm/topology/src/connection_handlers.rs
+++ b/crates/swarm/topology/src/connection_handlers.rs
@@ -106,10 +106,13 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             return;
         };
 
-        // Use the node_type recorded at PeerReady time for symmetric metric decrement.
+        // Read the authoritative node type from the peer manager. It is
+        // handshake-confirmed there, so gossip received during the connection
+        // cannot have changed it and the metric decrement stays symmetric
+        // with the increment recorded at PeerReady time.
         let node_type = self
-            .connected_node_types
-            .remove(&overlay)
+            .peer_manager
+            .node_type(&overlay)
             .unwrap_or(SwarmNodeType::Client);
 
         let connection_duration = connected_at.map(|t| t.elapsed());

--- a/crates/swarm/topology/src/metrics.rs
+++ b/crates/swarm/topology/src/metrics.rs
@@ -496,34 +496,47 @@ mod tests {
         assert_eq!(metrics.connected_clients(), 0);
     }
 
-    /// Demonstrates the bug scenario: connect as Storer, disconnect as Client causes drift.
-    /// The fix is in TopologyBehaviour which records node_type at PeerReady time.
+    /// Connect/disconnect with an interleaved gossip overwrite attempt stays
+    /// balanced: the disconnect path reads the authoritative node type from
+    /// the peer manager, where the handshake-confirmed value is write-once
+    /// and gossip cannot change it.
     #[test]
-    fn test_asymmetric_node_type_causes_drift() {
-        let metrics = TopologyMetrics::new();
+    fn test_gossip_overwrite_attempt_causes_no_drift() {
+        use vertex_swarm_peer_manager::{PeerManager, PeerManagerConfig};
+        use vertex_swarm_test_utils::{MockIdentity, test_swarm_peer};
 
-        // Peer connects as Storer (from handshake)
+        let metrics = TopologyMetrics::new();
+        let pm = PeerManager::new(
+            &MockIdentity::with_overlay(test_overlay(0)),
+            PeerManagerConfig::default(),
+        );
+        let peer = test_swarm_peer(1);
+        let overlay = test_overlay(1);
+
+        // Handshake confirms the peer as a storer.
+        pm.on_peer_ready(peer.clone(), SwarmNodeType::Storer);
         metrics.record_event(&TopologyEvent::PeerReady {
-            overlay: test_overlay(1),
+            overlay,
             peer_id: test_peer_id(1),
-            node_type: SwarmNodeType::Storer,
+            node_type: pm.node_type(&overlay).unwrap(),
             direction: ConnectionDirection::Outbound,
         });
         assert_eq!(metrics.connected_storers(), 1);
         assert_eq!(metrics.connected_clients(), 0);
 
-        // BUG SCENARIO: If gossip overwrites node_type to Client in PeerManager,
-        // disconnect would decrement clients instead of storers.
-        // This test documents the asymmetry — TopologyBehaviour's connected_node_types
-        // HashMap prevents this by recording the type at connect time.
+        // A gossip re-discovery of the same peer cannot overwrite the
+        // handshake-confirmed node type.
+        pm.store_discovered_peer(peer);
+        assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Storer));
+
+        // Disconnect reads the same authoritative value: gauges return to zero.
         metrics.record_event(&TopologyEvent::PeerDisconnected {
-            overlay: test_overlay(1),
+            overlay,
             reason: DisconnectReason::ConnectionError,
             connection_duration: Some(Duration::from_secs(120)),
-            node_type: SwarmNodeType::Client, // Wrong type!
+            node_type: pm.node_type(&overlay).unwrap(),
         });
-        // Storer counter is now stuck at 1 (drift), client saturated at 0
-        assert_eq!(metrics.connected_storers(), 1);
+        assert_eq!(metrics.connected_storers(), 0);
         assert_eq!(metrics.connected_clients(), 0);
     }
 

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -160,11 +160,13 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 // The old connection was already counted by a prior PeerReady event.
                 // Its registry entry is now overwritten, so handle_connection_closed
                 // will not emit PeerDisconnected -- we must decrement here.
-                // Use connected_node_types (recorded at PeerReady time) for symmetric decrement.
+                // The peer manager holds the authoritative handshake-confirmed
+                // node type; on_peer_ready for the new connection has not run
+                // yet, so this still reads the old connection's value.
                 let old_overlay = old_id.as_ref().unwrap_or(&overlay);
                 let old_node_type = self
-                    .connected_node_types
-                    .remove(old_overlay)
+                    .peer_manager
+                    .node_type(old_overlay)
                     .unwrap_or(SwarmNodeType::Client);
                 self.metrics.decrement_connected(old_node_type);
                 gauge!("peer_registry_active_connections").decrement(1.0);
@@ -247,9 +249,6 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 self.trim_overpopulated_bins();
             }
         }
-
-        // Record node_type for symmetric decrement on disconnect.
-        self.connected_node_types.insert(overlay, node_type);
 
         self.emit_event(TopologyEvent::PeerReady {
             overlay,

--- a/docs/networking/peer-management.md
+++ b/docs/networking/peer-management.md
@@ -64,9 +64,9 @@ Any type implementing `Clone + Eq + Hash + Send + Sync + Debug + Serialize + Des
 
 Per-peer state with atomic hot paths and per-peer locked cold paths.
 
-**Atomic fields (hot path):** score, connection state, latency, connection counters, last-seen timestamp.
+**Atomic fields (hot path):** score, connection state, latency, connection counters, last-seen timestamp, node type (a write-once-confirmed cell: gossip sets a provisional value, the handshake confirms it, and only a later handshake can change it).
 
-**Locked fields (cold path):** peer record (multiaddrs, node type), ban metadata.
+**Locked fields (cold path):** peer record (multiaddrs), ban metadata.
 
 ### ConnectionState
 


### PR DESCRIPTION
## Problem

A peer's node type is asserted during the handshake, but the gossip update path in PeerManager could later overwrite it: the hot-cache insert path rewrote the node type on every update, and the gossip BinFull path clobbered the stored record with the discovered-peer default (Client). Because of that drift, TopologyBehaviour kept its own `connected_node_types` HashMap shadow copy to label the `topology_connected_peers` gauges, and `crates/swarm/topology/src/metrics.rs` carried a test documenting the resulting drift bug: a connect could increment the storer gauge while the disconnect decremented the client gauge, leaving the storer gauge stuck.

## Change

- `NodeTypeCell` in the peer entry packs the `SwarmNodeType` and a confirmed bit into one atomic byte. Gossip may set or refresh a provisional value only while unconfirmed; the handshake confirms the value exactly once per session, and subsequent gossip writes to a confirmed cell are ignored (debug-logged when they differ). A later handshake may re-confirm a different value, since a node can legitimately change its type between sessions (client to storer upgrade).
- Every node type write site in peer-manager is now classified: `PeerManager::on_peer_ready` (handshake) confirms; `store_discovered_peer` (gossip) only seeds provisional values and refreshes addresses; the BinFull cold path preserves the previously stored node type instead of clobbering it.
- The `connected_node_types` shadow HashMap in TopologyBehaviour is deleted. Disconnect handling and connection-replacement decrement now read the authoritative node type from PeerManager.
- The drift-documenting metrics test is replaced by `test_gossip_overwrite_attempt_causes_no_drift`: connect, interleaved gossip overwrite attempt, disconnect leaves both gauges balanced at zero. New unit tests cover the cell semantics (gossip-then-handshake, handshake-then-gossip-ignored, reconnect re-confirm) at the cell, entry, and manager levels.

## Notes

The confirmed bit is process-local: records restored from the peer store start unconfirmed until the next handshake, so the on-disk `StoredPeer` format is unchanged. Pre-existing and out of scope here: the gossip BinFull path still overwrites other stored fields (`first_seen`, `ban_info`, backoff counters); only the node type is preserved by this PR.