### PR TITLE
refactor(swarm-bandwidth): route pseudosettle time through util-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8689,6 +8689,7 @@ dependencies = [
  "vertex-swarm-primitives",
  "vertex-swarm-test-utils",
  "vertex-tasks",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -8985,6 +8986,7 @@ dependencies = [
  "vertex-net-codec",
  "vertex-swarm-net-headers",
  "vertex-swarm-net-proto",
+ "vertex-util-runtime",
 ]
 
 [[package]]

--- a/crates/swarm/bandwidth/pseudosettle/Cargo.toml
+++ b/crates/swarm/bandwidth/pseudosettle/Cargo.toml
@@ -15,6 +15,7 @@ vertex-swarm-net-pseudosettle = { workspace = true }
 vertex-swarm-primitives = { workspace = true }
 vertex-swarm-api = { workspace = true }
 vertex-tasks = { workspace = true }
+vertex-util-runtime = { workspace = true }
 alloy-primitives = { workspace = true }
 async-trait = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/swarm/bandwidth/pseudosettle/src/lib.rs
+++ b/crates/swarm/bandwidth/pseudosettle/src/lib.rs
@@ -20,7 +20,6 @@ mod handle;
 mod service;
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::sync::mpsc;
 use vertex_swarm_api::{
@@ -175,10 +174,7 @@ fn refresh_allowance(state: &dyn SwarmPeerState, refresh_rate: u64) -> i64 {
 
 /// Get current timestamp in seconds.
 fn current_timestamp() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    vertex_util_runtime::time::now_unix_secs()
 }
 
 /// Create a new pseudosettle-only accounting instance.

--- a/crates/swarm/bandwidth/pseudosettle/src/service.rs
+++ b/crates/swarm/bandwidth/pseudosettle/src/service.rs
@@ -282,10 +282,7 @@ impl<A: SwarmBandwidthAccounting + 'static> SpawnableTask for PseudosettleServic
 
 /// Get current timestamp in seconds.
 fn current_timestamp() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    vertex_util_runtime::time::now_unix_secs()
 }
 
 #[cfg(test)]

--- a/crates/swarm/net/pseudosettle/Cargo.toml
+++ b/crates/swarm/net/pseudosettle/Cargo.toml
@@ -38,3 +38,4 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+vertex-util-runtime = { workspace = true }

--- a/crates/swarm/net/pseudosettle/src/protocol.rs
+++ b/crates/swarm/net/pseudosettle/src/protocol.rs
@@ -173,12 +173,7 @@ mod tests {
 
     /// Validate that a timestamp is within acceptable bounds of the current time.
     fn validate_timestamp(timestamp: i64, tolerance_secs: u64) -> Result<(), PseudosettleError> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|_| {
-                PseudosettleError::InvalidTimestamp("system time before unix epoch".into())
-            })?
-            .as_nanos() as i64;
+        let now = vertex_util_runtime::time::now_unix_nanos();
 
         let tolerance_nanos = (tolerance_secs as i64) * 1_000_000_000;
         let diff = (now - timestamp).abs();
@@ -197,10 +192,7 @@ mod tests {
 
     #[test]
     fn test_validate_timestamp_valid() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as i64;
+        let now = vertex_util_runtime::time::now_unix_nanos();
 
         assert!(validate_timestamp(now, 3).is_ok());
         assert!(validate_timestamp(now - 1_000_000_000, 3).is_ok());
@@ -209,10 +201,7 @@ mod tests {
 
     #[test]
     fn test_validate_timestamp_invalid() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as i64;
+        let now = vertex_util_runtime::time::now_unix_nanos();
 
         assert!(validate_timestamp(now - 5_000_000_000, 3).is_err());
         assert!(validate_timestamp(now + 10_000_000_000, 3).is_err());


### PR DESCRIPTION
Routes the pseudosettle time access through the new `vertex-util-runtime` foundation crate (#244), part of the #62 wasm-compatible time migration.

`vertex-swarm-bandwidth-pseudosettle` (settlement timestamp helper in `service.rs`) and `vertex-swarm-net-pseudosettle` (timestamp validation in `protocol.rs`) drop their direct `std::time::SystemTime` / `UNIX_EPOCH` boilerplate for `vertex_util_runtime::time::now_unix_secs` and `now_unix_nanos`. The bandwidth accounting path is in the wasm cone, so this removes a std::time dependency from a crate that must build for wasm32.

Behaviour is unchanged. The previous pre-epoch `InvalidTimestamp` branch is gone because the shared helper clamps a pre-epoch clock to zero.

Part of #62