### PR TITLE
refactor: route native timing crates through util-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8323,6 +8323,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "strum 0.28.0",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -8525,6 +8526,7 @@ dependencies = [
  "tracing-subscriber",
  "vertex-metrics",
  "vertex-tasks",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -8580,6 +8582,7 @@ dependencies = [
  "tracing",
  "vertex-observability",
  "vertex-storage",
+ "vertex-util-runtime",
  "zstd",
 ]
 
@@ -8856,6 +8859,7 @@ dependencies = [
  "vertex-swarm-peer",
  "vertex-swarm-spec",
  "vertex-swarm-test-utils",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -8879,6 +8883,7 @@ dependencies = [
  "vertex-observability",
  "vertex-swarm-net-proto",
  "vertex-swarm-primitives",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -8910,6 +8915,7 @@ dependencies = [
  "vertex-swarm-primitives",
  "vertex-swarm-spec",
  "vertex-tasks",
+ "vertex-util-runtime",
 ]
 
 [[package]]
@@ -8937,6 +8943,7 @@ dependencies = [
  "vertex-metrics",
  "vertex-net-local",
  "vertex-observability",
+ "vertex-util-runtime",
  "void",
 ]
 
@@ -9342,6 +9349,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vertex-metrics",
+ "vertex-util-runtime",
 ]
 
 [[package]]

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -12,6 +12,9 @@ description = "Lightweight metric primitives for Vertex: RAII guards, lazy macro
 workspace = true
 
 [dependencies]
+# internal crates
+vertex-util-runtime = { workspace = true }
+
 # metrics
 metrics = { workspace = true }
 

--- a/crates/metrics/src/guards.rs
+++ b/crates/metrics/src/guards.rs
@@ -1,9 +1,9 @@
 //! Drop-based RAII guards for automatic metric updates.
 
 use core::fmt;
-use std::time::Instant;
 
 use metrics::{Counter, Gauge, Histogram};
+use vertex_util_runtime::time::Instant;
 
 /// Increments a counter when dropped.
 pub struct CounterGuard(Counter);

--- a/crates/observability/Cargo.toml
+++ b/crates/observability/Cargo.toml
@@ -22,6 +22,7 @@ tokio-console = ["console-subscriber"]
 # Internal crates
 vertex-metrics = { workspace = true }
 vertex-tasks = { workspace = true }
+vertex-util-runtime = { workspace = true }
 
 # Metrics
 metrics = { workspace = true }

--- a/crates/observability/src/metrics/server.rs
+++ b/crates/observability/src/metrics/server.rs
@@ -183,10 +183,7 @@ async fn heap_dump_handler() -> Response {
             .into_response();
     }
 
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let timestamp = vertex_util_runtime::time::now_unix_secs();
     let path = std::path::PathBuf::from(format!("/tmp/vertex_heap_{timestamp}.heap"));
 
     match profiling::heap_dump(&path) {

--- a/crates/storage/redb/Cargo.toml
+++ b/crates/storage/redb/Cargo.toml
@@ -11,6 +11,7 @@ description = "redb backend for vertex-storage"
 [dependencies]
 vertex-storage.workspace = true
 vertex-observability.workspace = true
+vertex-util-runtime.workspace = true
 metrics.workspace = true
 parking_lot.workspace = true
 redb = "2"

--- a/crates/storage/redb/src/tx.rs
+++ b/crates/storage/redb/src/tx.rs
@@ -3,13 +3,13 @@
 use std::collections::HashSet;
 use std::mem::ManuallyDrop;
 use std::sync::OnceLock;
-use std::time::Instant;
 
 use parking_lot::Mutex;
 
 use metrics::{counter, histogram};
 use redb::{ReadableTable, ReadableTableMetadata, TableDefinition};
 use vertex_storage::{DatabaseError, DatabaseErrorInfo, DbTx, DbTxMut, Decode, Encode, Table};
+use vertex_util_runtime::time::Instant;
 
 use crate::metrics::{mode, operation};
 

--- a/crates/swarm/net/handshake/Cargo.toml
+++ b/crates/swarm/net/handshake/Cargo.toml
@@ -20,6 +20,7 @@ vertex-swarm-net-proto.workspace = true
 vertex-swarm-peer.workspace = true
 vertex-net-utils.workspace = true
 vertex-swarm-spec.workspace = true
+vertex-util-runtime.workspace = true
 
 ## alloy
 alloy-primitives.workspace = true

--- a/crates/swarm/net/handshake/src/metrics.rs
+++ b/crates/swarm/net/handshake/src/metrics.rs
@@ -1,13 +1,12 @@
 //! Metrics and tracing for the handshake protocol.
 
-use std::time::Instant;
-
 use metrics::{counter, gauge, histogram};
 use vertex_observability::{
     DURATION_FINE, DURATION_SECONDS, HistogramBucketConfig, LabelValue, StreamGuard,
     labels::{direction, outcome},
 };
 use vertex_swarm_peer::SwarmNodeType;
+use vertex_util_runtime::time::Instant;
 
 use crate::{HandshakeError, HandshakeInfo};
 

--- a/crates/swarm/net/headers/Cargo.toml
+++ b/crates/swarm/net/headers/Cargo.toml
@@ -17,6 +17,7 @@ vertex-net-codec.workspace = true
 vertex-observability.workspace = true
 vertex-swarm-net-proto.workspace = true
 vertex-swarm-primitives.workspace = true
+vertex-util-runtime.workspace = true
 
 ## async
 futures.workspace = true

--- a/crates/swarm/net/headers/src/metrics.rs
+++ b/crates/swarm/net/headers/src/metrics.rs
@@ -1,10 +1,9 @@
 //! Unified protocol exchange metrics for all headered protocols.
 
-use std::time::Instant;
-
 use metrics::{counter, histogram};
 use vertex_metrics::labels::{direction, outcome, reason};
 use vertex_observability::HistogramBucketConfig;
+use vertex_util_runtime::time::Instant;
 
 /// Histogram bucket configurations for protocol exchange metrics.
 pub const HISTOGRAM_BUCKETS: &[HistogramBucketConfig] = &[HistogramBucketConfig {

--- a/crates/swarm/net/hive/Cargo.toml
+++ b/crates/swarm/net/hive/Cargo.toml
@@ -23,6 +23,7 @@ vertex-swarm-api.workspace = true
 vertex-net-utils.workspace = true
 vertex-swarm-spec.workspace = true
 vertex-tasks.workspace = true
+vertex-util-runtime.workspace = true
 
 ## async
 futures.workspace = true

--- a/crates/swarm/net/hive/src/protocol.rs
+++ b/crates/swarm/net/hive/src/protocol.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use libp2p::PeerId;
-use std::time::Instant;
 
 use alloy_primitives::{B256, Signature};
 use futures::future::BoxFuture;
@@ -18,6 +17,7 @@ use vertex_swarm_net_headers::{
 use vertex_swarm_peer::{SwarmAddress, SwarmPeer, Timestamp};
 use vertex_swarm_primitives::{NetworkId, Nonce};
 use vertex_tasks::TaskExecutor;
+use vertex_util_runtime::time::Instant;
 
 use crate::PROTOCOL_NAME;
 use crate::cache::PeerCache;

--- a/crates/swarm/net/identify/Cargo.toml
+++ b/crates/swarm/net/identify/Cargo.toml
@@ -29,6 +29,7 @@ quick-protobuf-codec = "0.3"
 ## metrics
 vertex-metrics.workspace = true
 vertex-observability.workspace = true
+vertex-util-runtime.workspace = true
 metrics.workspace = true
 strum.workspace = true
 

--- a/crates/swarm/net/identify/src/behaviour.rs
+++ b/crates/swarm/net/identify/src/behaviour.rs
@@ -25,6 +25,7 @@ use libp2p::swarm::{
 };
 
 use vertex_net_local::{AddressScope, advertise_filter, classify_multiaddr};
+use vertex_util_runtime::time::Instant;
 
 use crate::{
     Config,
@@ -144,7 +145,7 @@ pub struct Behaviour {
     listen_addresses: ListenAddresses,
     external_addresses: ExternalAddresses,
     /// Per-connection start times for measuring identify exchange duration.
-    connection_timers: HashMap<ConnectionId, std::time::Instant>,
+    connection_timers: HashMap<ConnectionId, Instant>,
     /// Agent versions received via identify, shared with topology.
     agent_versions: AgentVersions,
 }
@@ -308,8 +309,7 @@ impl Behaviour {
             .or_default()
             .insert(conn, addr);
 
-        self.connection_timers
-            .insert(conn, std::time::Instant::now());
+        self.connection_timers.insert(conn, Instant::now());
 
         if let Some(cache) = self.discovered_peers.0.as_mut() {
             for addr in failed_addresses {

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -16,8 +16,11 @@ workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
 futures-util = { workspace = true, features = ["std"] }
 
-# metrics
+# internal crates
 vertex-metrics = { workspace = true }
+vertex-util-runtime = { workspace = true }
+
+# metrics
 metrics.workspace = true
 
 # misc

--- a/crates/tasks/src/shutdown.rs
+++ b/crates/tasks/src/shutdown.rs
@@ -16,6 +16,7 @@ use std::{
     time::Duration,
 };
 use tokio::sync::oneshot;
+use vertex_util_runtime::time::Instant;
 
 /// A Future that resolves when the shutdown event has been fired.
 #[derive(Debug)]
@@ -115,10 +116,10 @@ impl GracefulShutdownCounter {
     /// Block until all graceful tasks complete or timeout expires.
     /// Returns `true` if all tasks completed, `false` on timeout.
     pub(crate) fn wait_timeout(&self, timeout: Duration) -> bool {
-        let deadline = std::time::Instant::now() + timeout;
+        let deadline = Instant::now() + timeout;
         let mut guard = self.mutex.lock();
         while self.count.load(Ordering::SeqCst) > 0 {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return false;
             }


### PR DESCRIPTION
Routes the native-only timing crates through \`vertex-util-runtime\` so every clock access in the workspace goes through the one shared web-time-backed runtime, completing the consistency sweep for #62.

These crates are not in the enforced wasm cone, but the whole-workspace migration means every \`std::time\` access now flows through the single shared clock. The change is a mechanical import swap: \`std::time::{Instant,SystemTime,UNIX_EPOCH}\` becomes \`vertex_util_runtime::time::{Instant, now_unix_secs}\`. \`Duration\` stays on std since it is platform-neutral, and \`tokio::time\` sites are deliberately untouched.

Crates touched: \`vertex-observability\`, \`vertex-storage-redb\`, \`vertex-metrics\`, \`vertex-swarm-net-handshake\`, \`vertex-swarm-net-headers\`, \`vertex-swarm-net-hive\`, \`vertex-swarm-net-identify\`, \`vertex-tasks\`.

No behaviour change. \`cargo tree -i web-time\` confirms no new web-time version entered the graph.

Part of #62