### PR TITLE
feat(swarm-topology): connection profiles with GCRA dial-rate shaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9310,6 +9310,7 @@ dependencies = [
  "vertex-net-local",
  "vertex-net-peer-registry",
  "vertex-net-peer-store",
+ "vertex-net-ratelimiter",
  "vertex-net-utils",
  "vertex-observability",
  "vertex-swarm-api",

--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -5,6 +5,7 @@ use core::time::Duration;
 
 use libp2p::Multiaddr;
 use vertex_node_api::InfrastructureContext;
+use vertex_swarm_primitives::ConnectionProfile;
 
 use crate::components::{SwarmAccountingConfig, SwarmLocalStoreConfig, SwarmPricingConfig};
 use crate::{SwarmClientTypes, SwarmNetworkTypes, SwarmStorerTypes};
@@ -189,6 +190,14 @@ pub trait SwarmNetworkConfig {
     /// candidate left.
     fn trust_local_peers(&self) -> bool {
         true
+    }
+
+    /// Explicitly selected connection pacing profile, if any (default: none).
+    ///
+    /// `None` means the topology derives the profile from the node type via
+    /// [`ConnectionProfile::default_for`].
+    fn connection_profile(&self) -> Option<ConnectionProfile> {
+        None
     }
 }
 

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -100,7 +100,8 @@ pub use nectar_primitives::{
     SingleOwnerChunk, StandardChunkSet,
 };
 pub use vertex_swarm_primitives::{
-    OverlayAddress, Stamp, StampedChunk, StorageRadius, ValidatedChunk, ValidationError,
+    ConnectionProfile, OverlayAddress, Stamp, StampedChunk, StorageRadius, ValidatedChunk,
+    ValidationError,
 };
 
 // Re-export libp2p types used in config traits

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use clap::Args;
 use serde::{Deserialize, Serialize};
 use vertex_swarm_api::{
-    ConfigAddressKind, ConfigError, Multiaddr, SwarmNetworkConfig, SwarmPeerConfig,
-    SwarmRoutingConfig,
+    ConfigAddressKind, ConfigError, ConnectionProfile, Multiaddr, SwarmNetworkConfig,
+    SwarmPeerConfig, SwarmRoutingConfig,
 };
 use vertex_swarm_topology::{KademliaConfig, RoutingArgs};
 
@@ -143,6 +143,12 @@ pub struct NetworkArgs {
     #[serde(default = "default_mdns")]
     pub mdns: bool,
 
+    /// Connection pacing profile: aggressive, balanced, or conservative.
+    /// Defaults by node mode: client = aggressive, bootnode/storer = balanced.
+    #[arg(long = "network.connection-profile", value_name = "PROFILE")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_profile: Option<ConnectionProfile>,
+
     /// Maximum number of established connections (transport-level hard cap).
     ///
     /// Enforced by the swarm independently of kademlia bin logic. Lowering
@@ -180,6 +186,7 @@ impl Default for NetworkArgs {
             autonat: true,
             upnp: false,
             mdns: true,
+            connection_profile: None,
             max_peers: DEFAULT_MAX_PEERS,
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             peer: PeerArgs::default(),
@@ -236,6 +243,7 @@ pub struct NetworkConfig<R = KademliaConfig> {
     mdns: bool,
     discovery_enabled: bool,
     trust_local_peers: bool,
+    connection_profile: Option<ConnectionProfile>,
     max_peers: usize,
     idle_timeout: Duration,
     peer: PeerConfig,
@@ -266,6 +274,7 @@ impl<R> NetworkConfig<R> {
             mdns: self.mdns,
             discovery_enabled: self.discovery_enabled,
             trust_local_peers: self.trust_local_peers,
+            connection_profile: self.connection_profile,
             max_peers: self.max_peers,
             idle_timeout: self.idle_timeout,
             peer: self.peer,
@@ -299,6 +308,7 @@ impl Default for NetworkConfig<KademliaConfig> {
             mdns: true,
             discovery_enabled: true,
             trust_local_peers: true,
+            connection_profile: None,
             max_peers: DEFAULT_MAX_PEERS,
             idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
             peer: PeerConfig::default(),
@@ -376,6 +386,7 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
             mdns: args.mdns,
             discovery_enabled: !args.disable_discovery,
             trust_local_peers: !args.no_trust_local_peers,
+            connection_profile: args.connection_profile,
             max_peers: args.max_peers,
             idle_timeout: Duration::from_secs(args.idle_timeout_secs),
             peer: PeerConfig::from(&args.peer),
@@ -431,6 +442,10 @@ impl<R> SwarmNetworkConfig for NetworkConfig<R> {
 
     fn trust_local_peers(&self) -> bool {
         self.trust_local_peers
+    }
+
+    fn connection_profile(&self) -> Option<ConnectionProfile> {
+        self.connection_profile
     }
 }
 
@@ -693,5 +708,60 @@ mod tests {
         let config = PeerConfig::from(&args);
 
         assert_eq!(config.max_per_bin(), DEFAULT_PEER_MAX_PER_BIN);
+    }
+
+    #[test]
+    fn connection_profile_default_is_unset() {
+        use clap::Parser;
+
+        // No flag: the profile stays unset so the topology can derive the
+        // node-type default at build time.
+        let parsed = TestCli::try_parse_from(["test"]).expect("default should parse");
+        assert_eq!(parsed.network.connection_profile, None);
+
+        let config = NetworkConfig::try_from(&parsed.network).expect("valid args");
+        assert_eq!(config.connection_profile(), None);
+    }
+
+    #[test]
+    fn connection_profile_flag_parses_and_propagates() {
+        use clap::Parser;
+
+        for (value, expected) in [
+            ("aggressive", ConnectionProfile::Aggressive),
+            ("balanced", ConnectionProfile::Balanced),
+            ("conservative", ConnectionProfile::Conservative),
+        ] {
+            let parsed = TestCli::try_parse_from(["test", "--network.connection-profile", value])
+                .expect("profile value should parse");
+            assert_eq!(parsed.network.connection_profile, Some(expected));
+
+            let config = NetworkConfig::try_from(&parsed.network).expect("valid args");
+            assert_eq!(config.connection_profile(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn connection_profile_rejects_unknown_value() {
+        use clap::Parser;
+
+        assert!(
+            TestCli::try_parse_from(["test", "--network.connection-profile", "turbo"]).is_err()
+        );
+    }
+
+    #[test]
+    fn connection_profile_survives_with_routing() {
+        use clap::Parser;
+
+        let parsed = TestCli::try_parse_from(["test", "--network.connection-profile=conservative"])
+            .expect("profile value should parse");
+        let config = NetworkConfig::try_from(&parsed.network).expect("valid args");
+        // The type-changing routing swap must carry the profile through.
+        let swapped = config.with_routing(KademliaConfig::default());
+        assert_eq!(
+            swapped.connection_profile(),
+            Some(ConnectionProfile::Conservative)
+        );
     }
 }

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -139,6 +139,10 @@ impl<C: SwarmNetworkConfig> SwarmNetworkConfig for ConfigWithBootnodes<'_, C> {
     fn trust_local_peers(&self) -> bool {
         self.inner.trust_local_peers()
     }
+
+    fn connection_profile(&self) -> Option<vertex_swarm_api::ConnectionProfile> {
+        self.inner.connection_profile()
+    }
 }
 
 impl<C: SwarmPeerConfig> SwarmPeerConfig for ConfigWithBootnodes<'_, C> {

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -275,6 +275,49 @@ impl SwarmNodeType {
     }
 }
 
+/// Named bundle of topology pacing parameters.
+///
+/// A profile selects how aggressively a node builds out its routing table:
+/// connection-evaluation cadence, discovery dial rate, dial concurrency,
+/// bootstrap fill level, and per-evaluation candidate budgets. Profiles only
+/// set numbers; no topology logic branches on the variant. The concrete
+/// pacing bundle each variant maps to is defined by the topology layer
+/// (`vertex-swarm-topology`), which is also where the numbers are documented.
+///
+/// The default is derived from the node type ([`Self::default_for`]) and can
+/// be overridden per node (CLI: `--network.connection-profile`).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, strum::Display, strum::EnumString, strum::IntoStaticStr,
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+pub enum ConnectionProfile {
+    /// Fast table build-out: short evaluation interval and a high dial rate.
+    /// Suited to nodes that want retrieval-ready routing quickly.
+    Aggressive,
+    /// Steady build-out matching the established topology defaults.
+    Balanced,
+    /// Slow, low-impact build-out for constrained environments (metered
+    /// links, battery, tiny hosts).
+    Conservative,
+}
+
+impl ConnectionProfile {
+    /// The default profile for a node type.
+    ///
+    /// Clients default to [`Self::Aggressive`]: they are typically short-lived
+    /// and user-facing, so time-to-usable-topology dominates. Storers and
+    /// bootnodes default to [`Self::Balanced`]: they are long-lived, so steady
+    /// convergence costs nothing and avoids dial bursts against the network.
+    pub const fn default_for(node_type: SwarmNodeType) -> Self {
+        match node_type {
+            SwarmNodeType::Client => Self::Aggressive,
+            SwarmNodeType::Bootnode | SwarmNodeType::Storer => Self::Balanced,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -405,6 +448,37 @@ mod tests {
         // Client needs the chain only when SWAP settlement is enabled.
         assert!(!SwarmNodeType::Client.needs_chain(false));
         assert!(SwarmNodeType::Client.needs_chain(true));
+    }
+
+    #[test]
+    fn connection_profile_default_by_node_type() {
+        assert_eq!(
+            ConnectionProfile::default_for(SwarmNodeType::Client),
+            ConnectionProfile::Aggressive
+        );
+        assert_eq!(
+            ConnectionProfile::default_for(SwarmNodeType::Storer),
+            ConnectionProfile::Balanced
+        );
+        assert_eq!(
+            ConnectionProfile::default_for(SwarmNodeType::Bootnode),
+            ConnectionProfile::Balanced
+        );
+    }
+
+    #[test]
+    fn connection_profile_string_round_trip() {
+        use std::str::FromStr;
+
+        for (profile, name) in [
+            (ConnectionProfile::Aggressive, "aggressive"),
+            (ConnectionProfile::Balanced, "balanced"),
+            (ConnectionProfile::Conservative, "conservative"),
+        ] {
+            assert_eq!(profile.to_string(), name);
+            assert_eq!(ConnectionProfile::from_str(name).expect("parses"), profile);
+        }
+        assert!(ConnectionProfile::from_str("turbo").is_err());
     }
 }
 

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -18,6 +18,7 @@ vertex-swarm-identity.workspace = true
 vertex-swarm-spec.workspace = true
 vertex-net-dialer.workspace = true
 vertex-net-local.workspace = true
+vertex-net-ratelimiter.workspace = true
 vertex-net-utils.workspace = true
 vertex-net-peer-store.workspace = true
 vertex-tasks.workspace = true

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -24,7 +24,8 @@ use libp2p::{
 use tracing::{debug, info, warn};
 use vertex_net_local::{AddressScope, classify_multiaddr, same_subnet};
 use vertex_net_peer_store::PeerSnapshotStore;
-use vertex_swarm_api::{BanCause, PeerLifecycleEvent, SwarmIdentity};
+use vertex_net_ratelimiter::{Quota, RateLimitedErr, RateLimiter};
+use vertex_swarm_api::{BanCause, ConnectionProfile, PeerLifecycleEvent, SwarmIdentity};
 use vertex_swarm_net_hive::MAX_BATCH_SIZE;
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer::SwarmPeer;
@@ -48,12 +49,6 @@ use crate::nat_discovery::LocalAddressManager;
 
 /// Type-erased peer snapshot store.
 pub(crate) type PeerStore = Arc<dyn PeerSnapshotStore<PeerSnapshot>>;
-
-/// Default interval between connection-evaluation rounds.
-///
-/// Each round reconsiders which bins are under target and issues new dials.
-/// Shorter wastes work on a stable table; longer slows convergence after churn.
-pub const DEFAULT_DIAL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Post-handshake connections shorter than this are penalized as early
 /// disconnects, so a peer that repeatedly connects and immediately leaves is
@@ -91,6 +86,12 @@ impl LazyInterval {
         self.interval
             .get_or_insert_with(|| tokio::time::interval(self.period))
             .poll_tick(cx)
+    }
+
+    /// The configured period (build-time pacing assertions).
+    #[cfg(test)]
+    pub(crate) fn period(&self) -> Duration {
+        self.period
     }
 }
 
@@ -139,12 +140,27 @@ impl DialTarget {
 }
 
 /// Configuration for topology behaviour.
+///
+/// Pacing (evaluation cadence, dial-rate quota, dial concurrency, bootstrap
+/// fill, candidate budgets) is resolved from a [`ConnectionProfile`] at build
+/// time: the explicit [`Self::with_connection_profile`] selection wins,
+/// otherwise the network configuration's choice, otherwise the node-type
+/// default. The `Option` overrides here ([`Self::with_dial_interval`],
+/// [`Self::with_dial_quota`]) pin single knobs over whatever the profile
+/// resolves to, for tests and embedders.
 #[derive(Debug, Clone)]
 pub struct TopologyConfig {
     pub kademlia: KademliaConfig,
     /// Tuning knobs for gossip peer exchange and verification.
     pub gossip: GossipConfig,
-    pub dial_interval: Duration,
+    /// Explicit pacing profile; `None` defers to the network configuration
+    /// and then the node-type default.
+    pub connection_profile: Option<ConnectionProfile>,
+    /// Explicit connection-evaluation cadence; `None` uses the profile's
+    /// evaluation interval.
+    pub dial_interval: Option<Duration>,
+    /// Explicit discovery dial-rate quota; `None` uses the profile's quota.
+    pub dial_quota: Option<Quota>,
     pub early_disconnect_threshold: Duration,
 }
 
@@ -153,7 +169,9 @@ impl Default for TopologyConfig {
         Self {
             kademlia: KademliaConfig::default(),
             gossip: GossipConfig::default(),
-            dial_interval: DEFAULT_DIAL_INTERVAL,
+            connection_profile: None,
+            dial_interval: None,
+            dial_quota: None,
             early_disconnect_threshold: DEFAULT_EARLY_DISCONNECT_THRESHOLD,
         }
     }
@@ -175,8 +193,22 @@ impl TopologyConfig {
         self
     }
 
+    /// Select the connection pacing profile, overriding the network
+    /// configuration and the node-type default.
+    pub fn with_connection_profile(mut self, profile: ConnectionProfile) -> Self {
+        self.connection_profile = Some(profile);
+        self
+    }
+
+    /// Pin the connection-evaluation cadence over the profile's value.
     pub fn with_dial_interval(mut self, interval: Duration) -> Self {
-        self.dial_interval = interval;
+        self.dial_interval = Some(interval);
+        self
+    }
+
+    /// Pin the discovery dial-rate quota over the profile's value.
+    pub fn with_dial_quota(mut self, quota: Quota) -> Self {
+        self.dial_quota = Some(quota);
         self
     }
 
@@ -221,6 +253,16 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
 
     // Periodic dial interval
     pub(crate) dial_interval: LazyInterval,
+
+    /// GCRA bucket shaping the discovery dial rate. Bursts after a candidate
+    /// influx drain immediately up to the bucket size; beyond it, candidates
+    /// stay queued in routing until tokens replenish.
+    pub(crate) dial_rate: RateLimiter,
+
+    /// Armed when the dial-rate bucket refused a candidate: fires when the
+    /// next token is available so the drain resumes without waiting for the
+    /// evaluation tick.
+    pub(crate) dial_rate_timer: Option<Pin<Box<tokio::time::Sleep>>>,
 
     // Pending dnsaddr resolution for bootnodes (resolved_bootnodes, resolved_trusted)
     #[allow(clippy::type_complexity)]
@@ -394,18 +436,55 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
     // Routing
 
-    /// Drain candidates from the background evaluator's per-bin queues and dial them.
-    pub(crate) fn drain_candidate_queues(&mut self) {
-        let candidates = self.routing.drain_candidates();
-        if candidates.is_empty() {
-            return;
+    /// Drain candidates from the background evaluator's per-bin queues and
+    /// dial them, shaped by the dial-rate bucket.
+    ///
+    /// Each dialable candidate costs one token. When the bucket runs dry the
+    /// candidate returns to its queue and a timer is armed for the bucket's
+    /// reported wait, so the drain resumes as soon as a token replenishes
+    /// instead of waiting for the next evaluation tick. Candidates that are
+    /// no longer dialable (record gone, banned, in backoff, wrong address
+    /// scope) are dropped without spending a token.
+    pub(crate) fn drain_candidate_queues(&mut self, cx: &mut Context<'_>) {
+        if let Some(timer) = self.dial_rate_timer.as_mut() {
+            match timer.as_mut().poll(cx) {
+                Poll::Ready(()) => self.dial_rate_timer = None,
+                Poll::Pending => return,
+            }
         }
 
-        let mut dialable = self.peer_manager.get_dialable_peers(&candidates);
-        dialable.retain(|peer| self.can_advertise_to(peer));
+        while let Some(overlay) = self.routing.pop_candidate() {
+            let Some(swarm_peer) = self
+                .peer_manager
+                .get_dialable_peers(std::slice::from_ref(&overlay))
+                .pop()
+            else {
+                continue;
+            };
+            if !self.can_advertise_to(&swarm_peer) {
+                continue;
+            }
 
-        for swarm_peer in dialable {
-            self.dial(DialTarget::Known(swarm_peer), DialReason::Discovery);
+            match self.dial_rate.try_consume() {
+                Ok(()) => self.dial(DialTarget::Known(swarm_peer), DialReason::Discovery),
+                Err(RateLimitedErr::TooSoon(wait)) => {
+                    metrics::counter!("topology_dials_throttled_total").increment(1);
+                    self.routing.requeue_candidate(overlay);
+                    let mut timer = Box::pin(tokio::time::sleep(wait));
+                    if timer.as_mut().poll(cx).is_ready() {
+                        // Sub-millisecond wait already elapsed; keep draining.
+                        continue;
+                    }
+                    self.dial_rate_timer = Some(timer);
+                    return;
+                }
+                Err(RateLimitedErr::TooLarge) => {
+                    // Unreachable: a single token never exceeds the non-zero
+                    // bucket size. Requeue and stop draining defensively.
+                    self.routing.requeue_candidate(overlay);
+                    return;
+                }
+            }
         }
     }
 
@@ -890,8 +969,9 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
             }
         }
 
-        // Drain candidates produced by the background evaluator task.
-        self.drain_candidate_queues();
+        // Drain candidates produced by the background evaluator task, shaped
+        // by the dial-rate bucket (arms a wake-up timer when throttled).
+        self.drain_candidate_queues(cx);
 
         // Drain peer lifecycle events and execute the network-side actions
         // (disconnects and bans). Catches auto-bans from scoring events
@@ -1014,84 +1094,110 @@ mod tests {
     fn test_topology_config() {
         let config = TopologyConfig::new()
             .with_kademlia(KademliaConfig::default().with_nominal(3))
-            .with_dial_interval(Duration::from_secs(10));
+            .with_dial_interval(Duration::from_secs(10))
+            .with_connection_profile(ConnectionProfile::Conservative);
 
-        assert_eq!(config.dial_interval, Duration::from_secs(10));
+        assert_eq!(config.dial_interval, Some(Duration::from_secs(10)));
+        assert_eq!(
+            config.connection_profile,
+            Some(ConnectionProfile::Conservative)
+        );
         assert_eq!(config.kademlia.limits.nominal(), 3);
+
+        // Unset pacing knobs stay unresolved until build time.
+        let default = TopologyConfig::default();
+        assert_eq!(default.connection_profile, None);
+        assert_eq!(default.dial_interval, None);
+        assert!(default.dial_quota.is_none());
+    }
+
+    use vertex_swarm_api::{
+        DefaultPeerConfig, SwarmNetworkConfig, SwarmNodeType, SwarmPeerConfig, SwarmRoutingConfig,
+    };
+    use vertex_swarm_identity::Identity;
+
+    use crate::TopologyBehaviourBuilder;
+
+    /// Minimal network configuration for behaviour tests.
+    struct EventTestConfig {
+        peers: DefaultPeerConfig,
+        routing: KademliaConfig,
+        empty_addrs: Vec<Multiaddr>,
+    }
+
+    impl EventTestConfig {
+        fn new() -> Self {
+            Self {
+                peers: DefaultPeerConfig::default(),
+                routing: KademliaConfig::default(),
+                empty_addrs: Vec::new(),
+            }
+        }
+    }
+
+    impl SwarmNetworkConfig for EventTestConfig {
+        fn listen_addrs(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn bootnodes(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn discovery_enabled(&self) -> bool {
+            true
+        }
+        fn max_peers(&self) -> usize {
+            32
+        }
+        fn idle_timeout(&self) -> Duration {
+            Duration::from_secs(60)
+        }
+    }
+
+    impl SwarmPeerConfig for EventTestConfig {
+        type Peers = DefaultPeerConfig;
+        fn peers(&self) -> &Self::Peers {
+            &self.peers
+        }
+    }
+
+    impl SwarmRoutingConfig for EventTestConfig {
+        type Routing = KademliaConfig;
+        fn routing(&self) -> &Self::Routing {
+            &self.routing
+        }
+    }
+
+    fn test_behaviour_with(config: TopologyConfig) -> TopologyBehaviour<Identity> {
+        let identity = Identity::random(vertex_swarm_spec::init_testnet(), SwarmNodeType::Client);
+        let (behaviour, _handle) = TopologyBehaviourBuilder::new(identity, &EventTestConfig::new())
+            .with_config(config)
+            .try_build()
+            .expect("build without runtime");
+        behaviour
+    }
+
+    fn test_behaviour() -> TopologyBehaviour<Identity> {
+        test_behaviour_with(TopologyConfig::default())
+    }
+
+    async fn next_action(
+        behaviour: &mut TopologyBehaviour<Identity>,
+    ) -> ToSwarm<(), THandlerInEvent<ProtocolBehaviours<Identity>>> {
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            std::future::poll_fn(|cx| behaviour.poll(cx)),
+        )
+        .await
+        .expect("behaviour must emit an action")
     }
 
     mod lifecycle {
         use super::*;
 
         use libp2p::swarm::ConnectionId;
-        use vertex_swarm_api::{
-            BanCause, DefaultPeerConfig, SwarmNetworkConfig, SwarmNodeType, SwarmPeerConfig,
-            SwarmRoutingConfig,
-        };
-        use vertex_swarm_identity::Identity;
+        use vertex_swarm_api::BanCause;
         use vertex_swarm_peer_manager::LIFECYCLE_CHANNEL_CAPACITY;
         use vertex_swarm_test_utils::test_overlay;
-
-        use crate::TopologyBehaviourBuilder;
-
-        /// Minimal network configuration for behaviour tests.
-        struct EventTestConfig {
-            peers: DefaultPeerConfig,
-            routing: KademliaConfig,
-            empty_addrs: Vec<Multiaddr>,
-        }
-
-        impl EventTestConfig {
-            fn new() -> Self {
-                Self {
-                    peers: DefaultPeerConfig::default(),
-                    routing: KademliaConfig::default(),
-                    empty_addrs: Vec::new(),
-                }
-            }
-        }
-
-        impl SwarmNetworkConfig for EventTestConfig {
-            fn listen_addrs(&self) -> &[Multiaddr] {
-                &self.empty_addrs
-            }
-            fn bootnodes(&self) -> &[Multiaddr] {
-                &self.empty_addrs
-            }
-            fn discovery_enabled(&self) -> bool {
-                true
-            }
-            fn max_peers(&self) -> usize {
-                32
-            }
-            fn idle_timeout(&self) -> Duration {
-                Duration::from_secs(60)
-            }
-        }
-
-        impl SwarmPeerConfig for EventTestConfig {
-            type Peers = DefaultPeerConfig;
-            fn peers(&self) -> &Self::Peers {
-                &self.peers
-            }
-        }
-
-        impl SwarmRoutingConfig for EventTestConfig {
-            type Routing = KademliaConfig;
-            fn routing(&self) -> &Self::Routing {
-                &self.routing
-            }
-        }
-
-        fn test_behaviour() -> TopologyBehaviour<Identity> {
-            let identity =
-                Identity::random(vertex_swarm_spec::init_testnet(), SwarmNodeType::Client);
-            let (behaviour, _handle) =
-                TopologyBehaviourBuilder::new(identity, &EventTestConfig::new())
-                    .try_build()
-                    .expect("build without runtime");
-            behaviour
-        }
 
         /// Register an active (handshake-complete) connection in the registry.
         fn activate_connection(
@@ -1107,17 +1213,6 @@ mod tests {
                 .connection_registry
                 .activate(peer_id, connection_id, overlay);
             peer_id
-        }
-
-        async fn next_action(
-            behaviour: &mut TopologyBehaviour<Identity>,
-        ) -> ToSwarm<(), THandlerInEvent<ProtocolBehaviours<Identity>>> {
-            tokio::time::timeout(
-                Duration::from_secs(5),
-                std::future::poll_fn(|cx| behaviour.poll(cx)),
-            )
-            .await
-            .expect("behaviour must emit an action")
         }
 
         /// A `Banned` lifecycle event drained in poll closes the peer's
@@ -1185,6 +1280,102 @@ mod tests {
                     peer_id: closed, ..
                 } => assert_eq!(closed, peer_id),
                 _ => panic!("expected CloseConnection for the disconnect request"),
+            }
+        }
+    }
+
+    mod dial_rate {
+        use super::*;
+
+        use std::num::NonZeroU32;
+
+        use vertex_net_ratelimiter::Quota;
+        use vertex_swarm_test_utils::test_swarm_peer;
+
+        fn nz(n: u32) -> NonZeroU32 {
+            NonZeroU32::new(n).expect("non-zero")
+        }
+
+        /// Build a behaviour whose dial-rate bucket holds `burst` tokens over
+        /// `window`, with a known loopback listen address so candidate
+        /// multiaddrs pass the reachability filter.
+        fn throttled_behaviour(burst: u32, window: Duration) -> TopologyBehaviour<Identity> {
+            let behaviour = test_behaviour_with(
+                TopologyConfig::default().with_dial_quota(Quota::n_every(nz(burst), window)),
+            );
+            behaviour
+                .nat_discovery
+                .on_new_listen_addr("/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr"));
+            behaviour
+        }
+
+        /// Store a dialable loopback peer and queue it as a dial candidate.
+        fn queue_candidate(behaviour: &TopologyBehaviour<Identity>, n: u8) {
+            let peer = test_swarm_peer(n);
+            let overlay = OverlayAddress::from(*peer.overlay());
+            behaviour.peer_manager.store_discovered_peer(peer);
+            behaviour.routing.requeue_candidate(overlay);
+        }
+
+        /// Poll the behaviour once with a no-op waker.
+        fn poll_once(
+            behaviour: &mut TopologyBehaviour<Identity>,
+        ) -> Poll<ToSwarm<(), THandlerInEvent<ProtocolBehaviours<Identity>>>> {
+            let waker = futures::task::noop_waker();
+            let mut cx = Context::from_waker(&waker);
+            behaviour.poll(&mut cx)
+        }
+
+        /// The bucket absorbs a burst up to its size, then defers the rest:
+        /// the third candidate stays queued and a wake-up timer is armed.
+        #[tokio::test]
+        async fn burst_dials_immediately_then_throttles() {
+            let mut behaviour = throttled_behaviour(2, Duration::from_secs(600));
+            for n in [0x10, 0x20, 0x30] {
+                queue_candidate(&behaviour, n);
+            }
+
+            let mut dials = 0;
+            loop {
+                match poll_once(&mut behaviour) {
+                    Poll::Ready(ToSwarm::Dial { .. }) => dials += 1,
+                    Poll::Ready(_) => {}
+                    Poll::Pending => break,
+                }
+            }
+
+            assert_eq!(dials, 2, "burst must equal the bucket size");
+            assert!(
+                behaviour.dial_rate_timer.is_some(),
+                "throttled drain must arm the replenish timer"
+            );
+            assert!(
+                behaviour.routing.pop_candidate().is_some(),
+                "the throttled candidate must stay queued"
+            );
+        }
+
+        /// When tokens replenish, the armed timer wakes the poll loop and the
+        /// deferred candidate is dialed without waiting for the next
+        /// evaluation tick.
+        #[tokio::test]
+        async fn timer_resumes_drain_after_replenish() {
+            // 1 token per 100ms of real time: the second candidate defers,
+            // then drains when the timer fires.
+            let mut behaviour = throttled_behaviour(1, Duration::from_millis(100));
+            queue_candidate(&behaviour, 0x10);
+            queue_candidate(&behaviour, 0x20);
+
+            match next_action(&mut behaviour).await {
+                ToSwarm::Dial { .. } => {}
+                other => panic!("expected first Dial, got {other:?}"),
+            }
+            assert!(behaviour.dial_rate_timer.is_some());
+
+            // The awaited poll wakes via the armed timer once a token is back.
+            match next_action(&mut behaviour).await {
+                ToSwarm::Dial { .. } => {}
+                other => panic!("expected deferred Dial after replenish, got {other:?}"),
             }
         }
     }

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -11,7 +11,10 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::info;
 use vertex_net_dialer::{DialTracker, DialTrackerConfig};
 use vertex_net_local::LocalCapabilities;
-use vertex_swarm_api::{PeerConfigValues, SwarmBootnodeConfig, SwarmIdentity, SwarmSpec};
+use vertex_net_ratelimiter::RateLimiter;
+use vertex_swarm_api::{
+    ConnectionProfile, PeerConfigValues, SwarmBootnodeConfig, SwarmIdentity, SwarmSpec,
+};
 use vertex_swarm_net_handshake::HANDSHAKE_TIMEOUT;
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer_manager::{PeerManager, PeerManagerConfig};
@@ -31,6 +34,7 @@ use crate::kademlia::{
 };
 use crate::metrics::TopologyMetrics;
 use crate::nat_discovery::LocalAddressManager;
+use crate::profile::PacingProfile;
 
 /// Inputs the background tasks need, captured at build time so that
 /// [`TopologyBehaviour::spawn_tasks`] can start them later without re-deriving
@@ -44,6 +48,8 @@ pub(crate) struct PendingTopologyTasks {
     local_capabilities: Arc<LocalCapabilities>,
     /// Task-side gossip channel endpoints.
     gossip_channels: GossipChannels,
+    /// Profile-resolved cadence for the background connection evaluator.
+    evaluation_interval: Duration,
 }
 
 /// Builder for [`TopologyBehaviour`] and its [`TopologyHandle`].
@@ -64,6 +70,10 @@ pub struct TopologyBehaviourBuilder<I: SwarmIdentity + Clone> {
     scoring_config: SwarmScoringConfig,
     max_per_bin: usize,
     peer_store: Option<PeerStore>,
+    /// Connection profile selected in the network configuration (CLI/config
+    /// file). Overridden by an explicit [`TopologyConfig::with_connection_profile`];
+    /// falls back to the node-type default when both are unset.
+    network_profile: Option<ConnectionProfile>,
 }
 
 impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
@@ -86,6 +96,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
                 .build(),
             max_per_bin: peer_config.max_per_bin(),
             peer_store: None,
+            network_profile: network_config.connection_profile(),
         }
     }
 
@@ -133,15 +144,39 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
 
         let lifecycle_rx = peer_manager.subscribe();
 
-        // Allocation floors and depth recomputation must use the same
-        // saturation threshold (see the DepthAwareLimits invariants), so the
-        // spec value overrides whatever the kademlia config carried.
-        let mut kademlia_config = self.config.kademlia.clone();
+        // Resolve the pacing profile: explicit topology config, then network
+        // config (CLI/config file), then the node-type default. The profile
+        // only sets numbers on existing knobs; no logic branches on it.
+        let profile = self
+            .config
+            .connection_profile
+            .or(self.network_profile)
+            .unwrap_or_else(|| ConnectionProfile::default_for(self.identity.node_type()));
+        let pacing = PacingProfile::from(profile);
+        info!(%profile, "Connection profile selected");
+
+        // Pacing knobs come from the profile; allocation floors and depth
+        // recomputation must additionally use the same saturation threshold
+        // (see the DepthAwareLimits invariants), so the spec value overrides
+        // whatever the kademlia config carried.
+        let mut kademlia_config = self
+            .config
+            .kademlia
+            .clone()
+            .with_bootstrap_target(pacing.bootstrap_target);
+        kademlia_config.max_neighbor_candidates = pacing.max_neighbor_candidates;
+        kademlia_config.max_balanced_candidates = pacing.max_balanced_candidates;
         kademlia_config.limits = kademlia_config.limits.with_saturation(usize::from(
             SwarmIdentity::spec(&self.identity).saturation_peers(),
         ));
         let routing =
             KademliaRouting::new(self.identity.clone(), kademlia_config, peer_manager.clone());
+
+        let evaluation_interval = self
+            .config
+            .dial_interval
+            .unwrap_or(pacing.evaluation_interval);
+        let dial_quota = self.config.dial_quota.unwrap_or(pacing.dial_quota);
 
         let local_capabilities = Arc::new(LocalCapabilities::new());
 
@@ -200,12 +235,16 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             event_tx,
             pending_actions: VecDeque::new(),
             gossip,
-            dial_interval: LazyInterval::new(self.config.dial_interval),
+            dial_interval: LazyInterval::new(evaluation_interval),
+            dial_rate: RateLimiter::new(dial_quota),
+            dial_rate_timer: None,
             pending_bootnode_resolution: None,
             evaluator_handle,
             dial_tracker: DialTracker::new(DialTrackerConfig {
-                max_pending: 0,     // not used as a queue, only for direct in-flight tracking
-                max_in_flight: 256, // generous limit; routing capacity is the real gate
+                max_pending: 0, // not used as a queue, only for direct in-flight tracking
+                // Generous limit from the profile; routing capacity is the
+                // real gate on how many dials become connections.
+                max_in_flight: pacing.dial_concurrency,
                 pending_ttl: HANDSHAKE_TIMEOUT,
                 in_flight_timeout: HANDSHAKE_TIMEOUT,
                 cleanup_interval: Duration::from_secs(30),
@@ -226,6 +265,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
                 gossip_config,
                 local_capabilities,
                 gossip_channels,
+                evaluation_interval,
             }),
         };
 
@@ -258,6 +298,7 @@ impl<I: SwarmIdentity + Clone + 'static> TopologyBehaviour<I> {
             self.routing.clone(),
             &self.evaluator_handle,
             self.event_tx.clone(),
+            pending.evaluation_interval,
             &executor,
         );
 
@@ -294,6 +335,7 @@ mod tests {
     use vertex_swarm_identity::Identity;
 
     use crate::kademlia::KademliaConfig;
+    use crate::profile::PacingProfile;
 
     /// Minimal network configuration for exercising the builder.
     struct TestConfig {
@@ -301,6 +343,7 @@ mod tests {
         routing: KademliaConfig,
         bootnodes: Vec<Multiaddr>,
         empty_addrs: Vec<Multiaddr>,
+        connection_profile: Option<ConnectionProfile>,
     }
 
     impl TestConfig {
@@ -310,6 +353,7 @@ mod tests {
                 routing: KademliaConfig::default(),
                 bootnodes: vec!["/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr")],
                 empty_addrs: Vec::new(),
+                connection_profile: None,
             }
         }
     }
@@ -329,6 +373,9 @@ mod tests {
         }
         fn idle_timeout(&self) -> Duration {
             Duration::from_secs(60)
+        }
+        fn connection_profile(&self) -> Option<ConnectionProfile> {
+            self.connection_profile
         }
     }
 
@@ -401,5 +448,123 @@ mod tests {
             behaviour.spawn_tasks(),
             Err(TopologyError::TasksAlreadySpawned)
         ));
+    }
+
+    fn identity_of(node_type: SwarmNodeType) -> Identity {
+        Identity::random(vertex_swarm_spec::init_testnet(), node_type)
+    }
+
+    /// Assert that a built behaviour carries the pacing numbers of `profile`.
+    fn assert_pacing(behaviour: &TopologyBehaviour<Identity>, profile: ConnectionProfile) {
+        let pacing = PacingProfile::from(profile);
+        assert_eq!(behaviour.dial_interval.period(), pacing.evaluation_interval);
+        let config = behaviour.routing.config();
+        assert_eq!(
+            config.max_neighbor_candidates,
+            pacing.max_neighbor_candidates
+        );
+        assert_eq!(
+            config.max_balanced_candidates,
+            pacing.max_balanced_candidates
+        );
+    }
+
+    /// Without an explicit selection, the profile follows the node type.
+    #[test]
+    fn profile_defaults_by_node_type() {
+        for (node_type, expected) in [
+            (SwarmNodeType::Client, ConnectionProfile::Aggressive),
+            (SwarmNodeType::Storer, ConnectionProfile::Balanced),
+            (SwarmNodeType::Bootnode, ConnectionProfile::Balanced),
+        ] {
+            let (behaviour, _handle) =
+                TopologyBehaviourBuilder::new(identity_of(node_type), &TestConfig::new())
+                    .try_build()
+                    .expect("build without runtime");
+            assert_pacing(&behaviour, expected);
+        }
+    }
+
+    /// The network configuration's profile choice overrides the node-type
+    /// default.
+    #[test]
+    fn network_config_profile_overrides_node_type_default() {
+        let config = TestConfig {
+            connection_profile: Some(ConnectionProfile::Conservative),
+            ..TestConfig::new()
+        };
+        let (behaviour, _handle) =
+            TopologyBehaviourBuilder::new(identity_of(SwarmNodeType::Client), &config)
+                .try_build()
+                .expect("build without runtime");
+        assert_pacing(&behaviour, ConnectionProfile::Conservative);
+    }
+
+    /// An explicit topology config selection beats the network configuration.
+    #[test]
+    fn topology_config_profile_overrides_network_config() {
+        let config = TestConfig {
+            connection_profile: Some(ConnectionProfile::Conservative),
+            ..TestConfig::new()
+        };
+        let (behaviour, _handle) =
+            TopologyBehaviourBuilder::new(identity_of(SwarmNodeType::Client), &config)
+                .with_config(
+                    TopologyConfig::default().with_connection_profile(ConnectionProfile::Balanced),
+                )
+                .try_build()
+                .expect("build without runtime");
+        assert_pacing(&behaviour, ConnectionProfile::Balanced);
+    }
+
+    /// A pinned dial interval wins over the profile's evaluation interval
+    /// while the rest of the pacing still comes from the profile.
+    #[test]
+    fn explicit_dial_interval_overrides_profile() {
+        let (behaviour, _handle) =
+            TopologyBehaviourBuilder::new(identity_of(SwarmNodeType::Storer), &TestConfig::new())
+                .with_config(TopologyConfig::default().with_dial_interval(Duration::from_secs(7)))
+                .try_build()
+                .expect("build without runtime");
+
+        assert_eq!(behaviour.dial_interval.period(), Duration::from_secs(7));
+        let pacing = PacingProfile::from(ConnectionProfile::Balanced);
+        assert_eq!(
+            behaviour.routing.config().max_neighbor_candidates,
+            pacing.max_neighbor_candidates
+        );
+    }
+
+    /// The profile's bootstrap fill level flows into the depth-aware limits:
+    /// the depth-0 target is the bootstrap target (all profile values exceed
+    /// the testnet saturation floor).
+    #[test]
+    fn bootstrap_target_flows_from_profile() {
+        use vertex_swarm_primitives::{Bin, NeighborhoodDepth};
+
+        for profile in [
+            ConnectionProfile::Aggressive,
+            ConnectionProfile::Balanced,
+            ConnectionProfile::Conservative,
+        ] {
+            let (behaviour, _handle) = TopologyBehaviourBuilder::new(
+                identity_of(SwarmNodeType::Client),
+                &TestConfig::new(),
+            )
+            .with_config(TopologyConfig::default().with_connection_profile(profile))
+            .try_build()
+            .expect("build without runtime");
+
+            let pacing = PacingProfile::from(profile);
+            let saturation = behaviour.routing.limits().saturation();
+            let bin = Bin::new(0).expect("valid bin");
+            assert_eq!(
+                behaviour
+                    .routing
+                    .limits()
+                    .target(bin, NeighborhoodDepth::ZERO),
+                pacing.bootstrap_target.max(saturation),
+            );
+        }
     }
 }

--- a/crates/swarm/topology/src/kademlia/args.rs
+++ b/crates/swarm/topology/src/kademlia/args.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 use super::{DepthAwareLimits, KademliaConfig};
 
 /// Kademlia routing CLI arguments.
+///
+/// Pacing knobs (candidate budgets, evaluation cadence, dial rate) are not
+/// exposed here: they are bundled per connection profile and selected via
+/// `--network.connection-profile`.
 #[derive(Debug, Args, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct RoutingArgs {
@@ -23,16 +27,6 @@ pub struct RoutingArgs {
     #[arg(long = "network.routing.inbound-headroom")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inbound_headroom: Option<usize>,
-
-    /// Max pending connections for neighbor bins.
-    #[arg(long = "network.routing.max-neighbor-candidates")]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_neighbor_candidates: Option<usize>,
-
-    /// Max pending connections for balanced bins.
-    #[arg(long = "network.routing.max-balanced-candidates")]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_balanced_candidates: Option<usize>,
 }
 
 impl RoutingArgs {
@@ -48,17 +42,6 @@ impl RoutingArgs {
             limits = limits.with_inbound_headroom(headroom);
         }
 
-        KademliaConfig {
-            limits,
-            max_neighbor_candidates: self
-                .max_neighbor_candidates
-                .unwrap_or(defaults.max_neighbor_candidates),
-            max_balanced_candidates: self
-                .max_balanced_candidates
-                .unwrap_or(defaults.max_balanced_candidates),
-            neighborhood_stability_window: defaults.neighborhood_stability_window,
-            depth_lower_window: defaults.depth_lower_window,
-            phase_stability_window: defaults.phase_stability_window,
-        }
+        KademliaConfig { limits, ..defaults }
     }
 }

--- a/crates/swarm/topology/src/kademlia/candidate_queues.rs
+++ b/crates/swarm/topology/src/kademlia/candidate_queues.rs
@@ -48,7 +48,21 @@ impl CandidateQueues {
         true
     }
 
+    /// Pop the next candidate, highest bin first (deepest bins are the
+    /// scarcest and most valuable). Returns `None` when every bin is empty.
+    pub(super) fn pop_next(&self) -> Option<OverlayAddress> {
+        let mut pending = self.pending.lock();
+        for queue in self.bins.iter().rev() {
+            if let Some(peer) = queue.lock().pop_front() {
+                pending.remove(&peer);
+                return Some(peer);
+            }
+        }
+        None
+    }
+
     /// Drain all bins (highest PO first) into a single Vec.
+    #[cfg(test)]
     pub(super) fn drain_all(&self) -> Vec<OverlayAddress> {
         let mut pending = self.pending.lock();
         let mut result = Vec::new();
@@ -140,5 +154,23 @@ mod tests {
         // Bin 5 doesn't exist (only 0-3)
         assert!(!queues.push(b(5), peer));
         assert!(queues.snapshot_queued().is_empty());
+    }
+
+    #[test]
+    fn test_pop_next_highest_bin_first() {
+        let queues = CandidateQueues::new(32, 16);
+        let lo = SwarmAddress::with_first_byte(0x80);
+        let hi = SwarmAddress::with_first_byte(0x40);
+
+        queues.push(b(0), lo);
+        queues.push(b(1), hi);
+
+        assert_eq!(queues.pop_next(), Some(hi));
+        assert_eq!(queues.pop_next(), Some(lo));
+        assert_eq!(queues.pop_next(), None);
+
+        // Popped candidates leave the dedup set, so they can be re-queued.
+        assert!(queues.push(b(0), lo));
+        assert_eq!(queues.pop_next(), Some(lo));
     }
 }

--- a/crates/swarm/topology/src/kademlia/config.rs
+++ b/crates/swarm/topology/src/kademlia/config.rs
@@ -8,15 +8,20 @@
 //! per round, roughly one slot per Kademlia bin, so a single round can make
 //! progress on every bin without flooding the dialer. The depth-aware targets,
 //! not this budget, decide how many candidates actually become connections.
+//!
+//! The budgets and the bootstrap fill level are pacing knobs: production
+//! resolves them from the node's connection profile (see `crate::profile`)
+//! at behaviour construction, with the defaults here matching the Balanced
+//! profile.
 
 use std::time::Duration;
 
 use super::limits::DepthAwareLimits;
 
 /// Max new neighborhood (depth-bin) candidates enqueued per evaluation round.
-const DEFAULT_MAX_NEIGHBOR_CANDIDATES: usize = 16;
+pub(crate) const DEFAULT_MAX_NEIGHBOR_CANDIDATES: usize = 16;
 /// Max new balanced (non-depth-bin) candidates enqueued per evaluation round.
-const DEFAULT_MAX_BALANCED_CANDIDATES: usize = 16;
+pub(crate) const DEFAULT_MAX_BALANCED_CANDIDATES: usize = 16;
 /// Default stability window for the topology phase machine.
 const DEFAULT_PHASE_STABILITY_WINDOW: Duration = Duration::from_secs(60);
 
@@ -127,6 +132,13 @@ impl KademliaConfig {
         self.phase_stability_window = window;
         self
     }
+
+    /// Set the per-bin bootstrap fill target used while `depth == 0`
+    /// (production threads it from the connection profile).
+    pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
+        self.limits = self.limits.with_bootstrap_target(target);
+        self
+    }
 }
 
 #[cfg(test)]
