### PR TITLE
fix(topology): break the depth deadlock between trim, taper, and candidate supply

### DIFF
--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -85,8 +85,8 @@ pub use self::reporting::{
 };
 pub use self::rpc::RpcProviders;
 pub use self::spec::{
-    DEFAULT_NEIGHBORHOOD_LOW_WATERMARK, DEFAULT_SATURATION_PEERS, StaticSwarmSpecProvider,
-    SwarmSpec, SwarmSpecParser, SwarmSpecProvider, SwarmToken,
+    DEFAULT_SATURATION_PEERS, StaticSwarmSpecProvider, SwarmSpec, SwarmSpecParser,
+    SwarmSpecProvider, SwarmToken,
 };
 pub use self::swarm::{SwarmClient, SwarmStorer};
 pub use self::types::{

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -85,7 +85,8 @@ pub use self::reporting::{
 };
 pub use self::rpc::RpcProviders;
 pub use self::spec::{
-    StaticSwarmSpecProvider, SwarmSpec, SwarmSpecParser, SwarmSpecProvider, SwarmToken,
+    DEFAULT_NEIGHBORHOOD_LOW_WATERMARK, DEFAULT_SATURATION_PEERS, StaticSwarmSpecProvider,
+    SwarmSpec, SwarmSpecParser, SwarmSpecProvider, SwarmToken,
 };
 pub use self::swarm::{SwarmClient, SwarmStorer};
 pub use self::types::{

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -1107,8 +1107,7 @@ mod tests {
         let bin = Bin::from(test_overlay(0).proximity(&test_overlay(1)));
         let excluded = test_overlay(1);
 
-        let dialable =
-            pm.dialable_overlays_in_bin_excluding(bin, usize::MAX, |o| *o == excluded);
+        let dialable = pm.dialable_overlays_in_bin_excluding(bin, usize::MAX, |o| *o == excluded);
         assert!(!dialable.contains(&excluded));
     }
 

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -276,8 +276,25 @@ impl<I: SwarmIdentity> PeerManager<I> {
 
     /// Get dialable overlay addresses from a specific bin (not banned, not in backoff).
     pub fn dialable_overlays_in_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
+        self.dialable_overlays_in_bin_excluding(bin, count, |_| false)
+    }
+
+    /// Get dialable overlay addresses from a bin, skipping excluded overlays.
+    ///
+    /// `exclude` lets the caller remove overlays that are dialable but useless
+    /// as candidates, typically peers it is already connected to. Without the
+    /// exclusion, connected peers (hot and dialable) fill the returned slice
+    /// first and a bin with more connections than `count` yields no usable
+    /// candidates even when many unconnected peers are known.
+    pub fn dialable_overlays_in_bin_excluding(
+        &self,
+        bin: Bin,
+        count: usize,
+        exclude: impl Fn(&OverlayAddress) -> bool,
+    ) -> Vec<OverlayAddress> {
         self.index.filter_bin(bin, count, |overlay| {
             !self.banned_set.contains_key(overlay)
+                && !exclude(overlay)
                 && self.peers.get(overlay).is_some_and(|e| e.is_dialable())
         })
     }
@@ -1065,6 +1082,34 @@ mod tests {
         let storers = pm.known_storer_overlays();
         assert_eq!(storers.len(), 1);
         assert!(storers.contains(&test_overlay(3)));
+    }
+
+    #[test]
+    fn test_overlays_in_bin_accept_max_count() {
+        let pm = manager();
+        connect(&pm, 1, SwarmNodeType::Storer);
+
+        let bin = Bin::from(test_overlay(0).proximity(&test_overlay(1)));
+
+        let storers = pm.storer_overlays_in_bin(bin, usize::MAX);
+        assert_eq!(storers, vec![test_overlay(1)]);
+
+        let dialable = pm.dialable_overlays_in_bin(bin, usize::MAX);
+        assert_eq!(dialable, vec![test_overlay(1)]);
+    }
+
+    #[test]
+    fn test_dialable_overlays_excluding() {
+        let pm = manager();
+        connect(&pm, 1, SwarmNodeType::Storer);
+        connect(&pm, 2, SwarmNodeType::Storer);
+
+        let bin = Bin::from(test_overlay(0).proximity(&test_overlay(1)));
+        let excluded = test_overlay(1);
+
+        let dialable =
+            pm.dialable_overlays_in_bin_excluding(bin, usize::MAX, |o| *o == excluded);
+        assert!(!dialable.contains(&excluded));
     }
 
     #[test]

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -11,7 +11,7 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::info;
 use vertex_net_dialer::{DialTracker, DialTrackerConfig};
 use vertex_net_local::LocalCapabilities;
-use vertex_swarm_api::{PeerConfigValues, SwarmBootnodeConfig, SwarmIdentity};
+use vertex_swarm_api::{PeerConfigValues, SwarmBootnodeConfig, SwarmIdentity, SwarmSpec};
 use vertex_swarm_net_handshake::HANDSHAKE_TIMEOUT;
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer_manager::{PeerManager, PeerManagerConfig};
@@ -133,11 +133,14 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
 
         let lifecycle_rx = peer_manager.subscribe();
 
-        let routing = KademliaRouting::new(
-            self.identity.clone(),
-            self.config.kademlia.clone(),
-            peer_manager.clone(),
-        );
+        // Allocation floors and depth recomputation must use the same
+        // saturation threshold (see the DepthAwareLimits invariants), so the
+        // spec value overrides whatever the kademlia config carried.
+        let mut kademlia_config = self.config.kademlia.clone();
+        kademlia_config.limits = kademlia_config.limits.with_saturation(usize::from(
+            SwarmIdentity::spec(&self.identity).saturation_peers(),
+        ));
+        let routing = KademliaRouting::new(self.identity.clone(), kademlia_config, peer_manager.clone());
 
         let local_capabilities = Arc::new(LocalCapabilities::new());
 

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -140,7 +140,8 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
         kademlia_config.limits = kademlia_config.limits.with_saturation(usize::from(
             SwarmIdentity::spec(&self.identity).saturation_peers(),
         ));
-        let routing = KademliaRouting::new(self.identity.clone(), kademlia_config, peer_manager.clone());
+        let routing =
+            KademliaRouting::new(self.identity.clone(), kademlia_config, peer_manager.clone());
 
         let local_capabilities = Arc::new(LocalCapabilities::new());
 

--- a/crates/swarm/topology/src/kademlia/admission.rs
+++ b/crates/swarm/topology/src/kademlia/admission.rs
@@ -101,7 +101,8 @@ mod tests {
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
-            .with_bootstrap_target(1);
+            .with_bootstrap_target(1)
+            .with_saturation(1);
         let routing = make_routing(base, config);
 
         let ac = KademliaAdmissionControl::new(routing);
@@ -119,7 +120,8 @@ mod tests {
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
-            .with_bootstrap_target(1);
+            .with_bootstrap_target(1)
+            .with_saturation(1);
         let routing = make_routing(base, config);
 
         let occupied = SwarmAddress::with_first_byte(0xc0);
@@ -143,7 +145,8 @@ mod tests {
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
-            .with_bootstrap_target(1);
+            .with_bootstrap_target(1)
+            .with_saturation(1);
         let routing = make_routing(base, config);
 
         let peer = SwarmAddress::with_first_byte(0x80);
@@ -168,7 +171,8 @@ mod tests {
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
-            .with_bootstrap_target(1);
+            .with_bootstrap_target(1)
+            .with_saturation(1);
         let routing = make_routing(base, config);
 
         let peer1 = SwarmAddress::with_first_byte(0x80);

--- a/crates/swarm/topology/src/kademlia/candidates.rs
+++ b/crates/swarm/topology/src/kademlia/candidates.rs
@@ -85,6 +85,12 @@ impl<'a> CandidateSelector<'a> {
         self.bin_selections.get(&bin).copied().unwrap_or(0)
     }
 
+    /// The connected-peer index, with the selector's full borrow lifetime so
+    /// callers can hold it across mutable selector use.
+    pub(crate) fn connected_index(&self) -> &'a ProximityIndex {
+        self.connected_peers
+    }
+
     /// Try to add a peer as candidate (test-only, no ban/backoff check).
     ///
     /// Returns true if added, false if ineligible or at capacity.
@@ -167,6 +173,10 @@ pub(crate) fn select_neighborhood_candidates<I: SwarmIdentity>(
     max_bin: Bin,
 ) {
     let depth = selector.snapshot().limits.depth;
+    // Connected peers are dialable but useless as candidates; without the
+    // exclusion a bin with more connections than the requested count yields
+    // only already-connected overlays and starves.
+    let connected = selector.connected_index();
 
     // Iterate from highest PO down to depth
     for bin in neighborhood_bins(depth, max_bin).rev() {
@@ -186,7 +196,11 @@ pub(crate) fn select_neighborhood_candidates<I: SwarmIdentity>(
         }
 
         // Get peers from this bin (LRU order via KnownPeers)
-        for peer in peer_manager.dialable_overlays_in_bin(bin, selector.remaining()) {
+        for peer in
+            peer_manager.dialable_overlays_in_bin_excluding(bin, selector.remaining(), |overlay| {
+                connected.exists(overlay)
+            })
+        {
             if !selector.try_add_with_bin_capacity(peer, bin, effective, peer_manager) {
                 continue;
             }
@@ -232,6 +246,10 @@ pub(crate) fn select_balanced_candidates<I: SwarmIdentity>(
     // Sort by PO descending (prioritize higher bins)
     bin_stats.sort_by_key(|b| std::cmp::Reverse(b.0));
 
+    // See select_neighborhood_candidates: exclude connected peers from the
+    // candidate supply or saturating bins starve their own refill.
+    let connected = selector.connected_index();
+
     for (bin, effective, deficit) in bin_stats {
         if selector.is_full() {
             break;
@@ -241,7 +259,9 @@ pub(crate) fn select_balanced_candidates<I: SwarmIdentity>(
         let to_add = deficit.min(selector.remaining());
         let mut added = 0;
 
-        for peer in peer_manager.dialable_overlays_in_bin(bin, to_add) {
+        for peer in peer_manager
+            .dialable_overlays_in_bin_excluding(bin, to_add, |overlay| connected.exists(overlay))
+        {
             if added >= to_add || selector.is_full() {
                 break;
             }
@@ -269,6 +289,55 @@ mod tests {
 
     fn test_proximity_index() -> ProximityIndex {
         ProximityIndex::new(OverlayAddress::from([0u8; 32]), 31, 0)
+    }
+
+    #[test]
+    fn test_balanced_selection_skips_connected_supply() {
+        use vertex_swarm_test_utils::{MockIdentity, make_swarm_peer_minimal};
+
+        // Regression: connected peers are hot and dialable, so without the
+        // exclusion they fill the candidate slice first and a bin with more
+        // connections than its deficit yields no usable candidates, starving
+        // refill (observed live: every bin froze once connected >= deficit).
+        let identity = MockIdentity::with_first_byte(0x00);
+        let peer_manager = PeerManager::new(&identity);
+
+        // Seven known bin-0 peers; the first five are already connected.
+        let overlays: Vec<OverlayAddress> = (0..7u8).map(|i| make_overlay(0x80 + i)).collect();
+        for i in 0..7u8 {
+            peer_manager.store_discovered_peer(make_swarm_peer_minimal(0x80 + i));
+        }
+        let connected_index = test_proximity_index();
+        for overlay in overlays.iter().take(5) {
+            connected_index.add(*overlay).expect("add connected");
+        }
+
+        let limits = DepthAwareLimits::new(160, 3);
+        let snapshot = CandidateSnapshot {
+            limits: LimitsSnapshot::capture(&limits, d(8)),
+            in_progress: HashSet::new(),
+            queued: HashSet::new(),
+        };
+        let mut selector = CandidateSelector::new(&snapshot, &connected_index, 32);
+
+        // Bin 0 holds 5 connected against a saturation-floored target of 8:
+        // deficit 3, and exactly two unconnected candidates are known.
+        select_balanced_candidates(&mut selector, &peer_manager, |bin| {
+            if bin == b(0) { 5 } else { 0 }
+        });
+
+        let candidates = selector.finish();
+        assert_eq!(
+            candidates.len(),
+            2,
+            "the unconnected peers must be selected despite connected > deficit"
+        );
+        for c in &candidates {
+            assert!(
+                overlays.iter().skip(5).any(|o| o == c),
+                "selected a connected peer"
+            );
+        }
     }
 
     #[test]

--- a/crates/swarm/topology/src/kademlia/candidates.rs
+++ b/crates/swarm/topology/src/kademlia/candidates.rs
@@ -85,8 +85,8 @@ impl<'a> CandidateSelector<'a> {
         self.bin_selections.get(&bin).copied().unwrap_or(0)
     }
 
-    /// The connected-peer index, with the selector's full borrow lifetime so
-    /// callers can hold it across mutable selector use.
+    /// The connected-peer index, with the borrowed data's lifetime so callers
+    /// can hold it across mutable selector use.
     pub(crate) fn connected_index(&self) -> &'a ProximityIndex {
         self.connected_peers
     }
@@ -154,8 +154,9 @@ impl<'a> CandidateSelector<'a> {
         true
     }
 
-    /// Access the snapshot.
-    pub(crate) fn snapshot(&self) -> &CandidateSnapshot {
+    /// Access the snapshot, with the borrowed data's lifetime so callers can
+    /// hold it across mutable selector use.
+    pub(crate) fn snapshot(&self) -> &'a CandidateSnapshot {
         self.snapshot
     }
 
@@ -300,7 +301,7 @@ mod tests {
         // connections than its deficit yields no usable candidates, starving
         // refill (observed live: every bin froze once connected >= deficit).
         let identity = MockIdentity::with_first_byte(0x00);
-        let peer_manager = PeerManager::new(&identity);
+        let peer_manager = PeerManager::new(&identity, PeerManagerConfig::default());
 
         // Seven known bin-0 peers; the first five are already connected.
         let overlays: Vec<OverlayAddress> = (0..7u8).map(|i| make_overlay(0x80 + i)).collect();
@@ -312,7 +313,7 @@ mod tests {
             connected_index.add(*overlay).expect("add connected");
         }
 
-        let limits = DepthAwareLimits::new(160, 3);
+        let limits = DepthAwareLimits::new(160, 3).with_saturation(8);
         let snapshot = CandidateSnapshot {
             limits: LimitsSnapshot::capture(&limits, d(8)),
             in_progress: HashSet::new(),

--- a/crates/swarm/topology/src/kademlia/config.rs
+++ b/crates/swarm/topology/src/kademlia/config.rs
@@ -38,15 +38,15 @@ impl Default for KademliaConfig {
 }
 
 impl KademliaConfig {
-    /// Create with custom total target peers.
+    /// Create with custom total target peers, preserving all other limits.
     pub fn with_total_target(mut self, total: usize) -> Self {
-        self.limits = DepthAwareLimits::new(total, self.limits.nominal());
+        self.limits = self.limits.with_total_target(total);
         self
     }
 
-    /// Create with custom nominal minimum per bin.
+    /// Create with custom nominal minimum per bin, preserving all other limits.
     pub fn with_nominal(mut self, nominal: usize) -> Self {
-        self.limits = DepthAwareLimits::new(self.limits.total_target(), nominal);
+        self.limits = self.limits.with_nominal(nominal);
         self
     }
 
@@ -70,6 +70,12 @@ impl KademliaConfig {
     /// Set the per-bin bootstrap fill target used while `depth == 0`.
     pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
         self.limits = self.limits.with_bootstrap_target(target);
+        self
+    }
+
+    /// Set the saturation threshold (production threads it from the spec).
+    pub(crate) fn with_saturation(mut self, saturation: usize) -> Self {
+        self.limits = self.limits.with_saturation(saturation);
         self
     }
 }
@@ -106,6 +112,21 @@ mod tests {
         let config = KademliaConfig::default().with_nominal(5);
         assert_eq!(config.limits.nominal(), 5);
         assert_eq!(config.limits.total_target(), 160);
+    }
+
+    #[test]
+    fn test_builders_preserve_sibling_fields() {
+        // Builders must not silently reset other limits to defaults.
+        let config = KademliaConfig::default()
+            .with_inbound_headroom(8)
+            .with_total_target(64)
+            .with_nominal(5);
+        assert_eq!(config.limits.total_target(), 64);
+        assert_eq!(config.limits.nominal(), 5);
+        // Headroom survived the later builders: bin 7 at depth 8 has target
+        // 64 * 8 / 36 = 14, ceiling = max(14 + 8, 18) = 22.
+        assert!(config.limits.should_accept_inbound(b(7), d(8), 21));
+        assert!(!config.limits.should_accept_inbound(b(7), d(8), 22));
     }
 
     #[test]

--- a/crates/swarm/topology/src/kademlia/limits.rs
+++ b/crates/swarm/topology/src/kademlia/limits.rs
@@ -3,10 +3,13 @@
 //! Allocates more peers to higher bins (closer neighbors) where peers are
 //! scarcer and more valuable for retrieval parallelization.
 
+use vertex_swarm_api::DEFAULT_SATURATION_PEERS;
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth};
 
-/// Default minimum peers per bin (floor for the linear taper and for depth
-/// estimation). A bin is considered populated once it holds this many peers.
+/// Default minimum peers per bin for depth estimation. A bin is considered
+/// populated once it holds this many peers. Note this is NOT the taper floor:
+/// allocation targets are additionally floored at `saturation` so every
+/// balanced bin can reach the depth frontier (see [`DepthAwareLimits::target`]).
 const DEFAULT_NOMINAL: usize = 3;
 
 /// Default total connected-peer target across all bins. The linear taper
@@ -19,27 +22,46 @@ const DEFAULT_TOTAL_TARGET: usize = 160;
 /// single bin grow unbounded.
 pub(crate) const DEFAULT_INBOUND_HEADROOM: usize = 4;
 
-/// Default per-bin fill target during bootstrap (`depth == 0`).
+/// Default per-bin fill target during bootstrap (`depth == 0`), and the
+/// per-bin floor below which trimming never evicts ([`DepthAwareLimits::surplus`]).
 ///
 /// Before a neighborhood is established every bin is filled aggressively toward
 /// this bound so bins reach the saturation frontier quickly and depth can climb.
 /// Must be `>= SwarmSpec::saturation_peers()` or depth can never advance past 0.
 /// Bounded (not `usize::MAX`) so a node that has not yet established a
 /// neighborhood cannot be flooded by inbound connections. Matches the reference
-/// network's oversaturation level.
+/// network's oversaturation level, which is also its prune floor.
 pub(crate) const DEFAULT_BOOTSTRAP_TARGET: usize = 18;
 
 /// Depth-aware peer allocation with linear tapering across Kademlia bins.
 ///
 /// Stateless: callers provide depth explicitly to avoid dual-source-of-truth bugs.
+///
+/// # Depth coupling invariants
+///
+/// Neighborhood depth is recomputed from connected-peer bin counts against
+/// `SwarmSpec::saturation_peers()`: the shallowest bin below saturation caps
+/// the depth. Allocation and trimming must therefore never hold or cut a
+/// balanced bin below saturation, or depth deadlocks at that bin with no
+/// error signal:
+///
+/// - every allocation target (bootstrap, taper) is floored at `saturation`,
+/// - trimming ([`Self::surplus`]) only reclaims peers above
+///   `max(target, bootstrap_target)`, mirroring the reference network which
+///   prunes only above its oversaturation level (18) and never toward an
+///   allocation target.
 #[derive(Debug, Clone)]
 pub(crate) struct DepthAwareLimits {
     total_target: usize,
-    /// Minimum peers per bin.
+    /// Minimum peers per bin for depth estimation.
     nominal: usize,
     inbound_headroom: usize,
     /// Per-bin fill target during bootstrap (`depth == 0`).
     bootstrap_target: usize,
+    /// Per-bin saturation threshold from `SwarmSpec::saturation_peers()`.
+    /// Floors every balanced-bin allocation target so bins can reach the
+    /// depth frontier.
+    saturation: usize,
 }
 
 impl Default for DepthAwareLimits {
@@ -56,12 +78,27 @@ impl DepthAwareLimits {
             nominal,
             inbound_headroom: DEFAULT_INBOUND_HEADROOM,
             bootstrap_target: DEFAULT_BOOTSTRAP_TARGET,
+            saturation: DEFAULT_SATURATION_PEERS as usize,
         }
     }
 
     /// Create with custom inbound headroom.
     pub(crate) fn with_inbound_headroom(mut self, headroom: usize) -> Self {
         self.inbound_headroom = headroom;
+        self
+    }
+
+    /// Set the saturation floor from `SwarmSpec::saturation_peers()`.
+    ///
+    /// Must match the value the depth recomputation uses, and must not exceed
+    /// `bootstrap_target` (see the type-level invariants).
+    pub(crate) fn with_saturation(mut self, saturation: usize) -> Self {
+        debug_assert!(
+            saturation <= self.bootstrap_target,
+            "saturation ({saturation}) must be <= bootstrap_target ({}) or depth cannot climb",
+            self.bootstrap_target
+        );
+        self.saturation = saturation;
         self
     }
 
@@ -96,7 +133,11 @@ impl DepthAwareLimits {
             let d = depth.get() as usize;
             let weight_sum = d * (d + 1) / 2;
             let allocated = self.total_target.saturating_mul(weight) / weight_sum;
-            allocated.max(self.nominal)
+            // Floor at saturation: depth is capped by the shallowest bin below
+            // `saturation_peers`, so a target below it would pin depth at that
+            // bin forever (the taper alone gives shallow bins as few as
+            // total_target / weight_sum peers).
+            allocated.max(self.nominal).max(self.saturation)
         }
     }
 
@@ -122,13 +163,21 @@ impl DepthAwareLimits {
         }
     }
 
-    /// Surplus above target at specified depth (0 if at or below target).
+    /// Surplus eligible for trimming at the specified depth.
+    ///
+    /// Trimming reclaims peers only above `max(target, bootstrap_target)`,
+    /// never down to the taper target itself. The taper target is a dial
+    /// goal, not an eviction bound: evicting toward it after a depth increase
+    /// cuts shallow bins below saturation, which immediately collapses depth
+    /// back to the cut bin (observed live: depth 7 -> 0 with bins trimmed to
+    /// the exact taper targets). The reference network likewise prunes only
+    /// above its oversaturation level (18) regardless of allocation.
     pub(crate) fn surplus(&self, bin: Bin, depth: NeighborhoodDepth, connected: usize) -> usize {
         let target = self.target(bin, depth);
         if target == usize::MAX {
             0
         } else {
-            connected.saturating_sub(target)
+            connected.saturating_sub(target.max(self.bootstrap_target))
         }
     }
 
@@ -183,8 +232,12 @@ impl DepthAwareLimits {
 #[cfg(test)]
 impl DepthAwareLimits {
     /// Set the per-bin bootstrap fill target used while `depth == 0`.
+    ///
+    /// Clamps the saturation floor down to the target so small-scale test
+    /// fixtures keep the `saturation <= bootstrap_target` invariant.
     pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
         self.bootstrap_target = target;
+        self.saturation = self.saturation.min(target);
         self
     }
 
@@ -313,15 +366,109 @@ mod tests {
 
         // Weight sum for depth 8: 8 × 9 / 2 = 36
         // Bin 7: 160 × 8 / 36 = 35.5 → 35
-        // Bin 0: 160 × 1 / 36 = 4.4 → max(4, 3) = 4
+        // Bin 0: 160 × 1 / 36 = 4.4 → floored at saturation (8)
 
         assert_eq!(limits.target(b(7), d(8)), 35);
         assert_eq!(limits.target(b(6), d(8)), 31); // 160 × 7 / 36 = 31.1
-        assert_eq!(limits.target(b(0), d(8)), 4); // 160 × 1 / 36 = 4.4
+        assert_eq!(limits.target(b(0), d(8)), 8); // taper 4.4, saturation floor
 
         // Neighborhood (bin >= depth) returns MAX
         assert_eq!(limits.target(b(8), d(8)), usize::MAX);
         assert_eq!(limits.target(b(10), d(8)), usize::MAX);
+    }
+
+    #[test]
+    fn test_taper_floored_at_saturation_for_all_depths() {
+        // Depth is capped by the shallowest bin below saturation, so every
+        // balanced-bin target must be at least the saturation threshold or
+        // depth deadlocks at that bin.
+        let saturation = 8usize;
+        let limits = DepthAwareLimits::new(160, 3).with_saturation(saturation);
+
+        for depth in 1..=31u8 {
+            for bin in 0..depth {
+                let target = limits.target(b(bin), d(depth));
+                assert!(
+                    target >= saturation,
+                    "target {target} < saturation {saturation} at bin {bin}, depth {depth}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_trim_floor_never_cuts_below_bootstrap_target() {
+        // Trimming reclaims only above max(target, bootstrap_target): the
+        // taper target is a dial goal, not an eviction bound.
+        let limits = DepthAwareLimits::new(160, 3).with_saturation(8);
+
+        // At depth 7 the raw taper gives bin 0 only 160/28 = 5 (floored to 8),
+        // but trim must leave up to bootstrap_target (18) untouched.
+        assert_eq!(limits.surplus(b(0), d(7), 18), 0);
+        assert_eq!(limits.surplus(b(0), d(7), 26), 8);
+        assert_eq!(limits.surplus(b(1), d(7), 25), 7);
+
+        // Targets above the floor trim to the target as before.
+        assert_eq!(limits.surplus(b(7), d(8), 40), 5); // target 35
+    }
+
+    #[test]
+    fn test_trim_preserves_depth_regression() {
+        // Regression for the 2026-06-10 mainnet capture: depth climbed to 7,
+        // the depth-change trim cut bins 0/1/2 down to the raw taper targets
+        // (5/11/17), bin 0 fell below saturation and depth collapsed 7 -> 0
+        // permanently. With the trim and taper floors, applying the trim to
+        // the captured pre-trim populations must not reduce the recomputed
+        // depth.
+        let saturation = 8u8;
+        let low_watermark = 3u8;
+        let limits = DepthAwareLimits::new(160, 3).with_saturation(saturation as usize);
+        let depth = d(7);
+
+        // Connected-per-bin populations captured right before the trim.
+        let mut connected = [0usize; 32];
+        for (bin, count) in [
+            (0, 26),
+            (1, 25),
+            (2, 23),
+            (3, 16),
+            (4, 9),
+            (5, 11),
+            (6, 13),
+            (7, 14),
+            (8, 9),
+            (9, 3),
+        ] {
+            connected[bin] = count;
+        }
+
+        let before_depth = nectar_primitives::recompute_neighborhood_depth(
+            &connected.map(|c| c as u8),
+            saturation,
+            low_watermark,
+        );
+        assert!(before_depth.get() >= 7, "capture state supports depth 7");
+
+        // Apply the trim: every balanced bin loses its surplus.
+        let mut after = [0u8; 32];
+        for (i, slot) in after.iter_mut().enumerate() {
+            let bin = b(i as u8);
+            let surplus = if depth.contains(bin) {
+                0
+            } else {
+                limits.surplus(bin, depth, connected[i])
+            };
+            *slot = (connected[i] - surplus) as u8;
+        }
+
+        let after_depth =
+            nectar_primitives::recompute_neighborhood_depth(&after, saturation, low_watermark);
+        assert!(
+            after_depth.get() >= before_depth.get().min(7),
+            "trim collapsed depth: before={} after={}",
+            before_depth.get(),
+            after_depth.get()
+        );
     }
 
     #[test]

--- a/crates/swarm/topology/src/kademlia/limits.rs
+++ b/crates/swarm/topology/src/kademlia/limits.rs
@@ -22,15 +22,18 @@ const DEFAULT_TOTAL_TARGET: usize = 160;
 /// single bin grow unbounded.
 pub(crate) const DEFAULT_INBOUND_HEADROOM: usize = 4;
 
-/// Default per-bin fill target during bootstrap (`depth == 0`), and the
-/// per-bin floor below which trimming never evicts ([`DepthAwareLimits::surplus`]).
+/// Default per-bin oversaturation level: the bootstrap fill target
+/// (`depth == 0`), the floor below which trimming never evicts
+/// ([`DepthAwareLimits::surplus`]), and the minimum inbound ceiling
+/// ([`DepthAwareLimits::ceiling`]).
 ///
-/// Before a neighborhood is established every bin is filled aggressively toward
-/// this bound so bins reach the saturation frontier quickly and depth can climb.
-/// Must be `>= SwarmSpec::saturation_peers()` or depth can never advance past 0.
-/// Bounded (not `usize::MAX`) so a node that has not yet established a
-/// neighborhood cannot be flooded by inbound connections. Matches the reference
-/// network's oversaturation level, which is also its prune floor.
+/// Together with the saturation floor this defines the per-bin band: dial
+/// toward `max(taper, saturation)`, accept inbound up to this level, trim
+/// only above it. Before a neighborhood is established every bin is filled
+/// aggressively toward this bound so bins reach the saturation frontier
+/// quickly and depth can climb. Bounded (not `usize::MAX`) so a node that
+/// has not yet established a neighborhood cannot be flooded by inbound
+/// connections.
 pub(crate) const DEFAULT_BOOTSTRAP_TARGET: usize = 18;
 
 /// Depth-aware peer allocation with linear tapering across Kademlia bins.
@@ -40,16 +43,17 @@ pub(crate) const DEFAULT_BOOTSTRAP_TARGET: usize = 18;
 /// # Depth coupling invariants
 ///
 /// Neighborhood depth is recomputed from connected-peer bin counts against
-/// `SwarmSpec::saturation_peers()`: the shallowest bin below saturation caps
-/// the depth. Allocation and trimming must therefore never hold or cut a
+/// this type's `saturation` (threaded from `SwarmSpec::saturation_peers()`
+/// at behaviour construction): the shallowest bin below saturation caps the
+/// depth. Allocation and trimming must therefore never hold or cut a
 /// balanced bin below saturation, or depth deadlocks at that bin with no
-/// error signal:
+/// error signal. Both properties are structural, not asserted:
 ///
-/// - every allocation target (bootstrap, taper) is floored at `saturation`,
+/// - every allocation target (bootstrap and taper) is floored at
+///   `saturation` inside [`Self::target`], so no configuration can produce
+///   a target below it,
 /// - trimming ([`Self::surplus`]) only reclaims peers above
-///   `max(target, bootstrap_target)`, mirroring the reference network which
-///   prunes only above its oversaturation level (18) and never toward an
-///   allocation target.
+///   `max(target, bootstrap_target)`, never toward a dial target.
 #[derive(Debug, Clone)]
 pub(crate) struct DepthAwareLimits {
     total_target: usize,
@@ -88,18 +92,33 @@ impl DepthAwareLimits {
         self
     }
 
-    /// Set the saturation floor from `SwarmSpec::saturation_peers()`.
+    /// Set the saturation threshold from `SwarmSpec::saturation_peers()`.
     ///
-    /// Must match the value the depth recomputation uses, and must not exceed
-    /// `bootstrap_target` (see the type-level invariants).
+    /// Depth recomputation reads it back via [`Self::saturation`], so
+    /// allocation and the depth frontier always agree. Every allocation
+    /// target is floored at this value inside [`Self::target`], so no
+    /// combination with `bootstrap_target` can deadlock depth.
     pub(crate) fn with_saturation(mut self, saturation: usize) -> Self {
-        debug_assert!(
-            saturation <= self.bootstrap_target,
-            "saturation ({saturation}) must be <= bootstrap_target ({}) or depth cannot climb",
-            self.bootstrap_target
-        );
         self.saturation = saturation;
         self
+    }
+
+    /// Set the total connected-peer dial budget, preserving all other fields.
+    pub(crate) fn with_total_target(mut self, total_target: usize) -> Self {
+        self.total_target = total_target;
+        self
+    }
+
+    /// Set the per-bin depth-estimation minimum, preserving all other fields.
+    pub(crate) fn with_nominal(mut self, nominal: usize) -> Self {
+        self.nominal = nominal;
+        self
+    }
+
+    /// Per-bin saturation threshold; the depth frontier and all allocation
+    /// floors derive from this single value.
+    pub(crate) fn saturation(&self) -> usize {
+        self.saturation
     }
 
     /// Minimum peers per bin (floor).
@@ -119,8 +138,9 @@ impl DepthAwareLimits {
             // Bootstrap: no neighborhood established yet. Fill every bin
             // aggressively toward `bootstrap_target` so bins reach the
             // saturation frontier quickly and depth can climb. Bounded so a
-            // not-yet-established node cannot be flooded by inbound.
-            return self.bootstrap_target;
+            // not-yet-established node cannot be flooded by inbound. Floored
+            // at saturation so no configuration can pin depth at 0.
+            return self.bootstrap_target.max(self.saturation);
         }
 
         if depth.contains(bin) {
@@ -170,8 +190,7 @@ impl DepthAwareLimits {
     /// goal, not an eviction bound: evicting toward it after a depth increase
     /// cuts shallow bins below saturation, which immediately collapses depth
     /// back to the cut bin (observed live: depth 7 -> 0 with bins trimmed to
-    /// the exact taper targets). The reference network likewise prunes only
-    /// above its oversaturation level (18) regardless of allocation.
+    /// the exact taper targets).
     pub(crate) fn surplus(&self, bin: Bin, depth: NeighborhoodDepth, connected: usize) -> usize {
         let target = self.target(bin, depth);
         if target == usize::MAX {
@@ -181,30 +200,32 @@ impl DepthAwareLimits {
         }
     }
 
-    /// Target + inbound headroom (max before rejecting inbound). `usize::MAX` for neighborhood.
+    /// Maximum bin population before rejecting inbound. `usize::MAX` for
+    /// neighborhood bins.
+    ///
+    /// `max(target + headroom, bootstrap_target)`: shallow bins whose dial
+    /// target sits at the saturation floor still accept inbound up to the
+    /// oversaturation level, so churn erodes them toward `bootstrap_target`
+    /// rather than toward the depth frontier (dial to saturation, accept to
+    /// oversaturation, trim above it). This also keeps the ceiling aligned
+    /// with the trim floor in [`Self::surplus`].
     pub(crate) fn ceiling(&self, bin: Bin, depth: NeighborhoodDepth) -> usize {
         let target = self.target(bin, depth);
         if target == usize::MAX {
             usize::MAX
         } else {
-            target + self.inbound_headroom
+            (target + self.inbound_headroom).max(self.bootstrap_target)
         }
     }
 
-    /// Check if bin should accept inbound (allows headroom above target).
+    /// Check if bin should accept inbound (up to [`Self::ceiling`]).
     pub(crate) fn should_accept_inbound(
         &self,
         bin: Bin,
         depth: NeighborhoodDepth,
         connected: usize,
     ) -> bool {
-        let target = self.target(bin, depth);
-        if target == usize::MAX {
-            // Neighborhood: always accept
-            true
-        } else {
-            connected < target + self.inbound_headroom
-        }
+        connected < self.ceiling(bin, depth)
     }
 
     /// Estimate depth from known peer distribution (highest bin with >= nominal peers).
@@ -233,11 +254,11 @@ impl DepthAwareLimits {
 impl DepthAwareLimits {
     /// Set the per-bin bootstrap fill target used while `depth == 0`.
     ///
-    /// Clamps the saturation floor down to the target so small-scale test
-    /// fixtures keep the `saturation <= bootstrap_target` invariant.
+    /// Small-scale fixtures usually pair this with [`Self::with_saturation`];
+    /// targets are floored at saturation, so a bootstrap target below the
+    /// (default 8) saturation has no effect on its own.
     pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
         self.bootstrap_target = target;
-        self.saturation = self.saturation.min(target);
         self
     }
 
@@ -463,6 +484,10 @@ mod tests {
 
         let after_depth =
             nectar_primitives::recompute_neighborhood_depth(&after, saturation, low_watermark);
+        // The pre-trim state supports depth 9 via the sparse tail (bins 8-9);
+        // the invariant under test is that trimming never cuts depth below
+        // the climb the trim was triggered by (7), not that the tail anchor
+        // survives, hence the min.
         assert!(
             after_depth.get() >= before_depth.get().min(7),
             "trim collapsed depth: before={} after={}",

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -151,6 +151,15 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
             + atomic_load(&self.active_counts, bin)
     }
 
+    /// Peers in a bin that eviction can actually act on (handshaking and
+    /// active). In-flight dials hold capacity but cannot be evicted; counting
+    /// them into the trim surplus would force active evictions to pay for
+    /// slots the evictable population does not own, cutting the bin below
+    /// saturation and flapping depth.
+    fn evictable_count(&self, bin: Bin) -> usize {
+        atomic_load(&self.handshaking_counts, bin) + atomic_load(&self.active_counts, bin)
+    }
+
     /// The deepest bin in this routing table, as a typed [`Bin`].
     pub(crate) fn max_bin(&self) -> Bin {
         Bin::new(self.max_po).unwrap_or(Bin::MAX)
@@ -200,11 +209,13 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
             *slot = u8::try_from(size).unwrap_or(u8::MAX);
         }
 
-        let depth = recompute_neighborhood_depth(
-            &counts,
-            spec.saturation_peers(),
-            spec.neighborhood_low_watermark(),
-        );
+        // Saturation comes from the limits so the depth frontier and the
+        // allocation floors can never disagree, on any construction path;
+        // production threads `SwarmSpec::saturation_peers()` into the limits
+        // at behaviour construction.
+        let saturation = u8::try_from(self.config.limits.saturation()).unwrap_or(u8::MAX);
+        let depth =
+            recompute_neighborhood_depth(&counts, saturation, spec.neighborhood_low_watermark());
         NeighborhoodDepth::new(Bin::new(depth.get().min(self.max_po)).unwrap_or(Bin::MAX))
     }
 
@@ -282,8 +293,8 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         }
 
         for bin in balanced_bins(depth) {
-            let effective = self.effective_count(bin);
-            let surplus = self.config.limits.surplus(bin, depth, effective);
+            let evictable = self.evictable_count(bin);
+            let surplus = self.config.limits.surplus(bin, depth, evictable);
             if surplus == 0 {
                 continue;
             }
@@ -767,7 +778,8 @@ mod tests {
         // exercised with small numbers (default bootstrap fill is generous).
         let config = KademliaConfig::default()
             .with_nominal(2)
-            .with_bootstrap_target(2);
+            .with_bootstrap_target(2)
+            .with_saturation(2);
         let (routing, _pm) = make_routing(base, config);
 
         let peer1 = SwarmAddress::with_first_byte(0x80); // bin=0
@@ -961,7 +973,8 @@ mod tests {
         let config = KademliaConfig::default()
             .with_nominal(2)
             .with_inbound_headroom(0)
-            .with_bootstrap_target(2);
+            .with_bootstrap_target(2)
+            .with_saturation(2);
         let (routing, _pm) = make_routing(base, config);
 
         let peer1 = SwarmAddress::with_first_byte(0x80);
@@ -1052,11 +1065,12 @@ mod tests {
     #[test]
     fn test_eviction_candidates_handshaking_first() {
         let base = SwarmAddress::with_first_byte(0x00);
-        // Pin bootstrap_target (the trim floor) to 4 so a small bin-0
-        // population yields a surplus; this also clamps the test saturation
-        // floor to 4, keeping the depth-8 bin-0 target at 4 as the original
-        // scenario assumed.
-        let config = KademliaConfig::default().with_bootstrap_target(4);
+        // Pin the trim floor (bootstrap_target) and saturation to 4 so a
+        // small bin-0 population yields a surplus and the depth-8 bin-0
+        // target stays at 4 as the original scenario assumed.
+        let config = KademliaConfig::default()
+            .with_bootstrap_target(4)
+            .with_saturation(4);
         let (routing, _pm) = make_routing(base, config);
 
         // Place 5 active peers in bin 0 (bin=0)
@@ -1099,7 +1113,9 @@ mod tests {
     fn test_eviction_candidates_active_lowest_score() {
         let base = SwarmAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
-        let config = KademliaConfig::default().with_bootstrap_target(4);
+        let config = KademliaConfig::default()
+            .with_bootstrap_target(4)
+            .with_saturation(4);
         let (routing, _pm) = make_routing(base, config);
 
         // Place 6 active peers in bin 0
@@ -1126,10 +1142,54 @@ mod tests {
     }
 
     #[test]
+    fn test_eviction_ignores_in_flight_dials() {
+        let base = SwarmAddress::with_first_byte(0x00);
+        // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
+        let config = KademliaConfig::default()
+            .with_bootstrap_target(4)
+            .with_saturation(4);
+        let (routing, _pm) = make_routing(base, config);
+
+        // 5 active peers and 3 in-flight dials in bin 0. At depth 8 the trim
+        // floor is 4: the evictable population (5 active) carries a surplus
+        // of 1. Counting the dials in would claim a surplus of 4 and cut the
+        // bin's active set to 1, far below saturation, flapping depth.
+        for i in 0..5 {
+            let mut bytes = [0x00u8; 32];
+            bytes[0] = 0x80 + i;
+            force_active(&routing, OverlayAddress::from(bytes));
+        }
+        for i in 0..3 {
+            let mut bytes = [0x00u8; 32];
+            bytes[0] = 0x90 + i;
+            let peer = OverlayAddress::from(bytes);
+            atomic_inc(&routing.dialing_counts, routing.bin_for(&peer));
+            routing
+                .connection_phases
+                .write()
+                .insert(peer, ConnectionPhase::Dialing);
+        }
+        routing.depth.store(8, Ordering::Relaxed);
+
+        let candidates = routing.eviction_candidates(|_| 1);
+        assert_eq!(
+            candidates.len(),
+            1,
+            "surplus must be computed from the evictable population only"
+        );
+        assert_eq!(candidates[0].phase, EvictionPhase::Active);
+    }
+
+    #[test]
     fn test_eviction_prefers_least_reachable() {
         let base = SwarmAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
-        let (routing, _pm) = make_routing(base, KademliaConfig::default().with_bootstrap_target(4));
+        let (routing, _pm) = make_routing(
+            base,
+            KademliaConfig::default()
+                .with_bootstrap_target(4)
+                .with_saturation(4),
+        );
 
         // 6 active peers in bin 0; at depth 8 the target is 4, so surplus is 2.
         let peers: Vec<_> = (0..6)
@@ -1167,7 +1227,12 @@ mod tests {
 
         let base = SwarmAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
-        let (routing, _pm) = make_routing(base, KademliaConfig::default().with_bootstrap_target(4));
+        let (routing, _pm) = make_routing(
+            base,
+            KademliaConfig::default()
+                .with_bootstrap_target(4)
+                .with_saturation(4),
+        );
 
         // 6 active peers in bin 0; at depth 8 the target is 4, so surplus is 2.
         let peers: Vec<_> = (0..6)
@@ -1205,7 +1270,12 @@ mod tests {
 
         let base = SwarmAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
-        let (routing, _pm) = make_routing(base, KademliaConfig::default().with_bootstrap_target(4));
+        let (routing, _pm) = make_routing(
+            base,
+            KademliaConfig::default()
+                .with_bootstrap_target(4)
+                .with_saturation(4),
+        );
 
         // 5 active peers in bin 0; at depth 8 the target is 4, so surplus is 1.
         let peers: Vec<_> = (0..5)
@@ -1242,13 +1312,12 @@ mod tests {
     #[test]
     fn test_eviction_candidates_neighborhood_never_evicted() {
         let base = SwarmAddress::with_first_byte(0x00);
-        // Small total target plus a trim floor of 6 so below-depth bins
-        // (8 connected each) overflow and actually yield eviction candidates,
-        // while depth recomputation still sees them as saturated (spec
-        // saturation is 8).
+        // Trim floor pinned to the saturation default (8); dialing alone can
+        // never exceed it, so the overflow that yields eviction candidates
+        // must arrive through the inbound headroom band.
         let config = KademliaConfig::default()
             .with_total_target(8)
-            .with_bootstrap_target(6);
+            .with_bootstrap_target(8);
         let (routing, _pm) = make_routing(base, config);
 
         let connect = |peer: OverlayAddress| {
@@ -1257,12 +1326,21 @@ mod tests {
             routing.handshake_completed(&peer);
             SwarmRouting::connected(&*routing, peer);
         };
+        let accept_inbound = |peer: OverlayAddress| {
+            routing.reserve_inbound(&peer);
+            routing.handshake_completed(&peer);
+            SwarmRouting::connected(&*routing, peer);
+        };
 
-        // Saturate bins 0 and 1 (>= saturation) and anchor bin 2 with the low
-        // watermark so depth climbs to 2; bin 2 is then a neighborhood bin.
+        // Fill bins 0 and 1 to the trim floor by dialing, then overfill them
+        // through the inbound band; anchor bin 2 with the low watermark so
+        // depth climbs to 2 and bin 2 becomes a neighborhood bin.
         for bin in 0..2 {
             for idx in 0..8 {
                 connect(addr_in_bin(bin, idx));
+            }
+            for idx in 8..10 {
+                accept_inbound(addr_in_bin(bin, idx));
             }
         }
         for idx in 0..6 {

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -1005,8 +1005,8 @@ mod tests {
         // At depth 8, targets should vary by bin
         // Bin 7: 160 × 8 / 36 = 35
         assert_eq!(routing.config.limits.target(b(7), d(8)), 35);
-        // Bin 0: 160 × 1 / 36 = 4
-        assert_eq!(routing.config.limits.target(b(0), d(8)), 4);
+        // Bin 0: taper gives 160 × 1 / 36 = 4, floored at saturation (8)
+        assert_eq!(routing.config.limits.target(b(0), d(8)), 8);
         // Neighborhood (bin >= depth) returns MAX
         assert_eq!(routing.config.limits.target(b(8), d(8)), usize::MAX);
     }
@@ -1052,7 +1052,11 @@ mod tests {
     #[test]
     fn test_eviction_candidates_handshaking_first() {
         let base = SwarmAddress::with_first_byte(0x00);
-        let config = KademliaConfig::default(); // nominal=3, total_target=160
+        // Pin bootstrap_target (the trim floor) to 4 so a small bin-0
+        // population yields a surplus; this also clamps the test saturation
+        // floor to 4, keeping the depth-8 bin-0 target at 4 as the original
+        // scenario assumed.
+        let config = KademliaConfig::default().with_bootstrap_target(4);
         let (routing, _pm) = make_routing(base, config);
 
         // Place 5 active peers in bin 0 (bin=0)
@@ -1094,7 +1098,8 @@ mod tests {
     #[test]
     fn test_eviction_candidates_active_lowest_score() {
         let base = SwarmAddress::with_first_byte(0x00);
-        let config = KademliaConfig::default(); // nominal=3, total_target=160
+        // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
+        let config = KademliaConfig::default().with_bootstrap_target(4);
         let (routing, _pm) = make_routing(base, config);
 
         // Place 6 active peers in bin 0
@@ -1123,7 +1128,8 @@ mod tests {
     #[test]
     fn test_eviction_prefers_least_reachable() {
         let base = SwarmAddress::with_first_byte(0x00);
-        let (routing, _pm) = make_routing(base, KademliaConfig::default());
+        // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
+        let (routing, _pm) = make_routing(base, KademliaConfig::default().with_bootstrap_target(4));
 
         // 6 active peers in bin 0; at depth 8 the target is 4, so surplus is 2.
         let peers: Vec<_> = (0..6)
@@ -1160,7 +1166,8 @@ mod tests {
         use crate::PeerReachability;
 
         let base = SwarmAddress::with_first_byte(0x00);
-        let (routing, _pm) = make_routing(base, KademliaConfig::default());
+        // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
+        let (routing, _pm) = make_routing(base, KademliaConfig::default().with_bootstrap_target(4));
 
         // 6 active peers in bin 0; at depth 8 the target is 4, so surplus is 2.
         let peers: Vec<_> = (0..6)
@@ -1197,7 +1204,8 @@ mod tests {
         use crate::PeerReachability;
 
         let base = SwarmAddress::with_first_byte(0x00);
-        let (routing, _pm) = make_routing(base, KademliaConfig::default());
+        // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
+        let (routing, _pm) = make_routing(base, KademliaConfig::default().with_bootstrap_target(4));
 
         // 5 active peers in bin 0; at depth 8 the target is 4, so surplus is 1.
         let peers: Vec<_> = (0..5)
@@ -1234,9 +1242,13 @@ mod tests {
     #[test]
     fn test_eviction_candidates_neighborhood_never_evicted() {
         let base = SwarmAddress::with_first_byte(0x00);
-        // Small total target so below-depth bins overflow their tapered target
-        // and actually yield eviction candidates.
-        let config = KademliaConfig::default().with_total_target(8);
+        // Small total target plus a trim floor of 6 so below-depth bins
+        // (8 connected each) overflow and actually yield eviction candidates,
+        // while depth recomputation still sees them as saturated (spec
+        // saturation is 8).
+        let config = KademliaConfig::default()
+            .with_total_target(8)
+            .with_bootstrap_target(6);
         let (routing, _pm) = make_routing(base, config);
 
         let connect = |peer: OverlayAddress| {


### PR DESCRIPTION
Closes #225

## Problem

On mainnet, neighbourhood depth stayed at 0 indefinitely while the node held 150+ connections. Forensics on a 15-minute JSON capture showed three coupled bugs forming a deadlock:

1. **Trim cut below saturation.** The eviction surplus was computed against the linear taper target alone, so shallow bins were trimmed down to allocations (5, 11, 17 peers) below the saturation level (8) that depth recomputation requires. Every climb triggered a trim that immediately undid it.
2. **Taper floor below saturation.** The per-bin allocation `total_target * (bin + 1) / weight_sum` was floored only at `nominal` (3), so shallow-bin targets could never support a saturated bin in the first place.
3. **Candidate supply polluted by connected peers.** Dialable candidate selection drew from the known table without excluding already-connected overlays, so saturating bins returned only peers we were already connected to and starved their own refill.

## Fix

- Floor the taper allocation at saturation, and floor the bootstrap allocation at saturation so a `bootstrap_target` below saturation is unrepresentable (no runtime assert needed).
- Trim surplus is measured against `max(target, bootstrap_target)`, and only over the evictable population (handshaking and active); in-flight dials hold capacity but cannot be evicted, so charging their slots to active peers cut bins below saturation.
- Inbound admission gets an explicit ceiling band `(target + inbound_headroom).max(bootstrap_target)` so the dial path, inbound path, and trim floor describe one coherent band, mirroring the reference network's dial-to-saturation / accept-to-oversaturation behaviour.
- Depth recomputation reads saturation from the limits themselves instead of re-reading the spec, so there is a single source of truth; the node builder threads the spec's `saturation_peers` into the limits at construction.
- Both candidate selection paths exclude connected, in-progress, and queued overlays from the dialable supply, with the peer manager exposing `dialable_overlays_in_bin_excluding`. This also fixes an `attempt to add with overflow` panic in the over-fetch arithmetic when callers passed `usize::MAX`.

## Verification

- Capture-replay regression test reproducing the mainnet bin distribution (depth 7, bins 26/25/23/16/9/11/13/14/9/3) and asserting trim no longer collapses depth.
- Live mainnet run before review changes: depth climbed 0 to 9 in 88 seconds and held for 10+ minutes with bins pinned at the oversaturation band and 163 connections. A second live run after the review changes is recorded in the PR conversation.
- Three independent expert reviews (libp2p, Swarm protocol, Rust idiom) returned approve-with-changes; all pre-merge findings are applied here. Structural follow-ups are filed as #226, #227, #228, and #229.

AI Assistance: this PR was developed with the help of an AI coding agent (Claude Code); all changes were reviewed and verified by the author.
