### PR TITLE
feat(swarm-bandwidth): report accounting violations and implement PeerAffordability

### DIFF
--- a/crates/swarm/AGENTS.md
+++ b/crates/swarm/AGENTS.md
@@ -9,7 +9,7 @@ Root-level rules in `/AGENTS.md` apply here too. The notes below are the area-sp
 - `primitives`, `forks`, `spec`, `identity`: pure data and configuration. `nectar-primitives` is the canonical source for chunk and address types.
 - `peers/peer`: the `SwarmPeer` record with the EIP-191 handshake signature (distinct from postage EIP-191 signing, which lives upstream in `nectar-postage`). See the follow-up tracked at `nxm-rs/vertex` for extracting the sign-data primitive to nectar.
 - `peers/peer-manager`, `peers/peer-score`: lifecycle, persistence, scoring.
-- `bandwidth/{core,pricing,pseudosettle}`: per-peer balances in Accounting Units (AU). `swap` and `chequebook` are workspace-disabled.
+- `bandwidth/{core,pricing,pseudosettle,swap,chequebook}`: per-peer balances in Accounting Units (AU) and the settlement providers. `Accounting` implements `PeerAffordability` and the accounting and settlement services take an optional `PeerReporter` (both from `api`) so violations feed peer scoring; the node layer does the wiring.
 - `api`: the trait chain `SwarmPrimitives` to `SwarmNetworkTypes` to `SwarmClientTypes` to `SwarmStorerTypes`. Strictly libp2p-free with the documented `Multiaddr` exception.
 - `builder`: layered builders that produce `BuiltBootnode`, `BuiltClient`, `BuiltStorer`.
 - `node`: composes the libp2p `NetworkBehaviour` and exposes `BootNode`, `ClientNode`, `StorerNode`. This is where libp2p shows up.

--- a/crates/swarm/bandwidth/core/src/accounting/mod.rs
+++ b/crates/swarm/bandwidth/core/src/accounting/mod.rs
@@ -31,8 +31,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use vertex_swarm_api::{
-    Direction, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmIdentity, SwarmPeerBandwidth,
-    SwarmResult,
+    Direction, PeerAffordability, PeerReporter, ReportSource, SwarmAccountingConfig,
+    SwarmBandwidthAccounting, SwarmIdentity, SwarmPeerBandwidth, SwarmResult, SwarmScoringEvent,
 };
 use vertex_swarm_primitives::OverlayAddress;
 
@@ -47,6 +47,7 @@ pub struct Accounting<C, I: SwarmIdentity> {
     identity: I,
     providers: Arc<[Box<dyn SwarmSettlementProvider>]>,
     peers: RwLock<HashMap<OverlayAddress, Arc<PeerState>>>,
+    reporter: Option<Arc<dyn PeerReporter>>,
 }
 
 impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
@@ -57,6 +58,7 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             identity,
             providers: Arc::from(Vec::new()),
             peers: RwLock::new(HashMap::new()),
+            reporter: None,
         }
     }
 
@@ -74,7 +76,17 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             identity,
             providers: Arc::from(providers),
             peers: RwLock::new(HashMap::new()),
+            reporter: None,
         }
+    }
+
+    /// Attach a peer reporter so accounting violations feed peer scoring.
+    ///
+    /// Reporting is best-effort and non-blocking. Without a reporter,
+    /// violations only surface as errors to the caller, exactly as before.
+    pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
+        self.reporter = Some(reporter);
+        self
     }
 
     /// Get a reference to the configuration.
@@ -108,12 +120,28 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
         let disconnect_threshold = self.config.disconnect_threshold();
         let threshold = -(disconnect_threshold as i64);
         if projected < threshold {
+            // Law broken: the peer stopped accepting settlement (refresh or
+            // payment), letting our debt reach the disconnect threshold.
+            //
+            // Reported once per breach episode: a successful grant ends the
+            // episode, so retries against an already-broken balance do not
+            // stack score penalties.
+            if state.mark_breach()
+                && let Some(reporter) = &self.reporter
+            {
+                reporter.report_peer(
+                    &peer,
+                    SwarmScoringEvent::AccountingViolation,
+                    ReportSource::Accounting,
+                );
+            }
             return Err(AccountingError::DisconnectThreshold {
                 peer,
                 balance: current_balance,
                 threshold: disconnect_threshold,
             });
         }
+        state.clear_breach();
 
         state.add_reserved(price);
         Ok(ReceiveAction::new(state, price))
