### PR TITLE
feat(util-runtime): cfg-gated time and randomness foundation crate

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -101,7 +101,7 @@ jobs:
       # `+nightly` is load-bearing: rust-toolchain.toml pins the stable
       # channel and would otherwise override the installed nightly.
       - name: Build peer stack for wasm32
-        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-peer-score -p vertex-swarm-peer-manager
+        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager
 
   ci-success:
     name: ci success

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9345,6 +9345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-util-runtime"
+version = "0.1.0"
+dependencies = [
+ "getrandom 0.3.4",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "web-time",
+]
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ members = [
     # Tasks
     "crates/tasks",
 
+    # Util (cfg-gated foundation utilities: time and randomness)
+    "crates/util/runtime",
+
     # Network (protocol-agnostic utilities)
     "crates/net/dnsaddr",
     "crates/net/local",
@@ -172,6 +175,9 @@ vertex-observability = { path = "crates/observability" }
 
 # tasks
 vertex-tasks = { path = "crates/tasks" }
+
+# util (cfg-gated time and randomness foundation)
+vertex-util-runtime = { path = "crates/util/runtime" }
 
 # swarm
 vertex-swarm-identity = { path = "crates/swarm/identity" }
@@ -343,6 +349,10 @@ getrandom = { version = "0.2", default-features = false }
 # browser backend (`wasm_js` feature plus the `getrandom_backend` cfg set in
 # .cargo/config.toml for the wasm32 target).
 getrandom_04 = { package = "getrandom", version = "0.4", default-features = false }
+# The 0.3 line is what rand 0.9's rand_core resolves to. The wasm cone selects
+# its browser backend with the `wasm_js` feature plus the `getrandom_backend`
+# cfg set in .cargo/config.toml for the wasm32 target.
+getrandom_03 = { package = "getrandom", version = "0.3", default-features = false }
 paste = "1"
 once_cell = { version = "1.21", default-features = false, features = [
     "critical-section",
@@ -350,6 +360,8 @@ once_cell = { version = "1.21", default-features = false, features = [
 critical-section = { version = "1.2", features = ["std"] }
 rand = "0.9"
 rand_08 = { package = "rand", version = "0.8" }
+# Matches the rand 0.9 stack (rand_core 0.9, getrandom 0.3) for seeded CSPRNGs.
+rand_chacha = "0.9"
 rustc-hash = { version = "2.1", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = [

--- a/crates/util/runtime/Cargo.toml
+++ b/crates/util/runtime/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "vertex-util-runtime"
+description = "Cfg-gated foundation for wall-clock time and randomness that builds for native and wasm32"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# std::time re-export on native, browser clock on wasm32. Lets callers reach
+# time types through one import path and keeps the wasm split in one place.
+web-time = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+thiserror = { workspace = true }
+strum = { workspace = true }
+
+# rand 0.9's rand_core resolves getrandom 0.3 as its entropy source. On wasm32
+# the browser backend needs the `wasm_js` feature (the matching
+# `getrandom_backend="wasm_js"` cfg is set in .cargo/config.toml). This is a
+# transitive build requirement of the randomness facade, not a direct API use.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom_03 = { workspace = true, features = ["wasm_js"] }

--- a/crates/util/runtime/src/lib.rs
+++ b/crates/util/runtime/src/lib.rs
@@ -1,0 +1,37 @@
+//! Cfg-gated foundation for wall-clock time and randomness.
+//!
+//! This crate is the single home for the wasm/native split of two
+//! cross-cutting concerns:
+//!
+//! - [`time`]: wall-clock and monotonic time. The surface re-exports
+//!   `web-time`, which is a `std::time` re-export on native targets and the
+//!   browser clock on `wasm32`, so callers get one import path and the platform
+//!   choice lives in exactly one dependency.
+//! - [`rand`]: a getrandom-backed randomness facade that never touches a
+//!   thread-local generator, so it builds and runs under the
+//!   `getrandom_backend="wasm_js"` configuration used for browser targets.
+//!
+//! Centralising both here means downstream crates do not each repeat the
+//! `cfg(target_arch = "wasm32")` plumbing or the
+//! `SystemTime::now().duration_since(UNIX_EPOCH)` boilerplate. The crate builds
+//! for `wasm32-unknown-unknown` and that is enforced in CI.
+//!
+//! # What this crate does not own
+//!
+//! - The async runtime. Task spawning (`tokio::spawn` versus
+//!   `wasm_bindgen_futures::spawn_local`) lives in the task-executor layer, not
+//!   here.
+//! - Paused-time test clocks. Deterministic time control for tests stays with
+//!   `tokio::time`; this crate only provides the real platform clock.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+// On wasm32 the randomness facade reaches `getrandom` 0.3 through `rand`'s
+// entropy source. The `getrandom_03` dependency exists only to select that
+// crate's `wasm_js` browser backend feature; it is never named in source, so
+// reference it here to satisfy the unused-crate-dependencies lint.
+#[cfg(target_arch = "wasm32")]
+use getrandom_03 as _;
+
+pub mod rand;
+pub mod time;

--- a/crates/util/runtime/src/rand.rs
+++ b/crates/util/runtime/src/rand.rs
@@ -1,0 +1,138 @@
+//! Randomness facade backed by the operating system CSPRNG.
+//!
+//! Every accessor here seeds from `rand`'s `OsRng`, which routes to `getrandom`
+//! and works under the `getrandom_backend="wasm_js"` configuration in the
+//! browser. Nothing here touches `rand::rng()` or a thread-local generator, so
+//! the facade is safe on `wasm32` where thread-local entropy sourcing is
+//! fragile.
+//!
+//! Pick the right accessor for the job:
+//!
+//! - [`fill_bytes`] and [`crypto_rng`] are cryptographically secure. Use them
+//!   for key material, identifiers, nonces, and anything an adversary must not
+//!   predict.
+//! - [`non_crypto_rng`] is a fast, non-cryptographic PRNG. Use it for shuffles,
+//!   jitter, and sampling where predictability is not a security concern. Do
+//!   not use it for secrets.
+//!
+//! The infallible helpers panic only if the operating system entropy source
+//! fails, which on a healthy host does not happen. Use the `try_*` variants
+//! when a caller must handle that failure instead of aborting.
+
+use rand::{
+    CryptoRng, RngCore, SeedableRng, TryRngCore,
+    rngs::{OsRng, SmallRng},
+};
+use rand_chacha::ChaCha20Rng;
+
+/// Error returned when the operating system entropy source cannot be read.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum RngError {
+    /// The OS CSPRNG (`getrandom`) failed to produce entropy.
+    #[error("operating system entropy source unavailable: {0}")]
+    OsEntropyUnavailable(#[from] rand::rand_core::OsError),
+}
+
+/// Fills `dst` with cryptographically secure random bytes.
+///
+/// Use this for key and identifier material. Panics if the operating system
+/// entropy source fails; call [`try_fill_bytes`] to handle that case instead.
+#[inline]
+pub fn fill_bytes(dst: &mut [u8]) {
+    OsRng.unwrap_err().fill_bytes(dst);
+}
+
+/// Fills `dst` with cryptographically secure random bytes, surfacing entropy
+/// failures as a [`RngError`] rather than panicking.
+#[inline]
+pub fn try_fill_bytes(dst: &mut [u8]) -> Result<(), RngError> {
+    OsRng.try_fill_bytes(dst)?;
+    Ok(())
+}
+
+/// Returns a fresh cryptographically secure RNG seeded from OS entropy.
+///
+/// The returned generator implements [`CryptoRng`], which requires [`RngCore`],
+/// so it is suitable for key generation and other secret material. Panics if
+/// the operating system entropy source fails; use [`try_crypto_rng`] to handle
+/// that case instead.
+#[inline]
+pub fn crypto_rng() -> impl CryptoRng {
+    ChaCha20Rng::from_rng(&mut OsRng.unwrap_err())
+}
+
+/// Returns a fresh cryptographically secure RNG seeded from OS entropy,
+/// surfacing entropy failures as a [`RngError`] rather than panicking.
+#[inline]
+pub fn try_crypto_rng() -> Result<impl CryptoRng, RngError> {
+    Ok(ChaCha20Rng::try_from_rng(&mut OsRng)?)
+}
+
+/// Returns a fresh fast, non-cryptographic RNG seeded from OS entropy.
+///
+/// Use this for shuffles, jitter, and sampling. The output is not
+/// cryptographically secure and must not seed secrets. Panics if the operating
+/// system entropy source fails.
+#[inline]
+pub fn non_crypto_rng() -> impl RngCore {
+    SmallRng::from_rng(&mut OsRng.unwrap_err())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fill_bytes_changes_buffer() {
+        let mut a = [0u8; 32];
+        fill_bytes(&mut a);
+        assert_ne!(a, [0u8; 32], "32 zero bytes from the CSPRNG is implausible");
+    }
+
+    #[test]
+    fn fill_bytes_is_not_constant() {
+        let mut a = [0u8; 32];
+        let mut b = [0u8; 32];
+        fill_bytes(&mut a);
+        fill_bytes(&mut b);
+        assert_ne!(a, b, "two CSPRNG draws should differ");
+    }
+
+    #[test]
+    fn try_fill_bytes_succeeds() {
+        let mut a = [0u8; 16];
+        try_fill_bytes(&mut a).expect("OS entropy should be available in tests");
+        assert_ne!(a, [0u8; 16]);
+    }
+
+    #[test]
+    fn crypto_rng_produces_distinct_streams() {
+        let mut a = crypto_rng();
+        let mut b = crypto_rng();
+        assert_ne!(
+            a.next_u64(),
+            b.next_u64(),
+            "independently seeded crypto RNGs should diverge"
+        );
+    }
+
+    #[test]
+    fn try_crypto_rng_succeeds() {
+        let mut rng = try_crypto_rng().expect("OS entropy should be available in tests");
+        // Exercise the generator so the accessor is not optimised away.
+        let _ = rng.next_u64();
+    }
+
+    #[test]
+    fn non_crypto_rng_produces_distinct_streams() {
+        let mut a = non_crypto_rng();
+        let mut b = non_crypto_rng();
+        assert_ne!(
+            a.next_u64(),
+            b.next_u64(),
+            "independently seeded non-crypto RNGs should diverge"
+        );
+    }
+}

--- a/crates/util/runtime/src/time.rs
+++ b/crates/util/runtime/src/time.rs
@@ -1,0 +1,98 @@
+//! Wall-clock and monotonic time.
+//!
+//! The time types are re-exported from `web-time`, which is itself a
+//! `std::time` re-export on native targets and a browser-clock shim on
+//! `wasm32`. Because `web-time` already resolves the platform difference, this
+//! module needs no `cfg(target_arch = "wasm32")` gating of its own; it is a
+//! thin, documented surface over that crate plus a few deduplicated helpers.
+//!
+//! Reach for the helpers ([`now_unix_secs`], [`now_unix_millis`],
+//! [`now_unix_nanos`], [`now`]) instead of re-deriving Unix timestamps from
+//! [`SystemTime`] at each call site.
+
+pub use web_time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Returns the current monotonic instant.
+///
+/// Use this for measuring elapsed time and arming timers. It is not tied to
+/// wall-clock time and is not comparable across processes.
+#[inline]
+pub fn now() -> Instant {
+    Instant::now()
+}
+
+/// Returns the elapsed time since the Unix epoch as a [`Duration`].
+///
+/// Clamps to [`Duration::ZERO`] if the platform clock reports a time before the
+/// epoch, which only happens with a grossly misconfigured clock.
+#[inline]
+fn since_epoch() -> Duration {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+}
+
+/// Returns the current Unix timestamp in whole seconds.
+///
+/// Returns `0` if the platform clock is set before the Unix epoch.
+#[inline]
+pub fn now_unix_secs() -> u64 {
+    since_epoch().as_secs()
+}
+
+/// Returns the current Unix timestamp in whole milliseconds.
+///
+/// Returns `0` if the platform clock is set before the Unix epoch.
+#[inline]
+pub fn now_unix_millis() -> u64 {
+    // `as_millis` is `u128`; the value fits `u64` until well past year 500000.
+    since_epoch().as_millis() as u64
+}
+
+/// Returns the current Unix timestamp in nanoseconds.
+///
+/// The return type is `i64` to match the wire and accounting call sites that
+/// consume nanosecond timestamps. Returns `0` if the platform clock is set
+/// before the Unix epoch.
+#[inline]
+pub fn now_unix_nanos() -> i64 {
+    since_epoch().as_nanos() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_is_monotonic() {
+        let a = now();
+        let b = now();
+        assert!(b >= a);
+    }
+
+    #[test]
+    fn unix_secs_after_2023() {
+        // 2023-01-01T00:00:00Z in seconds.
+        assert!(now_unix_secs() > 1_672_531_200);
+    }
+
+    #[test]
+    fn unix_millis_after_2023() {
+        assert!(now_unix_millis() > 1_672_531_200_000);
+    }
+
+    #[test]
+    fn unix_nanos_after_2023() {
+        assert!(now_unix_nanos() > 1_672_531_200_000_000_000);
+    }
+
+    #[test]
+    fn units_are_consistent() {
+        let secs = now_unix_secs();
+        let millis = now_unix_millis();
+        // Milliseconds and seconds are read a moment apart, so allow a small
+        // skew rather than asserting exact equality.
+        assert!(millis / 1000 >= secs);
+        assert!(millis / 1000 <= secs + 2);
+    }
+}

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ check:
 # the wasm32-unknown-unknown target; rustflags come from .cargo/config.toml.
 # See docs/agents/wasm.md.
 wasm-peers:
-    cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-peer-score -p vertex-swarm-peer-manager
+    cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager
 
 build:
     cargo build --all-features


### PR DESCRIPTION
Adds `vertex-util-runtime` (`crates/util/runtime`), a small foundation crate that is the single cfg-gated home for wall-clock time and randomness, so the wasm/native split lives in exactly one place. The crate stands alone: it migrates no consumers and builds and tests green on both native and `wasm32-unknown-unknown`.

## API

The `time` module re-exports `web_time::{SystemTime, Instant, UNIX_EPOCH, Duration}` so callers reach time types through one import path, and adds deduplicated Unix-timestamp helpers that replace scattered `SystemTime::now().duration_since(UNIX_EPOCH)` boilerplate: `now_unix_secs() -> u64`, `now_unix_millis() -> u64`, `now_unix_nanos() -> i64` (i64 to match the existing nanosecond call sites), and `now() -> Instant`.

The `rand` module is a getrandom-backed facade that never touches a thread-local generator (no `rand::rng()`), which is the wasm-fragile piece being removed. It seeds every accessor from `OsRng`: `fill_bytes` and `crypto_rng()` are cryptographically secure (the latter returns a seeded `ChaCha20Rng`), `non_crypto_rng()` is a fast `SmallRng` for shuffles and jitter, and `try_*` siblings surface OS entropy failures as a `thiserror` `RngError` rather than panicking. The rustdoc states clearly which accessors are crypto-grade and which are not.

## wasm/native split

Time needs no `target_arch` gating because `web-time` resolves the platform difference itself. Randomness standardises on `rand 0.9` and reuses the `getrandom 0.3.4` already in the lockfile (the version `rand 0.9`'s `rand_core` resolves to); no new `getrandom` major and no new lockfile version are introduced. The crate owns the one `cfg(target_arch = "wasm32")` `getrandom_03` dependency that selects the `wasm_js` browser backend feature, matching the `getrandom_backend="wasm_js"` cfg already set in `.cargo/config.toml`.

The crate is added to the `wasm` CI job and the `wasm-peers` justfile target so `wasm32` compilation is enforced alongside the existing peer cone.

## Context

This is the foundation that the #62 migration sweep builds on. It does not close #62; the follow-up PRs that migrate the workspace onto this crate and contain the `rand` version sprawl, plus the closeout, remain.

Part of #62