### PR TITLE
refactor(swarm-peers): expose dialable supply as an iterator

### DIFF
--- a/crates/swarm/node/tests/bootnode_cluster.rs
+++ b/crates/swarm/node/tests/bootnode_cluster.rs
@@ -120,10 +120,7 @@ async fn three_node_convergence() -> Result<()> {
     // *Client* peers (today the gossip task short-circuits in
     // `vertex_swarm_topology::gossip::tasks::on_peer_authenticated` via
     // `!node_type.requires_storage()`, so two Client nodes never gossip
-    // about each other through a bootnode). Flipping the cluster to
-    // Storer-typed identities surfaces a separate `usize::MAX`-overflow
-    // bug in `vertex_swarm_peer_manager::storer_overlays_in_bin`, so we
-    // hold this assertion until those land separately.
+    // about each other through a bootnode).
     //
     // Until then, we assert the *necessary* precondition: each client
     // has its own routing snapshot of the bootnode (the only peer it

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -238,16 +238,22 @@ impl<I: SwarmIdentity> PeerManager<I> {
             .collect()
     }
 
-    /// Get known storer overlays in a specific proximity bin (not banned).
-    #[must_use]
-    pub fn storer_overlays_in_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
-        self.index.filter_bin(bin, count, |overlay| {
-            !self.banned_set.contains_key(overlay)
-                && self
-                    .peers
-                    .get(overlay)
-                    .is_some_and(|e| e.node_type() == SwarmNodeType::Storer)
-        })
+    /// Iterate known storer overlays in a specific proximity bin (not banned).
+    ///
+    /// Lazy over a snapshot of the bin's membership: the node-type and ban
+    /// checks run per item as the caller advances, so callers take only
+    /// what they need.
+    pub fn storer_overlays_in_bin(&self, bin: Bin) -> impl Iterator<Item = OverlayAddress> + '_ {
+        self.index
+            .peers_in_bin(bin)
+            .into_iter()
+            .filter(move |overlay| {
+                !self.banned_set.contains_key(overlay)
+                    && self
+                        .peers
+                        .get(overlay)
+                        .is_some_and(|e| e.node_type() == SwarmNodeType::Storer)
+            })
     }
 
     /// Get SwarmPeer data for multiple overlays.
@@ -274,35 +280,32 @@ impl<I: SwarmIdentity> PeerManager<I> {
             .collect()
     }
 
-    /// Get dialable overlay addresses from a specific bin (not banned, not in backoff).
-    pub fn dialable_overlays_in_bin(&self, bin: Bin, count: usize) -> Vec<OverlayAddress> {
-        self.dialable_overlays_in_bin_excluding(bin, count, |_| false)
+    /// Iterate dialable overlay addresses in a specific bin (not banned, not
+    /// in backoff).
+    pub fn dialable_overlays_in_bin(&self, bin: Bin) -> impl Iterator<Item = OverlayAddress> + '_ {
+        self.dialable_overlays_in_bin_excluding(bin, |_| false)
     }
 
-    /// Get dialable overlay addresses from a bin, skipping excluded overlays.
+    /// Iterate dialable overlay addresses in a bin, skipping excluded overlays.
     ///
     /// `exclude` lets the caller remove overlays that are dialable but useless
-    /// as candidates, typically peers it is already connected to. Without the
-    /// exclusion, connected peers (hot and dialable) fill the returned slice
-    /// first and a bin with more connections than `count` yields no usable
-    /// candidates even when many unconnected peers are known.
-    pub fn dialable_overlays_in_bin_excluding(
-        &self,
+    /// as candidates, typically peers it is already connected to. The iterator
+    /// is lazy over a snapshot of the bin's membership: exclusion, ban, and
+    /// dialability checks run per item as the caller advances, so callers take
+    /// only what they need and never pay for the rest of the bin.
+    pub fn dialable_overlays_in_bin_excluding<'a>(
+        &'a self,
         bin: Bin,
-        count: usize,
-        exclude: impl Fn(&OverlayAddress) -> bool,
-    ) -> Vec<OverlayAddress> {
-        self.index.filter_bin(bin, count, |overlay| {
-            !self.banned_set.contains_key(overlay)
-                && !exclude(overlay)
-                && self.peers.get(overlay).is_some_and(|e| e.is_dialable())
-        })
-    }
-
-    /// Get dialable peers from a specific bin (not banned, not in backoff).
-    pub fn dialable_in_bin(&self, bin: Bin, count: usize) -> Vec<SwarmPeer> {
-        let overlays = self.dialable_overlays_in_bin(bin, count);
-        self.get_swarm_peers(&overlays)
+        exclude: impl Fn(&OverlayAddress) -> bool + 'a,
+    ) -> impl Iterator<Item = OverlayAddress> + 'a {
+        self.index
+            .peers_in_bin(bin)
+            .into_iter()
+            .filter(move |overlay| {
+                !self.banned_set.contains_key(overlay)
+                    && !exclude(overlay)
+                    && self.peers.get(overlay).is_some_and(|e| e.is_dialable())
+            })
     }
 
     #[must_use]
