### PR TITLE
feat(swarm-node): enforce transport connection limits via libp2p connection_limits

### DIFF
--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -141,7 +141,10 @@ pub trait SwarmNetworkConfig {
     /// Whether peer discovery is enabled.
     fn discovery_enabled(&self) -> bool;
 
-    /// Maximum number of peer connections.
+    /// Maximum number of established peer connections.
+    ///
+    /// Enforced at the transport layer as a hard cap on total established
+    /// connections, independent of the topology's per-bin accounting.
     fn max_peers(&self) -> usize;
 
     /// Connection idle timeout.

--- a/crates/swarm/api/src/error.rs
+++ b/crates/swarm/api/src/error.rs
@@ -232,6 +232,12 @@ pub enum ConfigError {
         #[source]
         source: multiaddr::Error,
     },
+
+    /// The maximum-peers cap was set to zero. The transport enforces it as a
+    /// hard cap on established connections, so zero would deny every
+    /// connection and isolate the node.
+    #[error("max peers must be at least 1; 0 would deny every connection")]
+    ZeroMaxPeers,
 }
 
 /// Result type for configuration operations.

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -18,8 +18,17 @@ const DEFAULT_P2P_PORT: u16 = 1634;
 /// Default listen address.
 const DEFAULT_LISTEN_ADDR: &str = "0.0.0.0";
 