@@ -137,12 +149,6 @@ impl KademliaConfig {
             limits,
             ..Default::default()
         }
-    }
-
-    /// Set the per-bin bootstrap fill target used while `depth == 0`.
-    pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
-        self.limits = self.limits.with_bootstrap_target(target);
-        self
     }
 
     /// Set the per-bin oversaturation level (trim floor and minimum

--- a/crates/swarm/topology/src/kademlia/limits.rs
+++ b/crates/swarm/topology/src/kademlia/limits.rs
@@ -122,6 +122,17 @@ impl DepthAwareLimits {
         self
     }
 
+    /// Set the per-bin bootstrap fill target used while `depth == 0`
+    /// (production threads it from the connection profile).
+    ///
+    /// Targets are floored at saturation inside [`Self::target`], so a
+    /// bootstrap target below the saturation threshold has no effect on its
+    /// own and can never deadlock the depth climb.
+    pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
+        self.bootstrap_target = target;
+        self
+    }
+
     /// Set the total connected-peer dial budget, preserving all other fields.
     pub(crate) fn with_total_target(mut self, total_target: usize) -> Self {
         self.total_target = total_target;
@@ -286,18 +297,6 @@ impl DepthAwareLimits {
 
 #[cfg(test)]
 impl DepthAwareLimits {
-    /// Set the per-bin bootstrap fill target used while `depth == 0`.
-    ///
-    /// Small-scale fixtures usually pair this with [`Self::with_saturation`]
-    /// and [`Self::with_oversaturation_peers`]; targets are floored at
-    /// saturation, so a bootstrap target below the (default 8) saturation
-    /// has no effect on its own, and the trim floor and inbound ceiling
-    /// follow the (default 18) oversaturation level, not this knob.
-    pub(crate) fn with_bootstrap_target(mut self, target: usize) -> Self {
-        self.bootstrap_target = target;
-        self
-    }
-
     /// Set the per-bin oversaturation level (trim floor and minimum inbound
     /// ceiling).
     ///
@@ -308,7 +307,6 @@ impl DepthAwareLimits {
         self.oversaturation_peers = oversaturation;
         self
     }
-
     /// Expected available peers in bin (exponential estimate from uniform distribution).
     pub(crate) fn expected_available(&self, bin: Bin, depth: NeighborhoodDepth) -> usize {
         if depth == NeighborhoodDepth::ZERO || depth.contains(bin) {

--- a/crates/swarm/topology/src/kademlia/mod.rs
+++ b/crates/swarm/topology/src/kademlia/mod.rs
@@ -18,6 +18,8 @@ pub(crate) use candidates::{
     select_neighborhood_candidates,
 };
 pub use config::KademliaConfig;
+pub(crate) use config::{DEFAULT_MAX_BALANCED_CANDIDATES, DEFAULT_MAX_NEIGHBOR_CANDIDATES};
+pub(crate) use limits::DEFAULT_BOOTSTRAP_TARGET;
 pub(crate) use limits::DepthAwareLimits;
 pub(crate) use limits::LimitsSnapshot;
 pub use phase::TopologyPhase;

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -196,6 +196,12 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
         let max_po = identity.spec().max_po();
         let local_overlay = identity.overlay_address();
         let num_bins = (max_po as usize) + 1;
+        // A single bin must be able to hold a full evaluation round's worth
+        // of candidates for its category, or part of the round is silently
+        // dropped while it waits for the rate-shaped drain.
+        let queue_cap = config
+            .max_neighbor_candidates
+            .max(config.max_balanced_candidates);
 
         let topology_phase = Mutex::new(PhaseTracker::new(
             config.phase_stability_window,
@@ -214,7 +220,7 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
             depth: AtomicU8::new(0),
             pending_depth_lower: Mutex::new(None),
             config,
-            candidate_queues: CandidateQueues::new(num_bins, 16),
+            candidate_queues: CandidateQueues::new(num_bins, queue_cap),
             dialing_counts: make_atomic_vec(num_bins),
             handshaking_counts: make_atomic_vec(num_bins),
             active_counts: make_atomic_vec(num_bins),
@@ -227,6 +233,12 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
     /// Depth-aware per-bin capacity limits.
     pub(crate) fn limits(&self) -> &DepthAwareLimits {
         &self.config.limits
+    }
+
+    /// The resolved routing configuration (build-time pacing assertions).
+    #[cfg(test)]
+    pub(crate) fn config(&self) -> &KademliaConfig {
+        &self.config
     }
 
     /// Admission decision for a peer whose handshake is currently in
@@ -956,9 +968,18 @@ impl<I: SwarmIdentity> SwarmRouting<I> for KademliaRouting<I> {
 // Methods internalized from the poll loop — called only by the background evaluator task
 // and topology behaviour within the routing module.
 impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
-    /// Drain all pending candidates (called from poll loop). O(bins).
-    pub(crate) fn drain_candidates(&self) -> Vec<OverlayAddress> {
-        self.candidate_queues.drain_all()
+    /// Pop the next pending dial candidate, highest bin first (called from
+    /// the poll loop's rate-shaped drain). O(bins).
+    pub(crate) fn pop_candidate(&self) -> Option<OverlayAddress> {
+        self.candidate_queues.pop_next()
+    }
+
+    /// Return a popped candidate to its bin queue, e.g. when the dial-rate
+    /// bucket ran out before it could be dialed. Re-enters the dedup set so
+    /// the evaluator does not select it again while it waits.
+    pub(crate) fn requeue_candidate(&self, peer: OverlayAddress) {
+        let bin = self.bin_for(&peer);
+        let _ = self.candidate_queues.push(bin, peer);
     }
 
     /// Evaluate connections and enqueue candidates into per-bin queues.

--- a/crates/swarm/topology/src/kademlia/task.rs
+++ b/crates/swarm/topology/src/kademlia/task.rs
@@ -39,12 +39,14 @@ struct RoutingEvaluatorTask<I: SwarmIdentity> {
     routing: Arc<KademliaRouting<I>>,
     notify: Arc<Notify>,
     event_tx: broadcast::Sender<TopologyEvent>,
+    /// Fallback cadence between evaluations when no trigger arrives, from the
+    /// node's connection profile.
+    periodic: Duration,
 }
 
 impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
     async fn run(self, shutdown: GracefulShutdown) {
         let debounce = Duration::from_millis(100);
-        let periodic = Duration::from_secs(5);
         let mut shutdown = std::pin::pin!(shutdown);
 
         loop {
@@ -57,7 +59,7 @@ impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
                 _ = self.notify.notified() => {
                     tokio::time::sleep(debounce).await;
                 }
-                _ = tokio::time::sleep(periodic) => {}
+                _ = tokio::time::sleep(self.periodic) => {}
             }
             self.routing.evaluate_connections();
 
@@ -76,7 +78,8 @@ impl<I: SwarmIdentity + 'static> RoutingEvaluatorTask<I> {
     }
 }
 
-/// Spawn the routing evaluator task driven by the given handle's trigger.
+/// Spawn the routing evaluator task driven by the given handle's trigger,
+/// with `periodic` as the trigger-free fallback cadence.
 ///
 /// `event_tx` is the topology event channel; the task broadcasts
 /// [`TopologyEvent::PhaseChanged`] for phase transitions its periodic
@@ -85,12 +88,14 @@ pub(crate) fn spawn_evaluator<I: SwarmIdentity + 'static>(
     routing: Arc<KademliaRouting<I>>,
     handle: &RoutingEvaluatorHandle,
     event_tx: broadcast::Sender<TopologyEvent>,
+    periodic: Duration,
     executor: &TaskExecutor,
 ) {
     let task = RoutingEvaluatorTask {
         routing,
         notify: Arc::clone(&handle.notify),
         event_tx,
+        periodic,
     };
 
     executor.spawn_critical_with_graceful_shutdown_signal("topology.evaluator", move |shutdown| {

--- a/crates/swarm/topology/src/lib.rs
+++ b/crates/swarm/topology/src/lib.rs
@@ -11,13 +11,17 @@
 //! # Timing and capacity assumptions
 //!
 //! These defaults are not specified by the Book of Swarm; they trade
-//! responsiveness against churn and memory. They live in the `behaviour` module
-//! and can be overridden through [`TopologyConfig`].
+//! responsiveness against churn and memory. They live in the `behaviour` and
+//! `profile` modules and can be overridden through [`TopologyConfig`].
 //!
-//! - [`DEFAULT_DIAL_INTERVAL`] (5s) is the cadence of the connection-evaluation
-//!   loop: how often the behaviour reconsiders which bins are under target and
-//!   issues new dials. Shorter wastes work on a stable table; longer slows
-//!   convergence after churn.
+//! - Pacing (connection-evaluation cadence, discovery dial rate, dial
+//!   concurrency, bootstrap fill, candidate budgets) is bundled per
+//!   [`ConnectionProfile`] and resolved at build time: explicit selection
+//!   first, then the network configuration, then the node-type default
+//!   (client = aggressive, storer/bootnode = balanced). [`PacingProfile`]
+//!   documents the numbers. Discovery dials drain through a GCRA bucket so a
+//!   burst of fresh candidates (e.g. after gossip influx) goes out
+//!   immediately while the sustained rate stays bounded.
 //! - `DEFAULT_EARLY_DISCONNECT_THRESHOLD` (30s) is the floor below which a
 //!   post-handshake connection that drops is scored as an early disconnect, so a
 //!   peer that repeatedly connects and immediately leaves is penalized.
@@ -27,9 +31,9 @@
 //! - `EVENT_CHANNEL_CAPACITY` (256) and `COMMAND_CHANNEL_CAPACITY` (64) size the
 //!   event-broadcast and command buffers so a burst does not block the poll loop
 //!   while staying bounded.
-//! - The dialer tracks at most 256 in-flight dials, each bounded by the
-//!   handshake timeout; the per-bin routing targets, not this cap, are the real
-//!   gate on how many become connections.
+//! - In-flight dials are bounded by the profile's dial concurrency, each
+//!   bounded by the handshake timeout; the per-bin routing targets, not this
+//!   cap, are the real gate on how many become connections.
 //! - Gossip exchange and verification tuning (refresh cadence, queue bounds,
 //!   backoff and ban policy) lives in [`GossipConfig`], overridable through
 //!   [`TopologyConfig::with_gossip`]. The `gossip` module docs explain how the
@@ -53,6 +57,7 @@ mod protocol_handlers;
 mod composed;
 mod error;
 mod gossip;
+mod profile;
 mod reachability;
 mod readiness;
 mod tasks;
@@ -60,13 +65,18 @@ mod tasks;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-pub use behaviour::{DEFAULT_DIAL_INTERVAL, TopologyBehaviour, TopologyConfig};
+pub use behaviour::{TopologyBehaviour, TopologyConfig};
 pub use builder::TopologyBehaviourBuilder;
 pub use error::{DialError, DisconnectReason, RejectionReason, TopologyError, TopologyResult};
 pub use events::{ConnectionDirection, DialReason, TopologyCommand, TopologyEvent};
 pub use gossip::GossipConfig;
 pub use handle::{BinStats, RoutingStats, TopologyHandle};
+pub use profile::PacingProfile;
 
 pub use kademlia::{KademliaConfig, RoutingArgs, TopologyPhase};
 pub use reachability::{FAILURE_DECAY, FAILURE_THRESHOLD, PeerReachability, ReachabilityTracker};
 pub use readiness::{BinReadiness, ReadinessSnapshot};
+
+// Re-exported so consumers configure pacing without extra dependencies.
+pub use vertex_net_ratelimiter::Quota;
+pub use vertex_swarm_primitives::ConnectionProfile;

--- a/crates/swarm/topology/src/profile.rs
+++ b/crates/swarm/topology/src/profile.rs
@@ -1,0 +1,181 @@
+//! Pacing bundles for [`ConnectionProfile`]s.
+//!
+//! A profile names a build-out posture; this module owns the numbers each
+//! posture maps to. The bundle is resolved exactly once, in
+//! [`crate::TopologyBehaviourBuilder::try_build`], and only sets values on
+//! existing pacing knobs: the evaluation cadence, the GCRA dial-rate quota,
+//! the dial-concurrency cap, the bootstrap fill level, and the per-evaluation
+//! candidate budgets. No topology logic branches on the profile variant.
+//!
+//! # How the knobs interact
+//!
+//! The evaluator refreshes the candidate supply every
+//! [`PacingProfile::evaluation_interval`], selecting at most
+//! `max_neighbor_candidates + max_balanced_candidates` peers per round. The
+//! GCRA bucket ([`PacingProfile::dial_quota`]) then shapes how fast that
+//! supply drains into actual dials: a burst up to the bucket size goes out
+//! immediately (typically right after a gossip influx), and anything beyond
+//! it waits for token replenishment rather than for the next evaluation tick.
+//!
+//! # Profile numbers
+//!
+//! - **Balanced** reproduces the long-standing defaults: a 5 s evaluation
+//!   interval with a 16 + 16 candidate budget, and a bucket sized to that
+//!   budget (32 dials per 5 s, sustained 6.4 dials/s). One full round of
+//!   candidates can always be dialed as a burst, so steady-state behaviour is
+//!   unchanged from the pre-profile code.
+//! - **Aggressive** halves-and-more the cadence (2 s) and raises the budget
+//!   to 24 + 24 so a fresh node converts gossip influx into table coverage
+//!   quickly; the bucket allows the same burst of 32 but replenishes at 12.8
+//!   dials/s, keeping the worst-case sustained rate roughly double Balanced
+//!   instead of unbounded.
+//! - **Conservative** stretches the cadence to 10 s with an 8 + 8 budget and
+//!   a bucket of 8 per 10 s (0.8 dials/s sustained), for metered or
+//!   battery-constrained environments where convergence time is traded for
+//!   quiet.
+//!
+//! Bootstrap fill (`bootstrap_target`) scales the same way (24 / 18 / 12):
+//! it is the per-bin level a blind node (depth 0) fills toward, floored at
+//! the spec saturation threshold by `DepthAwareLimits` so no profile can
+//! deadlock the depth climb.
+
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+use vertex_net_ratelimiter::Quota;
+use vertex_swarm_primitives::ConnectionProfile;
+
+use crate::kademlia::{
+    DEFAULT_BOOTSTRAP_TARGET, DEFAULT_MAX_BALANCED_CANDIDATES, DEFAULT_MAX_NEIGHBOR_CANDIDATES,
+};
+
+/// Default cadence of connection-evaluation rounds (Balanced).
+///
+/// Each round reconsiders which bins are under target and refreshes the dial
+/// candidate supply. Shorter wastes work on a stable table; longer slows
+/// convergence after churn.
+const BALANCED_EVALUATION_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default cap on concurrent in-flight dials (Balanced). Generous because the
+/// per-bin routing targets, not this cap, are the real gate on how many dials
+/// become connections.
+const BALANCED_DIAL_CONCURRENCY: usize = 256;
+
+/// Numeric pacing bundle a [`ConnectionProfile`] resolves to.
+///
+/// Produced by `PacingProfile::from(profile)`; consumed by
+/// [`crate::TopologyBehaviourBuilder::try_build`], which threads each number
+/// into the existing config knob it parameterizes. See the module docs for
+/// the per-profile values and their rationale.
+#[derive(Debug, Clone, Copy)]
+pub struct PacingProfile {
+    /// Cadence of connection-evaluation rounds: both the behaviour's periodic
+    /// trigger and the background evaluator's own fallback tick.
+    pub evaluation_interval: Duration,
+    /// GCRA quota shaping the discovery dial rate. The bucket size is the
+    /// burst absorbed immediately after a candidate influx; the replenish
+    /// window sets the sustained rate.
+    pub dial_quota: Quota,
+    /// Maximum concurrent in-flight dials tracked by the dialer.
+    pub dial_concurrency: usize,
+    /// Per-bin fill target while no neighborhood is established (depth 0).
+    /// Floored at the spec saturation threshold by the depth-aware limits.
+    pub bootstrap_target: usize,
+    /// Maximum neighborhood (depth-bin) candidates selected per evaluation.
+    pub max_neighbor_candidates: usize,
+    /// Maximum balanced (non-depth-bin) candidates selected per evaluation.
+    pub max_balanced_candidates: usize,
+}
+
+/// Const non-zero constructor for quota burst sizes; a zero literal fails at
+/// compile time.
+const fn burst(n: u32) -> NonZeroU32 {
+    match NonZeroU32::new(n) {
+        Some(n) => n,
+        None => panic!("quota burst must be non-zero"),
+    }
+}
+
+/// Burst capacity shared by the Aggressive and Balanced buckets: one full
+/// Balanced evaluation round (16 + 16 candidates) can always go out at once.
+const FULL_ROUND_BURST: NonZeroU32 = burst(32);
+
+impl From<ConnectionProfile> for PacingProfile {
+    fn from(profile: ConnectionProfile) -> Self {
+        match profile {
+            ConnectionProfile::Aggressive => Self {
+                evaluation_interval: Duration::from_secs(2),
+                // Burst 32, sustained 12.8 dials/s.
+                dial_quota: Quota::n_every(FULL_ROUND_BURST, Duration::from_millis(2500)),
+                dial_concurrency: BALANCED_DIAL_CONCURRENCY,
+                bootstrap_target: 24,
+                max_neighbor_candidates: 24,
+                max_balanced_candidates: 24,
+            },
+            ConnectionProfile::Balanced => Self {
+                evaluation_interval: BALANCED_EVALUATION_INTERVAL,
+                // Burst 32, sustained 6.4 dials/s: exactly one full candidate
+                // round per evaluation interval, matching pre-profile pacing.
+                dial_quota: Quota::n_every(FULL_ROUND_BURST, BALANCED_EVALUATION_INTERVAL),
+                dial_concurrency: BALANCED_DIAL_CONCURRENCY,
+                bootstrap_target: DEFAULT_BOOTSTRAP_TARGET,
+                max_neighbor_candidates: DEFAULT_MAX_NEIGHBOR_CANDIDATES,
+                max_balanced_candidates: DEFAULT_MAX_BALANCED_CANDIDATES,
+            },
+            ConnectionProfile::Conservative => Self {
+                evaluation_interval: Duration::from_secs(10),
+                // Burst 8, sustained 0.8 dials/s.
+                dial_quota: Quota::n_every(burst(8), Duration::from_secs(10)),
+                dial_concurrency: 64,
+                bootstrap_target: 12,
+                max_neighbor_candidates: 8,
+                max_balanced_candidates: 8,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kademlia::KademliaConfig;
+
+    #[test]
+    fn balanced_matches_preprofile_defaults() {
+        // Balanced is the compatibility profile: its numbers must equal the
+        // config defaults so a node without a profile behaves as before.
+        let pacing = PacingProfile::from(ConnectionProfile::Balanced);
+        let defaults = KademliaConfig::default();
+
+        assert_eq!(pacing.evaluation_interval, Duration::from_secs(5));
+        assert_eq!(
+            pacing.max_neighbor_candidates,
+            defaults.max_neighbor_candidates
+        );
+        assert_eq!(
+            pacing.max_balanced_candidates,
+            defaults.max_balanced_candidates
+        );
+        assert_eq!(pacing.bootstrap_target, DEFAULT_BOOTSTRAP_TARGET);
+        assert_eq!(pacing.dial_concurrency, 256);
+    }
+
+    #[test]
+    fn profiles_order_by_aggressiveness() {
+        let aggressive = PacingProfile::from(ConnectionProfile::Aggressive);
+        let balanced = PacingProfile::from(ConnectionProfile::Balanced);
+        let conservative = PacingProfile::from(ConnectionProfile::Conservative);
+
+        assert!(aggressive.evaluation_interval < balanced.evaluation_interval);
+        assert!(balanced.evaluation_interval < conservative.evaluation_interval);
+
+        assert!(aggressive.bootstrap_target > balanced.bootstrap_target);
+        assert!(balanced.bootstrap_target > conservative.bootstrap_target);
+
+        assert!(aggressive.max_neighbor_candidates > balanced.max_neighbor_candidates);
+        assert!(balanced.max_neighbor_candidates > conservative.max_neighbor_candidates);
+
+        assert!(aggressive.dial_concurrency >= balanced.dial_concurrency);
+        assert!(balanced.dial_concurrency > conservative.dial_concurrency);
+    }
+}

--- a/docs/networking/peer-dialing-strategy.md
+++ b/docs/networking/peer-dialing-strategy.md
@@ -99,6 +99,22 @@ In-flight dials are tracked by `DialTracker` (`vertex-net-dialer`), whose pendin
 
 Bootstrap is not a special mode of the evaluator: bootnodes and trusted peers from configuration are dialed directly at startup (with dnsaddr resolution where needed) as `DialTarget::Unknown`, since their overlay addresses are not yet known and no capacity reservation applies. Everything after that first contact flows through gossip supply and the evaluation loop above.
 
+## Connection profiles and dial-rate shaping
+
+How aggressively the node builds out its table is bundled into a named connection profile (`aggressive`, `balanced`, `conservative`), selected by node type (client defaults to `aggressive`, storer and bootnode to `balanced`) and overridable with `--network.connection-profile`. A profile only sets numbers on existing knobs: the evaluation cadence, the per-evaluation candidate budgets, the bootstrap fill level, the dial-concurrency cap, and the discovery dial-rate quota. No topology logic branches on the profile.
+
+Discovery dials are not issued as fixed per-tick batches. The evaluator refreshes per-bin candidate queues on its cadence (and immediately on triggers such as gossip influx), and the dial pipeline drains those queues through a GCRA token bucket:
+
+| Profile | Evaluation interval | Candidate budget (neighbor + balanced) | Dial rate (burst / sustained) | Bootstrap fill |
+|---------|---------------------|----------------------------------------|-------------------------------|----------------|
+| aggressive | 2s | 24 + 24 | 32 / 12.8 per s | 24 |
+| balanced | 5s | 16 + 16 | 32 / 6.4 per s | 18 |
+| conservative | 10s | 8 + 8 | 8 / 0.8 per s | 12 |
+
+A burst of fresh candidates (typically right after a gossip exchange) is dialed immediately up to the bucket size; beyond that, candidates stay queued and a timer resumes the drain as soon as a token replenishes, so the node neither hammers the network after an influx nor waits a full evaluation interval to use newly arrived supply. Bootnode dials, trusted-peer dials, and explicit dial commands bypass the bucket.
+
+The bootstrap fill level is floored at the spec saturation threshold inside the depth-aware limits, so no profile can configure a fill too low for the depth climb. The profile bundle is also the intended home for future pacing knobs (for example per-protocol timeout tuning).
+
 ## Backoff
 
 Dial backoff lives in `PeerBackoff` (`vertex-net-peer-backoff`) and is tracked per peer by the `PeerManager`:


### PR DESCRIPTION
## Summary

Implements the connection-profile and dial-rate items of #228. Topology pacing is now a named bundle (`ConnectionProfile`: `aggressive`, `balanced`, `conservative`) selected by node type with a CLI override (`--network.connection-profile`), and discovery dials drain through a GCRA token bucket instead of fixed per-tick batches.

Part of #228 (the `TopologyPhase` machine and the pullsync readiness gate are separate units and keep the issue open).

## Profiles

`ConnectionProfile` lives in `vertex-swarm-primitives` next to `SwarmNodeType`; the numbers live in `vertex-swarm-topology::profile` as `PacingProfile`. A profile only sets numbers on existing knobs (evaluation cadence, candidate budgets, bootstrap fill, dial concurrency, dial-rate quota); no topology logic branches on the variant.

| Profile | Evaluation interval | Candidate budget | Dial rate (burst / sustained) | Bootstrap fill | Dial concurrency |
|---|---|---|---|---|---|
| aggressive (client default) | 2s | 24 + 24 | 32 / 12.8 per s | 24 | 256 |
| balanced (storer/bootnode default) | 5s | 16 + 16 | 32 / 6.4 per s | 18 | 256 |
| conservative | 10s | 8 + 8 | 8 / 0.8 per s | 12 | 64 |

Balanced is the compatibility profile: its numbers equal the pre-profile defaults (5s tick, 32-candidate round, bootstrap 18, 256 in-flight dials), and the bucket is sized to exactly one full round per interval, so steady-state behaviour for storers and bootnodes is unchanged. A unit test pins this equivalence. Clients are short-lived and user-facing, so they default to aggressive: time-to-usable-topology dominates and the worst-case sustained dial rate is still bounded at ~13/s. Conservative is for metered/battery/tiny hosts. Bootstrap fill is floored at the spec saturation threshold inside `DepthAwareLimits`, so no profile value can deadlock the depth climb.

Resolution order at `TopologyBehaviourBuilder::try_build`: explicit `TopologyConfig::with_connection_profile`, then the network configuration (CLI/config file via a `SwarmNetworkConfig::connection_profile` default method), then `ConnectionProfile::default_for(node_type)`. `with_dial_interval` and the new `with_dial_quota` pin single knobs over the profile for tests and embedders.

## GCRA drain model

The evaluator keeps refreshing per-bin candidate queues on its cadence (and immediately on gossip triggers); the bucket shapes the drain. The poll loop pops candidates highest-bin-first, pre-filters undialable ones without spending tokens, and charges one token per dial. On exhaustion the candidate returns to its queue (re-entering the dedup set so the evaluator does not double-select it) and a timer is armed for the bucket's reported wait, so the drain resumes as soon as a token replenishes rather than at the next tick. Bootnode, trusted-peer, and command dials bypass the bucket. Uses the existing `vertex-net-ratelimiter` GCRA `RateLimiter`; throttle events are counted in `topology_dials_throttled_total`.

Because budgets now come from the profile, the dead `--network.routing.max-neighbor-candidates` / `--network.routing.max-balanced-candidates` flags are removed, and the per-bin candidate queue cap follows the configured budgets instead of a hardcoded 16 (which would have silently truncated an aggressive round). The evaluator task's fallback tick now also follows the profile cadence instead of a hardcoded 5s.

## Notes

- The profile bundle is the intended home for the #64/#65 per-protocol timeout knobs later.
- `docs/networking/peer-dialing-strategy.md` gains a pacing section describing the profiles and the bucket.
- E2E: `cargo test -p vertex-swarm-node --all-features` (bootnode/storer cluster over real sockets) passes through profile-selected pacing. Mainnet smoke (depth climb timing per profile) to be done before merging.
