### PR TITLE
feat(swarm-topology): explicit topology phase machine

### DIFF
--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -310,6 +310,7 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
             TopologyEvent::PeerDisconnected { .. } => {}
             TopologyEvent::PeerRejected { .. } => {}
             TopologyEvent::DepthChanged { .. } => {}
+            TopologyEvent::PhaseChanged { .. } => {}
             TopologyEvent::DialFailed { .. } => {}
             TopologyEvent::PingCompleted { .. } => {}
         }

--- a/crates/swarm/node/tests/bootnode_cluster.rs
+++ b/crates/swarm/node/tests/bootnode_cluster.rs
@@ -23,7 +23,7 @@ use tokio::time::timeout;
 use vertex_swarm_api::{SwarmTopologyPeers as _, SwarmTopologyState as _, SwarmTopologyStats as _};
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth, all_bins};
 use vertex_swarm_test_utils::cluster::{ClusterBuilder, NodeRole};
-use vertex_swarm_topology::TopologyEvent;
+use vertex_swarm_topology::{TopologyEvent, TopologyPhase};
 
 /// Cap on wall-clock time the test will wait for handshakes to complete.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -162,6 +162,18 @@ async fn three_node_convergence() -> Result<()> {
             depth,
             NeighborhoodDepth::ZERO,
             "client {idx} kademlia depth should be 0 (small-PO peers only), got {depth}"
+        );
+    }
+
+    // The topology phase machine mirrors the depth result: a three-node
+    // cluster cannot anchor a neighborhood, so every node reports the
+    // Bootstrap phase on its readiness surface.
+    for (idx, client) in clients.iter().enumerate() {
+        let readiness = client.topology.readiness();
+        assert_eq!(
+            readiness.phase,
+            TopologyPhase::Bootstrap,
+            "client {idx} should report Bootstrap phase at depth 0"
         );
     }
 

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -583,6 +583,19 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         let _ = self.event_tx.send(event);
     }
 
+    /// Re-derive the topology phase after a connected-set or depth change
+    /// and broadcast the transition when the phase moved. The periodic
+    /// evaluator task covers the time-driven transitions between ticks.
+    pub(crate) fn refresh_topology_phase(&self) {
+        if let Some(transition) = self.routing.evaluate_phase() {
+            self.emit_event(TopologyEvent::PhaseChanged {
+                from: transition.from,
+                to: transition.to,
+                depth: transition.depth.get(),
+            });
+        }
+    }
+
     /// Push routing gauges for a single bin and global totals.
     pub(crate) fn push_routing_gauges(&self, bin: Bin) {
         // The metric label key stays "po" (the established observability name).

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -254,7 +254,12 @@ impl<I: SwarmIdentity + Clone + 'static> TopologyBehaviour<I> {
         };
 
         // Spawn background connection evaluator
-        spawn_evaluator(self.routing.clone(), &self.evaluator_handle, &executor);
+        spawn_evaluator(
+            self.routing.clone(),
+            &self.evaluator_handle,
+            self.event_tx.clone(),
+            &executor,
+        );
 
         // Spawn interface watcher for push-based subnet discovery.
         crate::tasks::spawn_interface_watcher(&executor);

--- a/crates/swarm/topology/src/connection_handlers.rs
+++ b/crates/swarm/topology/src/connection_handlers.rs
@@ -194,6 +194,8 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         if new_depth != old_depth {
             self.on_depth_changed(old_depth, new_depth);
         }
+
+        self.refresh_topology_phase();
     }
 
     pub(crate) fn handle_dial_failure(&mut self, failure: libp2p::swarm::behaviour::DialFailure) {

--- a/crates/swarm/topology/src/events.rs
+++ b/crates/swarm/topology/src/events.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use libp2p::{Multiaddr, PeerId};
 use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
 
+use crate::kademlia::TopologyPhase;
+
 pub use vertex_net_peer_registry::ConnectionDirection;
 
 pub(crate) use crate::error::{DialError, DisconnectReason, RejectionReason};
@@ -54,6 +56,15 @@ pub enum TopologyEvent {
     },
     /// Neighborhood depth changed.
     DepthChanged { old_depth: u8, new_depth: u8 },
+    /// The topology phase machine transitioned.
+    PhaseChanged {
+        /// Phase before the transition.
+        from: TopologyPhase,
+        /// Phase after the transition.
+        to: TopologyPhase,
+        /// Neighborhood depth at the transition.
+        depth: u8,
+    },
     /// Dial attempt failed (all addresses exhausted).
     DialFailed {
         /// Overlay address if known.

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -110,6 +110,8 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
             })
             .collect();
 
+        let (phase, time_in_phase) = self.routing.phase_status();
+
         ReadinessSnapshot {
             local_node_type: self.identity.node_type(),
             connected_peers,
@@ -121,6 +123,8 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
             bins_at_target,
             neighborhood_stable_for: self.routing.neighborhood_stable_for(),
             neighborhood_stability_window: self.routing.neighborhood_stability_window(),
+            phase,
+            time_in_phase,
         }
     }
 
@@ -128,8 +132,8 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
     ///
     /// State-driven, not timed: the predicate is evaluated immediately and
     /// then re-evaluated on every [`TopologyEvent::PeerReady`],