@@ -213,6 +241,43 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> SwarmBandwidthAccounting for Ac
     fn prepare_provide(&self, peer: OverlayAddress, price: u64) -> SwarmResult<ProvideAction> {
         Accounting::prepare_provide(self, peer, price)
             .map_err(vertex_swarm_api::SwarmError::accounting)
+    }
+}
+
+/// Affordability queries for the receive side of accounting.
+///
+/// Sign convention: `balance` is the peer's debt to us in AU (positive means
+/// the peer owes us, negative means we owe the peer). Receiving service
+/// debits our side, so a request of `price` moves the balance by `-price`.
+/// A debit is affordable while the projected balance
+/// (`balance - price - reserved`) stays at or above the negated disconnect
+/// threshold, mirroring the guard in [`Accounting::prepare_receive`]. For
+/// peers tracked with the standard thresholds, `can_afford(peer, price)` is
+/// true exactly when a `prepare_receive` for `price` would succeed. The
+/// per-peer threshold is read, so for client-only peers with scaled
+/// thresholds affordability is stricter than the config-wide guard.
+///
+/// Unknown peers are treated as fresh zero-balance peers with the configured
+/// default thresholds, matching [`Accounting::get_or_create_peer`]. The
+/// queries are read-only and never insert peer state, so client-only
+/// threshold scaling applies only once the peer record exists.
+impl<C: SwarmAccountingConfig, I: SwarmIdentity> PeerAffordability for Accounting<C, I> {
+    fn can_afford(&self, overlay: &OverlayAddress, price: u64) -> bool {
+        price <= self.allowance_remaining(overlay)
+    }
+
+    fn allowance_remaining(&self, overlay: &OverlayAddress) -> u64 {
+        let (balance, reserved, threshold) = match self.peers.read().get(overlay) {
+            Some(state) => (
+                state.balance(),
+                state.reserved_balance(),
+                state.disconnect_threshold(),
+            ),
+            None => (0, 0, self.config.disconnect_threshold()),
+        };
+
+        let headroom = balance as i128 + threshold as i128 - reserved as i128;
+        headroom.clamp(0, u64::MAX as i128) as u64
     }
 }
 