-/// Default maximum peers.
-const DEFAULT_MAX_PEERS: usize = 50;
+/// Default maximum established connections, enforced at the transport layer
+/// by the swarm's connection-limits behaviour.
+///
+/// This is a resource backstop, not a topology-shaping knob: the kademlia
+/// topology already budgets its own dials (a 160-peer taper across balanced
+/// bins by default) and additionally connects to every available
+/// neighborhood peer and accepts a few inbound per bin above target. A
+/// healthy saturated table therefore sits in the 200-300 connection range,
+/// so the transport cap defaults comfortably above that. Setting it near or
+/// below topology's own totals starves the routing table and stalls depth.
+const DEFAULT_MAX_PEERS: usize = 400;
 
 /// Default idle timeout in seconds.
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 60;
@@ -134,7 +143,11 @@ pub struct NetworkArgs {
     #[serde(default = "default_mdns")]
     pub mdns: bool,
 
-    /// Maximum number of peers.
+    /// Maximum number of established connections (transport-level hard cap).
+    ///
+    /// Enforced by the swarm independently of kademlia bin logic. Lowering
+    /// this below the topology's own connection totals (about 200-300 for a
+    /// saturated table) limits routing table health.
     #[arg(long = "network.max-peers", default_value_t = DEFAULT_MAX_PEERS)]
     pub max_peers: usize,
 
@@ -298,6 +311,12 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
     type Error = ConfigError;
 
     fn try_from(args: &NetworkArgs) -> Result<Self, Self::Error> {
+        // The cap is enforced at the transport layer, so zero would deny
+        // every connection and isolate the node. Fail fast instead.
+        if args.max_peers == 0 {
+            return Err(ConfigError::ZeroMaxPeers);
+        }
+
         let listen_addr_str = format!("/ip4/{}/tcp/{}", args.addr, args.port);
         let listen_addrs =
             vec![
@@ -642,6 +661,19 @@ mod tests {
 
         let result = NetworkConfig::try_from(&args);
         assert!(result.is_err());
+    }
+
+    /// The transport enforces max-peers as a hard cap, so a zero value would
+    /// isolate the node; configuration validation rejects it up front.
+    #[test]
+    fn network_config_fails_on_zero_max_peers() {
+        let args = NetworkArgs {
+            max_peers: 0,
+            ..Default::default()
+        };
+
+        let result = NetworkConfig::try_from(&args);
+        assert!(matches!(result, Err(ConfigError::ZeroMaxPeers)));
     }
 
     #[test]

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -2,6 +2,7 @@
 
 use eyre::Result;
 use libp2p::autonat::v2 as autonat;
+use libp2p::connection_limits::{self, ConnectionLimits};
 use libp2p::mdns;
 use libp2p::multiaddr::Protocol;
 use libp2p::swarm::behaviour::toggle::Toggle;
@@ -42,6 +43,46 @@ impl NatBehaviours {
             mdns_enabled: config.mdns_enabled(),
         }
     }
+}
+
+/// Maximum half-open inbound connections (accepted at the transport but not
+/// yet upgraded). Bounds the resources an accept flood can pin before any
+/// protocol negotiation happens.
+const MAX_PENDING_INCOMING: u32 = 64;
+
+/// Maximum in-flight outbound dials. The topology dialer paces its own dials
+/// at 32 concurrent attempts (`vertex-net-dialer`); the transport cap sits at
+/// twice that to leave room for bootnode dials, mDNS-discovered LAN dials,
+/// and operator-issued dial commands that do not flow through the tracker.
+const MAX_PENDING_OUTGOING: u32 = 64;
+
+/// Maximum established connections per peer. One connection per peer is the
+/// norm on this network; 2 tolerates the simultaneous-open race where both
+/// ends dial each other and a duplicate exists briefly. The topology layer
+/// detects and closes duplicate connections itself.
+const MAX_ESTABLISHED_PER_PEER: u32 = 2;
+
+/// Build the transport-level connection-limits behaviour from the network
+/// configuration.
+///
+/// The total established cap comes from `--network.max-peers` and is a
+/// resource backstop (file descriptors, memory, bandwidth), enforced by the
+/// swarm independently of kademlia bin logic. Topology keeps full ownership
+/// of connection composition: per-bin targets, saturation, inbound ceilings,
+/// and trimming. The transport cap only bounds how many connections can
+/// exist at all, so it must sit above topology's own steady-state total
+/// (see the `--network.max-peers` default rationale in the args module).
+pub(crate) fn build_connection_limits(
+    config: &impl SwarmNetworkConfig,
+) -> connection_limits::Behaviour {
+    let max_established = u32::try_from(config.max_peers()).unwrap_or(u32::MAX);
+    connection_limits::Behaviour::new(
+        ConnectionLimits::default()
+            .with_max_established(Some(max_established))
+            .with_max_established_per_peer(Some(MAX_ESTABLISHED_PER_PEER))
+            .with_max_pending_incoming(Some(MAX_PENDING_INCOMING))
+            .with_max_pending_outgoing(Some(MAX_PENDING_OUTGOING)),
+    )
 }
 
 /// Build the mDNS discovery behaviour as a [`Toggle`].
@@ -325,13 +366,100 @@ pub(crate) fn handle_identify_event(identify: &mut identify::Behaviour, event: i
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
+    use std::time::Duration;
+
     use libp2p::identity::Keypair;
+    use libp2p::swarm::{ListenError, SwarmEvent};
+    use libp2p_swarm_test::SwarmExt as _;
 
     use super::*;
 
     fn random_peer_id() -> PeerId {
         Keypair::generate_ed25519().public().to_peer_id()
+    }
+
+    /// Minimal network configuration carrying only the connection cap.
+    struct CapConfig {
+        max_peers: usize,
+    }
+
+    impl SwarmNetworkConfig for CapConfig {
+        fn listen_addrs(&self) -> &[Multiaddr] {
+            &[]
+        }
+        fn bootnodes(&self) -> &[Multiaddr] {
+            &[]
+        }
+        fn discovery_enabled(&self) -> bool {
+            false
+        }
+        fn max_peers(&self) -> usize {
+            self.max_peers
+        }
+        fn idle_timeout(&self) -> Duration {
+            Duration::from_secs(30)
+        }
+    }
+
+    /// Behaviour carrying only the connection-limits backstop, mirroring its
+    /// position as the admission gate in the node-type compositions.
+    #[derive(libp2p::swarm::NetworkBehaviour)]
+    struct LimitsOnly {
+        limits: connection_limits::Behaviour,
+    }
+
+    fn limits_swarm(max_peers: usize) -> Swarm<LimitsOnly> {
+        Swarm::new_ephemeral_tokio(|_| LimitsOnly {
+            limits: build_connection_limits(&CapConfig { max_peers }),
+        })
+    }
+
+    /// `--network.max-peers` flows into the transport cap: with a cap of 1,
+    /// the first connection is admitted and the second inbound connection is
+    /// denied with a connection-limits `Exceeded` cause.
+    #[tokio::test]
+    async fn max_peers_caps_established_connections() {
+        let mut listener = limits_swarm(1);
+        let mut first = limits_swarm(16);
+        let mut second = limits_swarm(16);
+
+        listener.listen().with_memory_addr_external().await;
+        first.connect(&mut listener).await;
+
+        let listen_addr = listener
+            .external_addresses()
+            .next()
+            .cloned()
+            .expect("listener has an external address");
+        second.dial(listen_addr).expect("dial is initiated");
+
+        let denial = async {
+            loop {
+                tokio::select! {
+                    event = listener.next_swarm_event() => {
+                        if let SwarmEvent::IncomingConnectionError {
+                            error: ListenError::Denied { cause },
+                            ..
+                        } = event
+                        {
+                            return cause;
+                        }
+                    }
+                    _ = first.next_swarm_event() => {}
+                    _ = second.next_swarm_event() => {}
+                }
+            }
+        };
+        let cause = tokio::time::timeout(Duration::from_secs(10), denial)
+            .await
+            .expect("listener denies the second connection");
+
+        let exceeded = cause
+            .downcast::<libp2p::connection_limits::Exceeded>()
+            .expect("denial cause is a connection-limits Exceeded");
+        assert_eq!(exceeded.limit(), 1, "the cap comes from max_peers");
     }
 
     #[test]

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -7,9 +7,12 @@
 //! initiate any pricing announcement of its own and does not run the other
 //! client protocols (retrieval, pushsync, pseudosettle).
 
+use std::convert::Infallible;
+
 use eyre::Result;
 use futures::StreamExt;
 use libp2p::autonat::v2 as autonat;
+use libp2p::connection_limits;
 use libp2p::mdns;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::upnp;
@@ -41,6 +44,10 @@ use crate::protocol::{BehaviourConfig as ClientBehaviourConfig, ClientBehaviour,
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "BootnodeEvent")]
 pub(crate) struct BootnodeBehaviour<I: SwarmIdentity + Clone> {
+    /// Transport-level connection caps (total, per-peer, pending). Listed
+    /// first so a denied connection is rejected before the other behaviours
+    /// allocate per-connection state.
+    pub(crate) connection_limits: connection_limits::Behaviour,
     pub(crate) identify: identify::Behaviour,
     pub(crate) autonat_client: Toggle<autonat::client::Behaviour>,
     pub(crate) autonat_server: Toggle<autonat::server::Behaviour>,
@@ -56,10 +63,12 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
         local_public_key: PublicKey,
         topology: TopologyBehaviour<I>,
         nat: NatBehaviours,
+        connection_limits: connection_limits::Behaviour,
     ) -> Self {
         let agent_versions = topology.agent_versions();
         let peer_id = local_public_key.to_peer_id();
         Self {
+            connection_limits,
             // Identify advertises addresses scoped to each peer (see
             // `addresses_for_remote`): a public peer never receives our private
             // or loopback addresses, matching the handshake's policy.
@@ -97,6 +106,13 @@ pub enum BootnodeEvent {
     Mdns(mdns::Event),
     Topology(()),
     Client(ClientEvent),
+}
+
+impl From<Infallible> for BootnodeEvent {
+    fn from(event: Infallible) -> Self {
+        // The connection-limits behaviour never emits events.
+        match event {}
+    }
 }
 
 impl From<identify::Event> for BootnodeEvent {
@@ -330,11 +346,12 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
         };
 
         let nat = NatBehaviours::from_config(network_config);
+        let connection_limits = super::base::build_connection_limits(network_config);
         let base = super::builder::build_base_node(
             infra,
             network_config,
             "Bootnode",
-            move |pk, topology| BootnodeBehaviour::from_parts(pk, topology, nat),
+            move |pk, topology| BootnodeBehaviour::from_parts(pk, topology, nat, connection_limits),
         )
         .await?;
 

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -5,11 +5,13 @@
 //!
 //! Use this for nodes that need to read from and write to the Swarm network.
 
+use std::convert::Infallible;
 use std::sync::Arc;
 
 use eyre::Result;
 use futures::StreamExt;
 use libp2p::autonat::v2 as autonat;
+use libp2p::connection_limits;
 use libp2p::mdns;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::upnp;
@@ -38,6 +40,10 @@ use crate::{ClientHandle, ClientService};
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "ClientNodeEvent")]
 pub(crate) struct ClientNodeBehaviour<I: SwarmIdentity + Clone> {
+    /// Transport-level connection caps (total, per-peer, pending). Listed
+    /// first so a denied connection is rejected before the other behaviours
+    /// allocate per-connection state.
+    pub(crate) connection_limits: connection_limits::Behaviour,
     pub(crate) identify: identify::Behaviour,
     pub(crate) autonat_client: Toggle<autonat::client::Behaviour>,
     pub(crate) autonat_server: Toggle<autonat::server::Behaviour>,
@@ -52,10 +58,12 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
         local_public_key: PublicKey,
         topology: TopologyBehaviour<I>,
         nat: NatBehaviours,
+        connection_limits: connection_limits::Behaviour,
     ) -> Self {
         let agent_versions = topology.agent_versions();
         let peer_id = local_public_key.to_peer_id();
         Self {
+            connection_limits,
             // Identify advertises addresses scoped to each peer (see
             // `addresses_for_remote`), so a public peer never receives our
             // private or loopback addresses. A NAT'd node with no public address
@@ -85,6 +93,13 @@ pub enum ClientNodeEvent {
     Mdns(mdns::Event),
     Topology(()),
     Client(ClientEvent),
+}
+
+impl From<Infallible> for ClientNodeEvent {
+    fn from(event: Infallible) -> Self {
+        // The connection-limits behaviour never emits events.
+        match event {}
+    }
 }
 
 impl From<identify::Event> for ClientNodeEvent {
@@ -402,11 +417,14 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
         };
 
         let nat = NatBehaviours::from_config(network_config);
+        let connection_limits = super::base::build_connection_limits(network_config);
         let mut base = super::builder::build_base_node(
             infra,
             network_config,
             "Client node",
-            move |pk, topology| ClientNodeBehaviour::from_parts(pk, topology, nat),
+            move |pk, topology| {
+                ClientNodeBehaviour::from_parts(pk, topology, nat, connection_limits)
+            },
         )
         .await?;
 

--- a/crates/swarm/topology/src/connection_handlers.rs
+++ b/crates/swarm/topology/src/connection_handlers.rs
@@ -224,15 +224,18 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         // Release routing capacity for this failed dial
         if let Some(overlay) = &overlay {
             self.routing.release_dial(overlay);
+            // Backoff applies even to locally-denied dials: redialing while
+            // the transport cap is exhausted would be denied again, so pacing
+            // the retry is correct either way.
             self.peer_manager.record_dial_failure(overlay);
 
-            // Score penalty based on error type, through the single report path
-            let scoring_event = match &classified_error {
-                DialError::ConnectionRefused => SwarmScoringEvent::ConnectionRefused,
-                _ => SwarmScoringEvent::ConnectionTimeout,
-            };
-            self.peer_manager
-                .report_peer(overlay, scoring_event, ReportSource::Topology);
+            // Score penalty based on error type, through the single report
+            // path. Locally-denied dials carry no penalty: the peer was never
+            // contacted, so the failure says nothing about the peer.
+            if let Some(scoring_event) = scoring_event_for_dial_error(&classified_error) {
+                self.peer_manager
+                    .report_peer(overlay, scoring_event, ReportSource::Topology);
+            }
         }
 
         warn!(
@@ -312,6 +315,21 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     }
 }
 
+/// Map a classified dial error to the scoring event reported against the
+/// peer, or `None` when the failure is not attributable to the peer.
+///
+/// [`DialError::Denied`] means a local admission policy (the transport
+/// connection-limits cap) rejected the dial before any packet left the host;
+/// penalizing the peer for it would degrade and eventually ban peers purely
+/// because the local node was busy.
+pub(crate) fn scoring_event_for_dial_error(error: &DialError) -> Option<SwarmScoringEvent> {
+    match error {
+        DialError::Denied => None,
+        DialError::ConnectionRefused => Some(SwarmScoringEvent::ConnectionRefused),
+        _ => Some(SwarmScoringEvent::ConnectionTimeout),
+    }
+}
+
 /// Classify a libp2p dial error into a structured `DialError` variant.
 pub(crate) fn classify_dial_error(error: &libp2p::swarm::DialError) -> DialError {
     use libp2p::core::transport::TransportError;
@@ -357,9 +375,45 @@ pub(crate) fn classify_dial_error(error: &libp2p::swarm::DialError) -> DialError
         libp2p::swarm::DialError::Aborted | libp2p::swarm::DialError::DialPeerConditionFalse(_) => {
             DialError::Stale
         }
-        libp2p::swarm::DialError::Denied { .. } => DialError::NegotiationFailed,
+        // A composed behaviour (the transport connection-limits cap) denied
+        // the dial locally; the peer was never contacted.
+        libp2p::swarm::DialError::Denied { .. } => DialError::Denied,
         libp2p::swarm::DialError::NoAddresses => DialError::NoRoute,
         libp2p::swarm::DialError::LocalPeerId { .. }
         | libp2p::swarm::DialError::WrongPeerId { .. } => DialError::Other(format!("{error:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A dial denied by a composed admission behaviour (the transport
+    /// connection-limits cap) classifies as `Denied`, not as a peer-side
+    /// negotiation failure.
+    #[test]
+    fn denied_dial_classifies_as_denied() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("connection limit exceeded")]
+        struct Exceeded;
+
+        let error = libp2p::swarm::DialError::Denied {
+            cause: libp2p::swarm::ConnectionDenied::new(Exceeded),
+        };
+        assert_eq!(classify_dial_error(&error), DialError::Denied);
+    }
+
+    /// Locally-denied dials carry no score penalty; network failures do.
+    #[test]
+    fn scoring_event_skips_locally_denied_dials() {
+        assert_eq!(scoring_event_for_dial_error(&DialError::Denied), None);
+        assert_eq!(
+            scoring_event_for_dial_error(&DialError::ConnectionRefused),
+            Some(SwarmScoringEvent::ConnectionRefused)
+        );
+        assert_eq!(
+            scoring_event_for_dial_error(&DialError::Timeout),
+            Some(SwarmScoringEvent::ConnectionTimeout)
+        );
     }
 }

--- a/crates/swarm/topology/src/error.rs
+++ b/crates/swarm/topology/src/error.rs
@@ -37,6 +37,11 @@ pub enum DialError {
     /// Protocol negotiation failed (no common protocols).
     #[error("protocol negotiation failed")]
     NegotiationFailed,
+    /// Dial denied by local connection-admission policy (for example the
+    /// transport connection-limits cap) before reaching the network. Not a
+    /// peer fault: the peer was never contacted.
+    #[error("dial denied by local connection limits")]
+    Denied,
     /// Stale connection attempt cleaned up.
     #[error("stale connection attempt")]
     Stale,

--- a/docs/networking/peer-management.md
+++ b/docs/networking/peer-management.md
@@ -144,6 +144,21 @@ When the number of distinct overlays seen from one group within the window excee
 
 Consumers can query the tracker through `PeerManager::overlays_seen_from_ip` and `PeerManager::ip_cycling_suspected`; the planned inbound handshake rate limiter uses these to throttle signature-recovery work for suspect source IPs. Observability: the `peer_manager_tracked_ips` gauge and the `peer_manager_ip_cycling_detections_total` counter.
 
+## Transport connection limits
+
+The swarm composes `libp2p::connection_limits` into every node-type behaviour (bootnode, client, storer) as a transport-level backstop, enforced before any other behaviour allocates per-connection state. The caps, built in `vertex-swarm-node` from the network configuration:
+
+| Limit | Source | Default |
+|-------|--------|---------|
+| Established total | `--network.max-peers` | 400 |
+| Established per peer | constant | 2 |
+| Pending incoming | constant | 64 |
+| Pending outgoing | constant | 64 |
+
+Division of responsibility: topology owns connection composition (per-bin targets, saturation, inbound ceilings, trimming) and its steady-state totals sit well below the transport cap; the transport cap only bounds resource consumption (file descriptors, memory) when topology accounting is bypassed or overwhelmed. The per-peer cap of 2 tolerates the simultaneous-open race; topology closes duplicate connections itself. The pending-outgoing cap of 64 sits at twice the dialer's 32 concurrent in-flight dials to leave room for bootnode, mDNS, and operator-issued dials.
+
+A dial denied by the limits surfaces to topology as `DialError::Denied` and carries no score penalty: the peer was never contacted, so the failure says nothing about it. The peer still receives normal dial backoff, which paces retries while the cap is exhausted. The hive gossip verifier uses its own short-lived swarm and is not subject to the main swarm's limits.
+
 ## Thread Safety
 
 All types are `Send + Sync`. The design ensures:


### PR DESCRIPTION
Composes `libp2p::connection_limits` into the bootnode and client node behaviours (the storer reuses the client composition) so transport-level caps (total established, established per peer, pending incoming/outgoing) are enforced independently of kademlia bin logic. Topology keeps reasoning about per-bin capacity only.

The total established cap comes from `--network.max-peers`. Constants cover established-per-peer (2, tolerating the simultaneous-open race), pending incoming (64), and pending outgoing (64, twice the dialer's in-flight budget).

The max-peers default rises from 50 to 400. The flag was previously unenforced, and topology's own steady-state totals (160-peer taper plus neighbourhood bins and inbound headroom) sit in the 200-300 range, so the transport cap acts as a resource backstop rather than a topology-shaping knob. A zero cap is rejected at configuration time since it would isolate the node.

Locally-denied dials classify as `DialError::Denied` in topology and carry no score penalty: the peer was never contacted, so the failure says nothing about it. Dial backoff still applies to pace retries while the cap is exhausted.

`docs/networking/peer-management.md` gains a section on the transport/topology division of responsibility.

Part of #229