### PR TITLE
refactor(swarm-identity): route randomness through util-runtime and drop thread-local RNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8791,13 +8791,15 @@ dependencies = [
  "eyre",
  "nectar-primitives",
  "rand 0.8.6",
- "rand 0.9.4",
  "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
  "tracing",
  "vertex-swarm-api",
  "vertex-swarm-peer",
  "vertex-swarm-primitives",
  "vertex-swarm-spec",
+ "vertex-util-runtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,10 @@ alloy-provider = { version = "2.0", default-features = false }
 alloy-contract = { version = "2.0", default-features = false }
 alloy-rpc-types-eth = { version = "2.0", default-features = false }
 alloy-signer = { version = "2.0" }
-alloy-signer-local = { version = "2.0", features = ["eip712", "keystore"] }
+# The `keystore` feature pulls `eth-keystore`, which does not build for
+# wasm32. It is enabled per-target (native-only) by the sole keystore consumer,
+# `vertex-swarm-identity`, so the rest of the workspace can compile for wasm.
+alloy-signer-local = { version = "2.0", features = ["eip712"] }
 alloy-sol-types = { version = "1.6" }
 alloy-chains = { version = "0.2", default-features = false }
 

--- a/crates/swarm/identity/Cargo.toml
+++ b/crates/swarm/identity/Cargo.toml
@@ -24,6 +24,7 @@ vertex-swarm-peer.workspace = true
 vertex-swarm-api.workspace = true
 vertex-swarm-primitives.workspace = true
 vertex-swarm-spec.workspace = true
+vertex-util-runtime.workspace = true
 
 # CLI
 clap = { workspace = true, features = ["derive"] }
@@ -31,8 +32,17 @@ serde = { workspace = true }
 
 # Utilities
 eyre.workspace = true
-rand.workspace = true
+# rand_08 is required only for the alloy eth-keystore call (it pins rand 0.8);
+# all other randomness flows through vertex-util-runtime.
 rand_08.workspace = true
+strum.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
+
+# Keystore creation and decryption are native-only: the alloy `keystore` feature
+# pulls `eth-keystore`, which does not build for wasm32. Enabling it here (rather
+# than in the shared workspace dep) keeps the rest of the workspace wasm-clean.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+alloy-signer-local = { workspace = true, features = ["keystore"] }
 
 [dev-dependencies]

--- a/crates/swarm/identity/src/args.rs
+++ b/crates/swarm/identity/src/args.rs
@@ -91,7 +91,7 @@ impl IdentityArgs {
 
         let nonce = self.nonce.map(Nonce::from).unwrap_or_else(|| {
             debug!("Generated new nonce");
-            Nonce::random()
+            crate::random_nonce()
         });
 
         Ok(Arc::new(Identity::new(signer, nonce, spec, node_type)))

--- a/crates/swarm/identity/src/keystore.rs
+++ b/crates/swarm/identity/src/keystore.rs
@@ -1,10 +1,30 @@
 //! Keystore utilities for identity management.
+//!
+//! Keystore creation is native-only: it relies on the alloy eth-keystore
+//! encoder, which does not build for `wasm32-unknown-unknown`. This is not a
+//! gap, because only bootnodes and storers persist a keystore and those node
+//! types never run in the browser; the wasm client uses an ephemeral
+//! [`crate::Identity::random`] identity instead. The wasm sibling of
+//! [`create_and_save_signer`] therefore returns [`KeystoreError::WasmUnsupported`].
 
 use alloy_signer_local::PrivateKeySigner;
 use eyre::{Result, WrapErr};
 use std::fs;
 use std::path::Path;
+
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::info;
+
+/// Errors specific to keystore handling.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum KeystoreError {
+    /// Keystore creation was requested on `wasm32`, where the eth-keystore
+    /// encoder is unavailable. Persistent identities are native-only.
+    #[error("keystore creation is not supported on wasm32; use an ephemeral identity")]
+    WasmUnsupported,
+}
 
 /// Resolve password from direct value or file.
 pub fn resolve_password(password: Option<&str>, password_file: Option<&str>) -> Result<String> {
@@ -25,6 +45,11 @@ pub fn resolve_password(password: Option<&str>, password_file: Option<&str>) -> 
 }
 
 /// Load a signer from an Ethereum keystore file.
+///
+/// Native-only: keystore decryption goes through the alloy eth-keystore decoder,
+/// which is unavailable on wasm. The wasm sibling returns
+/// [`KeystoreError::WasmUnsupported`].
+#[cfg(not(target_arch = "wasm32"))]
 pub fn load_signer_from_keystore(keystore_path: &Path, password: &str) -> Result<PrivateKeySigner> {
     info!(
         "Loading signing key from keystore: {}",
@@ -34,7 +59,23 @@ pub fn load_signer_from_keystore(keystore_path: &Path, password: &str) -> Result
         .wrap_err_with(|| format!("Failed to decrypt keystore at {}", keystore_path.display()))
 }
 
+/// Wasm sibling of [`load_signer_from_keystore`].
+///
+/// Keystore decryption is native-only, so this always fails with
+/// [`KeystoreError::WasmUnsupported`].
+#[cfg(target_arch = "wasm32")]
+pub fn load_signer_from_keystore(
+    _keystore_path: &Path,
+    _password: &str,
+) -> Result<PrivateKeySigner> {
+    Err(KeystoreError::WasmUnsupported.into())
+}
+
 /// Create a new random signer and save it to a keystore.
+///
+/// Native-only: see the module docs for why keystore creation is unavailable on
+/// wasm. The wasm sibling returns [`KeystoreError::WasmUnsupported`].
+#[cfg(not(target_arch = "wasm32"))]
 pub fn create_and_save_signer(keystore_path: &Path, password: &str) -> Result<PrivateKeySigner> {
     info!("Generating new signing key");
 
@@ -49,9 +90,11 @@ pub fn create_and_save_signer(keystore_path: &Path, password: &str) -> Result<Pr
 
     let dir = keystore_path.parent().unwrap_or(Path::new("."));
 
-    // Use rand 0.8 for alloy keystore compatibility
+    // The alloy eth-keystore API pins rand 0.8, so this one call site uses a
+    // rand 0.8 RNG rather than the workspace facade (which is rand 0.9). OsRng
+    // is getrandom-backed; the version pin here tracks the alloy dependency.
     let (signer, _uuid) =
-        PrivateKeySigner::new_keystore(dir, &mut rand_08::thread_rng(), password, Some(name))
+        PrivateKeySigner::new_keystore(dir, &mut rand_08::rngs::OsRng, password, Some(name))
             .wrap_err("Failed to create keystore")?;
 
     #[cfg(unix)]
@@ -63,4 +106,14 @@ pub fn create_and_save_signer(keystore_path: &Path, password: &str) -> Result<Pr
     }
 
     Ok(signer)
+}
+
+/// Wasm sibling of [`create_and_save_signer`].
+///
+/// Keystore creation is native-only, so this always fails with
+/// [`KeystoreError::WasmUnsupported`]. The wasm client uses an ephemeral
+/// identity and never reaches this path.
+#[cfg(target_arch = "wasm32")]
+pub fn create_and_save_signer(_keystore_path: &Path, _password: &str) -> Result<PrivateKeySigner> {
+    Err(KeystoreError::WasmUnsupported.into())
 }

--- a/crates/swarm/identity/src/lib.rs
+++ b/crates/swarm/identity/src/lib.rs
@@ -21,6 +21,17 @@ pub use keystore::{create_and_save_signer, load_signer_from_keystore, resolve_pa
 pub use vertex_swarm_api::IdentityError;
 pub use vertex_swarm_api::SwarmIdentity as IdentityTrait;
 
+/// Samples a cryptographically random [`Nonce`] from the runtime CSPRNG facade.
+///
+/// A nonce is 32 random bytes with no key-derivation step, so filling it from
+/// the wasm-safe facade keeps the same entropy guarantee as the upstream
+/// `Nonce::random()` while avoiding its thread-local RNG.
+pub(crate) fn random_nonce() -> Nonce {
+    let mut bytes = [0u8; 32];
+    vertex_util_runtime::rand::fill_bytes(&mut bytes);
+    Nonce::new(bytes)
+}
+
 /// Local node identity containing signing key, nonce, and network spec.
 ///
 /// Holds an `Arc<Spec>` for shared access to the network specification.
@@ -72,8 +83,14 @@ impl Identity {
 
     /// Creates a random ephemeral identity for testing.
     pub fn random(spec: Arc<Spec>, node_type: SwarmNodeType) -> Self {
-        let nonce = Nonce::random();
-        let signer = LocalSigner::random();
+        // Avoid the upstream `*::random()` helpers, which seed from a
+        // thread-local RNG. The nonce is filled from the wasm-safe runtime
+        // facade. The signer keygen runs through alloy, which pins rand 0.8,
+        // so it takes a rand 0.8 OS RNG (getrandom-backed, no thread-local)
+        // rather than the rand 0.9 facade; the pin tracks the alloy dependency,
+        // not a wasm gap.
+        let nonce = random_nonce();
+        let signer = LocalSigner::random_with(&mut rand_08::rngs::OsRng);
         let overlay = compute_overlay(&signer.address(), spec.network_id(), &nonce);
         Self {
             spec,


### PR DESCRIPTION
## What

Routes `vertex-swarm-identity` randomness through the `vertex-util-runtime` CSPRNG facade and removes thread-local RNG sourcing, so the crate is wasm-safe.

## Routed through the facade

The ephemeral nonce in `Identity::random` (and the CLI nonce fallback in `IdentityArgs::identity`) is now filled via `vertex_util_runtime::rand::fill_bytes` into a fresh `Nonce`, replacing `Nonce::random()`. A nonce is 32 random bytes with no key-derivation step, so this keeps the same entropy guarantee while dropping the thread-local RNG that `B256::random()` reaches for under `rand` + `std`.

## Kept on rand 0.8 (upstream pin), but no longer thread-local

Signing-key generation runs through alloy, which pins `rand` 0.8: its `LocalSigner::random_with` and `new_keystore` both want a `rand 0.8` `Rng + CryptoRng`, so our `rand 0.9` facade RNG cannot be passed to them (trait-version mismatch). Both call sites now take `rand_08::rngs::OsRng` instead of `rand_08::thread_rng()`. `OsRng` is getrandom-backed and wasm-safe; the `rand` 0.8 pin tracks the alloy dependency, not a wasm gap. This covers the ephemeral signer in `Identity::random` and the keystore encoder in `create_and_save_signer`.

## Keystore feature gating for the wasm cone

`create_and_save_signer` and `load_signer_from_keystore` pull alloy's `eth-keystore` encoder/decoder, which does not build for `wasm32-unknown-unknown` (its `uuid 0.8` path has no `new_v4` there). The `keystore` feature therefore moves off the shared workspace `alloy-signer-local` dependency and onto a native-only target table on `vertex-swarm-identity`, its sole consumer. The two keystore functions gain `#[cfg(target_arch = "wasm32")]` siblings with identical signatures that return a typed `KeystoreError::WasmUnsupported`, per the wasm.md "documented error variant, not a panic" rule. Keystore persistence is native-only by design: only bootnodes and storers persist a keystore and those node types never run in the browser; the wasm client uses an ephemeral identity.

## Verified already wasm-safe / left as-is

`compute_overlay`, `LocalSigner::address`, and the `Nonce`/`SwarmAddress` derivation paths carry no randomness. No direct `rand` (0.9) `rng()`/`thread_rng()` remained in the crate after the change, so the direct `rand` 0.9 dependency is dropped; `rand_08` stays for the alloy call sites.

## Testing

`cargo test -p vertex-swarm-identity --all-features` passes. `cargo clippy` is clean on lib and tests for the host target. `vertex-swarm-identity` and `vertex-util-runtime` cross-compile for `wasm32-unknown-unknown` (nightly + `-Z build-std`, with the project's `.cargo/config.toml` atomics rustflags), which is the #62 proof that the thread-local RNG is gone. `cargo tree` confirms no new `rand` or `getrandom` versions were introduced. The full workspace still builds natively after the `alloy-signer-local` feature move.

Part of #62