@@ -507,5 +572,150 @@ mod tests {
 
         // Both providers should have adjusted the balance
         assert_eq!(handle.balance(), 300);
+    }
+
+    #[derive(Default)]
+    struct RecordingReporter {
+        reports: parking_lot::Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
+    }
+
+    impl PeerReporter for RecordingReporter {
+        fn report_peer(
+            &self,
+            overlay: &OverlayAddress,
+            event: SwarmScoringEvent,
+            source: ReportSource,
+        ) {
+            self.reports.lock().push((*overlay, event, source));
+        }
+    }
+
+    /// Config with payment threshold 1000 and 25% tolerance, so the
+    /// disconnect threshold is 1250.
+    fn small_config() -> BandwidthConfig {
+        BandwidthConfig::new(
+            vertex_swarm_api::BandwidthMode::Pseudosettle,
+            1000,
+            25,
+            0,
+            0,
+            5,
+            crate::FixedPricingConfig::default(),
+        )
+    }
+
+    const SMALL_DISCONNECT_THRESHOLD: u64 = 1250;
+
+    #[test]
+    fn test_violation_reported_once_per_breach_episode() {
+        let reporter = Arc::new(RecordingReporter::default());
+        let accounting = Accounting::new(small_config(), test_identity())
+            .with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+        let peer = test_peer();
+
+        // First breach reports exactly once.
+        assert!(matches!(
+            accounting.prepare_receive(peer, 2000, true),
+            Err(AccountingError::DisconnectThreshold { .. })
+        ));
+        assert_eq!(reporter.reports.lock().len(), 1);
+        let (reported_peer, event, source) = reporter.reports.lock()[0];
+        assert_eq!(reported_peer, peer);
+        assert_eq!(event, SwarmScoringEvent::AccountingViolation);
+        assert_eq!(source, ReportSource::Accounting);
+
+        // Retrying against the same broken state does not stack reports.
+        assert!(accounting.prepare_receive(peer, 2000, true).is_err());
+        assert!(accounting.prepare_receive(peer, 3000, true).is_err());
+        assert_eq!(reporter.reports.lock().len(), 1);
+
+        // A successful grant ends the episode...
+        let action = accounting
+            .prepare_receive(peer, 100, true)
+            .expect("within threshold");
+        drop(action);
+        assert_eq!(reporter.reports.lock().len(), 1);
+
+        // ...so the next breach is a new episode and reports again.
+        assert!(accounting.prepare_receive(peer, 2000, true).is_err());
+        assert_eq!(reporter.reports.lock().len(), 2);
+    }
+
+    #[test]
+    fn test_no_reporter_behaviour_unchanged() {
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+
+        assert!(matches!(
+            accounting.prepare_receive(peer, 2000, true),
+            Err(AccountingError::DisconnectThreshold { .. })
+        ));
+
+        let action = accounting
+            .prepare_receive(peer, SMALL_DISCONNECT_THRESHOLD, true)
+            .expect("exactly at threshold is allowed");
+        action.apply();
+
+        let handle = accounting.for_peer(peer);
+        assert_eq!(handle.balance(), -(SMALL_DISCONNECT_THRESHOLD as i64));
+    }
+
+    #[test]
+    fn test_affordability_unknown_peer_is_fresh_and_read_only() {
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+
+        // Unknown peers are treated as fresh zero-balance peers.
+        assert_eq!(
+            accounting.allowance_remaining(&peer),
+            SMALL_DISCONNECT_THRESHOLD
+        );
+        assert!(accounting.can_afford(&peer, SMALL_DISCONNECT_THRESHOLD));
+        assert!(!accounting.can_afford(&peer, SMALL_DISCONNECT_THRESHOLD + 1));
+
+        // Affordability queries never insert peer state.
+        assert!(accounting.peers().is_empty());
+    }
+
+    #[test]
+    fn test_affordability_boundaries_match_prepare_receive() {
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+
+        // Build up debt: we owe the peer 500 AU.
+        let handle = accounting.for_peer(peer);
+        handle.record(500, Direction::Download);
+        assert_eq!(handle.balance(), -500);
+        assert_eq!(accounting.allowance_remaining(&peer), 750);
+
+        // Exactly at the threshold: affordable and grantable.
+        assert!(accounting.can_afford(&peer, 750));
+        assert!(accounting.prepare_receive(peer, 750, true).is_ok());
+
+        // Just over: refused by both.
+        assert!(!accounting.can_afford(&peer, 751));
+        assert!(accounting.prepare_receive(peer, 751, true).is_err());
+    }
+
+    #[test]
+    fn test_affordability_accounts_for_reservations() {
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+
+        let action = accounting
+            .prepare_receive(peer, 1000, true)
+            .expect("within threshold");
+
+        // The outstanding reservation consumes headroom.
+        assert_eq!(accounting.allowance_remaining(&peer), 250);
+        assert!(accounting.can_afford(&peer, 250));
+        assert!(!accounting.can_afford(&peer, 251));
+
+        // Releasing the reservation restores the headroom.
+        drop(action);
+        assert_eq!(
+            accounting.allowance_remaining(&peer),
+            SMALL_DISCONNECT_THRESHOLD
+        );
     }
 }

--- a/crates/swarm/bandwidth/core/src/accounting/peer.rs
+++ b/crates/swarm/bandwidth/core/src/accounting/peer.rs
@@ -1,6 +1,6 @@
 //! Atomic per-peer balance tracking for lock-free bandwidth recording.
 
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use vertex_swarm_api::SwarmPeerState;
@@ -20,6 +20,9 @@ pub struct PeerState {
     payment_threshold: u64,
     disconnect_threshold: u64,
     last_refresh: AtomicU64,
+    /// True while a disconnect-threshold breach episode is in progress and
+    /// has already been reported.
+    breach_reported: AtomicBool,
 }
 
 impl PeerState {
@@ -33,6 +36,7 @@ impl PeerState {
             payment_threshold,
             disconnect_threshold,
             last_refresh: AtomicU64::new(0),
+            breach_reported: AtomicBool::new(false),
         }
     }
 
@@ -117,6 +121,19 @@ impl PeerState {
     pub fn set_last_refresh(&self, timestamp: u64) {
         self.last_refresh.store(timestamp, Ordering::Relaxed);
     }
+
+    /// Mark the start of a disconnect-threshold breach episode.
+    ///
+    /// Returns true only on the first call of an episode, so a breach is
+    /// reported once until `clear_breach` starts a new episode.
+    pub(crate) fn mark_breach(&self) -> bool {
+        !self.breach_reported.swap(true, Ordering::Relaxed)
+    }
+
+    /// End the current breach episode (the peer was granted service again).
+    pub(crate) fn clear_breach(&self) {
+        self.breach_reported.store(false, Ordering::Relaxed);
+    }
 }
 
 impl SwarmPeerState for PeerState {
@@ -177,6 +194,7 @@ impl PeerState {
             payment_threshold: snapshot.payment_threshold,
             disconnect_threshold: snapshot.disconnect_threshold,
             last_refresh: AtomicU64::new(snapshot.last_refresh),
+            breach_reported: AtomicBool::new(false),
         }
     }
 }