-    /// [`TopologyEvent::PeerDisconnected`], and
-    /// [`TopologyEvent::DepthChanged`], the events that change snapshot
+    /// [`TopologyEvent::PeerDisconnected`], [`TopologyEvent::DepthChanged`],
+    /// and [`TopologyEvent::PhaseChanged`], the events that change snapshot
     /// state. The subscription is taken before the initial evaluation so a
     /// state change between the two cannot be missed.
     ///
@@ -155,7 +159,8 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
                 Ok(
                     TopologyEvent::PeerReady { .. }
                     | TopologyEvent::PeerDisconnected { .. }
-                    | TopologyEvent::DepthChanged { .. },
+                    | TopologyEvent::DepthChanged { .. }
+                    | TopologyEvent::PhaseChanged { .. },
                 ) => {
                     if predicate(&self.readiness()) {
                         return Ok(());
@@ -577,6 +582,7 @@ mod tests {
         assert!(!s.is_saturated());
         assert!(!s.is_warm());
         assert_eq!(s.bins_at_target, 0);
+        assert_eq!(s.phase, crate::TopologyPhase::Bootstrap);
 
         // Every bin reports the bootstrap-phase target while depth is 0.
         assert!(!s.bins.is_empty());
@@ -643,6 +649,15 @@ mod tests {
         assert!(bin0.target.is_some());
         // Neighborhood bins report no finite target.
         assert!(s.bins[1].target.is_none());
+
+        // The phase machine sees the depth climb on its next evaluation
+        // (depth moved within the stability window: Converging) and the
+        // snapshot exposes the committed phase.
+        h.routing
+            .evaluate_phase()
+            .expect("depth climb commits a phase transition");
+        let s = h.handle.readiness();
+        assert_eq!(s.phase, crate::TopologyPhase::Converging);
     }
 
     #[tokio::test]

--- a/crates/swarm/topology/src/kademlia/args.rs
+++ b/crates/swarm/topology/src/kademlia/args.rs
@@ -58,6 +58,7 @@ impl RoutingArgs {
                 .unwrap_or(defaults.max_balanced_candidates),
             neighborhood_stability_window: defaults.neighborhood_stability_window,
             depth_lower_window: defaults.depth_lower_window,
+            phase_stability_window: defaults.phase_stability_window,
         }
     }
 }

--- a/crates/swarm/topology/src/kademlia/config.rs
+++ b/crates/swarm/topology/src/kademlia/config.rs
@@ -17,6 +17,8 @@ use super::limits::DepthAwareLimits;
 const DEFAULT_MAX_NEIGHBOR_CANDIDATES: usize = 16;
 /// Max new balanced (non-depth-bin) candidates enqueued per evaluation round.
 const DEFAULT_MAX_BALANCED_CANDIDATES: usize = 16;
+/// Default stability window for the topology phase machine.
+const DEFAULT_PHASE_STABILITY_WINDOW: Duration = Duration::from_secs(60);
 
 /// Default window the neighborhood must stay saturated at an unchanged depth
 /// before it counts as ready (see `TopologyHandle::wait_until_neighborhood_ready`).
@@ -51,6 +53,12 @@ pub struct KademliaConfig {
     /// the saturation deficit is a single peer (see
     /// [`Self::with_depth_lower_window`]).
     pub(crate) depth_lower_window: Duration,
+    /// How long the neighborhood depth must hold still (with a saturated
+    /// neighborhood) before the topology phase machine reports
+    /// [`super::TopologyPhase::Stable`]. Any depth movement inside the
+    /// window keeps the node in `Converging`, so churn cannot flap the
+    /// phase. Default 60s.
+    pub(crate) phase_stability_window: Duration,
 }
 
 impl Default for KademliaConfig {
@@ -61,6 +69,7 @@ impl Default for KademliaConfig {
             max_balanced_candidates: DEFAULT_MAX_BALANCED_CANDIDATES,
             neighborhood_stability_window: DEFAULT_NEIGHBORHOOD_STABILITY_WINDOW,
             depth_lower_window: DEFAULT_DEPTH_LOWER_WINDOW,
+            phase_stability_window: DEFAULT_PHASE_STABILITY_WINDOW,
         }
     }
 }
@@ -108,6 +117,14 @@ impl KademliaConfig {
     /// depth stays below the published depth for the whole window.
     pub fn with_depth_lower_window(mut self, window: Duration) -> Self {
         self.depth_lower_window = window;
+        self
+    }
+
+    /// Set the phase-machine stability window: how long depth must hold
+    /// still, with a saturated neighborhood, before the topology phase
+    /// reports `Stable`.
+    pub fn with_phase_stability_window(mut self, window: Duration) -> Self {
+        self.phase_stability_window = window;
         self
     }
 }

--- a/crates/swarm/topology/src/kademlia/mod.rs
+++ b/crates/swarm/topology/src/kademlia/mod.rs
@@ -7,6 +7,7 @@ mod candidates;
 mod config;
 mod limits;
 pub(crate) mod peer_selection;
+mod phase;
 mod routing;
 mod task;
 
