### PR TITLE
feat(swarm-peer-manager): score decay, connected recovery, timed bans

### DIFF
--- a/crates/net/peer/score/src/lib.rs
+++ b/crates/net/peer/score/src/lib.rs
@@ -79,13 +79,17 @@ impl PeerScore {
     ///
     /// A `half_life_secs` of zero is treated as infinitely fast decay and
     /// resets the score to zero.
-    pub fn decay(&self, half_life_secs: u64, elapsed_secs: u64) {
+    ///
+    /// Returns `(old, new)` from the successful update so callers can keep
+    /// score aggregates consistent without racing a separate load.
+    pub fn decay(&self, half_life_secs: u64, elapsed_secs: u64) -> (f64, f64) {
         if elapsed_secs == 0 {
-            return;
+            let current = self.score.load(Ordering::Acquire);
+            return (current, current);
         }
         if half_life_secs == 0 {
-            self.score.store(0.0, Ordering::Release);
-            return;
+            let old = self.score.swap(0.0, Ordering::AcqRel);
+            return (old, 0.0);
         }
         let factor = 0.5_f64.powf(elapsed_secs as f64 / half_life_secs as f64);
         loop {
@@ -96,14 +100,16 @@ impl PeerScore {
                 .compare_exchange_weak(current, new_val, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
             {
-                return;
+                return (current, new_val);
             }
         }
     }
 
-    pub fn set_score(&self, score: f64) {
+    /// Set the score directly, clamped to bounds; returns `(old, new)`.
+    pub fn set_score(&self, score: f64) -> (f64, f64) {
         let clamped = score.clamp(MIN_SCORE, MAX_SCORE);
-        self.score.store(clamped, Ordering::Release);
+        let old = self.score.swap(clamped, Ordering::AcqRel);
+        (old, clamped)
     }
 
     pub fn should_ban(&self, threshold: f64) -> bool {
@@ -258,10 +264,25 @@ mod tests {
     }
 
     #[test]
+    fn test_set_score_returns_old_and_new() {
+        let score = PeerScore::new();
+        let (old, new) = score.set_score(42.0);
+        assert_eq!(old, 0.0);
+        assert!((new - 42.0).abs() < 0.001);
+
+        // Clamped values report the clamped new score.
+        let (old, new) = score.set_score(-200.0);
+        assert!((old - 42.0).abs() < 0.001);
+        assert!((new - MIN_SCORE).abs() < 0.001);
+    }
+
+    #[test]
     fn test_decay_halves_over_one_half_life() {
         let score = PeerScore::new();
         score.set_score(80.0);
-        score.decay(600, 600);
+        let (old, new) = score.decay(600, 600);
+        assert!((old - 80.0).abs() < 0.001);
+        assert!((new - 40.0).abs() < 0.001);
         assert!((score.score() - 40.0).abs() < 0.001);
 
         // Negative scores decay toward zero too.

--- a/crates/swarm/peers/peer-manager/src/entry.rs
+++ b/crates/swarm/peers/peer-manager/src/entry.rs
@@ -57,6 +57,16 @@ const STALE_THRESHOLD_SECS: u64 = 24 * 3600;
 /// Stale regardless of last_seen after this many consecutive failures (~48h of persistent failure).
 const STALE_FAILURE_THRESHOLD: u32 = 48;
 
+/// Score half-life for disconnected peers (10 minutes).
+pub(crate) const DISCONNECTED_SCORE_HALF_LIFE_SECS: u64 = 600;
+
+/// Score half-life for connected peers (5 minutes).
+///
+/// Double-rate decay: a connected peer that keeps behaving recovers its
+/// reputation twice as fast as a disconnected one, while a connected peer
+/// coasting on past goodwill loses it twice as fast too.
+pub(crate) const CONNECTED_SCORE_HALF_LIFE_SECS: u64 = 300;
+
 /// `(banned_at_unix_secs, reason)`. Runtime-only; never persisted.
 pub(crate) type BanInfo = (u64, String);
 
@@ -204,6 +214,13 @@ pub(crate) struct PeerEntry {
     last_seen: AtomicU64,
     backoff: PeerBackoff,
     ban_info: RwLock<Option<BanInfo>>,
+    /// Unix seconds of the last score decay pass over this entry.
+    ///
+    /// Updated by every tick (banned or not), so elapsed time is measured
+    /// against real ticks rather than an assumed cadence: a missed tick
+    /// decays by the true elapsed time on the next one, and a freshly
+    /// unbanned peer decays only from the tick that lifted the ban.
+    last_decay: AtomicU64,
     jitter_seed: u64,
     /// Unix seconds since the current connection completed its handshake;
     /// 0 while disconnected. Process-local, never persisted.
@@ -230,6 +247,7 @@ impl PeerEntry {
             last_seen: AtomicU64::new(now),
             backoff: PeerBackoff::new(),
             ban_info: RwLock::new(None),
+            last_decay: AtomicU64::new(now),
             jitter_seed: jitter_seed_from_overlay(&overlay),
             connected_since: AtomicU64::new(0),
             direction: AtomicU8::new(DIRECTION_NONE),
@@ -251,6 +269,7 @@ impl PeerEntry {
             last_seen: AtomicU64::new(snapshot.last_seen),
             backoff: PeerBackoff::new(),
             ban_info: RwLock::new(None),
+            last_decay: AtomicU64::new(unix_timestamp_secs()),
             jitter_seed: jitter_seed_from_overlay(&overlay),
             connected_since: AtomicU64::new(0),
             direction: AtomicU8::new(DIRECTION_NONE),
@@ -328,9 +347,42 @@ impl PeerEntry {
     /// Apply a scoring event, returning the outcome and score transition.
     ///
     /// Score changes flow exclusively through the peer manager's report
-    /// path; this is the only entry-level scoring write.
+    /// path; the only other scoring writes are the tick-driven
+    /// [`Self::decay_score`] and the unban-path [`Self::reset_score`].
     pub(crate) fn record_event(&self, event: SwarmScoringEvent) -> ScoreChange {
         self.scoring.record_event_change(event)
+    }
+
+    /// Decay the score toward zero for the time elapsed since the last
+    /// decay pass, returning `(old, new)` when a decay was applied.
+    ///
+    /// Connected peers decay at double rate
+    /// ([`CONNECTED_SCORE_HALF_LIFE_SECS`] vs
+    /// [`DISCONNECTED_SCORE_HALF_LIFE_SECS`]); both positive and negative
+    /// scores decay, so reputation is recency-weighted in either direction.
+    /// The elapsed clock always advances, but banned peers skip the decay
+    /// itself: their score is overwritten by the reset when the ban expires.
+    pub(crate) fn decay_score(&self, now_unix_secs: u64) -> Option<(f64, f64)> {
+        let prev = self.last_decay.swap(now_unix_secs, Ordering::AcqRel);
+        let elapsed = now_unix_secs.saturating_sub(prev);
+        if elapsed == 0 || self.is_banned() || self.score() == 0.0 {
+            return None;
+        }
+        let half_life = if self.is_connected() {
+            CONNECTED_SCORE_HALF_LIFE_SECS
+        } else {
+            DISCONNECTED_SCORE_HALF_LIFE_SECS
+        };
+        Some(self.scoring.decay(half_life, elapsed))
+    }
+
+    /// Reset the score to `score`, returning `(old, new)`.
+    ///
+    /// Used by the unban path to restart an expired ban at the disconnect
+    /// threshold; see [`SwarmPeerScore::reset`] for the warning-state
+    /// semantics.
+    pub(crate) fn reset_score(&self, score: f64) -> (f64, f64) {
+        self.scoring.reset(score)
     }
 
     /// Record connection state at handshake completion.
@@ -385,6 +437,12 @@ impl PeerEntry {
 
     pub(crate) fn ban(&self, reason: Option<String>) {
         *self.ban_info.write() = Some((unix_timestamp_secs(), reason.unwrap_or_default()));
+    }
+
+    /// Clear the ban marker (the manager's unban path owns the rest of the
+    /// unban bookkeeping: banned-set removal, score reset, lifecycle event).
+    pub(crate) fn clear_ban(&self) {
+        *self.ban_info.write() = None;
     }
 
     pub(crate) fn record_dial_failure(&self) {

--- a/crates/swarm/peers/peer-manager/src/maintenance.rs
+++ b/crates/swarm/peers/peer-manager/src/maintenance.rs
@@ -1,4 +1,5 @@
-//! Periodic maintenance: stale-peer purging and snapshot persistence.
+//! Periodic maintenance: score decay, ban expiry, stale-peer purging, and
+//! snapshot persistence.
 
 use metrics::gauge;
 use std::sync::atomic::Ordering;
@@ -13,11 +14,17 @@ impl<I: SwarmIdentity> PeerManager<I> {
     /// Single periodic entry point, driven from outside the crate (see
     /// [`crate::spawn_peer_manager_task`]).
     ///
-    /// Purges stale never-connected peers and writes a snapshot when one is
-    /// due ([`PeerManagerConfig::snapshot_interval`](crate::PeerManagerConfig)
+    /// In order: decays every peer's score toward zero (10 minute half-life
+    /// disconnected, 5 minutes connected), lifts expired timed bans
+    /// (resetting the score to the disconnect threshold and emitting
+    /// `Unbanned`), purges stale never-connected peers, and
+    /// writes a snapshot when one is due
+    /// ([`PeerManagerConfig::snapshot_interval`](crate::PeerManagerConfig)
     /// since the last write). `now_unix_secs` is injected so tests can drive
     /// the schedule without a clock.
     pub fn tick(&self, now_unix_secs: u64) {
+        self.decay_scores(now_unix_secs);
+        self.expire_bans(now_unix_secs);
         self.purge_stale();
 
         if self.store.is_none() {
@@ -51,6 +58,45 @@ impl<I: SwarmIdentity> PeerManager<I> {
         match store.store(&records) {
             Ok(()) => debug!(peers = records.len(), "wrote peer snapshot"),
             Err(e) => warn!(error = %e, "failed to write peer snapshot"),
+        }
+    }
+
+    /// Decay every peer's score toward zero for the time elapsed since the
+    /// peer's last decay pass.
+    ///
+    /// Disconnected peers decay at a 10 minute half-life, connected peers
+    /// at double rate (5 minutes); both positive and negative scores decay,
+    /// so reputation is recency-weighted. Elapsed time is tracked per peer
+    /// ([`PeerEntry::decay_score`]), so the decay is exact even when a tick
+    /// is missed. Banned peers are skipped: the unban path resets their
+    /// score outright.
+    fn decay_scores(&self, now_unix_secs: u64) {
+        for r in self.peers.iter() {
+            if let Some((old_score, new_score)) = r.value().decay_score(now_unix_secs) {
+                self.score_distribution
+                    .on_score_changed(old_score, new_score);
+            }
+        }
+    }
+
+    /// Lift every timed ban whose expiry has passed (`now >= until`).
+    ///
+    /// Permanent bans (expiry `None`) are never lifted here. Each expired
+    /// ban goes through [`Self::unban`]: banned-set removal, score reset to
+    /// the disconnect threshold, and a single
+    /// [`PeerLifecycleEvent::Unbanned`](vertex_swarm_api::PeerLifecycleEvent)
+    /// emission.
+    fn expire_bans(&self, now_unix_secs: u64) {
+        let expired: Vec<OverlayAddress> = self
+            .banned_set
+            .iter()
+            .filter(|r| r.value().is_some_and(|until| now_unix_secs >= until))
+            .map(|r| *r.key())
+            .collect();
+
+        for overlay in &expired {
+            debug!(?overlay, "ban expired; unbanning peer");
+            self.unban(overlay);
         }
     }
 

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use metrics::{counter, gauge};
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
@@ -68,6 +68,12 @@ pub struct PeerManagerConfig {
     pub max_per_bin: usize,
     /// Minimum time between periodic snapshots written by [`PeerManager::tick`].
     pub snapshot_interval: Duration,
+    /// How long a timed ban lasts before [`PeerManager::tick`] lifts it.
+    ///
+    /// Applies to every ban except [`PeerManager::ban_permanent`]. On expiry
+    /// the peer's score is reset to the disconnect threshold, so it must
+    /// behave to climb back; it is not forgiven to neutral.
+    pub ban_duration: Duration,
     /// Snapshot persistence; `None` keeps the peer set memory-only.
     pub store: Option<Arc<dyn PeerSnapshotStore<PeerSnapshot>>>,
 }
@@ -84,6 +90,13 @@ impl PeerManagerConfig {
     /// Trades snapshot-write frequency against how many freshly learned
     /// peers a crash can lose.
     pub const DEFAULT_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(300);
+
+    /// Default timed ban duration (12 hours).
+    ///
+    /// Long enough that a misbehaving peer cannot grind through ban cycles
+    /// cheaply, short enough that a transiently broken peer is not lost for
+    /// good; bans never survive a restart either way.
+    pub const DEFAULT_BAN_DURATION: Duration = Duration::from_secs(12 * 3600);
 }
 
 impl Default for PeerManagerConfig {
@@ -92,6 +105,7 @@ impl Default for PeerManagerConfig {
             scoring: SwarmScoringConfig::default(),
             max_per_bin: Self::DEFAULT_MAX_PER_BIN,
             snapshot_interval: Self::DEFAULT_SNAPSHOT_INTERVAL,
+            ban_duration: Self::DEFAULT_BAN_DURATION,
             store: None,
         }
     }
@@ -111,12 +125,16 @@ pub struct PeerManager<I: SwarmIdentity> {
     pub(crate) peers: DashMap<OverlayAddress, Arc<PeerEntry>>,
     /// Snapshot persistence (None for ephemeral/test mode).
     pub(crate) store: Option<Arc<dyn PeerSnapshotStore<PeerSnapshot>>>,
-    /// O(1) ban checks. Starts empty on every startup: bans are runtime-only.
-    pub(crate) banned_set: DashSet<OverlayAddress>,
+    /// O(1) ban checks, mapping each banned overlay to its ban expiry in
+    /// unix seconds (`None` for a permanent ban). Starts empty on every
+    /// startup: bans are runtime-only.
+    pub(crate) banned_set: DashMap<OverlayAddress, Option<u64>>,
     /// Scoring configuration.
     pub(crate) scoring_config: Arc<SwarmScoringConfig>,
     /// Minimum time between periodic snapshots.
     pub(crate) snapshot_interval: Duration,
+    /// Duration of a timed ban.
+    pub(crate) ban_duration: Duration,
     /// Unix seconds of the last periodic snapshot.
     pub(crate) last_snapshot: AtomicU64,
     /// Per-bucket gauge tracking of score distribution.
@@ -137,6 +155,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
             scoring,
             max_per_bin,
             snapshot_interval,
+            ban_duration,
             store,
         } = config;
         let local_overlay = identity.overlay_address();
@@ -147,9 +166,10 @@ impl<I: SwarmIdentity> PeerManager<I> {
             index: ProximityIndex::new(local_overlay, max_po, max_per_bin),
             peers: DashMap::new(),
             store,
-            banned_set: DashSet::new(),
+            banned_set: DashMap::new(),
             scoring_config: Arc::new(scoring),
             snapshot_interval,
+            ban_duration,
             last_snapshot: AtomicU64::new(unix_timestamp_secs()),
             score_distribution: Arc::new(ScoreDistribution::new()),
             lifecycle_tx,
@@ -196,7 +216,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
             .iter_by_proximity()
             .map(|(_, overlay)| overlay)
             .filter(|overlay| {
-                !self.banned_set.contains(overlay)
+                !self.banned_set.contains_key(overlay)
                     && self
                         .peers
                         .get(overlay)
@@ -209,7 +229,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
     #[must_use]
     pub fn storer_overlays_in_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
         self.index.filter_bin(bin, count, |overlay| {
-            !self.banned_set.contains(overlay)
+            !self.banned_set.contains_key(overlay)
                 && self
                     .peers
                     .get(overlay)
@@ -232,7 +252,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
         candidates
             .iter()
             .filter_map(|overlay| {
-                if self.banned_set.contains(overlay) {
+                if self.banned_set.contains_key(overlay) {
                     return None;
                 }
                 let entry = self.peers.get(overlay)?;
@@ -244,7 +264,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
     /// Get dialable overlay addresses from a specific bin (not banned, not in backoff).
     pub fn dialable_overlays_in_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
         self.index.filter_bin(bin, count, |overlay| {
-            !self.banned_set.contains(overlay)
+            !self.banned_set.contains_key(overlay)
                 && self.peers.get(overlay).is_some_and(|e| e.is_dialable())
         })
     }
@@ -274,7 +294,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
     /// Get a snapshot of all banned peer overlays.
     #[must_use]
     pub fn banned_set(&self) -> std::collections::HashSet<OverlayAddress> {
-        self.banned_set.iter().map(|r| *r).collect()
+        self.banned_set.iter().map(|r| *r.key()).collect()
     }
 
     /// Get a snapshot of all peers currently in backoff.
@@ -293,10 +313,10 @@ impl<I: SwarmIdentity> PeerManager<I> {
         self.peers.get(overlay).is_some_and(|e| e.is_in_backoff())
     }
 
-    /// Check if peer is banned (O(1) via DashSet).
+    /// Check if peer is banned (O(1) via the banned map).
     #[must_use]
     pub fn is_banned(&self, overlay: &OverlayAddress) -> bool {
-        self.banned_set.contains(overlay)
+        self.banned_set.contains_key(overlay)
     }
 
     /// Number of currently banned peers (O(1)).
@@ -305,14 +325,44 @@ impl<I: SwarmIdentity> PeerManager<I> {
         self.banned_set.len()
     }
 
-    /// Ban a peer (prevents dialing) and emit [`PeerLifecycleEvent::Banned`].
+    /// Ban a peer for [`PeerManagerConfig::ban_duration`] and emit
+    /// [`PeerLifecycleEvent::Banned`] with the expiry.
     ///
     /// Topology subscribes to the lifecycle stream and closes the banned
-    /// peer's connection. Bans are runtime-only: they never persist across a
-    /// restart and currently have no scheduled expiry within a session.
+    /// peer's connection. [`Self::tick`] lifts the ban once the expiry
+    /// passes, resetting the score to the disconnect threshold and emitting
+    /// [`PeerLifecycleEvent::Unbanned`]. Banning an already banned peer is a
+    /// no-op: the original expiry stands and no second event is emitted.
+    /// Bans are runtime-only and never persist across a restart.
     pub fn ban(&self, overlay: &OverlayAddress, cause: BanCause, reason: Option<String>) {
-        if !self.banned_set.insert(*overlay) {
-            return; // Already banned
+        let until = unix_timestamp_secs() + self.ban_duration.as_secs();
+        self.ban_with_expiry(overlay, cause, reason, Some(until));
+    }
+
+    /// Ban a peer with no scheduled expiry; [`Self::tick`] never lifts it,
+    /// so only a restart clears it (bans never persist).
+    ///
+    /// Reserved for operator-initiated bans; the operator surface that calls
+    /// this arrives with the gRPC work.
+    pub fn ban_permanent(&self, overlay: &OverlayAddress, cause: BanCause, reason: Option<String>) {
+        self.ban_with_expiry(overlay, cause, reason, None);
+    }
+
+    fn ban_with_expiry(
+        &self,
+        overlay: &OverlayAddress,
+        cause: BanCause,
+        reason: Option<String>,
+        until: Option<u64>,
+    ) {
+        use dashmap::mapref::entry::Entry;
+
+        match self.banned_set.entry(*overlay) {
+            // Already banned: keep the original expiry, emit nothing.
+            Entry::Occupied(_) => return,
+            Entry::Vacant(vacant) => {
+                vacant.insert(until);
+            }
         }
 
         gauge!("peer_manager_banned_peers").increment(1.0);
@@ -321,22 +371,44 @@ impl<I: SwarmIdentity> PeerManager<I> {
             && !entry.is_banned()
         {
             let old_state = entry.health_state();
-            warn!(?overlay, %cause, ?reason, "banning peer");
+            warn!(?overlay, %cause, ?reason, until, "banning peer");
             entry.ban(reason);
             on_health_changed(old_state, HealthState::Banned);
         }
 
         self.emit(PeerLifecycleEvent::Banned {
             overlay: *overlay,
-            until: None,
+            until,
             reason: cause,
         });
+    }
+
+    /// Lift a peer's ban: clear the ban state, reset the score to the
+    /// disconnect threshold, and emit [`PeerLifecycleEvent::Unbanned`].
+    ///
+    /// The score reset means an unbanned peer must behave to climb back; it
+    /// is not forgiven to neutral. The event is emitted exactly once per
+    /// ban (guarded by the banned-set removal).
+    pub(crate) fn unban(&self, overlay: &OverlayAddress) {
+        if let Some(entry) = self.peers.get(overlay) {
+            let old_state = entry.health_state();
+            entry.clear_ban();
+            let (old_score, new_score) =
+                entry.reset_score(self.scoring_config.disconnect_threshold());
+            self.score_distribution
+                .on_score_changed(old_score, new_score);
+            on_health_changed(old_state, entry.health_state());
+        }
+        if self.banned_set.remove(overlay).is_some() {
+            gauge!("peer_manager_banned_peers").decrement(1.0);
+            self.emit(PeerLifecycleEvent::Unbanned { overlay: *overlay });
+        }
     }
 
     /// Subscribe to the peer lifecycle event stream.
     ///
     /// The stream carries every [`PeerLifecycleEvent`]: connects,
-    /// disconnects, score warnings, disconnect requests, and bans.
+    /// disconnects, score warnings, disconnect requests, bans, and unbans.
     ///
     /// # Lagged-receiver policy
     ///
@@ -1594,6 +1666,273 @@ mod tests {
 
         assert_eq!(pm.node_type(&overlay), Some(SwarmNodeType::Storer));
         assert_eq!(pm.trust_level(&overlay), TrustLevel::Trusted);
+    }
+
+    #[test]
+    fn test_tick_decays_disconnected_score_across_ticks() {
+        let pm = manager();
+        let overlay = test_overlay(1);
+        pm.store_discovered_peer(test_swarm_peer(1));
+        for _ in 0..4 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Topology,
+            );
+        }
+        assert_eq!(pm.get_peer_score(&overlay), Some(-12.0));
+
+        // Two ticks spanning one disconnected half-life (10 minutes).
+        let start = unix_timestamp_secs();
+        pm.tick(start + 300);
+        pm.tick(start + 600);
+
+        let score = pm.get_peer_score(&overlay).unwrap();
+        assert!(
+            (score + 6.0).abs() < 0.1,
+            "one disconnected half-life must halve the score, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_tick_decays_connected_score_at_double_rate() {
+        let pm = manager();
+        let overlay = test_overlay(1);
+        connect(&pm, 1, SwarmNodeType::Client); // ConnectionSuccess: +1
+        for _ in 0..4 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Topology,
+            );
+        }
+        assert_eq!(pm.get_peer_score(&overlay), Some(-11.0));
+
+        // 10 minutes is two connected half-lives: the score quarters.
+        let start = unix_timestamp_secs();
+        pm.tick(start + 600);
+
+        let score = pm.get_peer_score(&overlay).unwrap();
+        assert!(
+            (score + 2.75).abs() < 0.1,
+            "two connected half-lives must quarter the score, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_decay_is_robust_to_missed_ticks() {
+        let pm = manager();
+        let overlay = test_overlay(1);
+        pm.store_discovered_peer(test_swarm_peer(1));
+        for _ in 0..4 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Topology,
+            );
+        }
+
+        // A single late tick spanning two half-lives decays by the true
+        // elapsed time, not by one tick interval.
+        let start = unix_timestamp_secs();
+        pm.tick(start + 1200);
+
+        let score = pm.get_peer_score(&overlay).unwrap();
+        assert!(
+            (score + 3.0).abs() < 0.1,
+            "a missed tick must still decay by the full elapsed time, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_positive_scores_decay_too() {
+        let pm = manager();
+        let overlay = test_overlay(1);
+        connect(&pm, 1, SwarmNodeType::Client); // +1
+
+        let start = unix_timestamp_secs();
+        pm.tick(start + 300); // one connected half-life
+
+        let score = pm.get_peer_score(&overlay).unwrap();
+        assert!(
+            (score - 0.5).abs() < 0.05,
+            "positive reputation is recency-weighted and decays, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_ban_expiry_resets_score_and_emits_unbanned_once() {
+        let pm = manager();
+        let overlay = test_overlay(1);
+        connect(&pm, 1, SwarmNodeType::Client);
+        let mut rx = pm.subscribe();
+
+        pm.ban(&overlay, BanCause::Requested, Some("test".into()));
+        let until = drain_events(&mut rx)
+            .iter()
+            .find_map(|e| match e {
+                PeerLifecycleEvent::Banned {
+                    overlay: o, until, ..
+                } if *o == overlay => *until,
+                _ => None,
+            })
+            .expect("timed ban must carry an expiry");
+
+        // One second before expiry: still banned.
+        pm.tick(until - 1);
+        assert!(pm.is_banned(&overlay));
+        assert!(
+            drain_events(&mut rx)
+                .iter()
+                .all(|e| !matches!(e, PeerLifecycleEvent::Unbanned { .. }))
+        );
+
+        // Exactly at expiry (now >= until): unbanned, score reset to the
+        // disconnect threshold so the peer must behave to climb back.
+        pm.tick(until);
+        assert!(!pm.is_banned(&overlay));
+        assert_eq!(pm.banned_count(), 0);
+        assert!(pm.eligible_peers().contains(&overlay));
+        assert_eq!(
+            pm.get_peer_score(&overlay),
+            Some(pm.scoring_config.disconnect_threshold()),
+            "an expired ban resets the score to the disconnect threshold"
+        );
+        let unbans = drain_events(&mut rx)
+            .iter()
+            .filter(|e| matches!(e, PeerLifecycleEvent::Unbanned { overlay: o } if *o == overlay))
+            .count();
+        assert_eq!(unbans, 1, "Unbanned must be emitted exactly once");
+
+        // Later ticks do not re-emit.
+        pm.tick(until + 600);
+        assert!(
+            drain_events(&mut rx)
+                .iter()
+                .all(|e| !matches!(e, PeerLifecycleEvent::Unbanned { .. }))
+        );
+    }
+
+    #[test]
+    fn test_permanent_ban_never_expires() {
+        let pm = manager();
+        let overlay = test_overlay(1);
+        connect(&pm, 1, SwarmNodeType::Client);
+        let mut rx = pm.subscribe();
+
+        pm.ban_permanent(&overlay, BanCause::Requested, Some("operator".into()));
+        assert!(drain_events(&mut rx).iter().any(|e| matches!(
+            e,
+            PeerLifecycleEvent::Banned {
+                overlay: o,
+                until: None,
+                ..
+            } if *o == overlay
+        )));
+
+        let start = unix_timestamp_secs();
+        pm.tick(start + 365 * 24 * 3600);
+        assert!(pm.is_banned(&overlay), "permanent bans never expire");
+        assert!(
+            drain_events(&mut rx)
+                .iter()
+                .all(|e| !matches!(e, PeerLifecycleEvent::Unbanned { .. }))
+        );
+    }
+
+    #[test]
+    fn test_reports_for_banned_peer_are_dropped() {
+        let pm = thresholds_manager();
+        let overlay = test_overlay(1);
+        connect(&pm, 1, SwarmNodeType::Client);
+        let mut rx = pm.subscribe();
+
+        // Drive the peer to the ban threshold.
+        for _ in 0..15 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Protocol("test"),
+            );
+        }
+        assert!(pm.is_banned(&overlay));
+        let until = drain_events(&mut rx)
+            .iter()
+            .find_map(|e| match e {
+                PeerLifecycleEvent::Banned {
+                    overlay: o, until, ..
+                } if *o == overlay => *until,
+                _ => None,
+            })
+            .expect("auto-ban must carry an expiry");
+        let score_at_ban = pm.get_peer_score(&overlay).unwrap();
+
+        // Lingering streams keep reporting: every report is dropped.
+        for _ in 0..5 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Protocol("test"),
+            );
+        }
+        assert_eq!(
+            pm.get_peer_score(&overlay),
+            Some(score_at_ban),
+            "reports while banned must not change the score"
+        );
+        assert!(
+            drain_events(&mut rx).is_empty(),
+            "reports while banned must not emit lifecycle events"
+        );
+
+        // The original expiry stands: the extra reports did not extend it.
+        pm.tick(until);
+        assert!(
+            !pm.is_banned(&overlay),
+            "reports during the ban must not extend the expiry"
+        );
+    }
+
+    #[test]
+    fn test_warning_fires_again_after_decay_recovery() {
+        let pm = thresholds_manager();
+        let overlay = test_overlay(1);
+        connect(&pm, 1, SwarmNodeType::Client); // +1
+        let mut rx = pm.subscribe();
+
+        // +1 -> -11: crosses the warn threshold (-10) once.
+        for _ in 0..4 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Topology,
+            );
+        }
+        let warnings = drain_events(&mut rx)
+            .iter()
+            .filter(|e| matches!(e, PeerLifecycleEvent::ScoreWarning { .. }))
+            .count();
+        assert_eq!(warnings, 1);
+
+        // One connected half-life halves -11 to about -5.5, above the warn
+        // threshold: the one-shot warning re-arms.
+        let start = unix_timestamp_secs();
+        pm.tick(start + 300);
+        assert!(pm.get_peer_score(&overlay).unwrap() > -10.0);
+
+        // Descend again: about -8.5 then about -11.5, warning fires again.
+        for _ in 0..2 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Topology,
+            );
+        }
+        let warnings = drain_events(&mut rx)
+            .iter()
+            .filter(|e| matches!(e, PeerLifecycleEvent::ScoreWarning { .. }))
+            .count();
+        assert_eq!(warnings, 1, "a recovered peer must be warnable again");
     }
 
     #[test]

--- a/crates/swarm/peers/peer-manager/src/scoring.rs
+++ b/crates/swarm/peers/peer-manager/src/scoring.rs
@@ -34,12 +34,22 @@ impl<I: SwarmIdentity> PeerManager<I> {
     ///
     /// Reports for unknown peers are dropped: scoring only applies to peers
     /// the manager tracks.
+    ///
+    /// Reports for banned peers are dropped entirely. A banned peer's
+    /// lingering streams can keep producing events until topology closes
+    /// the connection; ignoring them guarantees a repeat offender cannot
+    /// re-emit `Banned`, extend its ban expiry, or perturb the score that
+    /// the unban path resets to the disconnect threshold.
     pub fn report_peer(
         &self,
         overlay: &OverlayAddress,
         event: SwarmScoringEvent,
         source: ReportSource,
     ) {
+        if self.banned_set.contains_key(overlay) {
+            trace!(?overlay, ?event, "dropping report for banned peer");
+            return;
+        }
         let Some(entry) = self
             .peers
             .get(overlay)

--- a/crates/swarm/peers/peer-manager/src/tasks.rs
+++ b/crates/swarm/peers/peer-manager/src/tasks.rs
@@ -17,8 +17,11 @@ use crate::entry::unix_timestamp_secs;
 
 /// Default interval between maintenance ticks.
 ///
-/// Each tick purges stale peers; snapshots are written only when
-/// [`crate::PeerManagerConfig::snapshot_interval`] has elapsed.
+/// Each tick decays peer scores, lifts expired bans, and purges stale
+/// peers; snapshots are written only when
+/// [`crate::PeerManagerConfig::snapshot_interval`] has elapsed. Score decay
+/// is elapsed-based per peer, so a delayed or missed tick decays by the
+/// true elapsed time on the next run.
 pub const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Spawn the periodic maintenance task driving [`PeerManager::tick`].

--- a/crates/swarm/peers/peer-score/src/score.rs
+++ b/crates/swarm/peers/peer-score/src/score.rs
@@ -109,17 +109,35 @@ impl SwarmPeerScore {
         }
     }
 
-    /// Exponentially decay the score toward zero.
+    /// Exponentially decay the score toward zero, returning `(old, new)`.
     ///
     /// Delegates to [`PeerScore::decay`]; callers pass elapsed time from
     /// their own heartbeat. Resets the one-shot warning state when the
     /// decayed score has recovered above the warning threshold so a later
-    /// descent warns again.
-    pub fn decay(&self, half_life_secs: u64, elapsed_secs: u64) {
-        self.score.decay(half_life_secs, elapsed_secs);
-        if !self.config.should_warn(self.score.score()) {
+    /// descent warns again. The returned transition lets callers keep score
+    /// aggregates consistent under concurrent recording.
+    pub fn decay(&self, half_life_secs: u64, elapsed_secs: u64) -> (f64, f64) {
+        let (old_score, new_score) = self.score.decay(half_life_secs, elapsed_secs);
+        if !self.config.should_warn(new_score) {
             self.warned.store(false, Ordering::Release);
         }
+        (old_score, new_score)
+    }
+
+    /// Reset the score to `score` (clamped to the scale), returning
+    /// `(old, new)`.
+    ///
+    /// The one-shot warning state is aligned with the new value: a reset
+    /// into the warn band does not fire a fresh warning on the next
+    /// negative event (the caller already acted on the peer), while a reset
+    /// above the warn threshold re-arms the warning. The peer manager uses
+    /// this when a timed ban expires to restart the peer at the disconnect
+    /// threshold.
+    pub fn reset(&self, score: f64) -> (f64, f64) {
+        let (old_score, new_score) = self.score.set_score(score);
+        self.warned
+            .store(self.config.should_warn(new_score), Ordering::Release);
+        (old_score, new_score)
     }
 
     /// Record latency without affecting score.
@@ -358,6 +376,66 @@ mod tests {
             score.record_event(SwarmScoringEvent::AccountingViolation), // about -60
             ScoreOutcome::Warn
         );
+    }
+
+    #[test]
+    fn test_reset_returns_transition_and_aligns_warning() {
+        let score = SwarmPeerScore::with_defaults();
+
+        // Reset into the warn band (-75 is below the -50 warn threshold).
+        let (old, new) = score.reset(-75.0);
+        assert_eq!(old, 0.0);
+        assert_eq!(new, -75.0);
+        assert_eq!(score.score(), -75.0);
+
+        // The warning state matches the band: no fresh warning fires on the
+        // next negative event.
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ProtocolError),
+            ScoreOutcome::Ok
+        );
+
+        // Decay back above the warn threshold re-arms the warning; a fresh
+        // descent warns again.
+        score.decay(60, 600);
+        assert!(score.score() > -1.0);
+        score.record_event(SwarmScoringEvent::AccountingViolation); // about -20
+        score.record_event(SwarmScoringEvent::AccountingViolation); // about -40
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::AccountingViolation), // about -60
+            ScoreOutcome::Warn
+        );
+    }
+
+    #[test]
+    fn test_reset_above_warn_rearms_warning() {
+        let score = SwarmPeerScore::with_defaults();
+
+        // Warn once on the way down.
+        score.record_event(SwarmScoringEvent::MaliciousBehavior); // -50
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ProtocolError), // -53
+            ScoreOutcome::Warn
+        );
+
+        // Reset to neutral: warning is re-armed for the next descent.
+        let (old, new) = score.reset(0.0);
+        assert_eq!(old, -53.0);
+        assert_eq!(new, 0.0);
+        score.record_event(SwarmScoringEvent::MaliciousBehavior); // -50
+        assert_eq!(
+            score.record_event(SwarmScoringEvent::ProtocolError), // -53
+            ScoreOutcome::Warn
+        );
+    }
+
+    #[test]
+    fn test_decay_returns_transition() {
+        let score = SwarmPeerScore::with_defaults();
+        score.reset(-40.0);
+        let (old, new) = score.decay(600, 600);
+        assert!((old + 40.0).abs() < 0.001);
+        assert!((new + 20.0).abs() < 0.001);
     }
 
     #[test]

--- a/docs/networking/peer-management.md
+++ b/docs/networking/peer-management.md
@@ -117,18 +117,22 @@ Persistence is an opt-in, identity-only snapshot. The `PeerSnapshotStore` trait 
 
 The persisted record (`PeerSnapshot`) carries only the signed peer record, the last known node type, and a last-seen timestamp. Reputation never survives a restart: scores, bans, and dial backoff are runtime-only and the banned set starts empty on every startup. Bans are timed and re-earned within seconds of a misbehaving peer reconnecting, so persisting them buys nothing.
 
-Snapshots are written by `PeerManager::tick`, the single periodic maintenance entry point (snapshot when due, stale-peer purge every tick). The manager owns no timers; a thin driver (`spawn_peer_manager_task`) is spawned from the node launch path, and topology writes a final snapshot on graceful shutdown. Crash-loss story: a crash loses at most one snapshot interval (default 5 minutes) of newly discovered peers, which rediscovery via bootnodes and hive gossip replaces quickly.
+Snapshots are written by `PeerManager::tick`, the single periodic maintenance entry point (every tick: score decay, ban expiry, stale-peer purge; snapshot only when due). The manager owns no timers; a thin driver (`spawn_peer_manager_task`) is spawned from the node launch path, and topology writes a final snapshot on graceful shutdown. Crash-loss story: a crash loses at most one snapshot interval (default 5 minutes) of newly discovered peers, which rediscovery via bootnodes and hive gossip replaces quickly.
 
 ## Scoring
 
-Score is maintained atomically using fixed-point arithmetic (scaled by 100,000). Clamped to [-1,000,000, +1,000,000].
+Each peer's score is one atomic `f64` clamped to [-100, +100], owned by `vertex-net-peer-score` and wrapped with the Swarm threshold policy in `vertex-swarm-peer-score`. Every subsystem reports behaviour through `PeerManager::report_peer` (the `PeerReporter` trait); event weights are configured in `SwarmScoringConfig`.
 
-Default score adjustments:
-- `record_success()`: +1.0
-- `record_timeout()`: -1.5
-- `record_protocol_error()`: -3.0
+Default thresholds: warn at -50 (peer excluded from selection, `ScoreWarning` emitted once per descent), disconnect at -75 (`DisconnectRequested` plus dial backoff, edge-triggered), ban at -100 (timed ban, level-triggered).
 
-Custom adjustments via `add_score(delta)` or `set_score(value)`.
+### Lifecycle: decay, recovery, timed bans
+
+All lifecycle maintenance runs from `PeerManager::tick`, driven by the external periodic task; the manager owns no timers and `tick` takes the current unix time as a parameter.
+
+- **Decay.** Every tick, each peer's score decays exponentially toward zero: half-life 10 minutes while disconnected, 5 minutes while connected (double rate, so a connected peer that behaves recovers reputation twice as fast). Both positive and negative scores decay; reputation is recency-weighted in both directions. Elapsed time is tracked per peer, so a delayed or missed tick decays by the true elapsed time on the next run.
+- **Recovery.** When a decayed score climbs back above the warn threshold, the one-shot warning re-arms: a peer that recovers and then misbehaves again is warned again.
+- **Timed bans.** A ban lasts `PeerManagerConfig::ban_duration` (default 12 hours); the `Banned` lifecycle event carries the expiry as `until`. When the expiry passes, `tick` lifts the ban, emits `Unbanned` exactly once, and resets the score to the disconnect threshold: an unbanned peer must behave to climb back, it is not forgiven to neutral. Re-banning an already banned peer is a no-op (the original expiry stands), and score reports for banned peers are dropped entirely, so a repeat offender on a lingering stream can neither re-emit `Banned` nor extend its ban. Repeated offenders currently get the same fixed duration on each new ban; escalating durations are a possible follow-up.
+- **Permanent bans.** `PeerManager::ban_permanent` sets no expiry and the tick never lifts it. It is reserved for operator-initiated bans; the operator surface that calls it arrives with the gRPC work. All bans, timed or permanent, are runtime-only and cleared by a restart.
 
 ## Thread Safety
 


### PR DESCRIPTION
Drives the full peer reputation lifecycle from `PeerManager::tick`, the single periodic entry point introduced in #218, building on the `decay` primitive from #209 and the single report path plus `Unbanned` event from #216. The manager still owns no timers: everything is driven by the existing tick and its injected `now`.

## Decay and recovery

Every tick decays each unbanned peer's score exponentially toward zero: 10 minute half-life while disconnected, 5 minutes while connected (double rate, following the documented pattern of passing a smaller half-life). Both positive and negative scores decay, so reputation is recency-weighted in both directions. Elapsed time is tracked per entry in a `last_decay` AtomicU64, so a delayed or missed tick decays by the true elapsed time on the next run. The existing warn-flag reset in `SwarmPeerScore::decay` is preserved and the transition is now returned, so the score distribution gauges stay consistent and a recovered peer is warnable again.

## Timed bans

Bans now expire: default 12 hours, configurable via `PeerManagerConfig::ban_duration`. The banned map (`DashMap<OverlayAddress, Option<u64>>`) stores the expiry, and the `Banned` lifecycle event populates its `until` field. The tick scans for expired bans and lifts each one exactly once: banned-map removal, ban state cleared on the record, score reset to the disconnect threshold (the peer must behave to climb back; it is not forgiven to neutral), and a single `Unbanned` emission. `PeerManager::ban_permanent` stores no expiry and the scan never lifts it; it is reserved for operator-initiated bans and the operator surface that calls it arrives with the RPC work (the existing `TopologyCommand::BanPeer` path stays on the timed default).

## Reports during a ban

`report_peer` now drops reports for banned peers entirely, documented on the method: a repeat offender on a lingering stream cannot re-emit `Banned`, extend its ban expiry, or perturb the score that the unban path resets. Re-banning an already banned peer remains a no-op with the original expiry standing.

## Primitive changes

`PeerScore::decay` and `PeerScore::set_score` (vertex-net-peer-score) now return the `(old, new)` transition, matching the existing `add_score` contract, so aggregate maintainers do not race a separate load. `SwarmPeerScore` gains `reset(score)`, which aligns the one-shot warning state with the new value.

## Tests and docs

New tests cover: halving over one disconnected half-life across ticks, quartering at the connected double rate, elapsed-based robustness to a missed tick, positive-score decay, exact-boundary ban expiry (`now >= until`) with score reset and a single `Unbanned`, permanent bans never expiring, dropped reports during a ban (score frozen, no events, expiry not extended), and warn-after-recovery firing again. The scoring section of `docs/networking/peer-management.md` is rewritten with the lifecycle (decay rates, recovery, ban duration, reset-to-disconnect-threshold rule).

## Follow-ups (out of scope)

- Escalating durations for repeat offenders re-banned within a window (this PR keeps a fixed duration per ban).
- Pre-existing edge, unchanged here: per-bin admission replacement can evict a banned disconnected record from a full bin, which also clears its banned-map entry.