--- a/crates/swarm/bandwidth/core/src/builder.rs
+++ b/crates/swarm/bandwidth/core/src/builder.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use vertex_swarm_api::{
-    SwarmAccountingConfig, SwarmIdentity, SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig,
-    SwarmSettlementProvider, SwarmSpec,
+    PeerReporter, SwarmAccountingConfig, SwarmIdentity, SwarmPricing, SwarmPricingBuilder,
+    SwarmPricingConfig, SwarmSettlementProvider, SwarmSpec,
 };
 use vertex_swarm_bandwidth_pricing::NoPricer;
 
@@ -27,6 +27,7 @@ pub struct AccountingBuilder<C, P = NoPricer> {
     config: C,
     pricing: P,
     providers: Vec<Box<dyn SwarmSettlementProvider>>,
+    reporter: Option<Arc<dyn PeerReporter>>,
 }
 
 impl<C: SwarmAccountingConfig> AccountingBuilder<C, NoPricer> {
@@ -36,6 +37,7 @@ impl<C: SwarmAccountingConfig> AccountingBuilder<C, NoPricer> {
             config,
             pricing: NoPricer,
             providers: Vec::new(),
+            reporter: None,
         }
     }
 }
@@ -50,7 +52,14 @@ impl<C, P> AccountingBuilder<C, P> {
             config: self.config,
             pricing,
             providers: self.providers,
+            reporter: self.reporter,
         }
+    }
+
+    /// Attach a peer reporter so accounting violations feed peer scoring.
+    pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
+        self.reporter = Some(reporter);
+        self
     }
 
     /// Add a settlement provider.
@@ -119,13 +128,13 @@ impl<C: SwarmAccountingConfig + Clone + 'static, P: SwarmPricing + Clone + Send 
         self,
         identity: &I,
     ) -> ClientAccounting<Arc<Accounting<C, I>>, P> {
-        let accounting = Arc::new(Accounting::with_providers(
-            self.config,
-            identity.clone(),
-            self.providers,
-        ));
+        let mut accounting =
+            Accounting::with_providers(self.config, identity.clone(), self.providers);
+        if let Some(reporter) = self.reporter {
+            accounting = accounting.with_reporter(reporter);
+        }
 
-        ClientAccounting::new(accounting, self.pricing)
+        ClientAccounting::new(Arc::new(accounting), self.pricing)
     }
 }
 

--- a/crates/swarm/bandwidth/core/src/lib.rs
+++ b/crates/swarm/bandwidth/core/src/lib.rs
@@ -12,6 +12,11 @@
 //! - [`NoSettlement`] - No-op settlement provider
 //!
 //! Settlement providers (`PseudosettleProvider`, `SwapProvider`) are in sibling crates.
+//!
+//! [`Accounting`] also implements the `PeerAffordability` query surface and
+//! can report accounting violations through an optional `PeerReporter`
+//! (both from `vertex-swarm-api`), so peer selection and peer scoring can
+//! consume accounting state without depending on this crate's internals.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/swarm/bandwidth/pseudosettle/src/service.rs
+++ b/crates/swarm/bandwidth/pseudosettle/src/service.rs
@@ -7,7 +7,10 @@ use std::sync::Arc;
 use alloy_primitives::U256;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
-use vertex_swarm_api::{Direction, SwarmBandwidthAccounting, SwarmPeerBandwidth};
+use vertex_swarm_api::{
+    Direction, PeerReporter, ReportSource, SwarmBandwidthAccounting, SwarmPeerBandwidth,
+    SwarmScoringEvent,
+};
 use vertex_swarm_net_pseudosettle::PaymentAck;
 use vertex_swarm_node::{ClientCommand, PseudosettleEvent};
 use vertex_swarm_primitives::OverlayAddress;
@@ -28,6 +31,14 @@ pub enum PseudosettleCommand {
     },
 }
 