@@ -19,6 +20,8 @@ pub(crate) use candidates::{
 pub use config::KademliaConfig;
 pub(crate) use limits::DepthAwareLimits;
 pub(crate) use limits::LimitsSnapshot;
+pub use phase::TopologyPhase;
+pub(crate) use phase::{PhaseTracker, PhaseTransition};
 pub(crate) use routing::KademliaRouting;
 pub(crate) use task::{RoutingEvaluatorHandle, spawn_evaluator};
 

--- a/crates/swarm/topology/src/kademlia/phase.rs
+++ b/crates/swarm/topology/src/kademlia/phase.rs
@@ -1,0 +1,312 @@
+//! Explicit topology phase machine.
+//!
+//! Names the connection-building lifecycle that was previously implicit in
+//! the depth-aware limits (depth 0 selecting the bootstrap fill targets).
+//! The phase is derived deterministically from observable routing state, so
+//! it can always be re-derived from a fresh snapshot rather than depending
+//! on edge-triggered bookkeeping:
+//!
+//! - [`TopologyPhase::Bootstrap`]: published depth is 0. The known table is
+//!   too thin to anchor a neighborhood, and every bin fills toward the
+//!   bootstrap target.
+//! - [`TopologyPhase::Converging`]: depth is above 0 but moved within the
+//!   stability window, or the neighborhood has not yet reached the
+//!   saturation threshold. Connection building is still raising the
+//!   unsaturated frontier.
+//! - [`TopologyPhase::Stable`]: depth is above 0, has not moved for the
+//!   stability window, and the neighborhood holds at least the saturation
+//!   threshold in connected peers. Maintenance pacing suffices.
+//!
+//! Transitions are computed by [`PhaseTracker::evaluate`], which the routing
+//! layer drives from the depth-publication points (peer connect and
+//! disconnect) and the periodic connection evaluator. A `Stable` node falls
+//! back to `Converging` when depth moves or neighborhood saturation is
+//! lost, and all the way to `Bootstrap` only when depth returns to 0.
+
+use std::time::Duration;
+
+use web_time::Instant;
+
+use vertex_swarm_primitives::NeighborhoodDepth;
+
+/// Phase of the topology connection-building lifecycle.
+///
+/// Derived from published depth, depth movement within the stability
+/// window, and neighborhood saturation; see the module docs for the exact
+/// rules. Serialized in `snake_case` for metric labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum TopologyPhase {
+    /// Published depth is 0: fill every bin toward the bootstrap target.
+    Bootstrap,
+    /// Depth is climbing or the neighborhood is unsaturated: prioritize
+    /// dials that raise the unsaturated frontier.
+    Converging,
+    /// Depth steady for the stability window with a saturated
+    /// neighborhood: maintenance pacing, inbound mostly suffices.
+    Stable,
+}
+
+impl TopologyPhase {
+    /// All phases, in lifecycle order. Used to publish the per-phase gauge.
+    pub const ALL: [Self; 3] = [Self::Bootstrap, Self::Converging, Self::Stable];
+}
+
+/// A committed phase transition, returned by [`PhaseTracker::evaluate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PhaseTransition {
+    /// Phase before the transition.
+    pub(crate) from: TopologyPhase,
+    /// Phase after the transition.
+    pub(crate) to: TopologyPhase,
+    /// Neighborhood depth observed at the transition.
+    pub(crate) depth: NeighborhoodDepth,
+    /// Time spent in the previous phase.
+    pub(crate) time_in_phase: Duration,
+}
+
+/// Owns the current phase and computes transitions from observed state.
+///
+/// Pure state machine: callers supply the observation time, so tests drive
+/// it with simulated clocks. Recording (log lines, metrics, events) is the
+/// caller's concern.
+pub(crate) struct PhaseTracker {
+    phase: TopologyPhase,
+    entered_at: Instant,
+    stability_window: Duration,
+    last_depth: NeighborhoodDepth,
+    last_depth_change: Instant,
+}
+
+impl PhaseTracker {
+    /// Start tracking in [`TopologyPhase::Bootstrap`] at `now`.
+    pub(crate) fn new(stability_window: Duration, now: Instant) -> Self {
+        Self {
+            phase: TopologyPhase::Bootstrap,
+            entered_at: now,
+            stability_window,
+            last_depth: NeighborhoodDepth::ZERO,
+            last_depth_change: now,
+        }
+    }
+
+    /// The current phase.
+    pub(crate) fn phase(&self) -> TopologyPhase {
+        self.phase
+    }
+
+    /// Time spent in the current phase as of `now`.
+    pub(crate) fn time_in_phase(&self, now: Instant) -> Duration {
+        now.duration_since(self.entered_at)
+    }
+
+    /// Re-derive the phase from the observed state and commit a transition
+    /// when it moved.
+    ///
+    /// `depth` is the published neighborhood depth and
+    /// `neighborhood_saturated` whether the bins inside the depth boundary
+    /// together hold at least the saturation threshold in connected peers
+    /// (the same condition as `ReadinessSnapshot::is_saturated`). Depth
+    /// movement is timestamped here, so churn that leaves the derived phase
+    /// unchanged commits nothing and produces no transition spam.
+    pub(crate) fn evaluate(
+        &mut self,
+        depth: NeighborhoodDepth,
+        neighborhood_saturated: bool,
+        now: Instant,
+    ) -> Option<PhaseTransition> {
+        if depth != self.last_depth {
+            self.last_depth = depth;
+            self.last_depth_change = now;
+        }
+
+        let next = if depth == NeighborhoodDepth::ZERO {
+            TopologyPhase::Bootstrap
+        } else if !neighborhood_saturated
+            || now.duration_since(self.last_depth_change) < self.stability_window
+        {
+            TopologyPhase::Converging
+        } else {
+            TopologyPhase::Stable
+        };
+
+        if next == self.phase {
+            return None;
+        }
+
+        let transition = PhaseTransition {
+            from: self.phase,
+            to: next,
+            depth,
+            time_in_phase: self.time_in_phase(now),
+        };
+        self.phase = next;
+        self.entered_at = now;
+        Some(transition)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vertex_swarm_primitives::Bin;
+
+    const WINDOW: Duration = Duration::from_secs(60);
+
+    fn d(n: u8) -> NeighborhoodDepth {
+        NeighborhoodDepth::new(Bin::new(n).expect("valid bin"))
+    }
+
+    fn tracker(now: Instant) -> PhaseTracker {
+        PhaseTracker::new(WINDOW, now)
+    }
+
+    #[test]
+    fn starts_in_bootstrap() {
+        let now = Instant::now();
+        let t = tracker(now);
+        assert_eq!(t.phase(), TopologyPhase::Bootstrap);
+        assert_eq!(t.time_in_phase(now), Duration::ZERO);
+    }
+
+    #[test]
+    fn stays_bootstrap_while_depth_zero() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        assert_eq!(t.evaluate(d(0), false, base + WINDOW), None);
+        assert_eq!(t.evaluate(d(0), false, base + WINDOW * 2), None);
+        assert_eq!(t.phase(), TopologyPhase::Bootstrap);
+    }
+
+    #[test]
+    fn bootstrap_to_converging_on_first_depth_climb() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+
+        let transition = t
+            .evaluate(d(2), false, base + Duration::from_secs(5))
+            .expect("depth climb must transition");
+        assert_eq!(transition.from, TopologyPhase::Bootstrap);
+        assert_eq!(transition.to, TopologyPhase::Converging);
+        assert_eq!(transition.depth, d(2));
+        assert_eq!(transition.time_in_phase, Duration::from_secs(5));
+        assert_eq!(t.phase(), TopologyPhase::Converging);
+    }
+
+    #[test]
+    fn converging_to_stable_after_window_with_saturation() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        t.evaluate(d(2), true, base).expect("to converging");
+
+        // Saturated but depth moved more recently than the window: hold.
+        assert_eq!(t.evaluate(d(2), true, base + WINDOW / 2), None);
+        assert_eq!(t.phase(), TopologyPhase::Converging);
+
+        let transition = t
+            .evaluate(d(2), true, base + WINDOW)
+            .expect("window elapsed with saturation");
+        assert_eq!(transition.from, TopologyPhase::Converging);
+        assert_eq!(transition.to, TopologyPhase::Stable);
+        assert_eq!(transition.time_in_phase, WINDOW);
+    }
+
+    #[test]
+    fn converging_holds_without_saturation_even_after_window() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        t.evaluate(d(2), false, base).expect("to converging");
+
+        assert_eq!(t.evaluate(d(2), false, base + WINDOW * 2), None);
+        assert_eq!(t.phase(), TopologyPhase::Converging);
+
+        // Saturation arriving later (depth long steady) completes the climb.
+        let transition = t
+            .evaluate(d(2), true, base + WINDOW * 3)
+            .expect("saturation reached");
+        assert_eq!(transition.to, TopologyPhase::Stable);
+    }
+
+    #[test]
+    fn stable_falls_back_to_converging_on_depth_change() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        t.evaluate(d(2), true, base).expect("to converging");
+        t.evaluate(d(2), true, base + WINDOW).expect("to stable");
+
+        let transition = t
+            .evaluate(d(3), true, base + WINDOW * 2)
+            .expect("depth moved");
+        assert_eq!(transition.from, TopologyPhase::Stable);
+        assert_eq!(transition.to, TopologyPhase::Converging);
+    }
+
+    #[test]
+    fn stable_falls_back_to_converging_on_saturation_loss() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        t.evaluate(d(2), true, base).expect("to converging");
+        t.evaluate(d(2), true, base + WINDOW).expect("to stable");
+
+        let transition = t
+            .evaluate(d(2), false, base + WINDOW + Duration::from_secs(1))
+            .expect("saturation lost");
+        assert_eq!(transition.from, TopologyPhase::Stable);
+        assert_eq!(transition.to, TopologyPhase::Converging);
+    }
+
+    #[test]
+    fn collapse_to_depth_zero_returns_to_bootstrap() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        t.evaluate(d(2), true, base).expect("to converging");
+        t.evaluate(d(2), true, base + WINDOW).expect("to stable");
+
+        let transition = t
+            .evaluate(d(0), false, base + WINDOW * 2)
+            .expect("depth collapsed");
+        assert_eq!(transition.from, TopologyPhase::Stable);
+        assert_eq!(transition.to, TopologyPhase::Bootstrap);
+    }
+
+    #[test]
+    fn churn_within_window_produces_no_transition_spam() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        t.evaluate(d(2), true, base).expect("to converging");
+
+        // Depth flaps every few seconds; the derived phase never leaves
+        // Converging, so no transitions are committed.
+        for i in 1..20u64 {
+            let depth = if i % 2 == 0 { d(2) } else { d(3) };
+            assert_eq!(
+                t.evaluate(depth, true, base + Duration::from_secs(i * 5)),
+                None
+            );
+        }
+        assert_eq!(t.phase(), TopologyPhase::Converging);
+
+        // Only once depth holds still for the full window does it settle.
+        let settled = base + Duration::from_secs(19 * 5) + WINDOW;
+        let transition = t.evaluate(d(3), true, settled).expect("settled");
+        assert_eq!(transition.to, TopologyPhase::Stable);
+    }
+
+    #[test]
+    fn time_in_phase_resets_on_transition() {
+        let base = Instant::now();
+        let mut t = tracker(base);
+        t.evaluate(d(2), true, base + Duration::from_secs(10))
+            .expect("to converging");
+        assert_eq!(
+            t.time_in_phase(base + Duration::from_secs(25)),
+            Duration::from_secs(15)
+        );
+    }
+
+    #[test]
+    fn phase_labels_are_snake_case() {
+        let labels: Vec<&'static str> = TopologyPhase::ALL.iter().map(|p| (*p).into()).collect();
+        assert_eq!(labels, ["bootstrap", "converging", "stable"]);
+    }
+}

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -11,10 +11,10 @@ use std::{
 
 use super::{
     CandidateSelector, CandidateSnapshot, DepthAwareLimits, KademliaConfig, LimitsSnapshot,
-    RoutingCapacity, SwarmRouting, candidate_queues::CandidateQueues, select_balanced_candidates,
-    select_neighborhood_candidates,
+    PhaseTracker, PhaseTransition, RoutingCapacity, SwarmRouting, TopologyPhase,
+    candidate_queues::CandidateQueues, select_balanced_candidates, select_neighborhood_candidates,
 };
-use crate::metrics::{phase, record_phase_transition};
+use crate::metrics::{phase, record_phase_transition, record_topology_phase_change};
 use nectar_primitives::{ChunkAddress, recompute_neighborhood_depth};
 use parking_lot::{Mutex, RwLock};
 use tokio::time::Instant;
@@ -25,6 +25,7 @@ use vertex_swarm_primitives::{
     Bin, NeighborhoodDepth, OverlayAddress, ProximityOrder, SwarmNodeType, all_bins, balanced_bins,
     neighborhood_bins,
 };
+use web_time::Instant as PhaseInstant;
 
 /// Connection phase for capacity tracking.
 #[derive(PartialEq, Eq)]
@@ -183,6 +184,7 @@ pub(crate) struct KademliaRouting<I: SwarmIdentity> {
     /// neighborhood is below saturation. Updated on every routing-table
     /// mutation so dips between snapshots are never missed.
     neighborhood_stability: Mutex<Option<NeighborhoodStable>>,
+    topology_phase: Mutex<PhaseTracker>,
 }
 
 impl<I: SwarmIdentity> KademliaRouting<I> {
@@ -194,6 +196,14 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         let max_po = identity.spec().max_po();
         let local_overlay = identity.overlay_address();
         let num_bins = (max_po as usize) + 1;
+
+        let topology_phase = Mutex::new(PhaseTracker::new(
+            config.phase_stability_window,
+            PhaseInstant::now(),
+        ));
+        // Publish the initial phase gauge so operators see Bootstrap from
+        // startup rather than no phase until the first transition.
+        crate::metrics::set_topology_phase(TopologyPhase::Bootstrap);
 
         Arc::new(Self {
             identity,
@@ -210,6 +220,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
             active_counts: make_atomic_vec(num_bins),
             connection_phases: RwLock::new(HashMap::new()),
             neighborhood_stability: Mutex::new(None),
+            topology_phase,
         })
     }
 
@@ -605,6 +616,53 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
     /// before the neighborhood counts as ready for pull-syncing.
     pub(crate) fn neighborhood_stability_window(&self) -> Duration {
         self.config.neighborhood_stability_window
+    }
+
+    /// Whether the neighborhood is saturated: a depth boundary is
+    /// established and the bins inside it together hold at least the
+    /// saturation threshold in connected peers, the same condition as
+    /// [`crate::ReadinessSnapshot::is_saturated`].
+    fn neighborhood_saturated(&self, depth: NeighborhoodDepth) -> bool {
+        if depth == NeighborhoodDepth::ZERO {
+            return false;
+        }
+        self.neighborhood_connected(depth) >= self.config.limits.saturation()
+    }
+
+    /// Re-derive the topology phase from the published depth and current
+    /// neighborhood saturation, committing a transition when it moved.
+    ///
+    /// Driven from the depth-publication points (peer connect and
+    /// disconnect through the behaviour) and from the periodic connection
+    /// evaluator, which alone observes the time-based `Converging` to
+    /// `Stable` settle. On transition this logs one operator-facing line
+    /// and records the phase metrics; callers broadcast the matching
+    /// [`crate::TopologyEvent::PhaseChanged`] where they hold the event
+    /// channel.
+    pub(crate) fn evaluate_phase(&self) -> Option<PhaseTransition> {
+        let depth = self.depth();
+        let saturated = self.neighborhood_saturated(depth);
+        let mut tracker = self.topology_phase.lock();
+        let transition = tracker.evaluate(depth, saturated, PhaseInstant::now())?;
+
+        // Record while the tracker lock is held so concurrent evaluations
+        // committing back-to-back transitions cannot interleave their logs
+        // and gauge updates out of order.
+        info!(
+            from = %transition.from,
+            to = %transition.to,
+            depth = transition.depth.get(),
+            time_in_phase = ?transition.time_in_phase,
+            "topology phase changed"
+        );
+        record_topology_phase_change(transition.from, transition.to);
+        Some(transition)
+    }
+
+    /// Current topology phase and the time spent in it.
+    pub(crate) fn phase_status(&self) -> (TopologyPhase, Duration) {
+        let tracker = self.topology_phase.lock();
+        (tracker.phase(), tracker.time_in_phase(PhaseInstant::now()))
     }
 
     /// Connected peers in the neighborhood (bins >= depth).
@@ -1403,6 +1461,84 @@ mod tests {
             assert_eq!(routing.depth().get(), 3);
         }
         assert!(routing.pending_depth_lower.lock().is_none());
+    }
+
+    #[test]
+    fn test_phase_starts_bootstrap_and_converges_on_depth_climb() {
+        let base = SwarmAddress::with_first_byte(0x00);
+        let (routing, _pm) = make_routing(base, KademliaConfig::default());
+
+        assert_eq!(routing.phase_status().0, TopologyPhase::Bootstrap);
+        assert!(
+            routing.evaluate_phase().is_none(),
+            "no transition while depth stays 0"
+        );
+
+        // Same shape as test_depth_climbs_with_saturated_bins: depth -> 3.
+        for bin in 0..3 {
+            for idx in 0..8 {
+                SwarmRouting::connected(&*routing, addr_in_bin(bin, idx));
+            }
+        }
+        for idx in 0..3 {
+            SwarmRouting::connected(&*routing, addr_in_bin(3, idx));
+        }
+        assert_eq!(routing.depth().get(), 3);
+
+        let transition = routing.evaluate_phase().expect("depth climb transitions");
+        assert_eq!(transition.from, TopologyPhase::Bootstrap);
+        assert_eq!(transition.to, TopologyPhase::Converging);
+        assert_eq!(transition.depth.get(), 3);
+
+        assert!(
+            routing.evaluate_phase().is_none(),
+            "re-evaluation without state change commits nothing"
+        );
+        assert_eq!(routing.phase_status().0, TopologyPhase::Converging);
+    }
+
+    #[test]
+    fn test_phase_full_lifecycle_with_zero_window() {
+        // A zero stability window makes the time gate pass immediately, so
+        // the saturation condition alone drives Converging vs Stable and
+        // the lifecycle is testable without simulated clocks.
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default().with_phase_stability_window(Duration::ZERO);
+        let (routing, _pm) = make_routing(base, config);
+
+        // Saturate bin 0 (depth anchors at 1) and hold 9 connected peers in
+        // the neighborhood, above the saturation threshold of 8.
+        for idx in 0..8 {
+            SwarmRouting::connected(&*routing, addr_in_bin(0, idx));
+        }
+        for idx in 0..5 {
+            SwarmRouting::connected(&*routing, addr_in_bin(1, idx));
+        }
+        for idx in 0..3 {
+            SwarmRouting::connected(&*routing, addr_in_bin(2, idx));
+        }
+        SwarmRouting::connected(&*routing, addr_in_bin(3, 0));
+        assert_eq!(routing.depth().get(), 1);
+
+        let transition = routing.evaluate_phase().expect("saturated neighborhood");
+        assert_eq!(transition.to, TopologyPhase::Stable);
+
+        // Losing neighborhood saturation (9 -> 7 connected at depth 1)
+        // falls back to Converging.
+        SwarmRouting::on_peer_disconnected(&*routing, &addr_in_bin(1, 3));
+        SwarmRouting::on_peer_disconnected(&*routing, &addr_in_bin(1, 4));
+        assert_eq!(routing.depth().get(), 1);
+        let transition = routing.evaluate_phase().expect("saturation lost");
+        assert_eq!(transition.from, TopologyPhase::Stable);
+        assert_eq!(transition.to, TopologyPhase::Converging);
+
+        // Depth collapsing to 0 falls all the way back to Bootstrap.
+        for idx in 0..8 {
+            SwarmRouting::on_peer_disconnected(&*routing, &addr_in_bin(0, idx));
+        }
+        assert_eq!(routing.depth().get(), 0);
+        let transition = routing.evaluate_phase().expect("depth collapsed");
+        assert_eq!(transition.to, TopologyPhase::Bootstrap);
     }
 
     #[test]

