### PR TITLE
refactor(swarm-topology): route time and bootnode shuffle through util-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9326,6 +9326,7 @@ dependencies = [
  "vertex-swarm-spec",
  "vertex-swarm-test-utils",
  "vertex-tasks",
+ "vertex-util-runtime",
  "web-time",
 ]
 

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -20,6 +20,7 @@ vertex-net-ratelimiter.workspace = true
 vertex-net-utils.workspace = true
 vertex-net-peer-store.workspace = true
 vertex-tasks.workspace = true
+vertex-util-runtime.workspace = true
 vertex-swarm-net-handshake.workspace = true
 vertex-swarm-net-identify.workspace = true
 vertex-swarm-net-headers.workspace = true

--- a/crates/swarm/topology/src/dialing.rs
+++ b/crates/swarm/topology/src/dialing.rs
@@ -10,6 +10,7 @@ use vertex_net_dnsaddr::{is_dnsaddr, resolve_all};
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_primitives::SwarmNodeType;
+use vertex_util_runtime::rand::non_crypto_rng;
 
 use crate::DialReason;
 use crate::gossip::GossipInput;
@@ -122,7 +123,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
     pub(crate) fn connect_bootnodes(&mut self) {
         let mut bootnodes = self.bootnodes.clone();
-        bootnodes.shuffle(&mut rand::rng());
+        bootnodes.shuffle(&mut non_crypto_rng());
         let trusted_peers = self.trusted_peers.clone();
 
         if bootnodes.is_empty() && trusted_peers.is_empty() {

--- a/crates/swarm/topology/src/gossip/tasks.rs
+++ b/crates/swarm/topology/src/gossip/tasks.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -16,6 +16,7 @@ use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::PeerManager;
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
+use vertex_util_runtime::time::Instant;
 
 use super::events::{GossipAction, GossipCheckOk};
 use super::filter::{

--- a/crates/swarm/topology/src/reachability.rs
+++ b/crates/swarm/topology/src/reachability.rs
@@ -37,11 +37,11 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
 
 use libp2p::PeerId;
 use parking_lot::RwLock;
 use tracing::{debug, trace};
+use vertex_util_runtime::time::Instant;
 
 /// Number of consecutive negative liveness signals (failed ping or handshake
 /// fault) within [`FAILURE_DECAY`] that flip a peer to


### PR DESCRIPTION
Routes `vertex-swarm-topology` onto the shared `vertex-util-runtime` foundation so its wall-clock and randomness use the wasm-compatible primitives instead of `std` and `rand` directly.

`src/reachability.rs` and `src/gossip/tasks.rs` now import `vertex_util_runtime::time::Instant` (web-time backed) in place of `std::time::Instant`; `std::time::Duration` is unchanged. The `tokio::time` clocks for routing hysteresis and stability, and the `web_time::Instant` clocks in the kademlia phase and routing tables, are deliberately left untouched.

`src/dialing.rs` swaps the non-crypto bootnode-order shuffle from `rand::rng()` to `vertex_util_runtime::rand::non_crypto_rng()`, still driving `SliceRandom::shuffle`.

`web-time` and `rand` remain direct dependencies because the kademlia clocks still use `web-time` and the `SliceRandom` trait still comes from `rand`. `cargo tree -i web-time` and `cargo tree -i rand` confirm no new versions entered.

Behaviour is identical. `cargo test -p vertex-swarm-topology --all-features` (212 passed) and `cargo test -p vertex-swarm-node --all-features` (e2e handshakes/gossip/topology over local sockets) are green.

Part of #62