### PR TITLE
perf(swarm-net-hive): shard the validated-peer cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8884,6 +8884,8 @@ name = "vertex-swarm-net-hive"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "codspeed-criterion-compat",
+ "dashmap 6.2.1",
  "futures",
  "hashlink 0.10.0",
  "libp2p",

--- a/crates/swarm/net/hive/Cargo.toml
+++ b/crates/swarm/net/hive/Cargo.toml
@@ -49,3 +49,10 @@ strum.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
+dashmap.workspace = true
+vertex-swarm-peer = { workspace = true, features = ["test-utils"] }
+
+[[bench]]
+name = "peer_cache"
+harness = false

--- a/crates/swarm/net/hive/benches/peer_cache.rs
+++ b/crates/swarm/net/hive/benches/peer_cache.rs
@@ -1,0 +1,295 @@
+//! Concurrent throughput comparison of peer-cache locking strategies.
+//!
+//! Models the hive inbound validation access pattern: several gossip batches
+//! validated in parallel on blocking threads, each record performing one
+//! cache lookup. A hit clones the cached record out; a miss runs validation
+//! outside any lock and then inserts. The expensive miss-path work (ECDSA
+//! recovery) is identical for every strategy and is therefore excluded; the
+//! benchmark isolates the cache itself.
+//!
+//! Strategies:
+//!
+//! - `single_mutex`: one mutex around an LRU cache (the previous layout).
+//! - `rwlock_peek`: a read-write lock around an LRU cache; reads use `peek`,
+//!   trading away the LRU refresh on hit for shared read locks.
+//! - `sharded_mutex/N`: per-shard mutexes selected by the last overlay byte;
+//!   `N = 8` mirrors `src/cache.rs`.
+//! - `dashmap_aged`: a concurrent sharded map with a logical-clock stamp per
+//!   entry and a scan-evict once over capacity.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use alloy_primitives::{Address, B256, Signature};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use dashmap::DashMap;
+use hashlink::LruCache;
+use parking_lot::{Mutex, RwLock};
+use vertex_swarm_peer::{Nonce, SwarmAddress, SwarmPeer, Timestamp};
+
+/// Mirrors the capacity documented in `src/cache.rs`.
+const CAPACITY: usize = 256;
+/// Concurrent validation threads.
+const THREADS: usize = 8;
+/// Records per gossip batch (MAX_BATCH_SIZE).
+const BATCH: usize = 30;
+/// Batches each thread validates per measured iteration.
+const BATCHES_PER_THREAD: usize = 100;
+
+/// The cache operations the validation path needs.
+trait Cache: Sync {
+    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer>;
+    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer);
+}
+
+/// One mutex around the whole LRU cache.
+struct SingleMutex(Mutex<LruCache<SwarmAddress, SwarmPeer>>);
+
+impl SingleMutex {
+    fn new() -> Self {
+        Self(Mutex::new(LruCache::new(CAPACITY)))
+    }
+}
+
+impl Cache for SingleMutex {
+    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+        let mut guard = self.0.lock();
+        guard
+            .get(overlay)
+            .filter(|cached| cached.signature() == signature)
+            .cloned()
+    }
+
+    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+        self.0.lock().insert(overlay, peer);
+    }
+}
+
+/// Read-write lock; the read path peeks without refreshing LRU order.
+struct RwLockPeek(RwLock<LruCache<SwarmAddress, SwarmPeer>>);
+
+impl RwLockPeek {
+    fn new() -> Self {
+        Self(RwLock::new(LruCache::new(CAPACITY)))
+    }
+}
+
+impl Cache for RwLockPeek {
+    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+        self.0
+            .read()
+            .peek(overlay)
+            .filter(|cached| cached.signature() == signature)
+            .cloned()
+    }
+
+    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+        self.0.write().insert(overlay, peer);
+    }
+}
+
+/// Per-shard mutexes selected by the last overlay byte (the `src/cache.rs`
+/// layout, generalized over shard count).
+struct ShardedMutex {
+    shards: Vec<Mutex<LruCache<SwarmAddress, SwarmPeer>>>,
+    mask: usize,
+}
+
+impl ShardedMutex {
+    fn new(shard_count: usize) -> Self {
+        assert!(shard_count.is_power_of_two());
+        Self {
+            shards: (0..shard_count)
+                .map(|_| Mutex::new(LruCache::new(CAPACITY / shard_count)))
+                .collect(),
+            mask: shard_count - 1,
+        }
+    }
+
+    fn shard(&self, overlay: &SwarmAddress) -> &Mutex<LruCache<SwarmAddress, SwarmPeer>> {
+        &self.shards[usize::from(overlay.0[31]) & self.mask]
+    }
+}
+
+impl Cache for ShardedMutex {
+    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+        let mut shard = self.shard(overlay).lock();
+        shard
+            .get(overlay)
+            .filter(|cached| cached.signature() == signature)
+            .cloned()
+    }
+
+    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+        self.shard(&overlay).lock().insert(overlay, peer);
+    }
+}
+
+struct AgedEntry {
+    peer: SwarmPeer,
+    last_used: AtomicU64,
+}
+
+/// Concurrent sharded map with timestamp aging and scan-eviction.
+struct DashMapAged {
+    map: DashMap<SwarmAddress, AgedEntry>,
+    clock: AtomicU64,
+}
+
+impl DashMapAged {
+    fn new() -> Self {
+        Self {
+            map: DashMap::with_capacity(CAPACITY + 1),
+            clock: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Cache for DashMapAged {
+    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+        let entry = self.map.get(overlay)?;
+        if entry.peer.signature() != signature {
+            return None;
+        }
+        entry.last_used.store(
+            self.clock.fetch_add(1, Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
+        Some(entry.peer.clone())
+    }
+
+    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+        let stamp = self.clock.fetch_add(1, Ordering::Relaxed);
+        self.map.insert(
+            overlay,
+            AgedEntry {
+                peer,
+                last_used: AtomicU64::new(stamp),
+            },
+        );
+        while self.map.len() > CAPACITY {
+            let mut oldest: Option<(SwarmAddress, u64)> = None;
+            for entry in self.map.iter() {
+                let used = entry.value().last_used.load(Ordering::Relaxed);
+                if oldest.is_none_or(|(_, o)| used < o) {
+                    oldest = Some((*entry.key(), used));
+                }
+            }
+            let Some((key, _)) = oldest else { break };
+            self.map.remove(&key);
+        }
+    }
+}
+
+/// Deterministic overlay; the last byte spreads keys evenly across shards,
+/// matching the uniform distribution of real (hash-output) overlays.
+fn overlay(i: u64) -> SwarmAddress {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&i.to_le_bytes());
+    bytes[31] = i as u8;
+    SwarmAddress::from(B256::from(bytes))
+}
+
+fn signature() -> Signature {
+    let mut raw = [2u8; 65];
+    raw[64] = 0;
+    Signature::from_raw(&raw).expect("valid signature")
+}
+
+fn peer(i: u64) -> SwarmPeer {
+    SwarmPeer::from_parts(
+        vec!["/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr")],
+        signature(),
+        overlay(i),
+        Nonce::new([0u8; 32]),
+        Timestamp::from_seconds(0),
+        None,
+        Address::ZERO,
+    )
+}
+
+/// Run the validation-shaped workload on `cache` from `THREADS` threads.
+///
+/// `miss_every` of 0 means a pure-hit workload; otherwise every
+/// `miss_every`-th record in a batch is a fresh overlay (cache miss followed
+/// by an insert, as after a successful validation).
+fn run_workload<C: Cache>(cache: &C, sig: &Signature, fresh: &AtomicU64, miss_every: usize) {
+    std::thread::scope(|scope| {
+        for t in 0..THREADS {
+            scope.spawn(move || {
+                let mut cursor = (t * 37) as u64;
+                let mut hits = 0usize;
+                for _ in 0..BATCHES_PER_THREAD {
+                    for slot in 0..BATCH {
+                        let miss = miss_every != 0 && slot % miss_every == 0;
+                        let key = if miss {
+                            // Fresh keys live outside the hot range.
+                            (1 << 32) + fresh.fetch_add(1, Ordering::Relaxed)
+                        } else {
+                            cursor = (cursor + 1) % CAPACITY as u64;
+                            cursor
+                        };
+                        let addr = overlay(key);
+                        match cache.get(&addr, sig) {
+                            Some(found) => {
+                                hits += 1;
+                                black_box(found);
+                            }
+                            // Validation (outside any lock) then insert.
+                            None => cache.insert(addr, peer(key)),
+                        }
+                    }
+                }
+                black_box(hits);
+            });
+        }
+    });
+}
+
+fn bench_strategy<C: Cache>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    name: &str,
+    miss_every: usize,
+    cache: C,
+) {
+    // Pre-fill the hot set so hit-path behaviour dominates from the start.
+    for i in 0..CAPACITY as u64 {
+        cache.insert(overlay(i), peer(i));
+    }
+    let sig = signature();
+    let fresh = AtomicU64::new(0);
+    let label = if miss_every == 0 { "all_hits" } else { "mixed" };
+    group.bench_function(BenchmarkId::new(name, label), |b| {
+        b.iter(|| run_workload(&cache, &sig, &fresh, miss_every));
+    });
+}
+
+fn bench_peer_cache(c: &mut Criterion) {
+    for miss_every in [0usize, 10] {
+        let label = if miss_every == 0 {
+            "peer_cache_all_hits"
+        } else {
+            "peer_cache_mixed_hit_miss"
+        };
+        let mut group = c.benchmark_group(label);
+        group.throughput(Throughput::Elements(
+            (THREADS * BATCHES_PER_THREAD * BATCH) as u64,
+        ));
+        bench_strategy(&mut group, "single_mutex", miss_every, SingleMutex::new());
+        bench_strategy(&mut group, "rwlock_peek", miss_every, RwLockPeek::new());
+        for shards in [4usize, 8, 16] {
+            bench_strategy(
+                &mut group,
+                &format!("sharded_mutex/{shards}"),
+                miss_every,
+                ShardedMutex::new(shards),
+            );
+        }
+        bench_strategy(&mut group, "dashmap_aged", miss_every, DashMapAged::new());
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_peer_cache);
+criterion_main!(benches);

--- a/crates/swarm/net/hive/src/behaviour.rs
+++ b/crates/swarm/net/hive/src/behaviour.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 use crate::HIVE_INBOUND_QUOTA;
+use crate::cache::PeerCache;
 use crate::handler::{HiveCommand, HiveHandler, HiveHandlerEvent};
 use crate::peer_handler::{HivePeerHandler, LearnAndDial};
-use crate::protocol::{PeerCache, new_peer_cache};
 use libp2p::{
     Multiaddr, PeerId,
     swarm::{
@@ -45,7 +45,7 @@ pub enum HiveEvent {
 /// Behaviour for the Swarm hive protocol.
 pub struct HiveBehaviour<I> {
     identity: Arc<I>,
-    cache: PeerCache,
+    cache: Arc<PeerCache>,
     events: VecDeque<ToSwarm<HiveEvent, HiveCommand>>,
     /// Cloned into each per-connection handler so the protocol reader can
     /// consult the inbound policy.
@@ -71,7 +71,7 @@ where
     pub fn with_peer_handler(identity: Arc<I>, peer_handler: Arc<dyn HivePeerHandler>) -> Self {
         Self {
             identity,
-            cache: new_peer_cache(),
+            cache: Arc::new(PeerCache::default()),
             events: VecDeque::new(),
             peer_handler,
             inbound_limit: Arc::new(KeyedRateLimiter::new(HIVE_INBOUND_QUOTA)),

--- a/crates/swarm/net/hive/src/cache.rs
+++ b/crates/swarm/net/hive/src/cache.rs
@@ -1,0 +1,215 @@
+//! Sharded cache of recently validated peer records.
+//!
+//! Inbound gossip batches from different connections are validated
+//! concurrently on blocking threads, and every record consults this cache to
+//! skip a redundant ECDSA recovery. A single lock around the whole cache
+//! serializes those lookups, so the keyspace is split into shards, each with
+//! its own mutex and an independent LRU list. Concurrent batches contend only
+//! when two records map to the same shard.
+//!
+//! Shard selection uses the last byte of the overlay address. Overlay
+//! addresses are hash outputs, so any byte is uniformly distributed across
+//! arbitrary peers, but peers in the local neighborhood share a leading
+//! prefix; the last byte stays uniform even for them.
+//!
+//! See `benches/peer_cache.rs` for the concurrent-throughput comparison
+//! against a single mutex, a read-write lock, and a sharded map with
+//! timestamp aging.
+
+use alloy_primitives::Signature;
+use hashlink::LruCache;
+use parking_lot::Mutex;
+use vertex_swarm_peer::{SwarmAddress, SwarmPeer};
+
+/// Maximum validated peers to cache across all shards (bounds memory).
+pub(crate) const PEER_CACHE_CAPACITY: usize = 256;
+
+/// Number of independently locked shards. A power of two so shard selection
+/// is a bit mask.
+const SHARD_COUNT: usize = 8;
+
+const _: () = {
+    assert!(
+        SHARD_COUNT.is_power_of_two(),
+        "shard mask requires a power-of-two shard count"
+    );
+    assert!(
+        PEER_CACHE_CAPACITY.is_multiple_of(SHARD_COUNT),
+        "capacity must split evenly across shards"
+    );
+};
+
+/// Sharded LRU cache of recently validated peers, keyed by overlay address.
+///
+/// The capacity bound is global ([`PEER_CACHE_CAPACITY`]); each shard holds
+/// an equal slice of it and ages its entries with its own LRU list, so
+/// eviction is approximate global LRU.
+pub(crate) struct PeerCache {
+    shards: [Mutex<LruCache<SwarmAddress, SwarmPeer>>; SHARD_COUNT],
+}
+
+impl Default for PeerCache {
+    fn default() -> Self {
+        Self {
+            shards: core::array::from_fn(|_| {
+                Mutex::new(LruCache::new(PEER_CACHE_CAPACITY / SHARD_COUNT))
+            }),
+        }
+    }
+}
+
+impl PeerCache {
+    /// Shard owning the given overlay address.
+    #[allow(clippy::indexing_slicing)] // byte 31 of a 32-byte address; index masked below SHARD_COUNT
+    fn shard(&self, overlay: &SwarmAddress) -> &Mutex<LruCache<SwarmAddress, SwarmPeer>> {
+        let index = usize::from(overlay.0[31]) & (SHARD_COUNT - 1);
+        &self.shards[index]
+    }
+
+    /// Look up a previously validated record, returning a clone only when the
+    /// cached record carries the same signature.
+    ///
+    /// A hit refreshes the entry's LRU position within its shard. A cached
+    /// record with a different signature is treated as a miss; the caller
+    /// re-validates and overwrites via [`Self::insert`].
+    pub(crate) fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+        let mut shard = self.shard(overlay).lock();
+        shard
+            .get(overlay)
+            .filter(|cached| cached.signature() == signature)
+            .cloned()
+    }
+
+    /// Store a validated record, evicting the least recently used entry of
+    /// its shard when the shard is full.
+    pub(crate) fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+        self.shard(&overlay).lock().insert(overlay, peer);
+    }
+
+    /// Total number of cached records across all shards.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.shards.iter().map(|shard| shard.lock().len()).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256};
+    use vertex_swarm_peer::{Nonce, Timestamp};
+
+    use super::*;
+
+    fn signature(byte: u8) -> Signature {
+        let mut raw = [byte; 65];
+        raw[64] = 0; // valid recovery id (parity)
+        Signature::from_raw(&raw).unwrap()
+    }
+
+    fn overlay(index: usize) -> SwarmAddress {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
+        // Spread the low byte so shards fill evenly.
+        bytes[31] = (index % 251) as u8;
+        SwarmAddress::from(B256::from(bytes))
+    }
+
+    fn peer(index: usize, sig: Signature) -> SwarmPeer {
+        SwarmPeer::from_parts(
+            Vec::new(),
+            sig,
+            overlay(index),
+            Nonce::new([0u8; 32]),
+            Timestamp::from_seconds(0),
+            None,
+            Address::ZERO,
+        )
+    }
+
+    #[test]
+    fn get_returns_only_signature_matches() {
+        let cache = PeerCache::default();
+        let sig = signature(2);
+        cache.insert(overlay(1), peer(1, sig));
+
+        assert!(cache.get(&overlay(1), &sig).is_some());
+        assert!(cache.get(&overlay(1), &signature(3)).is_none());
+        assert!(cache.get(&overlay(2), &sig).is_none());
+    }
+
+    #[test]
+    fn insert_deduplicates_by_overlay() {
+        let cache = PeerCache::default();
+        let old = signature(2);
+        let new = signature(3);
+        cache.insert(overlay(1), peer(1, old));
+        cache.insert(overlay(1), peer(1, new));
+
+        assert_eq!(cache.len(), 1);
+        assert!(cache.get(&overlay(1), &old).is_none());
+        assert!(cache.get(&overlay(1), &new).is_some());
+    }
+
+    #[test]
+    fn capacity_is_bounded_and_recently_used_survive() {
+        let cache = PeerCache::default();
+        let sig = signature(2);
+
+        // Insert a hot set, then keep it warm while flooding with three times
+        // the total capacity of one-shot entries.
+        let hot: Vec<SwarmAddress> = (0..16).map(overlay).collect();
+        for (i, key) in hot.iter().enumerate() {
+            cache.insert(*key, peer(i, sig));
+        }
+        for i in 16..(16 + PEER_CACHE_CAPACITY * 3) {
+            cache.insert(overlay(i), peer(i, sig));
+            for key in &hot {
+                assert!(cache.get(key, &sig).is_some(), "hot entry evicted");
+            }
+        }
+
+        assert!(cache.len() <= PEER_CACHE_CAPACITY);
+    }
+
+    /// Concurrency stress: hammer overlapping keys from many threads and
+    /// assert the dedup and capacity invariants hold under contention.
+    #[test]
+    fn concurrent_access_keeps_invariants() {
+        const THREADS: usize = 8;
+        const KEYS: usize = PEER_CACHE_CAPACITY * 2;
+        const ROUNDS: usize = 50;
+
+        let cache = PeerCache::default();
+        let sig = signature(2);
+
+        std::thread::scope(|scope| {
+            for t in 0..THREADS {
+                let cache = &cache;
+                let sig = &sig;
+                scope.spawn(move || {
+                    for round in 0..ROUNDS {
+                        for i in 0..KEYS {
+                            // Stagger threads so gets and inserts interleave
+                            // on the same keys.
+                            let key = (i + t * 31 + round * 7) % KEYS;
+                            if cache.get(&overlay(key), sig).is_none() {
+                                cache.insert(overlay(key), peer(key, *sig));
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        assert!(cache.len() <= PEER_CACHE_CAPACITY);
+        // Every cached record is retrievable under its own overlay with the
+        // signature it was stored with (no torn or misfiled entries).
+        let mut cached = 0usize;
+        for i in 0..KEYS {
+            if cache.get(&overlay(i), &sig).is_some() {
+                cached += 1;
+            }
+        }
+        assert_eq!(cached, cache.len());
+    }
+}

--- a/crates/swarm/net/hive/src/handler.rs
+++ b/crates/swarm/net/hive/src/handler.rs
@@ -32,8 +32,9 @@ use vertex_swarm_net_handler_core::HandlerCore;
 use vertex_swarm_net_headers::{Inbound, Outbound, ProtocolStreamError, UpgradeError};
 use vertex_swarm_peer::SwarmPeer;
 
+use crate::cache::PeerCache;
 use crate::peer_handler::HivePeerHandler;
-use crate::protocol::{HiveInner, HiveOutboundInner, HiveOutboundProtocol, PeerCache};
+use crate::protocol::{HiveInner, HiveOutboundInner, HiveOutboundProtocol};
 
 /// Timeout for stream processing (headers exchange + protobuf + validation).
 const STREAM_TIMEOUT: Duration = Duration::from_secs(10);
@@ -72,7 +73,7 @@ pub(crate) type HiveInboundProtocol<I> = Inbound<HiveInner<I>>;
 pub struct HiveHandler<I: SwarmIdentity> {
     remote_peer_id: PeerId,
     identity: Arc<I>,
-    cache: PeerCache,
+    cache: Arc<PeerCache>,
     /// Shared handler core: events, substream rate limiter, outbound flag.
     core: HandlerCore<HiveHandlerEvent>,
     /// Bounded by [`MAX_PENDING_BROADCASTS`].
@@ -90,7 +91,7 @@ where
     pub(crate) fn new(
         identity: Arc<I>,
         remote_peer_id: PeerId,
-        cache: PeerCache,
+        cache: Arc<PeerCache>,
         inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
         peer_handler: Arc<dyn HivePeerHandler>,
     ) -> Self {

--- a/crates/swarm/net/hive/src/lib.rs
+++ b/crates/swarm/net/hive/src/lib.rs
@@ -50,6 +50,7 @@ use std::time::Duration;
 use vertex_net_ratelimiter::Quota;
 
 mod behaviour;
+mod cache;
 mod codec;
 mod error;
 mod handler;

--- a/crates/swarm/net/hive/src/protocol.rs
+++ b/crates/swarm/net/hive/src/protocol.rs
@@ -3,12 +3,10 @@
 use std::sync::Arc;
 
 use libp2p::PeerId;
-use parking_lot::Mutex;
 use std::time::Instant;
 
 use alloy_primitives::{B256, Signature};
 use futures::future::BoxFuture;
-use hashlink::LruCache;
 use metrics::{counter, histogram};
 use tracing::{debug, warn};
 use vertex_net_codec::FramedProto;
@@ -22,6 +20,7 @@ use vertex_swarm_primitives::{NetworkId, Nonce};
 use vertex_tasks::TaskExecutor;
 
 use crate::PROTOCOL_NAME;
+use crate::cache::PeerCache;
 use crate::codec::encode_peers;
 use crate::error::ValidationFailure;
 use crate::metrics::{
@@ -34,18 +33,7 @@ use vertex_net_ratelimiter::KeyedRateLimiter;
 /// 32 KiB frame limit (fits ~100 peers at typical size).
 const MAX_MESSAGE_SIZE: usize = 32 * 1024;
 
-/// Maximum validated peers to cache (bounds memory).
-const PEER_CACHE_CAPACITY: usize = 256;
-
 type Framed = FramedProto<MAX_MESSAGE_SIZE>;
-
-/// Shared cache of recently validated peers, keyed by overlay address.
-pub(crate) type PeerCache = Arc<Mutex<LruCache<SwarmAddress, SwarmPeer>>>;
-
-/// Create a new peer validation cache.
-pub(crate) fn new_peer_cache() -> PeerCache {
-    Arc::new(Mutex::new(LruCache::new(PEER_CACHE_CAPACITY)))
-}
 
 /// Result of inbound peer validation.
 #[derive(Debug)]
@@ -56,7 +44,7 @@ pub struct ValidatedPeers {
 /// Inbound handler that receives and validates peers.
 pub struct HiveInner<I: SwarmIdentity> {
     identity: Arc<I>,
-    cache: PeerCache,
+    cache: Arc<PeerCache>,
     remote_peer_id: PeerId,
     inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
     peer_handler: Arc<dyn HivePeerHandler>,
@@ -71,7 +59,7 @@ impl<I: SwarmIdentity> std::fmt::Debug for HiveInner<I> {
 impl<I: SwarmIdentity> HiveInner<I> {
     pub(crate) fn new(
         identity: Arc<I>,
-        cache: PeerCache,
+        cache: Arc<PeerCache>,
         remote_peer_id: PeerId,
         inbound_limit: Arc<KeyedRateLimiter<PeerId>>,
         peer_handler: Arc<dyn HivePeerHandler>,
@@ -159,7 +147,7 @@ async fn validate_batch_blocking(
     raw_peers: Vec<vertex_swarm_net_proto::hive::SwarmPeer>,
     network_id: NetworkId,
     local_overlay: SwarmAddress,
-    cache: PeerCache,
+    cache: Arc<PeerCache>,
 ) -> (Vec<SwarmPeer>, usize, usize) {
     let Ok(executor) = TaskExecutor::try_current() else {
         return validate_batch(raw_peers, network_id, &local_overlay, &cache);
@@ -181,7 +169,7 @@ fn validate_batch(
     raw_peers: Vec<vertex_swarm_net_proto::hive::SwarmPeer>,
     network_id: NetworkId,
     local_overlay: &SwarmAddress,
-    cache: &Mutex<LruCache<SwarmAddress, SwarmPeer>>,
+    cache: &PeerCache,
 ) -> (Vec<SwarmPeer>, usize, usize) {
     let validation_start = Instant::now();
     let mut valid_count = 0usize;
@@ -219,7 +207,7 @@ fn validate_proto_peer(
     p: vertex_swarm_net_proto::hive::SwarmPeer,
     network_id: NetworkId,
     local_overlay: &SwarmAddress,
-    cache: &Mutex<LruCache<SwarmAddress, SwarmPeer>>,
+    cache: &PeerCache,
 ) -> Result<SwarmPeer, ValidationFailure> {
     let overlay = B256::try_from(p.overlay.as_slice()).map_err(ValidationFailure::OverlayLength)?;
 
@@ -234,14 +222,9 @@ fn validate_proto_peer(
 
     // Tier 1: Check LRU cache - validated earlier in this session.
     // On signature mismatch, falls through to tier 2 which re-validates and overwrites.
-    {
-        let mut guard = cache.lock();
-        if let Some(cached) = guard.get(&peer_overlay)
-            && *cached.signature() == signature
-        {
-            counter!("hive_validation_cache_total", "outcome" => "cache_hit").increment(1);
-            return Ok(cached.clone());
-        }
+    if let Some(cached) = cache.get(&peer_overlay, &signature) {
+        counter!("hive_validation_cache_total", "outcome" => "cache_hit").increment(1);
+        return Ok(cached);
     }
     counter!("hive_validation_cache_total", "outcome" => "miss").increment(1);
 
@@ -277,8 +260,8 @@ fn validate_proto_peer(
         return Err(ValidationFailure::MissingPeerId);
     }
 
-    // Store validated peer in LRU cache.
-    cache.lock().insert(peer_overlay, peer.clone());
+    // Store validated peer in the cache.
+    cache.insert(peer_overlay, peer.clone());
 
     Ok(peer)
 }


### PR DESCRIPTION
Closes #124

## Access pattern

Inbound hive batches from different connections are validated concurrently (each batch runs `validate_batch` on a blocking thread), and every record performs exactly one cache interaction: a hit takes the lock briefly to look up, compare signatures, refresh LRU order, and clone the record out; a miss runs the expensive ECDSA recovery entirely outside any lock and then takes the lock once to insert. Hits dominate in steady state because gossip re-sends known peers, so the workload is read-mostly with short critical sections, but `hashlink::LruCache::get` mutates on every hit (it moves the entry to the list front), so even the read path needs exclusive access. That rules out a plain `RwLock` unless the LRU refresh is given up, and it makes lock spread, not reader sharing, the right lever.

## What changed

`src/cache.rs` introduces a `PeerCache` of eight independently locked `Mutex<LruCache>` shards. The capacity bound stays 256 as a documented module-level constant, split evenly across shards, with compile-time asserts that the shard count is a power of two and divides the capacity. The hit path keeps its exact semantics: LRU refresh on hit, signature mismatch treated as a miss, revalidation overwriting the stale entry.

Shard selection uses the last byte of the overlay address rather than a prefix. Peers in the local neighborhood share a leading prefix by definition, so a prefix-keyed shard would concentrate exactly the peers a node gossips about most into one shard; the trailing byte stays uniformly distributed even for them.

No new runtime dependencies (`parking_lot` and `hashlink` were already direct deps), so the wasm cone is unchanged. `dashmap` and `criterion` are dev-only, used by the benchmark. The hive public API and wire bytes are untouched.

## Measurements

`benches/peer_cache.rs` (criterion) models the validation workload per the issue: 8 threads, 30-record batches, 256-entry hot set, measured over 24000 lookups per iteration, on an all-hit workload and a mixed workload with 10% fresh-key misses. The ECDSA miss cost is excluded since it is identical across strategies and happens outside any lock.

| strategy | all hits | mixed 90/10 hit/miss |
|---|---|---|
| single mutex (previous layout) | 5.17 M lookups/s | 2.62 M lookups/s |
| rwlock + peek (drops LRU refresh) | 21.90 M lookups/s | 3.07 M lookups/s |
| sharded mutex, 4 shards | 13.54 M lookups/s | 8.43 M lookups/s |
| sharded mutex, 8 shards (shipped) | 27.91 M lookups/s | 13.00 M lookups/s |
| sharded mutex, 16 shards | 39.34 M lookups/s | 13.23 M lookups/s |
| dashmap + timestamp aging | 19.09 M lookups/s | 0.63 M lookups/s |

The 8-shard mutex wins the realistic comparison: 5.4x the single mutex on all-hits and 5.0x on mixed. 16 shards only improves the synthetic all-hit loop while halving per-shard LRU depth to 16 entries, so 8 ships. DashMap collapses on the mixed workload because capacity eviction needs a full scan per overflow insert, and the rwlock variant barely helps once inserts appear because every write still excludes all readers and the hit path loses its LRU refresh.

Correctness under contention is covered by a deterministic stress test in `src/cache.rs` (8 threads hammering overlapping keys, asserting the capacity bound, dedup, and that every cached record is retrievable under its own key), which avoids timing assertions so it cannot flake in CI.