+/// An outbound settlement awaiting the peer's ack.
+struct PendingSettlement {
+    /// The amount we offered to settle.
+    amount: u64,
+    /// Channel completing the originating settle request.
+    response_tx: oneshot::Sender<Result<u64, PseudosettleSettlementError>>,
+}
+
 /// Processes settlement commands from handles and network events.
 pub struct PseudosettleService<A: SwarmBandwidthAccounting> {
     /// Receive commands from handles.
@@ -41,9 +52,11 @@ pub struct PseudosettleService<A: SwarmBandwidthAccounting> {
     /// Tokens per second for rate limiting settlements.
     refresh_rate: u64,
     /// Track pending outbound settlements (waiting for ack).
-    pending: HashMap<OverlayAddress, oneshot::Sender<Result<u64, PseudosettleSettlementError>>>,
+    pending: HashMap<OverlayAddress, PendingSettlement>,
     /// Track last settlement time per peer (for rate limiting).
     last_settlement: HashMap<OverlayAddress, u64>,
+    /// Optional reporter feeding settlement violations into peer scoring.
+    reporter: Option<Arc<dyn PeerReporter>>,
 }
 
 impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
@@ -63,6 +76,27 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
             refresh_rate,
             pending: HashMap::new(),
             last_settlement: HashMap::new(),
+            reporter: None,
+        }
+    }
+
+    /// Attach a peer reporter so settlement violations feed peer scoring.
+    ///
+    /// Reporting is best-effort and non-blocking. Without a reporter the
+    /// service behaves exactly as before.
+    pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
+        self.reporter = Some(reporter);
+        self
+    }
+
+    /// Report an accounting violation if a reporter is attached.
+    fn report_violation(&self, peer: &OverlayAddress) {
+        if let Some(reporter) = &self.reporter {
+            reporter.report_peer(
+                peer,
+                SwarmScoringEvent::AccountingViolation,
+                ReportSource::Accounting,
+            );
         }
     }
 
@@ -115,8 +149,14 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
                     return;
                 }
 
-                // Store the response channel for when we get the ack
-                self.pending.insert(peer, response_tx);
+                // Store the offer and response channel for when we get the ack
+                self.pending.insert(
+                    peer,
+                    PendingSettlement {
+                        amount,
+                        response_tx,
+                    },
+                );
                 self.last_settlement.insert(peer, now);
 
                 debug!(%peer, %amount, "Sending pseudosettle request");
@@ -128,10 +168,10 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
                 }) {
                     warn!(%peer, error = ?e, "Failed to send pseudosettle command");
                     // Remove the pending entry and notify failure
-                    if let Some(tx) = self.pending.remove(&peer) {
-                        let _ = tx.send(Err(PseudosettleSettlementError::NetworkError(
-                            e.to_string(),
-                        )));
+                    if let Some(pending) = self.pending.remove(&peer) {
+                        let _ = pending.response_tx.send(Err(
+                            PseudosettleSettlementError::NetworkError(e.to_string()),
+                        ));
                     }
                 }
             }
@@ -144,12 +184,19 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
                 debug!(%peer, amount = %ack.amount, "Pseudosettle ack received");
 
                 // Complete pending request with accepted amount