@@ -1085,30 +1088,35 @@ mod tests {
     }
 
     #[test]
-    fn test_overlays_in_bin_accept_max_count() {
+    fn test_overlays_in_bin_yield_full_supply() {
         let pm = manager();
         connect(&pm, 1, SwarmNodeType::Storer);
 
         let bin = Bin::from(test_overlay(0).proximity(&test_overlay(1)));
 
-        let storers = pm.storer_overlays_in_bin(bin, usize::MAX);
+        let storers: Vec<_> = pm.storer_overlays_in_bin(bin).collect();
         assert_eq!(storers, vec![test_overlay(1)]);
 
-        let dialable = pm.dialable_overlays_in_bin(bin, usize::MAX);
+        let dialable: Vec<_> = pm.dialable_overlays_in_bin(bin).collect();
         assert_eq!(dialable, vec![test_overlay(1)]);
     }
 
     #[test]
     fn test_dialable_overlays_excluding() {
         let pm = manager();
-        connect(&pm, 1, SwarmNodeType::Storer);
+        // Overlays 2 and 3 share a proximity bin relative to the zero local
+        // overlay.
         connect(&pm, 2, SwarmNodeType::Storer);
+        connect(&pm, 3, SwarmNodeType::Storer);
 
-        let bin = Bin::from(test_overlay(0).proximity(&test_overlay(1)));
-        let excluded = test_overlay(1);
+        let bin = Bin::from(test_overlay(0).proximity(&test_overlay(2)));
+        let excluded = test_overlay(2);
 
-        let dialable = pm.dialable_overlays_in_bin_excluding(bin, usize::MAX, |o| *o == excluded);
+        let dialable: Vec<_> = pm
+            .dialable_overlays_in_bin_excluding(bin, |o| *o == excluded)
+            .collect();
         assert!(!dialable.contains(&excluded));
+        assert!(dialable.contains(&test_overlay(3)));
     }
 
     #[test]
@@ -1171,7 +1179,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dialable_in_bin() {
+    fn test_dialable_in_bin_skips_banned() {
         let pm = manager();
 
         // First bytes 0x80, 0xc0, 0xa0: all bin 0 relative to the zero local
@@ -1183,8 +1191,9 @@ mod tests {
         let p1 = OverlayAddress::from(*make_swarm_peer_minimal(0x80).overlay());
         pm.ban(&p1, BanCause::Requested, None);
 
-        let dialable = pm.dialable_in_bin(Bin::new(0).unwrap(), 2);
+        let dialable: Vec<_> = pm.dialable_overlays_in_bin(Bin::new(0).unwrap()).collect();
         assert_eq!(dialable.len(), 2);
+        assert!(!dialable.contains(&p1));
     }
 
     #[test]

--- a/crates/swarm/peers/peer-manager/src/proximity_index.rs
+++ b/crates/swarm/peers/peer-manager/src/proximity_index.rs
@@ -162,37 +162,14 @@ impl ProximityIndex {
     }
 
     /// Get all addresses in a specific bin (insertion order).
+    ///
+    /// Returns a snapshot taken under the bin's read lock; the result does
+    /// not observe later membership changes. With a nonzero `max_per_bin`
+    /// the snapshot is bounded by that cap.
     pub fn peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress> {
         self.bins
             .get(bin.as_index())
             .map_or_else(Vec::new, |bucket| bucket.read().iter().copied().collect())
-    }
-
-    /// Get up to `count` addresses from a bin that match `predicate`
-    /// (insertion order).
-    ///
-    /// Iterates under the read lock with early exit once `count` matches are found,
-    /// avoiding materializing the entire bin into a Vec.
-    pub fn filter_bin(
-        &self,
-        bin: Bin,
-        count: usize,
-        mut predicate: impl FnMut(&OverlayAddress) -> bool,
-    ) -> Vec<OverlayAddress> {
-        let Some(bucket) = self.bins.get(bin.as_index()) else {
-            return Vec::new();
-        };
-        let bucket = bucket.read();
-        let mut result = Vec::with_capacity(count.min(bucket.len()));
-        for addr in bucket.iter() {
-            if result.len() >= count {
-                break;
-            }
-            if predicate(addr) {
-                result.push(*addr);
-            }
-        }
-        result
     }
 
     /// Iterate from shallowest to deepest proximity order (ascending PO).
@@ -578,35 +555,13 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_bin() {
-        let index = ProximityIndex::new(local_overlay(), 31, 0);
+    fn test_peers_in_bin_empty_and_out_of_range() {
+        let index = ProximityIndex::new(local_overlay(), 3, 0);
 
-        // All in bin 0
-        let addr1 = OverlayAddress::from([0x80; 32]);
-        let addr2 = OverlayAddress::from([0xc0; 32]);
-        let addr3 = OverlayAddress::from([0xa0; 32]);
-        let addr4 = OverlayAddress::from([0xb0; 32]);
+        // Empty bin yields an empty snapshot.
+        assert!(index.peers_in_bin(b(2)).is_empty());
 
-        index.add(addr1).unwrap();
-        index.add(addr2).unwrap();
-        index.add(addr3).unwrap();
-        index.add(addr4).unwrap();
-
-        // Filter with predicate that rejects addr2
-        let result = index.filter_bin(b(0), 3, |a| *a != addr2);
-        assert_eq!(result.len(), 3);
-        assert!(!result.contains(&addr2));
-
-        // Filter with count limit (early exit)
-        let result = index.filter_bin(b(0), 1, |_| true);
-        assert_eq!(result.len(), 1);
-
-        // Filter with no matches
-        let result = index.filter_bin(b(0), 10, |_| false);
-        assert!(result.is_empty());
-
-        // Filter on empty bin
-        let result = index.filter_bin(b(5), 10, |_| true);
-        assert!(result.is_empty());
+        // A bin index beyond max_po is out of range, not a panic.
+        assert!(index.peers_in_bin(b(31)).is_empty());
     }
 }

--- a/crates/swarm/topology/src/kademlia/candidates.rs
+++ b/crates/swarm/topology/src/kademlia/candidates.rs
@@ -174,9 +174,8 @@ pub(crate) fn select_neighborhood_candidates<I: SwarmIdentity>(
     max_bin: Bin,
 ) {
     let depth = selector.snapshot().limits.depth;
-    // Connected peers are dialable but useless as candidates; without the
-    // exclusion a bin with more connections than the requested count yields
-    // only already-connected overlays and starves.
+    // Connected peers are dialable but useless as candidates; exclude them
+    // so the supply yields only overlays the node can actually dial.
     let connected = selector.connected_index();
 
     // Iterate from highest PO down to depth
@@ -196,12 +195,22 @@ pub(crate) fn select_neighborhood_candidates<I: SwarmIdentity>(
             continue;
         }
 
-        // Get peers from this bin (LRU order via KnownPeers)
-        for peer in
-            peer_manager.dialable_overlays_in_bin_excluding(bin, selector.remaining(), |overlay| {
-                connected.exists(overlay)
-            })
+        // Pull lazily from the bin's dialable supply until the selector
+        // fills or the bin reaches its target; rejected peers (queued,
+        // duplicate) simply advance to the next one.
+        for peer in peer_manager
+            .dialable_overlays_in_bin_excluding(bin, |overlay| connected.exists(overlay))
         {
+            if selector.is_full() {
+                break;
+            }
+            if !selector
+                .snapshot()
+                .limits
+                .needs_more(bin, effective + selector.bin_selected(bin))
+            {
+                break;
+            }
             if !selector.try_add_with_bin_capacity(peer, bin, effective, peer_manager) {
                 continue;
             }
@@ -261,7 +270,7 @@ pub(crate) fn select_balanced_candidates<I: SwarmIdentity>(
         let mut added = 0;
 
         for peer in peer_manager
-            .dialable_overlays_in_bin_excluding(bin, to_add, |overlay| connected.exists(overlay))
+            .dialable_overlays_in_bin_excluding(bin, |overlay| connected.exists(overlay))
         {
             if added >= to_add || selector.is_full() {
                 break;

--- a/crates/swarm/topology/src/kademlia/peer_selection.rs
+++ b/crates/swarm/topology/src/kademlia/peer_selection.rs
@@ -42,7 +42,7 @@ pub(crate) fn known_neighborhood_peers<I: SwarmIdentity>(
     let max_bin = Bin::new(peer_manager.index().max_po()).unwrap_or(Bin::MAX);
     let mut overlays = Vec::new();
     for bin in neighborhood_bins(depth, max_bin) {
-        for overlay in peer_manager.storer_overlays_in_bin(bin, usize::MAX) {
+        for overlay in peer_manager.storer_overlays_in_bin(bin) {
             if exclude.is_some_and(|e| &overlay == e) {
                 continue;
             }
@@ -54,7 +54,7 @@ pub(crate) fn known_neighborhood_peers<I: SwarmIdentity>(
 
 /// 3-phase distant selection: close-to-recipient + per-bin + fill.
 ///
-/// Returns unfiltered peers with their bin — caller applies IP/scope filtering.
+/// Returns unfiltered peers with their bin; caller applies IP/scope filtering.
 pub(crate) fn select_for_distant<I: SwarmIdentity>(
     local_overlay: &OverlayAddress,
     peer_manager: &PeerManager<I>,


### PR DESCRIPTION
## Summary

`dialable_overlays_in_bin_excluding` (and its siblings `dialable_overlays_in_bin` and `storer_overlays_in_bin`) took a `count` and returned a `Vec`, which forced callers to guess how many entries to request before knowing how many would survive their own eligibility checks. That count-based contract is what originally motivated the `saturating_mul(2)` over-fetch heuristic in candidate selection, and even after the exclusion widening in #230 it still let a caller under-fetch whenever the selector rejected some of the returned overlays (queued, in-progress, duplicate).

This PR replaces the contract with lazy `impl Iterator<Item = OverlayAddress>` returns. The supply snapshots the bin's membership once (under the bin read lock, bounded by the per-bin cap) and runs the ban, dialability, and caller-exclusion checks per item as the consumer advances, so callers take exactly what they need and no over-fetch arithmetic can come back.

## Changes

- `PeerManager::dialable_overlays_in_bin_excluding`, `dialable_overlays_in_bin`, and `storer_overlays_in_bin` now return `impl Iterator` and no longer take a `count`. The `exclude` closure stays, so callers keep excluding connected peers.
- `ProximityIndex::filter_bin` is removed; the manager filters lazily over `peers_in_bin` snapshots instead.
- `PeerManager::dialable_in_bin` is removed: it had no callers outside its own test and is trivially recomposed from `dialable_overlays_in_bin` plus `get_swarm_peers`.
- Topology candidate selection pulls from the supply until the selector fills or the bin reaches its capacity target, instead of pre-sizing the fetch with `selector.remaining()` / `to_add`.
- The stale `usize::MAX`-overflow note in the bootnode cluster test is dropped; with no count parameter that bug class no longer exists.
- Tests preserve the prior regression coverage: collecting the full supply stays safe (the old `usize::MAX` concern) and connected peers stay excludable via the caller's closure.

## Testing

- `cargo test -p vertex-swarm-peer-manager -p vertex-swarm-topology --all-features`
- `cargo test -p vertex-swarm-node --all-features` (bootnode cluster and AutoNAT dialback e2e)
- `cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-peer-score -p vertex-swarm-peer-manager`
- `cargo fmt --all`, clippy clean with `-D warnings`

Part of #229