### PR TITLE
feat(node-core): opt-in database persistence with in-memory default

### DIFF
--- a/bin/vertex/src/cli.rs
+++ b/bin/vertex/src/cli.rs
@@ -90,6 +90,13 @@ pub async fn run() -> Result<()> {
         config.apply_args(&args.infra, &args.protocol);
         config.protocol.override_node_type(node_type);
 
+        // Resolve database config from CLI args (in-memory unless persistence
+        // is opted into via --db.path or --db.persist)
+        let database_config = config
+            .infra
+            .database
+            .database_config(dirs.network.join("db").join("vertex.redb"));
+
         // Build metrics config from CLI args
         let metrics_config = args.infra.observability.metrics.metrics_config();
 
@@ -107,6 +114,7 @@ pub async fn run() -> Result<()> {
         let executor = TaskExecutor::current();
         let launch_ctx = (executor.clone(), dirs.clone())
             .with_metrics(metrics_config, &histogram_buckets)?
+            .with_database_config(database_config)
             .start_metrics_server()
             .await?;
 

--- a/crates/node/api/src/context.rs
+++ b/crates/node/api/src/context.rs
@@ -13,4 +13,12 @@ pub trait InfrastructureContext: Send + Sync {
 
     /// Get the data directory for persistent storage.
     fn data_dir(&self) -> &Path;
+
+    /// Get the resolved database file path.
+    ///
+    /// Returns `None` when no persistence has been configured, in which
+    /// case consumers should use an in-memory database.
+    fn db_path(&self) -> Option<&Path> {
+        None
+    }
 }

--- a/crates/node/builder/src/builder.rs
+++ b/crates/node/builder/src/builder.rs
@@ -4,6 +4,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 
 use vertex_node_api::{InfrastructureContext, NodeBuildsProtocol, NodeProtocol, NodeRpcConfig};
+use vertex_node_core::args::DatabaseConfig;
 use vertex_node_core::dirs::DataDirs;
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
 use vertex_tasks::TaskExecutor;
@@ -16,16 +17,25 @@ pub struct LaunchContext<A = ()> {
     pub executor: TaskExecutor,
     pub dirs: DataDirs,
     pub api: A,
+    pub database: DatabaseConfig,
 }
 
 impl<A> LaunchContext<A> {
-    /// Create a new launch context.
+    /// Create a new launch context with an in-memory database configuration.
     pub fn new(executor: TaskExecutor, dirs: DataDirs, api: A) -> Self {
         Self {
             executor,
             dirs,
             api,
+            database: DatabaseConfig::default(),
         }
+    }
+
+    /// Set the resolved database configuration.
+    #[must_use]
+    pub fn with_database_config(mut self, database: DatabaseConfig) -> Self {
+        self.database = database;
+        self
     }
 
     /// Get the data directory root.
@@ -41,6 +51,10 @@ impl<A: Send + Sync> InfrastructureContext for LaunchContext<A> {
 
     fn data_dir(&self) -> &Path {
         &self.dirs.network
+    }
+
+    fn db_path(&self) -> Option<&Path> {
+        self.database.path.as_deref()
     }
 }
 
@@ -97,6 +111,13 @@ impl<A> WithLaunchContext<A> {
     /// Get a reference to the launch context.
     pub fn context(&self) -> &LaunchContext<A> {
         &self.ctx
+    }
+
+    /// Set the resolved database configuration on the launch context.
+    #[must_use]
+    pub fn with_database_config(mut self, database: DatabaseConfig) -> Self {
+        self.ctx = self.ctx.with_database_config(database);
+        self
     }
 
     /// Get the data directories.

--- a/crates/node/builder/src/launch.rs
+++ b/crates/node/builder/src/launch.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use vertex_node_api::InfrastructureContext;
+use vertex_node_core::args::DatabaseConfig;
 use vertex_node_core::dirs::DataDirs;
 use vertex_observability::{
     HistogramBucketConfig, Hooks, MetricsServer, MetricsServerConfig, PrometheusRecorder,
@@ -61,6 +62,7 @@ impl<L, R> Attached<L, R> {
 pub struct LaunchContextWith<T> {
     executor: TaskExecutor,
     dirs: DataDirs,
+    database: DatabaseConfig,
     attachment: T,
 }
 
@@ -69,6 +71,7 @@ impl<T> LaunchContextWith<T> {
         Self {
             executor,
             dirs,
+            database: DatabaseConfig::default(),
             attachment,
         }
     }
@@ -81,6 +84,18 @@ impl<T> LaunchContextWith<T> {
         &self.dirs
     }
 
+    /// Get the resolved database configuration.
+    pub fn database(&self) -> &DatabaseConfig {
+        &self.database
+    }
+
+    /// Set the resolved database configuration.
+    #[must_use]
+    pub fn with_database_config(mut self, database: DatabaseConfig) -> Self {
+        self.database = database;
+        self
+    }
+
     pub fn attachment(&self) -> &T {
         &self.attachment
     }
@@ -91,11 +106,12 @@ impl<T> LaunchContextWith<T> {
 
     /// Attach another value, preserving access to previous state.
     pub fn attach<A>(self, attachment: A) -> LaunchContextWith<Attached<T, A>> {
-        LaunchContextWith::new(
-            self.executor,
-            self.dirs,
-            Attached::new(self.attachment, attachment),
-        )
+        LaunchContextWith {
+            executor: self.executor,
+            dirs: self.dirs,
+            database: self.database,
+            attachment: Attached::new(self.attachment, attachment),
+        }
     }
 
     pub fn inspect<F>(self, f: F) -> Self
@@ -148,6 +164,10 @@ impl<T: Send + Sync> InfrastructureContext for LaunchContextWith<T> {
 
     fn data_dir(&self) -> &Path {
         &self.dirs.network
+    }
+
+    fn db_path(&self) -> Option<&Path> {
+        self.database.path.as_deref()
     }
 }
 

--- a/crates/node/core/src/args/database.rs
+++ b/crates/node/core/src/args/database.rs
@@ -1,4 +1,8 @@
 //! Database CLI arguments.
+//!
+//! The database is in-memory by default. Persistence is opt-in: `--db.path`
+//! selects an explicit database file, while `--db.persist` uses the
+//! conventional default location under the network data directory.
 
 use std::path::PathBuf;
 
@@ -10,23 +14,23 @@ use serde::{Deserialize, Serialize};
 #[command(next_help_heading = "Database")]
 #[serde(default)]
 pub struct DatabaseArgs {
-    /// Use in-memory database (no persistence).
-    #[arg(long = "db.memory", conflicts_with = "path")]
-    pub memory_only: bool,
+    /// Persist the database at the default location (<datadir>/<network>/db/vertex.redb).
+    #[arg(long = "db.persist")]
+    pub persist: bool,
+
+    /// Persist the database at a custom file path (implies --db.persist).
+    #[arg(long = "db.path", value_name = "PATH")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
 
     /// Database cache size in megabytes.
     #[arg(long = "db.cache", value_name = "MB")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_size_mb: Option<u64>,
-
-    /// Custom database file path (default: <datadir>/db/vertex.redb).
-    #[arg(long = "db.path", value_name = "PATH")]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<PathBuf>,
 }
 
 /// Resolved database configuration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct DatabaseConfig {
     /// Path to the database file (None for in-memory).
     pub path: Option<PathBuf>,
@@ -37,16 +41,69 @@ pub struct DatabaseConfig {
 impl DatabaseArgs {
     /// Build a resolved database configuration.
     ///
-    /// If `--db.memory` is set, the path is `None` (in-memory database).
-    /// Otherwise, uses `--db.path` or falls back to `default_path`.
+    /// `--db.path` takes precedence. Otherwise `--db.persist` selects
+    /// `default_path`. With neither flag the path is `None` and the
+    /// database is in-memory.
     pub fn database_config(&self, default_path: PathBuf) -> DatabaseConfig {
         DatabaseConfig {
-            path: if self.memory_only {
-                None
-            } else {
-                Some(self.path.clone().unwrap_or(default_path))
-            },
+            path: self
+                .path
+                .clone()
+                .or_else(|| self.persist.then_some(default_path)),
             cache_size_mb: self.cache_size_mb,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        database: DatabaseArgs,
+    }
+
+    fn default_path() -> PathBuf {
+        PathBuf::from("/data/network/db/vertex.redb")
+    }
+
+    #[test]
+    fn no_flags_resolves_in_memory() {
+        let cli = TestCli::try_parse_from(["test"]).expect("default should parse");
+        let config = cli.database.database_config(default_path());
+        assert_eq!(config.path, None, "no flags means in-memory");
+    }
+
+    #[test]
+    fn persist_flag_resolves_default_path() {
+        let cli = TestCli::try_parse_from(["test", "--db.persist"]).expect("flag should parse");
+        let config = cli.database.database_config(default_path());
+        assert_eq!(config.path, Some(default_path()));
+    }
+
+    #[test]
+    fn path_flag_resolves_custom_path() {
+        let cli = TestCli::try_parse_from(["test", "--db.path", "/custom/db.redb"])
+            .expect("flag should parse");
+        let config = cli.database.database_config(default_path());
+        assert_eq!(config.path, Some(PathBuf::from("/custom/db.redb")));
+    }
+
+    #[test]
+    fn path_flag_wins_over_persist() {
+        let cli = TestCli::try_parse_from(["test", "--db.persist", "--db.path", "/custom/db.redb"])
+            .expect("flags should parse");
+        let config = cli.database.database_config(default_path());
+        assert_eq!(config.path, Some(PathBuf::from("/custom/db.redb")));
+    }
+
+    #[test]
+    fn cache_size_carries_through() {
+        let cli = TestCli::try_parse_from(["test", "--db.cache", "256"]).expect("should parse");
+        let config = cli.database.database_config(default_path());
+        assert_eq!(config.cache_size_mb, Some(256));
     }
 }

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -37,6 +37,7 @@ The `SwarmSpec` provides network-level constants (network ID, bootnodes, contrac
 | **Bandwidth** | `--bandwidth.*` | Client, Storer | Accounting mode, pricing, thresholds |
 | **Storage** | `--storage.*` | Storer | Reserve capacity, cache size, redistribution |
 | **Identity** | `--password`, `--nonce`, etc. | All | Keystore, overlay nonce, ephemeral mode |
+| **Database** | `--db.*` | All | Opt-in database persistence and cache size |
 | **Network selection** | `--mainnet`, `--testnet` | All | Which Swarm network to join |
 
 Run `vertex node --help` for the full argument listing with defaults.
@@ -52,6 +53,18 @@ The merge order is:
 3. **CLI argument** overrides (highest priority)
 
 This ensures operators can set base configuration in a file and selectively override individual values from the command line.
+
+## Database Persistence
+
+The node database is in-memory by default: nothing is written to disk and all database state is lost on shutdown. Persistence is opt-in:
+
+| Flag | Effect |
+|------|--------|
+| `--db.persist` | Persist the database at the default location `<datadir>/<network>/db/vertex.redb` |
+| `--db.path <PATH>` | Persist the database at a custom file path (implies `--db.persist`) |
+| `--db.cache <MB>` | Database cache size in megabytes |
+
+When both `--db.path` and `--db.persist` are given, the explicit path wins.
 
 ## Bandwidth Modes
 


### PR DESCRIPTION
## Summary

This PR builds the protocol-agnostic infrastructure surface for opt-in database persistence, with in-memory as the default.

The `--db.memory` flag was dead: `DatabaseArgs::database_config()` had zero callers and the shared database was opened unconditionally at a hardcoded path. This PR removes the dead flag, inverts the default to in-memory, and wires the resolved configuration through the launch contexts so the swarm builder can consume it.

## Changes

- `vertex-node-core`: `DatabaseArgs` drops `--db.memory` and gains `--db.persist` (persist at the conventional `<datadir>/<network>/db/vertex.redb` location). `--db.path <PATH>` persists at an explicit file and implies persistence; it wins when both flags are given. `--db.cache` is unchanged. `database_config(default_path)` resolves to `DatabaseConfig { path: Option<PathBuf>, cache_size_mb }` where `None` means in-memory.
- `vertex-node-api`: `InfrastructureContext` gains `db_path() -> Option<&Path>` with a default impl returning `None`, the same tier as `data_dir()`. Contexts that do not carry a database configuration (FFI, examples) keep compiling with in-memory semantics.
- `vertex-node-builder`: `LaunchContext` and `LaunchContextWith` carry a resolved `DatabaseConfig` (default in-memory), settable via `with_database_config`, and implement `db_path()` from it. `attach()` preserves the configuration across state transitions.
- `bin/vertex`: the CLI resolves the database configuration once from the merged config and hands it to the launch context.
- `docs/cli/configuration.md`: documents the new model (in-memory default, `--db.persist` / `--db.path` opt in).

## Scope

The swarm builder still opens its database at the hardcoded `<network>/db/vertex.redb` path and does not yet read `ctx.db_path()`; a follow-up PR flips that call site. This PR is mergeable standalone with zero behaviour change for a running node: the removed flag was dead, and the new plumbing is exercised but not yet consumed by the swarm builder.

Known limitation carried over from the existing pattern: `InfraConfig::apply_args` replaces the file-loaded args wholesale with the CLI values, as it does for every other args group, so `database.*` keys in `config.toml` are overridden by CLI defaults. Aligning config-file merge semantics across all args groups is a separate concern.

## Testing

- Unit tests for arg resolution: no flags resolves in-memory, `--db.persist` resolves the default path, `--db.path` resolves the custom path and wins over `--db.persist`, cache size carries through.
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p vertex-node-core -p vertex-node-api -p vertex-node-builder`, `cargo check --all-features` all green.
- E2e: release binary starts cleanly on testnet, `--db.persist` / `--db.path` / `--db.cache` parse on a live run, `--db.memory` is rejected, and the node still writes its database at the hardcoded path as expected for this PR.