-                if let Some(tx) = self.pending.remove(&peer) {
+                if let Some(pending) = self.pending.remove(&peer) {
+                    if ack.amount > U256::from(pending.amount) {
+                        // Law broken: an ack may accept at most the amount
+                        // offered for settlement; over-acceptance desyncs
+                        // the mutual books.
+                        self.report_violation(&peer);
+                    }
+
                     // Credit our balance (we paid, debt reduced)
                     let handle = self.accounting.for_peer(peer);
                     handle.record(ack.amount.as_limbs()[0], Direction::Upload);
 
-                    let _ = tx.send(Ok(ack.amount.as_limbs()[0]));
+                    let _ = pending.response_tx.send(Ok(ack.amount.as_limbs()[0]));
                 } else {
                     warn!(%peer, "Received ack for unknown settlement");
                 }
@@ -239,4 +286,141 @@ fn current_timestamp() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use vertex_swarm_bandwidth::{Accounting, BandwidthConfig};
+    use vertex_swarm_test_utils::{Identity, test_identity, test_peer};
+
+    type TestService = PseudosettleService<Accounting<BandwidthConfig, Identity>>;
+
+    #[derive(Default)]
+    struct RecordingReporter {
+        reports: parking_lot::Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
+    }
+
+    impl PeerReporter for RecordingReporter {
+        fn report_peer(
+            &self,
+            overlay: &OverlayAddress,
+            event: SwarmScoringEvent,
+            source: ReportSource,
+        ) {
+            self.reports.lock().push((*overlay, event, source));
+        }
+    }
+
+    fn build_service() -> TestService {
+        let (_cmd_tx, command_rx) = mpsc::unbounded_channel();
+        let (_evt_tx, event_rx) = mpsc::unbounded_channel();
+        let (client_tx, _client_rx) = mpsc::unbounded_channel();
+        let accounting = Arc::new(Accounting::new(BandwidthConfig::default(), test_identity()));
+
+        PseudosettleService::new(command_rx, event_rx, client_tx, accounting, 4_500_000)
+    }
+
+    fn insert_pending(
+        svc: &mut TestService,
+        peer: OverlayAddress,
+        amount: u64,
+    ) -> oneshot::Receiver<Result<u64, PseudosettleSettlementError>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        svc.pending.insert(
+            peer,
+            PendingSettlement {
+                amount,
+                response_tx,
+            },
+        );
+        response_rx
+    }
+
+    #[tokio::test]
+    async fn over_acceptance_reports_violation_per_message() {
+        let reporter = Arc::new(RecordingReporter::default());
+        let mut svc = build_service().with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+        let peer = test_peer();
+
+        // The peer acks more than we offered.
+        let mut rx = insert_pending(&mut svc, peer, 100);
+        svc.handle_event(PseudosettleEvent::Sent {
+            peer,
+            ack: PaymentAck::now(U256::from(200u64)),
+        })
+        .await;
+
+        assert_eq!(reporter.reports.lock().len(), 1);
+        let (reported_peer, event, source) = reporter.reports.lock()[0];
+        assert_eq!(reported_peer, peer);
+        assert_eq!(event, SwarmScoringEvent::AccountingViolation);
+        assert_eq!(source, ReportSource::Accounting);
+        // The accounting effect of the ack is unchanged by reporting.
+        assert_eq!(rx.try_recv().unwrap().unwrap(), 200);
+
+        // Every over-acceptance ack is an independent wire-level violation,
+        // so a repeat offence reports again (no debounce).
+        let _rx = insert_pending(&mut svc, peer, 100);
+        svc.handle_event(PseudosettleEvent::Sent {
+            peer,
+            ack: PaymentAck::now(U256::from(300u64)),
+        })
+        .await;
+        assert_eq!(reporter.reports.lock().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn lawful_acks_do_not_report() {
+        let reporter = Arc::new(RecordingReporter::default());
+        let mut svc = build_service().with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+        let peer = test_peer();
+
+        // Full acceptance is lawful.
+        let mut rx = insert_pending(&mut svc, peer, 100);
+        svc.handle_event(PseudosettleEvent::Sent {
+            peer,
+            ack: PaymentAck::now(U256::from(100u64)),
+        })
+        .await;
+        assert_eq!(rx.try_recv().unwrap().unwrap(), 100);
+
+        // Underpayment (time-capped acceptance) is lawful too.
+        let mut rx = insert_pending(&mut svc, peer, 100);
+        svc.handle_event(PseudosettleEvent::Sent {
+            peer,
+            ack: PaymentAck::now(U256::from(10u64)),
+        })
+        .await;
+        assert_eq!(rx.try_recv().unwrap().unwrap(), 10);
+
+        // An ack with no pending settlement is ignored, not reported: it can
+        // be a local race rather than provable peer misbehaviour.
+        svc.handle_event(PseudosettleEvent::Sent {
+            peer,
+            ack: PaymentAck::now(U256::from(10u64)),
+        })
+        .await;
+
+        assert!(reporter.reports.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn no_reporter_behaviour_unchanged() {
+        let mut svc = build_service();
+        let peer = test_peer();
+
+        let mut rx = insert_pending(&mut svc, peer, 100);
+        svc.handle_event(PseudosettleEvent::Sent {
+            peer,
+            ack: PaymentAck::now(U256::from(200u64)),
+        })
+        .await;
+
+        // Same outcome as with a reporter: the ack completes the settlement.
+        assert_eq!(rx.try_recv().unwrap().unwrap(), 200);
+        let handle = svc.accounting.for_peer(peer);
+        assert_eq!(handle.balance(), 200);
+    }
 }

--- a/crates/swarm/bandwidth/swap/src/service.rs
+++ b/crates/swarm/bandwidth/swap/src/service.rs
@@ -15,7 +15,10 @@ use alloy_primitives::{Address, U256};
 use alloy_signer::SignerSync;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
-use vertex_swarm_api::{Direction, SwarmBandwidthAccounting, SwarmPeerBandwidth};
+use vertex_swarm_api::{
+    Direction, PeerReporter, ReportSource, SwarmBandwidthAccounting, SwarmPeerBandwidth,
+    SwarmScoringEvent,
+};
 use vertex_swarm_bandwidth_chequebook::{Cheque, ChequeExt, SignedCheque};
 use vertex_swarm_node::{ClientCommand, SwapEvent};
 use vertex_swarm_primitives::OverlayAddress;
@@ -90,6 +93,8 @@ pub struct SwapService<A: SwarmBandwidthAccounting, S> {
     peers: HashMap<OverlayAddress, PeerChequeState>,
     /// Track pending outbound settlements (waiting for the wire ack).
     pending: HashMap<OverlayAddress, PendingSettlement>,
+    /// Optional reporter feeding settlement violations into peer scoring.
+    reporter: Option<Arc<dyn PeerReporter>>,
     /// Optional on-chain chequebook client for cashing received cheques.
     #[cfg(feature = "swap-chequebook")]
     cashout: Option<crate::cashout::Cashout>,
@@ -128,6 +133,7 @@ where
             chain,
             peers: HashMap::new(),
             pending: HashMap::new(),
+            reporter: None,
             #[cfg(feature = "swap-chequebook")]
             cashout: None,
         }
@@ -138,6 +144,26 @@ where
     pub fn with_cashout(mut self, cashout: crate::cashout::Cashout) -> Self {
         self.cashout = Some(cashout);
         self
+    }
+
+    /// Attach a peer reporter so settlement violations feed peer scoring.
+    ///
+    /// Reporting is best-effort and non-blocking. Without a reporter the
+    /// service behaves exactly as before.
+    pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
+        self.reporter = Some(reporter);
+        self
+    }
+
+    /// Report an accounting violation if a reporter is attached.
+    fn report_violation(&self, peer: &OverlayAddress) {
+        if let Some(reporter) = &self.reporter {
+            reporter.report_peer(
+                peer,
+                SwarmScoringEvent::AccountingViolation,
+                ReportSource::Accounting,
+            );
+        }
     }
 
     /// Run the service event loop with graceful shutdown support.
@@ -291,6 +317,15 @@ where
                         self.maybe_cash(peer, cheque).await;
                     }
                     Err(e) => {
+                        // An unknown identity can be local wiring lag (the
+                        // handshake info is not yet registered), so only
+                        // authenticated rejections count against the peer.
+                        if !matches!(e, SwapSettlementError::UnknownPeerIdentity) {
+                            // Law broken: a cheque must name our beneficiary,
+                            // authenticate against the peer's issuer, and
+                            // strictly increase the cumulative payout.
+                            self.report_violation(&peer);
+                        }
                         warn!(%peer, error = %e, "Rejected received cheque");
                     }
                 }
