### PR TITLE
refactor: route wasm-playground and ffi randomness through util-runtime

### DIFF
--- a/bin/wasm-playground/Cargo.toml
+++ b/bin/wasm-playground/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 console_error_panic_hook = "0.1.7"
 tracing-wasm = "0.2.1"
-rand = { workspace = true }
+vertex-util-runtime = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/bin/wasm-playground/src/lib.rs
+++ b/bin/wasm-playground/src/lib.rs
@@ -3,7 +3,6 @@ use std::convert::TryInto;
 use ethers_signers::LocalWallet;
 use ethers_signers::Signer;
 use postage::batch;
-use rand::RngCore;
 use tracing::{debug, error, info, trace, warn};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -257,11 +256,9 @@ fn main() -> Result<(), JsValue> {
     // the closure that runs when the private key "Generate" button is clicked
     let pk_input_clone = pk_input.clone();
     let pk_closure = Closure::wrap(Box::new(move |_event: Event| {
-        // Generate a private key
-        // use rand to get a random 32 byte array
-        let mut rng = rand::thread_rng();
+        // Generate a private key: a wasm-safe CSPRNG draw of 32 bytes.
         let mut pk = [0u8; 32];
-        rng.fill_bytes(&mut pk);
+        vertex_util_runtime::rand::fill_bytes(&mut pk);
         pk_input_clone.set_value(hex::encode(pk).as_str());
     }) as Box<dyn FnMut(Event)>);
 
@@ -271,11 +268,9 @@ fn main() -> Result<(), JsValue> {
     // the closure that runs when the batch id "Generate" button is clicked
     let batch_id_input_clone = batch_id_input.clone();
     let batch_id_closure = Closure::wrap(Box::new(move |_event: Event| {
-        // Generate a batch id
-        // use rand to get a random 32 byte array
-        let mut rng = rand::thread_rng();
+        // Generate a batch id: a wasm-safe CSPRNG draw of 32 bytes.
         let mut batch_id = [0u8; 32];
-        rng.fill_bytes(&mut batch_id);
+        vertex_util_runtime::rand::fill_bytes(&mut batch_id);
         batch_id_input_clone.set_value(hex::encode(batch_id).as_str());
     }) as Box<dyn FnMut(Event)>);
 


### PR DESCRIPTION
## What

Routes the wasm-playground browser demo's randomness through the `vertex-util-runtime` facade and confirms the vertex-ffi surface needs no change.

`bin/wasm-playground/src/lib.rs` generated demo 32-byte private keys and batch ids with `rand::thread_rng().fill_bytes()`. `thread_rng()` is exactly the wasm-fragile thread-local entropy path this refactor removes: it is the live, in-browser proof that the facade works on wasm32. Both call sites now draw through `vertex_util_runtime::rand::fill_bytes(&mut buf)`, which is getrandom-backed and wasm-safe. The direct `rand` dependency is dropped from the crate manifest in favour of `vertex-util-runtime` (it was the crate's only `rand` use).

`crates/ffi/src/api/client.rs` builds its client identity through `Identity::random()` and `Nonce::random()`. `Identity::random()` delegates to `Nonce::random()` (nectar, `alloy_primitives::B256::random`) and `LocalSigner::random()` (alloy), both getrandom-backed and already wasm-safe. The FFI surface has no direct `thread_rng`/`fill_bytes`/`RngCore`, so nothing there needed rerouting. This was verification only.

## Verification

`vertex-util-runtime` (the facade wasm-playground now calls, including `fill_bytes`) compiles cleanly for `wasm32-unknown-unknown` via `nix develop`, which is the #62 browser-path proof.

`cargo test -p vertex-ffi --all-features` passes (6 tests). Clippy is clean on the ffi lib and tests/benches. `cargo tree` shows a single `rand v0.9.4` and `getrandom v0.3.4`: the dependency swap introduces no new or duplicate versions.

Note on wasm-playground build scope: the crate is not currently a workspace member and references path crates (`bmt`, `postage`, `ethers-signers`) that no longer exist in the tree, so it cannot compile standalone independently of this change. The `thread_rng` removal is the scoped, correct change for #62; reviving the crate into the workspace is out of scope for this unit.

Part of #62