--- a/crates/swarm/topology/src/kademlia/task.rs
+++ b/crates/swarm/topology/src/kademlia/task.rs
@@ -3,12 +3,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::Notify;
+use tokio::sync::{Notify, broadcast};
 use tracing::debug;
 use vertex_swarm_api::SwarmIdentity;
 use vertex_tasks::{GracefulShutdown, TaskExecutor};
 
 use super::routing::KademliaRouting;
+use crate::events::TopologyEvent;
 
 /// Handle for triggering evaluation from the topology behaviour.
 #[derive(Clone)]
@@ -37,6 +38,7 @@ impl RoutingEvaluatorHandle {
 struct RoutingEvaluatorTask<I: SwarmIdentity> {
     routing: Arc<KademliaRouting<I>>,
     notify: Arc<Notify>,
+    event_tx: broadcast::Sender<TopologyEvent>,
 }
 
 impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
@@ -58,19 +60,37 @@ impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
                 _ = tokio::time::sleep(periodic) => {}
             }
             self.routing.evaluate_connections();
+
+            // The periodic tick is the only place that observes the
+            // time-driven Converging -> Stable settle: the behaviour
+            // re-derives the phase on connect/disconnect, but a quiet
+            // table changes phase purely by the stability window passing.
+            if let Some(transition) = self.routing.evaluate_phase() {
+                let _ = self.event_tx.send(TopologyEvent::PhaseChanged {
+                    from: transition.from,
+                    to: transition.to,
+                    depth: transition.depth.get(),
+                });
+            }
         }
     }
 }
 
 /// Spawn the routing evaluator task driven by the given handle's trigger.
