### PR TITLE
feat(swarm-topology): deterministic readiness surface on TopologyHandle

### DIFF
--- a/crates/swarm/AGENTS.md
+++ b/crates/swarm/AGENTS.md
@@ -13,7 +13,7 @@ Root-level rules in `/AGENTS.md` apply here too. The notes below are the area-sp
 - `api`: the trait chain `SwarmPrimitives` to `SwarmNetworkTypes` to `SwarmClientTypes` to `SwarmStorerTypes`. Strictly libp2p-free with the documented `Multiaddr` exception.
 - `builder`: layered builders that produce `BuiltBootnode`, `BuiltClient`, `BuiltStorer`.
 - `node`: composes the libp2p `NetworkBehaviour` and exposes `BootNode`, `ClientNode`, `StorerNode`. This is where libp2p shows up. Also owns `PeerSelector`: retrieval and pushsync candidate selection ordered by peer score and affordability on top of proximity. The builder wires it from the topology handle (scores via the peer manager) and the bandwidth accounting (affordability, per-peer chunk price, best-effort settlement trigger).
-- `topology`: libp2p behaviour for peer discovery, kademlia routing, reachability tracking.
+- `topology`: libp2p behaviour for peer discovery, kademlia routing, reachability tracking. Also owns the deterministic readiness surface: `TopologyHandle::readiness` snapshots exact connected counts, depth, and per-bin shortfalls from the routing table and peer manager (never from metrics), and `wait_until` plus its shorthands (`wait_until_routable`, `wait_until_depth`, `wait_until_saturated`, `wait_until_ready`) await readiness conditions event-driven via the `TopologyEvent` broadcast.
 - `localstore`, `storer`, `redistribution`: storer-side configuration and the chunk-store/reserve implementation.
 - `rpc`: tonic-generated gRPC services and a `GrpcServiceProvider` trait.
 - `test-utils`: `MockIdentity`, `MockTopology`, and fixtures.

--- a/crates/swarm/builder/examples/download_chunk.rs
+++ b/crates/swarm/builder/examples/download_chunk.rs
@@ -4,11 +4,11 @@
 //! `DefaultClientBuilder`, spawn its event loop, dial bootnodes, await a
 //! deterministic readiness gate, then retrieve a chunk by address.
 //!
-//! Readiness is `TopologyHandle::wait_until_routable`, which resolves the
-//! moment a storer is connected. That is the state from which a retrieval has a
-//! peer to ask; it is event-driven, never a timed guess. A fuller readiness
-//! surface (target depth, neighborhood saturation) is tracked in
-//! <https://github.com/nxm-rs/vertex/issues/194>.
+//! Readiness is `TopologyHandle::wait_until_ready`, the composite warm gate:
+//! for a client it resolves the moment a storer is connected, the state from
+//! which a retrieval has a peer to ask. It is event-driven, never a timed
+//! guess. Stronger conditions (target depth, neighborhood saturation) are
+//! available through `TopologyHandle::wait_until` and its shorthands.
 //!
 //! Run with: `cargo run -p vertex-swarm-builder --example download_chunk`
 
@@ -75,8 +75,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     executor.spawn_critical_with_graceful_shutdown_signal("swarm.node", task_fn);
     providers.topology().connect_bootnodes().await?;
 
-    // Deterministic readiness: resolve once a storer is connected.
-    providers.topology().wait_until_routable().await?;
+    // Deterministic readiness: the warm gate for a client resolves once a
+    // storer is connected.
+    providers.topology().wait_until_ready().await?;
 
     let address = ChunkAddress::new([0u8; 32]);
     println!("Retrieving chunk {address}");

--- a/crates/swarm/builder/examples/upload_chunk.rs
+++ b/crates/swarm/builder/examples/upload_chunk.rs
@@ -4,11 +4,11 @@
 //! `DefaultClientBuilder`, spawn its event loop, dial bootnodes, await a
 //! deterministic readiness gate, then push a pre-stamped chunk.
 //!
-//! Readiness is `TopologyHandle::wait_until_routable`, which resolves the
-//! moment a storer is connected. That is the state from which a push can reach
-//! the closest storers; it is event-driven, never a timed guess. A fuller
-//! readiness surface (target depth, neighborhood saturation) is tracked in
-//! <https://github.com/nxm-rs/vertex/issues/194>.
+//! Readiness is `TopologyHandle::wait_until_ready`, the composite warm gate:
+//! for a client it resolves the moment a storer is connected, the state from
+//! which a push can reach the closest storers. It is event-driven, never a
+//! timed guess. Stronger conditions (target depth, neighborhood saturation)
+//! are available through `TopologyHandle::wait_until` and its shorthands.
 //!
 //! Run with: `cargo run -p vertex-swarm-builder --example upload_chunk`
 