@@ -570,6 +605,102 @@ mod tests {
             svc.accept_cheque(peer, &cheque),
             Err(SwapSettlementError::UnknownPeerIdentity)
         ));
+    }
+
+    #[derive(Default)]
+    struct RecordingReporter {
+        reports: std::sync::Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
+    }
+
+    impl PeerReporter for RecordingReporter {
+        fn report_peer(
+            &self,
+            overlay: &OverlayAddress,
+            event: SwarmScoringEvent,
+            source: ReportSource,
+        ) {
+            self.reports.lock().unwrap().push((*overlay, event, source));
+        }
+    }
+
+    #[tokio::test]
+    async fn rejected_cheque_reports_violation() {
+        let issuer = PrivateKeySigner::random();
+        let reporter = Arc::new(RecordingReporter::default());
+        let mut svc = build_service(PrivateKeySigner::random())
+            .with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: Address::repeat_byte(0x22),
+            issuer: issuer.address(),
+        });
+
+        // A cheque drawn for someone else is an authenticated violation.
+        let cheque = peer_cheque(
+            &issuer,
+            Address::repeat_byte(0xaa),
+            Address::repeat_byte(0x77),
+            1_000,
+        );
+        svc.handle_event(SwapEvent::ChequeReceived {
+            peer,
+            cheque,
+            peer_rate: U256::ZERO,
+        })
+        .await;
+
+        let reports = reporter.reports.lock().unwrap();
+        assert_eq!(reports.len(), 1);
+        let (reported_peer, event, source) = *reports.first().unwrap();
+        assert_eq!(reported_peer, peer);
+        assert_eq!(event, SwarmScoringEvent::AccountingViolation);
+        assert_eq!(source, ReportSource::Accounting);
+    }
+
+    #[tokio::test]
+    async fn unknown_identity_rejection_does_not_report() {
+        let issuer = PrivateKeySigner::random();
+        let reporter = Arc::new(RecordingReporter::default());
+        let mut svc = build_service(PrivateKeySigner::random())
+            .with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+        let peer = test_peer();
+
+        // No registered swap identity: the rejection may be local wiring
+        // lag, so it must not count against the peer.
+        let cheque = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 1_000);
+        svc.handle_event(SwapEvent::ChequeReceived {
+            peer,
+            cheque,
+            peer_rate: U256::ZERO,
+        })
+        .await;
+
+        assert!(reporter.reports.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn accepted_cheque_does_not_report() {
+        let issuer = PrivateKeySigner::random();
+        let reporter = Arc::new(RecordingReporter::default());
+        let mut svc = build_service(PrivateKeySigner::random())
+            .with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+        let peer = test_peer();
+        svc.peers.entry(peer).or_default().info = Some(PeerSwapInfo {
+            beneficiary: Address::repeat_byte(0x22),
+            issuer: issuer.address(),
+        });
+
+        let cheque = peer_cheque(&issuer, Address::repeat_byte(0xaa), OUR_BENEFICIARY, 1_000);
+        svc.handle_event(SwapEvent::ChequeReceived {
+            peer,
+            cheque,
+            peer_rate: U256::ZERO,
+        })
+        .await;
+
+        assert!(reporter.reports.lock().unwrap().is_empty());
+        let handle = svc.accounting.for_peer(peer);
+        assert_eq!(handle.balance(), -1_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This implements the accounting half of the peer-reporting design that landed in #208: bandwidth accounting and the settlement services can now feed `SwarmScoringEvent::AccountingViolation` into peer scoring through an optional `PeerReporter`, and `Accounting` implements `PeerAffordability` so peer selection can gate requests on accounting headroom. Nothing is wired into the node or builder here; node-level wiring follows in a separate PR. Context for the eventual consumers: #175 and #176 (no closing keywords on purpose, they close when selection consumes `PeerAffordability`).

## Reporter plumbing

`Accounting`, `PseudosettleService`, and `SwapService` each gain a builder-style `with_reporter(Arc<dyn PeerReporter>)` and store it as `Option<Arc<dyn PeerReporter>>`. Reporting is best-effort and non-blocking; with no reporter configured every path behaves exactly as before, which the tests assert explicitly. `AccountingBuilder` passes the reporter through so the wiring PR has a single attachment point.

## Violation sites

Each site carries a one-line comment naming the broken law:

- **Disconnect-threshold breach in `Accounting::prepare_receive`**: with time-based refresh and settlement working, a lawful relationship never reaches the disconnect tolerance; getting there means the peer stopped accepting settlement. Reported once per breach episode: a per-peer atomic flag debounces repeated calls against the same already-broken balance (so retries do not stack -20 severe penalties), and a successful grant ends the episode so a later breach reports again. The debounce decision is tested.
- **Pseudosettle over-acceptance**: an ack that accepts more than the offered amount desyncs the mutual books. The pending settlement now records the offered amount so the ack can be checked against it. Every over-ack is an independent wire message and reports each time, deliberately undebounced (tested). The credited amount is left unchanged in this PR to keep no-reporter behaviour identical; clamping the credit to the offered amount is a candidate follow-up.
- **Swap cheque rejection**: a received cheque that fails authenticated validation (wrong beneficiary, issuer mismatch, signature recovery failure, non-increasing cumulative payout, amount overflow) is reported. `UnknownPeerIdentity` rejections are excluded because they can be local wiring lag rather than provable peer misbehaviour.

Audited but deliberately not reported: pseudosettle underpayment and zero-acks are lawful time-capped acceptance per the protocol, and their cumulative effect surfaces at the disconnect-threshold breach above; acks with no pending settlement are ignored, not reported, since they can be a local race.

## Affordability semantics

`PeerAffordability` is implemented on `Accounting`, the type with per-peer balance visibility. The sign convention is documented in the impl rustdoc: balance is the peer's debt to us in AU, receiving service moves it by `-price`, and a debit is affordable while `balance - price - reserved` stays at or above the negated disconnect threshold, mirroring the `prepare_receive` guard. `allowance_remaining` is the clamped headroom `max(0, balance + disconnect_threshold - reserved)`, so `can_afford(peer, price)` is exactly `price <= allowance_remaining(peer)`. Unknown peers are treated as fresh zero-balance peers with the configured default thresholds, matching what `get_or_create_peer` would create, and the queries are read-only: they never insert peer state. For client-only peers with scaled per-peer thresholds, affordability reads the per-peer threshold and is therefore stricter than the config-wide `prepare_receive` guard; that divergence is documented.

## Tests

Boundary tests assert affordability agrees with `prepare_receive` exactly at the threshold, just over it, under outstanding reservations, and for unknown peers; reporting tests cover once-per-episode debounce, per-message over-ack reports, authenticated-vs-unknown cheque rejections, and byte-for-byte identical behaviour with no reporter configured.