+///
+/// `event_tx` is the topology event channel; the task broadcasts
+/// [`TopologyEvent::PhaseChanged`] for phase transitions its periodic
+/// evaluation commits.
 pub(crate) fn spawn_evaluator<I: SwarmIdentity + 'static>(
     routing: Arc<KademliaRouting<I>>,
     handle: &RoutingEvaluatorHandle,
+    event_tx: broadcast::Sender<TopologyEvent>,
     executor: &TaskExecutor,
 ) {
     let task = RoutingEvaluatorTask {
         routing,
         notify: Arc::clone(&handle.notify),
+        event_tx,
     };
 
     executor.spawn_critical_with_graceful_shutdown_signal("topology.evaluator", move |shutdown| {

--- a/crates/swarm/topology/src/lib.rs
+++ b/crates/swarm/topology/src/lib.rs
@@ -67,6 +67,6 @@ pub use events::{ConnectionDirection, DialReason, TopologyCommand, TopologyEvent
 pub use gossip::GossipConfig;
 pub use handle::{BinStats, RoutingStats, TopologyHandle};
 
-pub use kademlia::{KademliaConfig, RoutingArgs};
+pub use kademlia::{KademliaConfig, RoutingArgs, TopologyPhase};
 pub use reachability::{FAILURE_DECAY, FAILURE_THRESHOLD, PeerReachability, ReachabilityTracker};
 pub use readiness::{BinReadiness, ReadinessSnapshot};

--- a/crates/swarm/topology/src/metrics.rs
+++ b/crates/swarm/topology/src/metrics.rs
@@ -11,9 +11,9 @@ use vertex_observability::{
 };
 use vertex_swarm_primitives::SwarmNodeType;
 
-use crate::DialReason;
 use crate::error::{DialError, DisconnectReason, RejectionReason};
 use crate::events::{ConnectionDirection, TopologyEvent};
+use crate::{DialReason, TopologyPhase};
 
 /// Pre-computed proximity order labels (`&'static str`) to avoid per-call allocation.
 /// Covers bins 0-31 which is the full practical range for Kademlia routing.
@@ -130,6 +130,12 @@ impl TopologyMetrics {
             }
             TopologyEvent::PingCompleted { rtt, .. } => {
                 self.record_ping_completed(*rtt);
+            }
+            TopologyEvent::PhaseChanged { .. } => {
+                // Recorded where the transition is committed
+                // (`record_topology_phase_change` in the routing layer),
+                // which also covers transitions found by the background
+                // evaluator task that do not flow through `emit_event`.
             }
         }
     }
@@ -300,6 +306,29 @@ impl TopologyMetrics {
 /// Record connection phase transition metrics.
 pub(crate) fn record_phase_transition(from: &'static str, to: &'static str) {
     counter!("topology_phase_transitions_total", "from" => from, "to" => to).increment(1);
+}
+
+/// Publish the one-hot `topology_phase` gauge: 1 for the current phase,
+/// 0 for every other, so the current phase reads as the label whose gauge
+/// is 1. Called once at startup (Bootstrap) and on every transition.
+pub(crate) fn set_topology_phase(current: TopologyPhase) {
+    for phase in TopologyPhase::ALL {
+        let label: &'static str = phase.into();
+        gauge!("topology_phase", "phase" => label).set(if phase == current { 1.0 } else { 0.0 });
+    }
+}
+
+/// Record a topology phase machine transition: a `from`/`to` labelled
+/// counter plus the [`set_topology_phase`] gauge update.
+///
+/// Distinct from [`record_phase_transition`], which tracks per-connection
+/// dialing/handshaking/active slots; this tracks the node-level
+/// bootstrap/converging/stable lifecycle.
+pub(crate) fn record_topology_phase_change(from: TopologyPhase, to: TopologyPhase) {
+    let from_label: &'static str = from.into();
+    let to_label: &'static str = to.into();
+    counter!("topology_phase_changes_total", "from" => from_label, "to" => to_label).increment(1);
+    set_topology_phase(to);
 }
 
 /// Phase transition labels.

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -265,6 +265,8 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             self.on_depth_changed(old_depth, new_depth);
         }
 
+        self.refresh_topology_phase();
+
         self.emit_event(TopologyEvent::PeerReady {
             overlay,
             peer_id,

--- a/crates/swarm/topology/src/readiness.rs
+++ b/crates/swarm/topology/src/readiness.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth, SwarmNodeType};
 
+use crate::kademlia::TopologyPhase;
+
 /// Connection shortfall for one bin relative to its depth-aware target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinReadiness {
@@ -67,6 +69,12 @@ pub struct ReadinessSnapshot {
     /// The configured window [`Self::neighborhood_stable_for`] must reach
     /// for [`Self::is_neighborhood_ready`].
     pub neighborhood_stability_window: Duration,
+    /// Current topology phase, as last committed by the phase machine
+    /// (re-derived on every connect, disconnect, and periodic evaluation
+    /// tick, so it can lag a quiet table by at most one tick).
+    pub phase: TopologyPhase,
+    /// Time spent in the current phase.
+    pub time_in_phase: Duration,
 }
 
 impl ReadinessSnapshot {
@@ -148,6 +156,8 @@ mod tests {
             bins_at_target: 0,
             neighborhood_stable_for: None,
             neighborhood_stability_window: Duration::from_secs(30),
+            phase: TopologyPhase::Bootstrap,
+            time_in_phase: Duration::ZERO,
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the implicit "bootstrap mode" predicate (depth == 0 inside `DepthAwareLimits::target()`) with an explicit, observable `TopologyPhase` machine. The `depth == 0` allocation branch in the limits is untouched: the phase machine names and observes the lifecycle state, becoming the canonical answer to "what phase are we in" for consumers and operators, so the upcoming dial-shaping and pullsync-readiness work can hook into it.

## Phase machine

`TopologyPhase` (`Bootstrap`/`Converging`/`Stable`, exported from `vertex-swarm-topology`) lives in `kademlia/phase.rs` as a pure state machine (`PhaseTracker`): callers supply the observation time, so the transition table is unit-tested with simulated clocks. The phase is re-derived deterministically from observable routing state rather than edge-triggered:

- `Bootstrap`: published depth is 0. The known table is too thin to anchor a neighborhood; every bin fills toward the bootstrap target.
- `Converging`: depth is above 0 but moved within the stability window, or the neighborhood has not reached the saturation threshold (same condition as `ReadinessSnapshot::is_saturated`: connected peers in bins inside the depth boundary total at least the spec's saturation target).
- `Stable`: depth above 0, unmoved for the stability window, neighborhood saturated.

A `Stable` node falls back to `Converging` when depth moves or saturation is lost, and all the way to `Bootstrap` only when depth returns to 0. Depth churn that leaves the derived phase unchanged commits nothing, so there is no transition spam within the window.

The stability window is a `KademliaConfig` knob (`with_phase_stability_window`, default 60s, deliberately no CLI flag).

## Evaluation points

The routing layer re-derives the phase at the existing depth-publication points (handshake completion and connection close in the behaviour) and on the periodic connection-evaluator tick, which alone observes the time-driven `Converging` -> `Stable` settle on a quiet table. The evaluator task now receives the topology event channel so timer-driven transitions broadcast like every other.

## Observability

- One `info!` line per transition: `from`, `to`, `depth`, `time_in_phase`, recorded under the tracker lock so concurrent evaluations cannot interleave out of order.
- `topology_phase_changes_total{from,to}` counter (labels via `strum::IntoStaticStr`, snake_case), distinct from the existing per-connection `topology_phase_transitions_total`.
- One-hot `topology_phase{phase}` gauge published from startup (Bootstrap) and updated on every transition.
- `TopologyEvent::PhaseChanged { from, to, depth }` broadcast on the topology event stream; `TopologyHandle::wait_until` re-evaluates on it.
- `ReadinessSnapshot` now carries `phase` and `time_in_phase`, read from authoritative routing state.

## Tests

- Transition table in `phase.rs` under simulated clocks: bootstrap -> converging on first depth climb, converging -> stable after the window with saturation, converging holds without saturation, stable -> converging on depth change and on saturation loss, collapse to bootstrap at depth 0, and no transition spam under depth churn within the window.
- Routing-level lifecycle tests through real connect/disconnect sequences (zero window isolates the saturation condition).
- The three-node `vertex-swarm-node` convergence test asserts every node reports `Bootstrap` on the readiness surface, mirroring the depth-0 result (a three-node cluster cannot saturate a neighborhood, so deeper phases are out of reach there).

Part of #228