### PR TITLE
refactor(net): route dialer and codec time through util-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8337,6 +8337,7 @@ dependencies = [
  "quick-protobuf-codec",
  "strum 0.28.0",
  "thiserror 2.0.18",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -8350,7 +8351,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "vertex-metrics",
- "web-time",
+ "vertex-util-runtime",
 ]
 
 [[package]]

--- a/crates/net/codec/Cargo.toml
+++ b/crates/net/codec/Cargo.toml
@@ -19,3 +19,4 @@ quick-protobuf-codec.workspace = true
 quick-protobuf.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+vertex-util-runtime.workspace = true

--- a/crates/net/codec/src/utils.rs
+++ b/crates/net/codec/src/utils.rs
@@ -1,7 +1,6 @@
 //! Codec utility functions for common encoding patterns.
 
 use alloy_primitives::U256;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Encode a U256 as big-endian bytes with leading zeros trimmed.
 ///
@@ -32,10 +31,7 @@ pub fn decode_u256_be(bytes: &[u8]) -> U256 {
 /// Returns the current Unix timestamp in nanoseconds (0 if clock is before epoch).
 #[inline]
 pub fn current_unix_timestamp_nanos() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos() as i64)
-        .unwrap_or(0)
+    vertex_util_runtime::time::now_unix_nanos()
 }
 
 #[cfg(test)]

--- a/crates/net/dialer/Cargo.toml
+++ b/crates/net/dialer/Cargo.toml
@@ -18,7 +18,7 @@ metrics = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 vertex-metrics = { workspace = true }
-web-time = { workspace = true }
+vertex-util-runtime = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/crates/net/dialer/src/tracker.rs
+++ b/crates/net/dialer/src/tracker.rs
@@ -3,12 +3,12 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::time::Instant;
 
 use hashlink::{LinkedHashMap, LruCache};
 use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::{Multiaddr, PeerId};
 use metrics::{counter, gauge};
+use vertex_util_runtime::time::Instant;
 
 use crate::backoff::{BackoffEntry, backoff_remaining, jitter_seed_for};
 use crate::config::DialTrackerConfig;

--- a/crates/net/dialer/src/types.rs
+++ b/crates/net/dialer/src/types.rs
@@ -1,9 +1,9 @@
 //! Types for dial tracking.
 
 use std::fmt::Debug;
-use std::time::Instant;
 
 use libp2p::{Multiaddr, PeerId};
+use vertex_util_runtime::time::Instant;
 
 /// Why a dial request could not be enqueued.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error, strum::IntoStaticStr)]


### PR DESCRIPTION
Routes `crates/net/dialer` and `crates/net/codec` time access through the new `vertex-util-runtime` foundation crate so the wasm peer cone gets a single, consistent clock surface.

`net/dialer` (`types.rs`, `tracker.rs`) imported `std::time::Instant` even though the crate already declared `web-time`, an inconsistency that would break the wasm build it feeds. Both now use `vertex_util_runtime::time::Instant` (web-time backed on every target). The now-unused direct `web-time` dependency is dropped; web-time is still resolved transitively at a single `v1.1.0`.

`net/codec`'s `current_unix_timestamp_nanos` now delegates to `vertex_util_runtime::time::now_unix_nanos`, which has byte-identical behaviour (clamps to 0 before the epoch). The public function signature is unchanged, so the pseudosettle caller needs no change and is untouched.

No `tokio::time::Instant` was touched and no public API changed.

Verification: `cargo clippy` (lib and tests) clean, `cargo test -p vertex-net-dialer -p vertex-net-codec --all-features` green, and the wasm cone (`vertex-swarm-peer-manager`, `vertex-util-runtime`) builds for `wasm32-unknown-unknown`.

Part of #62