### PR TITLE
feat(swarm-node): wire reporter into accounting; accounting-aware peer selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8757,6 +8757,7 @@ dependencies = [
  "vertex-swarm-redistribution",
  "vertex-swarm-rpc",
  "vertex-swarm-spec",
+ "vertex-swarm-test-utils",
  "vertex-swarm-topology",
  "vertex-tasks",
 ]
@@ -9057,6 +9058,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
+ "auto_impl",
  "bytes",
  "clap 4.6.1",
  "eyre",

--- a/crates/swarm/AGENTS.md
+++ b/crates/swarm/AGENTS.md
@@ -12,7 +12,7 @@ Root-level rules in `/AGENTS.md` apply here too. The notes below are the area-sp
 - `bandwidth/{core,pricing,pseudosettle,swap,chequebook}`: per-peer balances in Accounting Units (AU) and the settlement providers. `Accounting` implements `PeerAffordability` and the accounting and settlement services take an optional `PeerReporter` (both from `api`) so violations feed peer scoring; the node layer does the wiring.
 - `api`: the trait chain `SwarmPrimitives` to `SwarmNetworkTypes` to `SwarmClientTypes` to `SwarmStorerTypes`. Strictly libp2p-free with the documented `Multiaddr` exception.
 - `builder`: layered builders that produce `BuiltBootnode`, `BuiltClient`, `BuiltStorer`.
-- `node`: composes the libp2p `NetworkBehaviour` and exposes `BootNode`, `ClientNode`, `StorerNode`. This is where libp2p shows up.
+- `node`: composes the libp2p `NetworkBehaviour` and exposes `BootNode`, `ClientNode`, `StorerNode`. This is where libp2p shows up. Also owns `PeerSelector`: retrieval and pushsync candidate selection ordered by peer score and affordability on top of proximity. The builder wires it from the topology handle (scores via the peer manager) and the bandwidth accounting (affordability, per-peer chunk price, best-effort settlement trigger).
 - `topology`: libp2p behaviour for peer discovery, kademlia routing, reachability tracking.
 - `localstore`, `storer`, `redistribution`: storer-side configuration and the chunk-store/reserve implementation.
 - `rpc`: tonic-generated gRPC services and a `GrpcServiceProvider` trait.

--- a/crates/swarm/builder/Cargo.toml
+++ b/crates/swarm/builder/Cargo.toml
@@ -117,6 +117,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 nectar-postage.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
+vertex-swarm-test-utils.workspace = true
 
 # Client upload/download examples. They build a client through the public builder
 # and drive the chunk sender/provider directly, the way an FFI or gRPC embedder

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -9,15 +9,16 @@ use tracing::{info, warn};
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_node_api::InfrastructureContext;
 use vertex_storage_redb::RedbDatabase;
-#[cfg(feature = "swap")]
-use vertex_swarm_api::SwarmClientAccounting;
-use vertex_swarm_api::{PeerConfigValues, SwarmLaunchConfig, SwarmNodeType, SwarmPeerConfig};
+use vertex_swarm_api::{
+    PeerConfigValues, PeerReporter, SwarmClientAccounting, SwarmLaunchConfig, SwarmNodeType,
+    SwarmPeerConfig,
+};
 use vertex_swarm_bandwidth::{
     Accounting, AccountingBuilder, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::args::NetworkConfig;
-use vertex_swarm_node::{BootNode, ClientNode};
+use vertex_swarm_node::{AccountingSettlement, BootNode, ClientNode, PeerSelector};
 use vertex_swarm_peer_manager::{
     DEFAULT_TICK_INTERVAL, DbPeerSnapshotStore, PeerSnapshot, spawn_peer_manager_task,
 };
@@ -60,58 +61,6 @@ where
     match network.peers().store_path() {
         Some(path) => info!(path = %path.display(), "Peers database"),
         None => info!("Peers database: ephemeral"),
-    }
-}
-
-#[cfg(not(feature = "swap"))]
-#[allow(clippy::type_complexity)]
-fn build_accounting<A>(
-    spec: Arc<Spec>,
-    identity: &Arc<Identity>,
-    config: A,
-) -> ClientAccounting<
-    Arc<vertex_swarm_bandwidth::Accounting<A, Arc<Identity>>>,
-    <A::Pricing as vertex_swarm_api::SwarmPricingBuilder<Spec>>::Pricer,
->
-where
-    A: vertex_swarm_api::SwarmAccountingConfig
-        + vertex_swarm_api::SwarmPricingConfig
-        + Clone
-        + 'static,
-    A::Pricing: vertex_swarm_api::SwarmPricingBuilder<Spec>,
-{
-    AccountingBuilder::new(config)
-        .with_pricer_from_config(spec)
-        .build(identity)
-}
-
-/// Build client accounting, embedding the SWAP settlement provider when enabled.
-///
-/// Returns the accounting plus the swap wiring to spawn after the node command
-/// channel exists. When SWAP is not enabled the wiring is `None` and the
-/// accounting is identical to [`build_accounting`].
-#[cfg(feature = "swap")]
-#[allow(clippy::type_complexity)]
-fn build_accounting_with_swap(
-    spec: &Arc<Spec>,
-    identity: &Arc<Identity>,
-    config: &DefaultBandwidthConfig,
-    swap_config: &SwapConfig,
-) -> (
-    ClientAccounting<
-        Arc<vertex_swarm_bandwidth::Accounting<DefaultBandwidthConfig, Arc<Identity>>>,
-        FixedPricer<Spec>,
-    >,
-    Option<crate::swap::SwapWiring>,
-) {
-    let builder = AccountingBuilder::new(config.clone()).with_pricer_from_config(Arc::clone(spec));
-
-    match crate::swap::SwapWiring::prepare(spec, identity, config, swap_config) {
-        Some((provider, wiring)) => (
-            builder.with_settlement(provider).build(identity),
-            Some(wiring),
-        ),
-        None => (builder.build(identity), None),
     }
 }
 
