### PR TITLE
refactor(swarm-peers): route peer-stack time through util-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8387,7 +8387,7 @@ dependencies = [
  "parking_lot",
  "strum 0.28.0",
  "tokio",
- "web-time",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -9159,7 +9159,7 @@ dependencies = [
  "vertex-swarm-primitives",
  "vertex-swarm-test-utils",
  "vertex-tasks",
- "web-time",
+ "vertex-util-runtime",
 ]
 
 [[package]]

--- a/crates/net/peer/registry/Cargo.toml
+++ b/crates/net/peer/registry/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 libp2p = { workspace = true }
 parking_lot = { workspace = true }
 strum = { workspace = true }
-web-time = { workspace = true }
+vertex-util-runtime = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/crates/net/peer/registry/src/registry.rs
+++ b/crates/net/peer/registry/src/registry.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use libp2p::{PeerId, swarm::ConnectionId};
 use parking_lot::RwLock;
-use web_time::Instant;
+use vertex_util_runtime::time::Instant;
 
 use crate::ActivateResult;
 use crate::ConnectionDirection;

--- a/crates/net/peer/registry/src/state.rs
+++ b/crates/net/peer/registry/src/state.rs
@@ -1,7 +1,7 @@
 //! Connection state for peers in the registry.
 
 use libp2p::{PeerId, swarm::ConnectionId};
-use web_time::Instant;
+use vertex_util_runtime::time::Instant;
 
 use crate::ConnectionDirection;
 

--- a/crates/swarm/peers/peer-manager/Cargo.toml
+++ b/crates/swarm/peers/peer-manager/Cargo.toml
@@ -24,6 +24,9 @@ vertex-swarm-peer-score = { workspace = true }
 # Tasks
 vertex-tasks = { workspace = true }
 
+# Runtime (cfg-gated time and randomness)
+vertex-util-runtime = { workspace = true }
+
 # Observability
 metrics = { workspace = true }
 
@@ -36,8 +39,6 @@ tracing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 strum = { workspace = true }
 thiserror = { workspace = true }
-# std::time re-export on native, browser clock on wasm32.
-web-time = { workspace = true }
 
 # Concurrency
 dashmap = { workspace = true }

--- a/crates/swarm/peers/peer-manager/src/entry.rs
+++ b/crates/swarm/peers/peer-manager/src/entry.rs
@@ -15,7 +15,6 @@ use vertex_swarm_api::SwarmScoringEvent;
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_score::{PeerScore, ScoreChange, SwarmPeerScore, SwarmScoringConfig};
 use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
-use web_time::{SystemTime, UNIX_EPOCH};
 
 /// Exclusive health state for a peer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,14 +102,11 @@ pub struct PeerSnapshot {
 
 /// Current wall-clock time in unix seconds.
 ///
-/// Uses `web_time` so the same code path compiles for native targets (where
-/// it is a re-export of `std::time`) and for wasm32 (where the browser clock
-/// backs it).
+/// Delegates to [`vertex_util_runtime::time::now_unix_secs`], the single
+/// cfg-gated clock source for the workspace (native `std::time`, browser clock
+/// on wasm32).
 pub(crate) fn unix_timestamp_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    vertex_util_runtime::time::now_unix_secs()
 }
 
 pub(crate) fn jitter_seed_from_overlay(overlay: &OverlayAddress) -> u64 {


### PR DESCRIPTION
Routes the peer stack's wall-clock and monotonic time through `vertex-util-runtime`, the single cfg-gated home for time and randomness, removing the direct `web-time` dependency from the peer manager and peer registry.

`vertex-swarm-peer-manager`'s private `unix_timestamp_secs()` now delegates to `vertex_util_runtime::time::now_unix_secs()`. The saturating semantics are identical (`unwrap_or(Duration::ZERO).as_secs()` matches the old `map(as_secs).unwrap_or(0)`), so the ~35 call sites across `manager.rs`, `tasks.rs`, and `entry.rs` are untouched.

`vertex-net-peer-registry` imports `Instant` from the `vertex_util_runtime::time` re-export in `registry.rs` and `state.rs`. The re-export is the same `web-time::Instant` type, so behaviour is byte-identical.

Both crates drop their direct `web-time` dependency in favour of `vertex-util-runtime`.

This area is in the wasm cone. No `tokio::time::Instant` usage was touched. The `wasm32-unknown-unknown` cross-compile stays green and `cargo tree` confirms no new `web-time` or `getrandom` versions entered.

Part of #62