@@ -89,8 +89,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     executor.spawn_critical_with_graceful_shutdown_signal("swarm.node", task_fn);
     providers.topology().connect_bootnodes().await?;
 
-    // Deterministic readiness: resolve once a storer is connected.
-    providers.topology().wait_until_routable().await?;
+    // Deterministic readiness: the warm gate for a client resolves once a
+    // storer is connected.
+    providers.topology().wait_until_ready().await?;
 
     let chunk = ContentChunk::new(&b"hello swarm"[..])?;
     let address = *chunk.address();

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -173,7 +173,6 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             command_tx,
             event_tx.clone(),
             agent_versions.clone(),
-            metrics.clone(),
         );
 
         // Queue static NAT addresses to emit as external addresses on first poll

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -6,17 +6,17 @@ use libp2p::{Multiaddr, PeerId};
 use nectar_primitives::ChunkAddress;
 use tokio::sync::{broadcast, mpsc};
 use vertex_swarm_api::{
-    SwarmIdentity, SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers,
+    SwarmIdentity, SwarmSpec, SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers,
     SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats,
 };
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer_manager::PeerManager;
-use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress, all_bins};
 
 use crate::behaviour::ConnectionRegistry;
 use crate::events::TopologyEvent;
 use crate::kademlia::KademliaRouting;
-use crate::metrics::TopologyMetrics;
+use crate::readiness::{BinReadiness, ReadinessSnapshot};
 use crate::{TopologyCommand, TopologyError};
 
 /// Handle for querying topology state. Cheap to clone.
@@ -28,7 +28,6 @@ pub struct TopologyHandle<I: SwarmIdentity> {
     command_tx: mpsc::Sender<TopologyCommand>,
     event_tx: broadcast::Sender<TopologyEvent>,
     agent_versions: identify::AgentVersions,
-    metrics: Arc<TopologyMetrics>,
 }
 
 impl<I: SwarmIdentity> Clone for TopologyHandle<I> {
@@ -41,13 +40,11 @@ impl<I: SwarmIdentity> Clone for TopologyHandle<I> {
             command_tx: self.command_tx.clone(),
             event_tx: self.event_tx.clone(),
             agent_versions: Arc::clone(&self.agent_versions),
-            metrics: Arc::clone(&self.metrics),
         }
     }
 }
 
 impl<I: SwarmIdentity> TopologyHandle<I> {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         identity: Arc<I>,
         routing: Arc<KademliaRouting<I>>,
@@ -56,7 +53,6 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
         command_tx: mpsc::Sender<TopologyCommand>,
         event_tx: broadcast::Sender<TopologyEvent>,
         agent_versions: identify::AgentVersions,
-        metrics: Arc<TopologyMetrics>,
     ) -> Self {
         Self {
             identity,
@@ -66,7 +62,6 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
             command_tx,
             event_tx,
             agent_versions,
-            metrics,
         }
     }
 
@@ -74,41 +69,99 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
         self.event_tx.subscribe()
     }
 
-    /// Resolve once the node is connected to at least one storer, the
-    /// deterministic point from which a chunk push or retrieval can route.
+    /// Take a readiness snapshot from authoritative topology state.
     ///
-    /// Both [`SwarmChunkSender::send_chunk`](vertex_swarm_api::SwarmChunkSender)
-    /// and [`SwarmChunkProvider::retrieve_chunk`](vertex_swarm_api::SwarmChunkProvider)
-    /// pick the closest storers from the routing table; with none connected the
-    /// push fails with `NoStorer` and the retrieval has nowhere to ask. This gate
-    /// is state-driven, not timed: it returns as soon as a storer is present and
-    /// otherwise waits for the [`TopologyEvent::PeerReady`] that brings one in.
+    /// Counts come from the routing table's connected-peer index and the
+    /// peer manager's handshake-confirmed node types; per-bin targets come
+    /// from the depth-aware limits at the current depth. See
+    /// [`ReadinessSnapshot`] for field semantics and consistency caveats.
+    pub fn readiness(&self) -> ReadinessSnapshot {
+        let depth = self.routing.depth();
+        let limits = self.routing.limits();
+        let max_bin = self.routing.max_bin();
+        let saturation_threshold = self.identity.spec().saturation_peers() as usize;
+
+        let mut connected_peers = 0;
+        let mut neighborhood_connected = 0;
+        let mut bins_at_target = 0;
+        let bins: Vec<BinReadiness> = all_bins(max_bin)
+            .map(|bin| {
+                let (connected, _known) = self.routing.bin_peer_counts(bin);
+                connected_peers += connected;
+                if depth.contains(bin) {
+                    neighborhood_connected += connected;
+                }
+                let raw_target = limits.target(bin, depth);
+                let (target, deficit) = if raw_target == usize::MAX {
+                    // Neighborhood bins connect to every available peer.
+                    (None, 0)
+                } else {
+                    if connected >= raw_target {
+                        bins_at_target += 1;
+                    }
+                    (Some(raw_target), raw_target.saturating_sub(connected))
+                };
+                BinReadiness {
+                    bin,
+                    connected,
+                    target,
+                    deficit,
+                }
+            })
+            .collect();
+
+        ReadinessSnapshot {
+            local_node_type: self.identity.node_type(),
+            connected_peers,
+            connected_storers: self.routing.connected_storer_total(),
+            depth,
+            neighborhood_connected,
+            saturation_threshold,
+            bins,
+            bins_at_target,
+        }
+    }
+
+    /// Resolve once `predicate` holds for a fresh [`ReadinessSnapshot`].
     ///