@@ -294,11 +243,13 @@ struct ClientNodeParts {
 /// Shared launch path for the node types backed by a client node (client and
 /// storer).
 ///
-/// Builds the bandwidth accounting (with SWAP settlement embedded when enabled),
-/// constructs the node and the verified chunk provider, spawns the client
-/// service and the SWAP settlement service, connects the chain provider when the
-/// node type requires one, and wraps the node run loop in a task that owns the
-/// accounting and chain handles for the node's lifetime.
+/// Builds the node, then the bandwidth accounting (reporting violations to the
+/// peer manager, with SWAP settlement embedded when enabled) and the verified
+/// chunk provider with score- and affordability-aware candidate selection,
+/// spawns the client service and the SWAP settlement service, connects the
+/// chain provider when the node type requires one, and wraps the node run loop
+/// in a task that owns the accounting and chain handles for the node's
+/// lifetime.
 async fn build_client_backed_node(
     ctx: &dyn InfrastructureContext,
     params: ClientNodeParams<'_>,
@@ -312,14 +263,13 @@ async fn build_client_backed_node(
     // Prepare SWAP settlement first: the provider must be embedded in the
     // accounting, and the swap event sink must be routed at node build time.
     #[cfg(feature = "swap")]
-    let (accounting, swap_wiring) =
-        build_accounting_with_swap(params.spec, params.identity, params.bandwidth, params.swap);
-    #[cfg(not(feature = "swap"))]
-    let accounting = build_accounting(
-        params.spec.clone(),
+    let (swap_provider, swap_wiring) = crate::swap::SwapWiring::prepare(
+        params.spec,
         params.identity,
-        params.bandwidth.clone(),
-    );
+        params.bandwidth,
+        params.swap,
+    )
+    .unzip();
 
     let node_builder = ClientNode::builder(params.identity.clone());
     #[cfg(feature = "swap")]
@@ -338,7 +288,36 @@ async fn build_client_backed_node(
         DEFAULT_TICK_INTERVAL,
         ctx.executor(),
     );
-    let chunk_provider = NetworkChunkProvider::new(client_handle.clone(), topology.clone());
+
+    // The peer manager behind the topology handle is the reporting authority:
+    // accounting and the settlement services report violations through it so
+    // misbehaving peers are scored down.
+    let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
+
+    let accounting_builder = AccountingBuilder::new(params.bandwidth.clone())
+        .with_pricer_from_config(Arc::clone(params.spec))
+        .with_reporter(Arc::clone(&reporter));
+    #[cfg(feature = "swap")]
+    let accounting = match swap_provider {
+        Some(provider) => accounting_builder
+            .with_settlement(provider)
+            .build(params.identity),
+        None => accounting_builder.build(params.identity),
+    };
+    #[cfg(not(feature = "swap"))]
+    let accounting = accounting_builder.build(params.identity);
+
+    // Retrieval and pushsync candidate selection consults peer scores and
+    // affordability on top of proximity order.
+    let selector = Arc::new(PeerSelector::new(
+        Arc::new(topology.clone()),
+        accounting.bandwidth().clone(),
+        Arc::new(accounting.pricing().clone()),
+        Arc::new(AccountingSettlement::new(accounting.bandwidth().clone())),
+    ));
+
+    let chunk_provider =
+        NetworkChunkProvider::new(client_handle.clone(), topology.clone()).with_selector(selector);
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
     // Spawn client service as independent task with graceful shutdown
@@ -369,6 +348,7 @@ async fn build_client_backed_node(
             ctx,
             accounting.bandwidth().clone(),
             client_handle,
+            Arc::clone(&reporter),
             #[cfg(feature = "chain")]
             chain_provider.as_ref(),
         );
@@ -496,5 +476,47 @@ impl SwarmLaunchConfig for StorerConfig {
 
         let providers = StorerRpcProviders::new(parts.topology, parts.chunks);
         Ok((parts.task, providers))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use vertex_swarm_api::{SwarmAccountingConfig, SwarmIdentity};
+    use vertex_swarm_peer_manager::{PeerManager, PeerManagerConfig};
+    use vertex_swarm_test_utils::{test_identity_arc, test_swarm_peer};
+
+    /// The launch path hands the peer manager to the accounting builder as the
+    /// peer reporter. Verify that composition end to end: an accounting
+    /// violation must reach the peer manager and lower the peer's score.
+    #[test]
+    fn accounting_violation_reaches_peer_manager() {
+        let identity = test_identity_arc();
+        let peer_manager = PeerManager::new(&identity, PeerManagerConfig::default());
+        let overlay = peer_manager.store_discovered_peer(test_swarm_peer(0xab));
+        let baseline = peer_manager
+            .get_peer_score(&overlay)
+            .expect("stored peer has a score");
+
+        let reporter: Arc<dyn PeerReporter> = peer_manager.clone();
+        let config = DefaultBandwidthConfig::default();
+        let over_limit = config.disconnect_threshold() + 1;
+        let accounting = AccountingBuilder::new(config)
+            .with_pricer_from_config(identity.spec().clone())
+            .with_reporter(reporter)
+            .build(&identity);
+
+        // A debit projected past the disconnect threshold is the violation the
+        // accounting reports.
+        let result = accounting
+            .bandwidth()
+            .prepare_receive(overlay, over_limit, true);
+        assert!(result.is_err());
+
+        let after = peer_manager
+            .get_peer_score(&overlay)
+            .expect("peer still scored");
+        assert!(after < baseline, "violation must lower the score");
     }
 }

--- a/crates/swarm/builder/src/providers.rs
+++ b/crates/swarm/builder/src/providers.rs
@@ -1,12 +1,14 @@
 //! RPC provider implementations for Swarm nodes.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use nectar_primitives::SwarmAddress;
 use vertex_swarm_api::{
     ChunkAddress, ChunkRetrievalResult, PushReceipt, StampedChunk, SwarmChunkProvider,
     SwarmChunkSender, SwarmError, SwarmIdentity, SwarmResult, SwarmTopologyRouting,
 };
-use vertex_swarm_node::ClientHandle;
+use vertex_swarm_node::{ClientHandle, PeerSelector};
 use vertex_swarm_topology::TopologyHandle;
 
 /// Number of closest peers to try when pushing a chunk before giving up.
@@ -20,6 +22,7 @@ const RETRIEVE_CANDIDATE_COUNT: usize = 3;
 pub struct NetworkChunkProvider<I: SwarmIdentity> {
     client_handle: ClientHandle,
     topology: TopologyHandle<I>,
+    selector: Option<Arc<PeerSelector>>,
 }
 
 impl<I: SwarmIdentity> NetworkChunkProvider<I> {
@@ -27,6 +30,22 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         Self {
             client_handle,
             topology,
+            selector: None,
+        }
+    }
+
+    /// Order retrieval and pushsync candidates with `selector` (score- and
+    /// affordability-aware) instead of plain proximity order.
+    pub fn with_selector(mut self, selector: Arc<PeerSelector>) -> Self {
+        self.selector = Some(selector);
+        self
+    }
+
+    /// Order proximity-sorted `candidates` for a request on `chunk`.
+    fn select(&self, candidates: Vec<SwarmAddress>, chunk: &ChunkAddress) -> Vec<SwarmAddress> {
+        match &self.selector {
+            Some(selector) => selector.order(candidates, chunk),
+            None => candidates,
         }
     }
 }
@@ -38,6 +57,7 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         let closest_peers = self
             .topology
             .closest_to(&chunk_address, RETRIEVE_CANDIDATE_COUNT);
+        let closest_peers = self.select(closest_peers, &chunk_address);
         let attempts = closest_peers.len();
 
         // Try each closest peer in order and return the first success. The
@@ -88,6 +108,7 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     async fn push_to_closest(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
         let address = *chunk.address();
         let closest = self.topology.closest_to(&address, PUSH_CANDIDATE_COUNT);
+        let closest = self.select(closest, &address);
         let attempts = closest.len();
 
         // Try each closest peer in order and return the first receipt. The

--- a/crates/swarm/builder/src/swap.rs
+++ b/crates/swarm/builder/src/swap.rs
@@ -26,7 +26,9 @@ use alloy_signer_local::PrivateKeySigner;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 use vertex_node_api::InfrastructureContext;
-use vertex_swarm_api::{SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmIdentity, SwarmSpec};
+use vertex_swarm_api::{
+    PeerReporter, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmIdentity, SwarmSpec,
+};
 use vertex_swarm_bandwidth_swap::service::SwapCommand;
 use vertex_swarm_bandwidth_swap::{SwapEvent, SwapHandle, SwapProvider, SwapService};
 use vertex_swarm_identity::Identity;
@@ -135,15 +137,17 @@ impl SwapWiring {
     ///
     /// The service records cheque-driven balance changes against `accounting`
     /// (the same instance the provider settles through), drains the provider's
-    /// command channel, and consumes routed swap wire events. Its `SendCheque`
-    /// commands are forwarded to the node through `client_handle`. With the
-    /// `chain` feature and a connected provider, received cheques are also cashed
-    /// on chain, paying out to our beneficiary.
+    /// command channel, and consumes routed swap wire events. Cheque violations
+    /// are reported through `reporter` so they feed peer scoring. Its
+    /// `SendCheque` commands are forwarded to the node through `client_handle`.
+    /// With the `chain` feature and a connected provider, received cheques are
+    /// also cashed on chain, paying out to our beneficiary.
     pub(crate) fn spawn<A>(
         self,
         ctx: &dyn InfrastructureContext,
         accounting: Arc<A>,
         client_handle: ClientHandle,
+        reporter: Arc<dyn PeerReporter>,
         #[cfg(feature = "chain")] chain_provider: Option<&SharedChainProvider>,
     ) where
         A: SwarmBandwidthAccounting + 'static,
@@ -163,7 +167,8 @@ impl SwapWiring {
             self.chequebook,
             self.beneficiary,
             self.chain,
-        );
+        )
+        .with_reporter(reporter);
 
         #[cfg(feature = "chain")]
         let service = attach_cashout(service, chain_provider, self.beneficiary);

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -66,6 +66,7 @@ metrics.workspace = true
 vertex-net-peer-store.workspace = true
 
 ## misc
+auto_impl.workspace = true
 bytes.workspace = true
 eyre.workspace = true
 parking_lot.workspace = true

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -17,6 +17,7 @@ mod bootnodes;
 mod client_service;
 mod node;
 mod protocol;
+mod selection;
 mod swarm_client;
 
 pub use node::{
@@ -31,6 +32,7 @@ pub use client_service::{ClientHandle, ClientService, RetrievalError, RetrievalR
 pub use protocol::SwapEvent;
 pub use protocol::{ClientCommand, ClientEvent, PseudosettleEvent};
 
+pub use selection::{AccountingSettlement, PeerScores, PeerSelector, SettlementTrigger};
 pub use swarm_client::{BootnodeClient, Client, FullClient};
 
 pub use bootnodes::BootnodeProvider;

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -1,0 +1,395 @@
+//! Score- and affordability-aware peer selection for retrieval and pushsync.
+//!
+//! Topology returns candidate storers in proximity order. [`PeerSelector`]
+//! reorders them with two additional signals before a request goes out:
+//!
+//! - Peers whose score is in the warned range are excluded, so a peer that is
+//!   being scored down is not asked again while it misbehaves.
+//! - Peers we cannot afford (the per-chunk debit would cross their disconnect
+//!   threshold) rank behind affordable ones.
+//!
+//! Proximity stays the primary key within each group. When every candidate is
+//! warned or unaffordable, the original proximity order is used unchanged:
+//! degraded service beats failing the request outright. When a request is
+//! blocked on balance (no affordable candidate at all), a best-effort
+//! settlement is triggered for the unaffordable candidates so they become
+//! usable again; the settlement providers themselves decide whether any
+//! payment is actually due.
+//!
+//! The price consulted per candidate is [`SwarmPricing::peer_price`], the same
+//! per-peer chunk price the accounting layer debits when the request is
+//! served.
+
+use std::sync::Arc;
+
+use nectar_primitives::ChunkAddress;
+use tracing::debug;
+use vertex_swarm_api::{
+    DEFAULT_PEER_WARN_THRESHOLD, PeerAffordability, SwarmBandwidthAccounting, SwarmIdentity,
+    SwarmPeerBandwidth, SwarmPricing,
+};
+use vertex_swarm_primitives::OverlayAddress;
+use vertex_swarm_topology::TopologyHandle;
+use vertex_tasks::TaskExecutor;
+
+/// Source of live peer scores for candidate selection.
+///
+/// Implemented over the topology handle (which queries the peer manager, the
+/// authority that owns peer records) and by test mocks.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait PeerScores: Send + Sync {
+    /// Current score for the peer, or `None` when the peer is unknown.
+    fn peer_score(&self, overlay: &OverlayAddress) -> Option<f64>;
+}
+
+impl<I: SwarmIdentity> PeerScores for TopologyHandle<I> {
+    fn peer_score(&self, overlay: &OverlayAddress) -> Option<f64> {
+        self.peer_manager().get_peer_score(overlay)
+    }
+}
+
+/// Best-effort settlement trigger for requests blocked on balance.
+///
+/// Implemented over bandwidth accounting (see [`AccountingSettlement`]) and by
+/// test mocks.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait SettlementTrigger: Send + Sync {
+    /// Start settlement with `peer` without waiting for the outcome.
+    fn trigger_settlement(&self, peer: OverlayAddress);
+}
+
+/// [`SettlementTrigger`] over a bandwidth accounting instance.
+///
+/// Settlement runs as a spawned task on the current task executor so
+/// selection never blocks on settlement I/O. Failures are logged at debug
+/// level; the next request retries naturally.
+pub struct AccountingSettlement<B> {
+    bandwidth: B,
+}
+
+impl<B> AccountingSettlement<B> {
+    /// Trigger settlement through `bandwidth`.
+    pub fn new(bandwidth: B) -> Self {
+        Self { bandwidth }
+    }
+}
+
+impl<B> SettlementTrigger for AccountingSettlement<B>
+where
+    B: SwarmBandwidthAccounting + 'static,
+    B::Peer: 'static,
+{
+    fn trigger_settlement(&self, peer: OverlayAddress) {
+        let Ok(executor) = TaskExecutor::try_current() else {
+            debug!(%peer, "no task executor; settlement not triggered");
+            return;
+        };
+        let handle = self.bandwidth.for_peer(peer);
+        executor.spawn(async move {
+            if let Err(error) = handle.settle().await {
+                debug!(%peer, %error, "best-effort settlement failed");
+            }
+        });
+    }
+}
+
+/// Reorders proximity-ordered candidates by score and affordability.
+///
+/// Built by the node assembly from the topology handle (scores), bandwidth
+/// accounting (affordability and settlement), and the pricer (per-peer chunk
+/// price). Consumed by the retrieval and pushsync candidate-selection paths.
+pub struct PeerSelector {
+    scores: Arc<dyn PeerScores>,
+    affordability: Arc<dyn PeerAffordability>,
+    pricing: Arc<dyn SwarmPricing>,
+    settlement: Arc<dyn SettlementTrigger>,
+}
+
+impl PeerSelector {
+    /// Compose a selector from its query and trigger surfaces.
+    pub fn new(
+        scores: Arc<dyn PeerScores>,
+        affordability: Arc<dyn PeerAffordability>,
+        pricing: Arc<dyn SwarmPricing>,
+        settlement: Arc<dyn SettlementTrigger>,
+    ) -> Self {
+        Self {
+            scores,
+            affordability,
+            pricing,
+            settlement,
+        }
+    }
+
+    /// Order `candidates` (in proximity order) for a request on `chunk`.
+    ///
+    /// Applies the ranking described at the module level. When the request is
+    /// blocked on balance (candidates exist but none is affordable), triggers
+    /// best-effort settlement for the unaffordable candidates before
+    /// returning them in proximity order.
+    pub fn order(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        chunk: &ChunkAddress,
+    ) -> Vec<OverlayAddress> {
+        let ranked = rank_candidates(
+            &candidates,
+            |peer| self.scores.peer_score(peer),
+            |peer| {
+                self.affordability
+                    .can_afford(peer, self.pricing.peer_price(peer, chunk))
+            },
+        );
+
+        if ranked.blocked_on_balance() {
+            for peer in &ranked.unaffordable {
+                self.settlement.trigger_settlement(*peer);
+            }
+        }
+
+        ranked.ordered
+    }
+}
+
+/// Outcome of ranking a candidate set.
+struct RankedCandidates {
+    /// Candidates to attempt, best first.
+    ordered: Vec<OverlayAddress>,
+    /// How many of `ordered` passed the affordability check.
+    affordable: usize,
+    /// Candidates that failed the affordability check, in proximity order.
+    unaffordable: Vec<OverlayAddress>,
+}
+
+impl RankedCandidates {
+    /// True when candidates exist but none is currently affordable.
+    fn blocked_on_balance(&self) -> bool {
+        self.affordable == 0 && !self.unaffordable.is_empty()
+    }
+}
+
+/// Rank proximity-ordered `candidates` by score and affordability.
+///
+/// Warned peers (score at or below [`DEFAULT_PEER_WARN_THRESHOLD`]) are
+/// excluded. Affordable peers keep their proximity order and rank before
+/// unaffordable ones, which also keep theirs. If every candidate is warned,
+/// the original proximity order is returned unchanged.
+fn rank_candidates(
+    candidates: &[OverlayAddress],
+    score: impl Fn(&OverlayAddress) -> Option<f64>,
+    can_afford: impl Fn(&OverlayAddress) -> bool,
+) -> RankedCandidates {
+    let mut ordered = Vec::with_capacity(candidates.len());
+    let mut unaffordable = Vec::new();
+
+    for peer in candidates {
+        if score(peer).is_some_and(|s| s <= DEFAULT_PEER_WARN_THRESHOLD) {
+            continue;
+        }
+        if can_afford(peer) {
+            ordered.push(*peer);
+        } else {
+            unaffordable.push(*peer);
+        }
+    }
+
+    if ordered.is_empty() && unaffordable.is_empty() {
+        // Every candidate is warned. Fall back to plain proximity order so a
+        // degraded request can still be attempted.
+        return RankedCandidates {
+            ordered: candidates.to_vec(),
+            affordable: 0,
+            unaffordable: Vec::new(),
+        };
+    }
+
+    let affordable = ordered.len();
+    ordered.extend_from_slice(&unaffordable);
+    RankedCandidates {
+        ordered,
+        affordable,
+        unaffordable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    fn peer(n: u8) -> OverlayAddress {
+        OverlayAddress::from([n; 32])
+    }
+
+    struct FixedScores(HashMap<OverlayAddress, f64>);
+
+    impl PeerScores for FixedScores {
+        fn peer_score(&self, overlay: &OverlayAddress) -> Option<f64> {
+            self.0.get(overlay).copied()
+        }
+    }
+
+    struct FixedAffordability {
+        unaffordable: Vec<OverlayAddress>,
+    }
+
+    impl PeerAffordability for FixedAffordability {
+        fn can_afford(&self, overlay: &OverlayAddress, _price: u64) -> bool {
+            !self.unaffordable.contains(overlay)
+        }
+
+        fn allowance_remaining(&self, _overlay: &OverlayAddress) -> u64 {
+            0
+        }
+    }
+
+    struct UnitPricer;
+
+    impl SwarmPricing for UnitPricer {
+        fn price(&self, _chunk: &ChunkAddress) -> u64 {
+            1
+        }
+
+        fn peer_price(&self, _peer: &OverlayAddress, _chunk: &ChunkAddress) -> u64 {
+            1
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingSettlement {
+        triggered: Mutex<Vec<OverlayAddress>>,
+    }
+
+    impl SettlementTrigger for RecordingSettlement {
+        fn trigger_settlement(&self, peer: OverlayAddress) {
+            self.triggered.lock().unwrap().push(peer);
+        }
+    }
+
+    fn warned(peers: &[OverlayAddress]) -> impl Fn(&OverlayAddress) -> Option<f64> + '_ {
+        move |p| {
+            if peers.contains(p) {
+                Some(DEFAULT_PEER_WARN_THRESHOLD)
+            } else {
+                Some(0.0)
+            }
+        }
+    }
+
+    fn unaffordable(peers: &[OverlayAddress]) -> impl Fn(&OverlayAddress) -> bool + '_ {
+        move |p| !peers.contains(p)
+    }
+
+    #[test]
+    fn healthy_affordable_candidates_keep_proximity_order() {
+        let candidates = vec![peer(1), peer(2), peer(3)];
+        let ranked = rank_candidates(&candidates, warned(&[]), unaffordable(&[]));
+        assert_eq!(ranked.ordered, candidates);
+        assert_eq!(ranked.affordable, 3);
+        assert!(ranked.unaffordable.is_empty());
+        assert!(!ranked.blocked_on_balance());
+    }
+
+    #[test]
+    fn warned_peer_is_excluded() {
+        let candidates = vec![peer(1), peer(2), peer(3)];
+        let ranked = rank_candidates(&candidates, warned(&[peer(2)]), unaffordable(&[]));
+        assert_eq!(ranked.ordered, vec![peer(1), peer(3)]);
+    }
+
+    #[test]
+    fn unknown_peer_is_not_treated_as_warned() {
+        let candidates = vec![peer(1), peer(2)];
+        let ranked = rank_candidates(&candidates, |_| None, unaffordable(&[]));
+        assert_eq!(ranked.ordered, candidates);
+    }
+
+    #[test]
+    fn unaffordable_peer_is_deprioritized() {
+        let candidates = vec![peer(1), peer(2), peer(3)];
+        let ranked = rank_candidates(&candidates, warned(&[]), unaffordable(&[peer(1)]));
+        assert_eq!(ranked.ordered, vec![peer(2), peer(3), peer(1)]);
+        assert_eq!(ranked.affordable, 2);
+        assert!(!ranked.blocked_on_balance());
+    }
+
+    #[test]
+    fn all_unaffordable_falls_back_to_proximity_order() {
+        let candidates = vec![peer(1), peer(2), peer(3)];
+        let ranked = rank_candidates(
+            &candidates,
+            warned(&[]),
+            unaffordable(&[peer(1), peer(2), peer(3)]),
+        );
+        assert_eq!(ranked.ordered, candidates);
+        assert!(ranked.blocked_on_balance());
+    }
+
+    #[test]
+    fn all_warned_falls_back_to_proximity_order() {
+        let candidates = vec![peer(1), peer(2)];
+        let ranked = rank_candidates(&candidates, warned(&[peer(1), peer(2)]), unaffordable(&[]));
+        assert_eq!(ranked.ordered, candidates);
+        assert!(!ranked.blocked_on_balance());
+    }
+
+    #[test]
+    fn empty_candidates_stay_empty() {
+        let ranked = rank_candidates(&[], warned(&[]), unaffordable(&[]));
+        assert!(ranked.ordered.is_empty());
+        assert!(!ranked.blocked_on_balance());
+    }
+
+    fn selector(
+        scores: HashMap<OverlayAddress, f64>,
+        unaffordable: Vec<OverlayAddress>,
+        settlement: Arc<RecordingSettlement>,
+    ) -> PeerSelector {
+        PeerSelector::new(
+            Arc::new(FixedScores(scores)),
+            Arc::new(FixedAffordability { unaffordable }),
+            Arc::new(UnitPricer),
+            settlement,
+        )
+    }
+
+    #[test]
+    fn selector_orders_and_skips_settlement_when_affordable_exists() {
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel = selector(HashMap::new(), vec![peer(1)], Arc::clone(&settlement));
+
+        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
+        assert_eq!(ordered, vec![peer(2), peer(1)]);
+        assert!(settlement.triggered.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn selector_triggers_settlement_when_blocked_on_balance() {
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel = selector(
+            HashMap::new(),
+            vec![peer(1), peer(2)],
+            Arc::clone(&settlement),
+        );
+
+        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
+        assert_eq!(ordered, vec![peer(1), peer(2)]);
+        assert_eq!(
+            *settlement.triggered.lock().unwrap(),
+            vec![peer(1), peer(2)]
+        );
+    }
+
+    #[test]
+    fn selector_excludes_warned_peers() {
+        let settlement = Arc::new(RecordingSettlement::default());
+        let mut scores = HashMap::new();
+        scores.insert(peer(1), DEFAULT_PEER_WARN_THRESHOLD - 1.0);
+        let sel = selector(scores, Vec::new(), Arc::clone(&settlement));
+
+        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
+        assert_eq!(ordered, vec![peer(2)]);
+    }
+}

--- a/crates/swarm/node/src/swarm_client.rs
+++ b/crates/swarm/node/src/swarm_client.rs
@@ -1,13 +1,16 @@
 //! Unified client for Swarm nodes.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use nectar_primitives::{AnyChunk, ChunkAddress};
 use vertex_swarm_api::{
     BootnodeComponents, ClientComponents, HasAccounting, HasTopology, StampedChunk, SwarmClient,
     SwarmClientAccounting, SwarmError, SwarmResult, SwarmTopologyRouting,
 };
+use vertex_swarm_primitives::OverlayAddress;
 
-use crate::ClientHandle;
+use crate::{ClientHandle, PeerSelector};
 
 /// Number of closest peers to try, in order, for a retrieval.
 const CLOSEST_PEER_COUNT: usize = 3;
@@ -20,6 +23,7 @@ const CLOSEST_PEER_COUNT: usize = 3;
 pub struct Client<C, S = ()> {
     components: C,
     client_handle: ClientHandle,
+    selector: Option<Arc<PeerSelector>>,
     _storage: std::marker::PhantomData<S>,
 }
 
@@ -29,7 +33,23 @@ impl<C, S> Client<C, S> {
         Self {
             components,
             client_handle,
+            selector: None,
             _storage: std::marker::PhantomData,
+        }
+    }
+
+    /// Order retrieval and pushsync candidates with `selector` (score- and
+    /// affordability-aware) instead of plain proximity order.
+    pub fn with_selector(mut self, selector: Arc<PeerSelector>) -> Self {
+        self.selector = Some(selector);
+        self
+    }
+
+    /// Order proximity-sorted `candidates` for a request on `chunk`.
+    fn select(&self, candidates: Vec<OverlayAddress>, chunk: &ChunkAddress) -> Vec<OverlayAddress> {
+        match &self.selector {
+            Some(selector) => selector.order(candidates, chunk),
+            None => candidates,
         }
     }
 
@@ -87,6 +107,7 @@ where
             .components
             .topology()
             .closest_to(address, CLOSEST_PEER_COUNT);
+        let closest = self.select(closest, address);
         let attempts = closest.len();
 
         // Walk the closest peers in order and return the first response. The
@@ -125,6 +146,7 @@ where
             .components
             .topology()
             .closest_to(&address, CLOSEST_PEER_COUNT);
+        let closest = self.select(closest, &address);
 
         let peer = closest.into_iter().next().ok_or(SwarmError::NoStorer {
             chunk_address: address,
@@ -299,6 +321,90 @@ mod tests {
         assert_eq!(receipt.signature, test_signature());
         assert_eq!(receipt.nonce, Nonce::from([9u8; 32]));
         assert_eq!(receipt.storage_radius.get(), 5);
+    }
+
+    #[tokio::test]
+    async fn put_prefers_affordable_candidate_over_closer_unaffordable_one() {
+        use crate::{PeerScores, PeerSelector, SettlementTrigger};
+        use vertex_swarm_api::{PeerAffordability, SwarmPricing};
+
+        struct NoScores;
+        impl PeerScores for NoScores {
+            fn peer_score(&self, _overlay: &OverlayAddress) -> Option<f64> {
+                None
+            }
+        }
+
+        struct AllUnaffordableExcept(OverlayAddress);
+        impl PeerAffordability for AllUnaffordableExcept {
+            fn can_afford(&self, overlay: &OverlayAddress, _price: u64) -> bool {
+                *overlay == self.0
+            }
+
+            fn allowance_remaining(&self, _overlay: &OverlayAddress) -> u64 {
+                0
+            }
+        }
+
+        struct UnitPricer;
+        impl SwarmPricing for UnitPricer {
+            fn price(&self, _chunk: &ChunkAddress) -> u64 {
+                1
+            }
+
+            fn peer_price(&self, _peer: &OverlayAddress, _chunk: &ChunkAddress) -> u64 {
+                1
+            }
+        }
+
+        struct NoSettlement;
+        impl SettlementTrigger for NoSettlement {
+            fn trigger_settlement(&self, _peer: OverlayAddress) {}
+        }
+
+        let closer = OverlayAddress::from([1u8; 32]);
+        let affordable = OverlayAddress::from([2u8; 32]);
+        let selector = Arc::new(PeerSelector::new(
+            Arc::new(NoScores),
+            Arc::new(AllUnaffordableExcept(affordable)),
+            Arc::new(UnitPricer),
+            Arc::new(NoSettlement),
+        ));
+
+        let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+        let handle = ClientHandle::new(tx);
+        let topology = MockTopology::default().with_closest(vec![closer, affordable]);
+        let bandwidth = Arc::new(Accounting::new(
+            DefaultBandwidthConfig::default(),
+            test_identity(),
+        ));
+        let pricer = FixedPricer::new(10_000, vertex_swarm_spec::init_mainnet());
+        let accounting = ClientAccounting::new(bandwidth, pricer);
+        let client = Client::client(topology, accounting, handle.clone()).with_selector(selector);
+
+        let stamped = test_stamped_chunk();
+        let put = tokio::spawn(async move { client.put(stamped).await });
+
+        // The push must target the affordable candidate even though another
+        // candidate is closer in proximity order.
+        let cmd = rx.recv().await.expect("command emitted");
+        match cmd {
+            ClientCommand::PushChunk { peer, address, .. } => {
+                assert_eq!(peer, affordable);
+                handle.complete_push(
+                    address,
+                    PushReceipt {
+                        storer: affordable,
+                        signature: test_signature(),
+                        nonce: Nonce::from([9u8; 32]),
+                        storage_radius: StorageRadius::new(Bin::new(5).unwrap()),
+                    },
+                );
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        put.await.unwrap().expect("push resolves");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Wires the peer reporting path into bandwidth accounting and makes retrieval/pushsync candidate selection score- and affordability-aware.

**Reporter wiring.** `build_client_backed_node` now builds the node first, takes the peer manager from the topology handle as `Arc<dyn PeerReporter>`, and hands it to `AccountingBuilder::with_reporter` and to the swap settlement service (`SwapService::with_reporter`) for every client-backed node type (client and storer). `SwarmScoringEvent::AccountingViolation` now has live producers end to end: a disconnect-threshold breach in `Accounting::prepare_receive` or a cheque violation in the swap service reaches `PeerManager::report_peer` and feeds scoring, lifecycle events, and bans. The pseudosettle service already takes a reporter but is not yet spawned anywhere in the launch path, so there is nothing further to wire for it in this PR.

**Selection.** New `PeerSelector` in `vertex-swarm-node` (`selection.rs`), applied at all four candidate-selection sites: `NetworkChunkProvider::{retrieve_chunk, push_to_closest}` in the builder and `Client::{get, put}` in the node crate. Topology still yields candidates in proximity order; the selector then excludes peers whose score is at or below `DEFAULT_PEER_WARN_THRESHOLD` (queried live via the peer manager behind the topology handle) and partitions the rest by `PeerAffordability::can_afford` at the per-peer chunk price from `SwarmPricing::peer_price`, the same price the accounting layer debits when the request is served. Affordable peers rank ahead of unaffordable ones; proximity order is preserved within each group. If every candidate is warned or unaffordable, the original proximity order is returned unchanged: degraded service beats failing the request outright.

**Settlement trigger.** Per #175, when a request is blocked on balance (candidates exist but none is affordable) the selector fires a best-effort settlement for the unaffordable candidates through the existing public settlement surface (`SwarmPeerBandwidth::settle`, spawned on the task executor). The settlement providers self-guard (the swap provider no-ops below the early-payment trigger and the service actor serializes commands), so repeated triggers do not double-pay. Pacing settlement against a single peer's allowance remains the bandwidth layer's job and is tracked by the self-throttle issues below.

## Notes

- The warned-range check uses `DEFAULT_PEER_WARN_THRESHOLD` from `vertex-swarm-api`. The peer manager exposes `get_peer_score` but no query for its configured warn threshold, and peer-manager changes are out of scope here (a parallel PR is reworking its storage); if an operator overrides `--network.peer.warn-threshold`, selection still excludes at the default. Worth folding into the peer manager query surface in a follow-up.
- The accounting read surface used by `providers.rs` is trait-only (`PeerAffordability`, `SwarmPricing`, both from `vertex-swarm-api`); no concrete bandwidth-crate types leak into the provider.
- Decision recorded for #176: the push path does not yet debit accounting anywhere (neither send nor receive side), so this PR gates and ranks pushes by the same affordability surface retrieval uses; the actual debit and the `ceil(chunk_size / settle_unit_size)` cost model land with #131.

## Tests

- `selection.rs` unit matrix: warned peer excluded, unknown peer not treated as warned, unaffordable peer deprioritized, all-unaffordable falls back to proximity order (and triggers settlement), all-warned falls back to proximity order, healthy affordable candidates preserve proximity order, settlement not triggered while an affordable candidate exists.
- `swarm_client.rs`: `put` routes to the affordable candidate over a closer unaffordable one.
- `launch.rs`: builder-level wiring test that an accounting violation (debit past the disconnect threshold) reaches the peer manager and lowers the peer's score, composed exactly as the launch path wires it.
- Full workspace `cargo test --all-features` green; `cargo clippy --all-targets --all-features -- -D warnings` clean.
- E2e: `vertex node --swarm testnet` starts clean, dials bootnodes, no panics, clean shutdown. Live retrieval/pushsync cannot be exercised against testnet (bee 2.9.0-rc1 bootnodes reset after protocol negotiation, #217); the selection unit matrix is the functional verification.

## Related

#130, #131, and #132 (outbound self-throttling) will reuse `PeerAffordability` and compose with this selection: selection picks affordable peers, the self-throttle paces requests to each.

Closes #175
Closes #176
