### PR TITLE
test(swarm-topology): pin oversaturation floor in eviction tiebreak test

### DIFF
--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -1598,6 +1598,7 @@ mod tests {
             base,
             KademliaConfig::default()
                 .with_bootstrap_target(4)
+                .with_oversaturation_peers(4)
                 .with_saturation(4),
         );
 


### PR DESCRIPTION
main is red. The `test` CI job on main (sha 3a4bc50) fails on `kademlia::routing::tests::test_eviction_tiebreak_keeps_bin_prefix_spread`.

The test sets `bootstrap_target` and `saturation` to 4 so that bin 0 sits over its trim floor with a surplus of 2, then asserts the prefix-diversity tie-break evicts from the clustered sub-trie. It predates the `bootstrap_target` / `oversaturation_peers` split from #234 and never pinned `oversaturation_peers`. With the band left at its default of 18, the trim floor in `DepthAwareLimits::surplus` clamps to 18, the bin's surplus is 0, and `eviction_candidates` returns nothing, so the assertion fails.

This only manifests once both #234 (the split) and #235 (the tie-break test) are present on main. Each was green against its own base; the interaction landed red at merge because the merge was not re-tested against the combined tree.

The fix pins `oversaturation_peers(4)` in the test config, matching every sibling eviction test (for example `test_eviction_prefers_least_reachable`), restoring the intended surplus of 2. Test-only change, no production code touched.

`cargo test -p vertex-swarm-topology test_eviction_tiebreak_keeps_bin_prefix_spread` passes with the change.

This unblocks the rebases of #236, #238, #239, and #240, whose only red check is this same pre-existing failure.