-    /// The subscription is taken before the initial state read so a storer that
-    /// becomes ready between the two cannot be missed. Returns
-    /// [`TopologyError::ServiceShutdown`] if the topology service stops before a
-    /// storer connects.
+    /// State-driven, not timed: the predicate is evaluated immediately and
+    /// then re-evaluated on every [`TopologyEvent::PeerReady`],
+    /// [`TopologyEvent::PeerDisconnected`], and
+    /// [`TopologyEvent::DepthChanged`], the events that change snapshot
+    /// state. The subscription is taken before the initial evaluation so a
+    /// state change between the two cannot be missed.
     ///
-    /// This is the minimal readiness condition for routing. A fuller surface
-    /// (neighborhood saturation, target depth) is tracked for storer-side
-    /// consumers; see the follow-up issue referenced from the chunk examples.
-    pub async fn wait_until_routable(&self) -> Result<(), TopologyError> {
+    /// If the event subscription lags (events dropped under burst), the
+    /// predicate is re-evaluated against current state unconditionally
+    /// rather than trusting the stream, so a missed event cannot strand the
+    /// waiter. Cancel-safe: dropping the returned future drops the
+    /// subscription and leaks nothing. Returns
+    /// [`TopologyError::ServiceShutdown`] if the topology event channel
+    /// closes before the predicate holds.
+    pub async fn wait_until(
+        &self,
+        mut predicate: impl FnMut(&ReadinessSnapshot) -> bool,
+    ) -> Result<(), TopologyError> {
         let mut events = self.event_tx.subscribe();
 
-        if self.connected_storer_count() > 0 {
+        if predicate(&self.readiness()) {
             return Ok(());
         }
 
         loop {
             match events.recv().await {
-                Ok(TopologyEvent::PeerReady { node_type, .. }) if node_type.requires_storage() => {
-                    return Ok(());
+                Ok(
+                    TopologyEvent::PeerReady { .. }
+                    | TopologyEvent::PeerDisconnected { .. }
+                    | TopologyEvent::DepthChanged { .. },
+                ) => {
+                    if predicate(&self.readiness()) {
+                        return Ok(());
+                    }
                 }
                 Ok(_) => continue,
-                // Lagged: events were dropped, so re-read state directly rather
-                // than trust the stream. A storer may have connected in the gap.
                 Err(broadcast::error::RecvError::Lagged(_)) => {
-                    if self.connected_storer_count() > 0 {
+                    if predicate(&self.readiness()) {
                         return Ok(());
                     }
                 }
@@ -119,8 +172,48 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
         }
     }
 
-    fn connected_storer_count(&self) -> u64 {
-        self.metrics.connected_storers()
+    /// Resolve once the node is connected to at least one storer, the
+    /// deterministic point from which a chunk push or retrieval can route.
+    ///
+    /// Both [`SwarmChunkSender::send_chunk`](vertex_swarm_api::SwarmChunkSender)
+    /// and [`SwarmChunkProvider::retrieve_chunk`](vertex_swarm_api::SwarmChunkProvider)
+    /// pick the closest storers from the routing table; with none connected the
+    /// push fails with `NoStorer` and the retrieval has nowhere to ask. This is
+    /// the minimal readiness condition; see [`Self::wait_until_ready`] for the
+    /// composite warm gate and [`Self::wait_until`] for the event semantics.
+    pub async fn wait_until_routable(&self) -> Result<(), TopologyError> {
+        self.wait_until(ReadinessSnapshot::is_routable).await
+    }
+
+    /// Resolve once the neighborhood depth reaches `min_depth`.
+    ///
+    /// Driven by [`TopologyEvent::DepthChanged`]; see [`Self::wait_until`]
+    /// for the event semantics.
+    pub async fn wait_until_depth(
+        &self,
+        min_depth: NeighborhoodDepth,
+    ) -> Result<(), TopologyError> {
+        self.wait_until(move |s| s.depth_reached(min_depth)).await
+    }
+
+    /// Resolve once the neighborhood is saturated: a depth boundary is
+    /// established and the bins at or beyond it hold at least the spec's
+    /// per-bin saturation target in connected peers.
+    ///
+    /// See [`ReadinessSnapshot::is_saturated`] for the condition and
+    /// [`Self::wait_until`] for the event semantics.
+    pub async fn wait_until_saturated(&self) -> Result<(), TopologyError> {
+        self.wait_until(ReadinessSnapshot::is_saturated).await
+    }
+
+    /// Resolve once the node is warm for its node type: routable for
+    /// clients and bootnodes, routable plus neighborhood-saturated for
+    /// storers.
+    ///
+    /// See [`ReadinessSnapshot::is_warm`] for the condition and
+    /// [`Self::wait_until`] for the event semantics.
+    pub async fn wait_until_ready(&self) -> Result<(), TopologyError> {
+        self.wait_until(ReadinessSnapshot::is_warm).await
     }
 
     /// Get direct access to the peer manager for scoring/banning queries.
@@ -194,7 +287,7 @@ impl<I: SwarmIdentity> SwarmTopologyPeers for TopologyHandle<I> {
 
 impl<I: SwarmIdentity> SwarmTopologyStats for TopologyHandle<I> {
     fn connected_peers_count(&self) -> usize {
-        (self.metrics.connected_storers() + self.metrics.connected_clients()) as usize
+        self.routing.connected_peers_total()
     }
 
     fn routing_peers_count(&self) -> usize {
@@ -319,5 +412,305 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
             known_peers_total: self.routing.known_peers_total(),
             connected_peers_total: self.routing.connected_peers_total(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    use std::time::Duration;
+
+    use super::*;
+    use crate::behaviour::ConnectionRegistry;
+    use crate::kademlia::{KademliaConfig, SwarmRouting};
+    use vertex_net_peer_registry::ConnectionDirection;
+    use vertex_swarm_peer_manager::{PeerManagerConfig, TrustLevel};
+    use vertex_swarm_primitives::SwarmNodeType;
+    use vertex_swarm_test_utils::{MockIdentity, test_overlay, test_peer_id, test_swarm_peer};
+
+    struct ReadinessHarness {
+        handle: TopologyHandle<MockIdentity>,
+        routing: Arc<KademliaRouting<MockIdentity>>,
+        peer_manager: Arc<PeerManager<MockIdentity>>,
+        event_tx: broadcast::Sender<TopologyEvent>,
+        // Held so handle commands stay sendable; unused by these tests.
+        _command_rx: mpsc::Receiver<TopologyCommand>,
+    }
+
+    fn harness(node_type: SwarmNodeType, event_capacity: usize) -> ReadinessHarness {
+        let identity = MockIdentity::with_overlay(test_overlay(0)).with_node_type(node_type);
+        let peer_manager = PeerManager::new(&identity, PeerManagerConfig::default());
+        let routing = KademliaRouting::new(
+            identity.clone(),
+            KademliaConfig::default(),
+            peer_manager.clone(),
+        );
+        let (event_tx, _) = broadcast::channel(event_capacity);
+        let (command_tx, command_rx) = mpsc::channel(8);
+        let handle = TopologyHandle::new(
+            Arc::new(identity),
+            routing.clone(),
+            Arc::new(ConnectionRegistry::new()),
+            peer_manager.clone(),
+            command_tx,
+            event_tx.clone(),
+            identify::new_agent_versions(),
+        );
+        ReadinessHarness {
+            handle,
+            routing,
+            peer_manager,
+            event_tx,
+            _command_rx: command_rx,
+        }
+    }
+
+    impl ReadinessHarness {
+        /// Connect a peer through the same path the behaviour uses: record
+        /// it in the peer manager, then in the routing table.
+        fn connect(&self, n: u8, node_type: SwarmNodeType) -> OverlayAddress {
+            self.peer_manager.on_peer_connected(
+                test_swarm_peer(n),
+                node_type,
+                ConnectionDirection::Outbound,
+                TrustLevel::Normal,
+                None,
+            );
+            let overlay = test_overlay(n);
+            SwarmRouting::connected(&*self.routing, overlay);
+            overlay
+        }
+
+        fn emit_peer_ready(&self, n: u8, node_type: SwarmNodeType) {
+            let _ = self.event_tx.send(TopologyEvent::PeerReady {
+                overlay: test_overlay(n),
+                peer_id: test_peer_id(n),
+                node_type,
+                direction: ConnectionDirection::Outbound,
+            });
+        }
+
+        fn emit_ping(&self, n: u8) {
+            let _ = self.event_tx.send(TopologyEvent::PingCompleted {
+                overlay: test_overlay(n),
+                rtt: Duration::from_millis(1),
+            });
+        }
+    }
+
+    #[test]
+    fn empty_snapshot_is_cold_and_complete() {
+        let h = harness(SwarmNodeType::Client, 16);
+        let s = h.handle.readiness();
+
+        assert_eq!(s.local_node_type, SwarmNodeType::Client);
+        assert_eq!(s.connected_peers, 0);
+        assert_eq!(s.connected_storers, 0);
+        assert_eq!(s.depth, NeighborhoodDepth::ZERO);
+        assert_eq!(s.neighborhood_connected, 0);
+        assert!(!s.is_routable());
+        assert!(!s.is_saturated());
+        assert!(!s.is_warm());
+        assert_eq!(s.bins_at_target, 0);
+
+        // Every bin reports the bootstrap-phase target while depth is 0.
+        assert!(!s.bins.is_empty());
+        for bin in &s.bins {
+            assert_eq!(bin.connected, 0);
+            let target = bin.target.expect("finite target at depth 0");
+            assert!(target > 0);
+            assert_eq!(bin.deficit, target);
+        }
+    }
+
+    #[test]
+    fn snapshot_counts_storers_exactly() {
+        let h = harness(SwarmNodeType::Client, 16);
+        h.connect(1, SwarmNodeType::Storer);
+        h.connect(2, SwarmNodeType::Storer);
+        h.connect(3, SwarmNodeType::Client);
+
+        let s = h.handle.readiness();
+        assert_eq!(s.connected_peers, 3);
+        assert_eq!(s.connected_storers, 2);
+        assert!(s.is_routable());
+        assert!(s.is_warm(), "client is warm once routable");
+
+        let per_bin_total: usize = s.bins.iter().map(|b| b.connected).sum();
+        assert_eq!(per_bin_total, s.connected_peers);
+        // Depth 0: the whole table is the neighborhood.
+        assert_eq!(s.neighborhood_connected, s.connected_peers);
+    }
+
+    /// Saturate bin 0 (8 peers at proximity order 0) while keeping bin 1
+    /// unsaturated, anchoring depth at 1, and connect enough peers at or
+    /// beyond the boundary to cross the neighborhood saturation threshold.
+    fn saturate_to_depth_one(h: &ReadinessHarness) {
+        // First byte 0x80..=0x87: proximity order 0 to the local 0x00 overlay.
+        for n in 0x80..0x88 {
+            h.connect(n, SwarmNodeType::Storer);
+        }
+        // Bin 1 (0x40..): 5 peers, below the per-bin saturation of 8.
+        for n in 0x40..0x45 {
+            h.connect(n, SwarmNodeType::Storer);
+        }
+        // Bin 2 (0x20..): 3 peers. Bin 3 (0x10): 1 peer.
+        for n in 0x20..0x23 {
+            h.connect(n, SwarmNodeType::Storer);
+        }
+        h.connect(0x10, SwarmNodeType::Storer);
+    }
+
+    #[test]
+    fn snapshot_reports_depth_and_saturation() {
+        let h = harness(SwarmNodeType::Storer, 16);
+        saturate_to_depth_one(&h);
+
+        let s = h.handle.readiness();
+        assert_eq!(s.depth.get(), 1);
+        // Bins at or beyond depth 1: 5 + 3 + 1 = 9 connected.
+        assert_eq!(s.neighborhood_connected, 9);
+        assert!(s.is_saturated());
+        assert!(s.is_warm(), "storer is warm once saturated and routable");
+        // Bin 0 is balanced (below depth) and holds 8 of its target.
+        let bin0 = &s.bins[0];
+        assert_eq!(bin0.connected, 8);
+        assert!(bin0.target.is_some());
+        // Neighborhood bins report no finite target.
+        assert!(s.bins[1].target.is_none());
+    }
+
+    #[tokio::test]
+    async fn wait_until_routable_resolves_on_peer_ready_event() {
+        let h = harness(SwarmNodeType::Client, 16);
+
+        let waiter = {
+            let handle = h.handle.clone();
+            tokio::spawn(async move { handle.wait_until_routable().await })
+        };
+        // Let the waiter subscribe and park on the event stream.
+        tokio::task::yield_now().await;
+
+        h.connect(1, SwarmNodeType::Storer);
+        h.emit_peer_ready(1, SwarmNodeType::Storer);
+
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must resolve on the triggering event")
+            .expect("waiter task must not panic")
+            .expect("wait_until_routable must succeed");
+    }
+
+    #[tokio::test]
+    async fn wait_until_ready_for_storer_requires_saturation() {
+        let h = harness(SwarmNodeType::Storer, 64);
+
+        let mut waiter = Box::pin(h.handle.wait_until_ready());
+        assert!(futures::poll!(waiter.as_mut()).is_pending());
+
+        // One storer makes the node routable but not saturated: the storer
+        // warm gate must hold out.
+        h.connect(1, SwarmNodeType::Storer);
+        h.emit_peer_ready(1, SwarmNodeType::Storer);
+        assert!(futures::poll!(waiter.as_mut()).is_pending());
+
+        saturate_to_depth_one(&h);
+        h.emit_peer_ready(0x80, SwarmNodeType::Storer);
+
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("storer warm gate must resolve once saturated")
+            .expect("wait_until_ready must succeed");
+    }
+
+    #[tokio::test]
+    async fn wait_until_depth_resolves_on_depth_change() {
+        let h = harness(SwarmNodeType::Storer, 64);
+        let min_depth = NeighborhoodDepth::new(Bin::new(1).expect("valid bin"));
+
+        let mut waiter = Box::pin(h.handle.wait_until_depth(min_depth));
+        assert!(futures::poll!(waiter.as_mut()).is_pending());
+
+        saturate_to_depth_one(&h);
+        let _ = h.event_tx.send(TopologyEvent::DepthChanged {
+            old_depth: 0,
+            new_depth: 1,
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("depth gate must resolve on DepthChanged")
+            .expect("wait_until_depth must succeed");
+    }
+
+    #[tokio::test]
+    async fn dropping_wait_future_releases_subscription() {
+        let h = harness(SwarmNodeType::Client, 16);
+        assert_eq!(h.event_tx.receiver_count(), 0);
+
+        let mut waiter = Box::pin(h.handle.wait_until_routable());
+        assert!(futures::poll!(waiter.as_mut()).is_pending());
+        assert_eq!(h.event_tx.receiver_count(), 1);
+
+        drop(waiter);
+        assert_eq!(
+            h.event_tx.receiver_count(),
+            0,
+            "dropping the future must drop its subscription"
+        );
+    }
+
+    #[tokio::test]
+    async fn lagged_receiver_reevaluates_state() {
+        // Capacity 1: the second send overwrites the first and the parked
+        // receiver observes Lagged instead of the events themselves.
+        let h = harness(SwarmNodeType::Client, 1);
+
+        let mut waiter = Box::pin(h.handle.wait_until_routable());
+        assert!(futures::poll!(waiter.as_mut()).is_pending());
+
+        // State flips while the receiver is parked, but the only events in
+        // the stream are pings, which the waiter does not re-evaluate on.
+        // Resolution therefore proves the Lagged arm re-read the state.
+        h.connect(1, SwarmNodeType::Storer);
+        h.emit_ping(1);
+        h.emit_ping(1);
+
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("lagged waiter must re-evaluate state")
+            .expect("wait_until_routable must succeed");
+    }
+
+    #[tokio::test]
+    async fn wait_until_custom_predicate_tracks_disconnects() {
+        let h = harness(SwarmNodeType::Client, 16);
+        h.connect(1, SwarmNodeType::Storer);
+        h.connect(2, SwarmNodeType::Storer);
+
+        // A predicate over the full snapshot resolves immediately when
+        // already true.
+        h.handle
+            .wait_until(|s| s.connected_peers >= 2)
+            .await
+            .expect("predicate already true");
+
+        let mut waiter = Box::pin(h.handle.wait_until(|s| s.connected_peers <= 1));
+        assert!(futures::poll!(waiter.as_mut()).is_pending());
+
+        let overlay = test_overlay(2);
+        SwarmRouting::on_peer_disconnected(&*h.routing, &overlay);
+        h.peer_manager.on_peer_disconnected(&overlay, "test");
+        let _ = h.event_tx.send(TopologyEvent::PeerDisconnected {
+            overlay,
+            reason: crate::DisconnectReason::ConnectionError,
+            connection_duration: None,
+            node_type: SwarmNodeType::Storer,
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("predicate must re-evaluate on PeerDisconnected")
+            .expect("wait_until must succeed");
     }
 }

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -421,6 +421,23 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         self.connected_peers.len()
     }
 
+    /// Connected peers whose handshake-confirmed node type stores chunks.
+    ///
+    /// Walks the connected-peer index (bounded by the connection targets)
+    /// and resolves each node type from the peer manager, the authoritative
+    /// holder of handshake-confirmed types.
+    pub(crate) fn connected_storer_total(&self) -> usize {
+        self.connected_peers
+            .all_peers()
+            .into_iter()
+            .filter(|overlay| {
+                self.peer_manager
+                    .node_type(overlay)
+                    .is_some_and(|node_type| node_type.requires_storage())
+            })
+            .count()
+    }
+
     pub(crate) fn connected_overlays_in_bin(&self, bin: Bin) -> Vec<OverlayAddress> {
         self.connected_peers.peers_in_bin(bin)
     }

--- a/crates/swarm/topology/src/lib.rs
+++ b/crates/swarm/topology/src/lib.rs
@@ -54,6 +54,7 @@ mod composed;
 mod error;
 mod gossip;
 mod reachability;
+mod readiness;
 mod tasks;
 
 #[cfg(test)]
@@ -68,3 +69,4 @@ pub use handle::{BinStats, RoutingStats, TopologyHandle};
 
 pub use kademlia::{KademliaConfig, RoutingArgs};
 pub use reachability::{FAILURE_DECAY, FAILURE_THRESHOLD, PeerReachability, ReachabilityTracker};
+pub use readiness::{BinReadiness, ReadinessSnapshot};

--- a/crates/swarm/topology/src/readiness.rs
+++ b/crates/swarm/topology/src/readiness.rs
@@ -1,0 +1,186 @@
+//! Deterministic node-readiness state assembled from authoritative
+//! topology sources.
+//!
+//! [`ReadinessSnapshot`] is built by `TopologyHandle::readiness` from the
+//! Kademlia routing table (connected peers per bin, neighborhood depth,
+//! depth-aware bin targets) and the peer manager (handshake-confirmed node
+//! types). The predicate methods on the snapshot define the readiness
+//! conditions that `TopologyHandle::wait_until` and its named shorthands
+//! await: routability, target depth, neighborhood saturation, and the
+//! composite warm signal selected by the local node type.
+
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, SwarmNodeType};
+
+/// Connection shortfall for one bin relative to its depth-aware target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinReadiness {
+    /// The bin.
+    pub bin: Bin,
+    /// Connected peers currently in the bin.
+    pub connected: usize,
+    /// The bin's connection target from the depth-aware limits, or `None`
+    /// for neighborhood bins, which connect to every available peer.
+    pub target: Option<usize>,
+    /// Peers still missing before the bin reaches its target. Zero for
+    /// neighborhood bins and for bins at or above target.
+    pub deficit: usize,
+}
+
+/// A cheap, consistent-enough snapshot of the node's readiness state.
+///
+/// Counts come from the routing table's connected-peer index and the peer
+/// manager's handshake-confirmed node types, not from metrics. Fields are
+/// read individually without a global lock, so a snapshot taken during
+/// heavy churn can be transiently inconsistent between fields; every field
+/// is exact the moment it is read.
+#[derive(Debug, Clone)]
+pub struct ReadinessSnapshot {
+    /// The local node's type, selecting the composite warm condition
+    /// (see [`Self::is_warm`]).
+    pub local_node_type: SwarmNodeType,
+    /// Total connected peers in the routing table.
+    pub connected_peers: usize,
+    /// Connected peers whose handshake-confirmed node type stores chunks.
+    pub connected_storers: usize,
+    /// Current neighborhood depth.
+    pub depth: NeighborhoodDepth,
+    /// Connected peers in bins at or beyond the depth boundary.
+    pub neighborhood_connected: usize,
+    /// Per-bin saturation target from the network spec; the threshold the
+    /// neighborhood must reach for [`Self::is_saturated`].
+    pub saturation_threshold: usize,
+    /// Per-bin readiness, shallowest bin first.
+    pub bins: Vec<BinReadiness>,
+    /// Bins with a finite target whose connected count meets it.
+    pub bins_at_target: usize,
+}
+
+impl ReadinessSnapshot {
+    /// Whether a chunk push or retrieval has a peer to ask: at least one
+    /// connected storer.
+    #[must_use]
+    pub fn is_routable(&self) -> bool {
+        self.connected_storers > 0
+    }
+
+    /// Whether the neighborhood depth has reached `min_depth`.
+    #[must_use]
+    pub fn depth_reached(&self, min_depth: NeighborhoodDepth) -> bool {
+        self.depth >= min_depth
+    }
+
+    /// Whether the neighborhood is saturated: a depth boundary is
+    /// established and the bins at or beyond it together hold at least
+    /// [`Self::saturation_threshold`] connected peers.
+    ///
+    /// The threshold is the same per-bin saturation target that gates the
+    /// depth frontier, applied to the neighborhood as a whole.
+    #[must_use]
+    pub fn is_saturated(&self) -> bool {
+        self.depth > NeighborhoodDepth::ZERO
+            && self.neighborhood_connected >= self.saturation_threshold
+    }
+
+    /// The composite warm signal for the local node type.
+    ///
+    /// A storer is warm once it is routable and its neighborhood is
+    /// saturated; it needs the neighborhood to hold the chunks it is
+    /// responsible for. Every other node type is warm as soon as it is
+    /// routable, the point from which pushes and retrievals can proceed.
+    #[must_use]
+    pub fn is_warm(&self) -> bool {
+        if self.local_node_type.requires_storage() {
+            self.is_routable() && self.is_saturated()
+        } else {
+            self.is_routable()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn depth(n: u8) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(Bin::new(n).expect("valid bin"))
+    }
+
+    fn snapshot(node_type: SwarmNodeType) -> ReadinessSnapshot {
+        ReadinessSnapshot {
+            local_node_type: node_type,
+            connected_peers: 0,
+            connected_storers: 0,
+            depth: NeighborhoodDepth::ZERO,
+            neighborhood_connected: 0,
+            saturation_threshold: 8,
+            bins: Vec::new(),
+            bins_at_target: 0,
+        }
+    }
+
+    #[test]
+    fn empty_snapshot_is_cold() {
+        let s = snapshot(SwarmNodeType::Client);
+        assert!(!s.is_routable());
+        assert!(!s.is_saturated());
+        assert!(!s.is_warm());
+        assert!(s.depth_reached(NeighborhoodDepth::ZERO));
+        assert!(!s.depth_reached(depth(1)));
+    }
+
+    #[test]
+    fn routable_with_one_storer() {
+        let mut s = snapshot(SwarmNodeType::Client);
+        s.connected_peers = 1;
+        s.connected_storers = 1;
+        assert!(s.is_routable());
+        assert!(s.is_warm(), "a client is warm as soon as it can route");
+        assert!(!s.is_saturated());
+    }
+
+    #[test]
+    fn clients_alone_are_not_routable() {
+        let mut s = snapshot(SwarmNodeType::Client);
+        s.connected_peers = 5;
+        s.connected_storers = 0;
+        assert!(!s.is_routable());
+        assert!(!s.is_warm());
+    }
+
+    #[test]
+    fn saturation_requires_established_depth() {
+        let mut s = snapshot(SwarmNodeType::Storer);
+        s.connected_peers = 20;
+        s.connected_storers = 20;
+        s.neighborhood_connected = 20;
+        // Depth 0: no boundary established yet, so not saturated.
+        assert!(!s.is_saturated());
+        assert!(!s.is_warm(), "a storer is not warm before saturation");
+
+        s.depth = depth(1);
+        assert!(s.is_saturated());
+        assert!(s.is_warm());
+    }
+
+    #[test]
+    fn saturation_requires_threshold_in_neighborhood() {
+        let mut s = snapshot(SwarmNodeType::Storer);
+        s.connected_peers = 30;
+        s.connected_storers = 30;
+        s.depth = depth(2);
+        s.neighborhood_connected = 7;
+        assert!(!s.is_saturated());
+
+        s.neighborhood_connected = 8;
+        assert!(s.is_saturated());
+    }
+
+    #[test]
+    fn depth_reached_is_monotonic_in_min_depth() {
+        let mut s = snapshot(SwarmNodeType::Client);
+        s.depth = depth(3);
+        assert!(s.depth_reached(depth(1)));
+        assert!(s.depth_reached(depth(3)));
+        assert!(!s.depth_reached(depth(4)));
+    }
+}


### PR DESCRIPTION
Closes #194

Adds `ReadinessSnapshot`, a cheap snapshot assembled from authoritative topology state: exact connected and storer counts from the routing table's connected-peer index resolved against the peer manager's handshake-confirmed node types, the current neighborhood depth, per-bin shortfall against the depth-aware limits (bootstrap targets at depth 0, linear taper below depth, no finite target for neighborhood bins), bins-at-target, and the neighborhood saturation threshold from the network spec. Exposed as `TopologyHandle::readiness`.

On top of the snapshot, `TopologyHandle::wait_until(predicate)` awaits an arbitrary readiness condition event-driven: the predicate is evaluated immediately after subscribing (so no state change can be missed between the check and the subscription) and re-evaluated on `PeerReady`, `PeerDisconnected`, and `DepthChanged`, the events that change snapshot state. On a lagged broadcast receiver the predicate is re-evaluated against current state unconditionally rather than trusting the stream. The future is cancel-safe: dropping it drops the subscription and leaks nothing.

Named shorthands cover the ladder from issue #194: `wait_until_routable` (one storer connected, the existing minimal gate, now refactored onto the snapshot), `wait_until_depth(min_depth)` driven by `DepthChanged`, `wait_until_saturated` (a depth boundary established and the bins at or beyond it holding at least the spec's per-bin saturation target in connected peers, the same `saturation_peers` value that gates the depth frontier), and `wait_until_ready`, the composite warm gate selected by the local node type: routable for clients and bootnodes, routable plus neighborhood-saturated for storers.

The metrics-derived readiness path is gone: `wait_until_routable` no longer reads the `connected_storers` gauge and `SwarmTopologyStats::connected_peers_count` now reads the routing table directly, so the handle no longer holds `TopologyMetrics` at all (the metrics themselves are untouched; the behaviour still owns them). The chunk upload/download examples gate on `wait_until_ready`.

Tests cover snapshot correctness against real manager and routing state (exact storer counts, depth and saturation at a constructed depth-1 table, per-bin targets and deficits), event-driven resolution (routable on `PeerReady`, depth on `DepthChanged`, a custom predicate on `PeerDisconnected`), the storer warm gate holding out until saturation, cancel-safety via subscriber-count restoration, and lagged-receiver re-evaluation with a capacity-1 channel flooded by non-triggering events.