### PR TITLE
feat(tasks): wasm spawn path for the task executor

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -101,7 +101,7 @@ jobs:
       # `+nightly` is load-bearing: rust-toolchain.toml pins the stable
       # channel and would otherwise override the installed nightly.
       - name: Build peer stack for wasm32
-        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager
+        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager -p vertex-tasks
 
   ci-success:
     name: ci success

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9355,6 +9355,7 @@ dependencies = [
  "tracing",
  "vertex-metrics",
  "vertex-util-runtime",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,7 @@ prost = "0.13"
 ## async
 futures = "0.3"
 futures-util = "0.3"
+wasm-bindgen-futures = "0.4"
 
 ## atomics
 portable-atomic = { version = "1", features = ["float", "serde"] }

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 # async
-tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
 futures-util = { workspace = true, features = ["std"] }
 
 # internal crates
@@ -29,6 +28,16 @@ parking_lot.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 dyn-clone.workspace = true
+
+# Native spawns onto the multi-thread tokio runtime via a runtime handle.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
+
+# Wasm spawns onto the browser event loop via wasm-bindgen-futures. Single-thread
+# tokio only: no rt-multi-thread, no net, no signal.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
+wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -19,16 +19,18 @@ use futures_util::{
     Future, FutureExt, TryFutureExt,
     future::{BoxFuture, Either, select},
 };
-use tokio::{
-    runtime::Handle,
-    sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
-    task::JoinHandle,
-};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tracing::{debug, error, info, warn};
 use vertex_metrics::OperationGuard;
 
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::runtime::Handle;
+
 pub mod metrics;
 pub mod shutdown;
+mod task_handle;
+
+pub use task_handle::TaskHandle;
 
 use crate::metrics::TaskExecutorMetrics;
 use crate::shutdown::GracefulShutdownCounter;
@@ -100,21 +102,20 @@ static GLOBAL_EXECUTOR: OnceLock<TaskExecutor> = OnceLock::new();
 #[auto_impl::auto_impl(&, Arc)]
 pub trait TaskSpawner: Send + Sync + Unpin + std::fmt::Debug + DynClone {
     /// Spawns the task onto the runtime.
-    /// See also [`Handle::spawn`].
-    fn spawn(&self, fut: BoxFuture<'static, ()>) -> JoinHandle<()>;
+    fn spawn(&self, fut: BoxFuture<'static, ()>) -> TaskHandle;
 
     /// This spawns a critical task onto the runtime.
-    fn spawn_critical(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> JoinHandle<()>;
+    fn spawn_critical(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle;
 
     /// Spawns a blocking task onto the runtime.
-    fn spawn_blocking(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> JoinHandle<()>;
+    fn spawn_blocking(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle;
 
     /// This spawns a critical blocking task onto the runtime.
     fn spawn_critical_blocking(
         &self,
         name: &'static str,
         fut: BoxFuture<'static, ()>,
-    ) -> JoinHandle<()>;
+    ) -> TaskHandle;
 }
 
 dyn_clone::clone_trait_object!(TaskSpawner);
@@ -131,16 +132,17 @@ impl TokioTaskExecutor {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl TaskSpawner for TokioTaskExecutor {
-    fn spawn(&self, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
+    fn spawn(&self, fut: BoxFuture<'static, ()>) -> TaskHandle {
         tokio::task::spawn(fut)
     }
 
-    fn spawn_critical(&self, _name: &'static str, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
+    fn spawn_critical(&self, _name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle {
         tokio::task::spawn(fut)
     }
 
-    fn spawn_blocking(&self, _name: &'static str, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
+    fn spawn_blocking(&self, _name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle {
         tokio::task::spawn_blocking(move || tokio::runtime::Handle::current().block_on(fut))
     }
 
@@ -148,9 +150,50 @@ impl TaskSpawner for TokioTaskExecutor {
         &self,
         _name: &'static str,
         fut: BoxFuture<'static, ()>,
-    ) -> JoinHandle<()> {
+    ) -> TaskHandle {
         tokio::task::spawn_blocking(move || tokio::runtime::Handle::current().block_on(fut))
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TaskSpawner for TokioTaskExecutor {
+    fn spawn(&self, fut: BoxFuture<'static, ()>) -> TaskHandle {
+        spawn_local_abortable(fut)
+    }
+
+    fn spawn_critical(&self, _name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle {
+        spawn_local_abortable(fut)
+    }
+
+    fn spawn_blocking(&self, _name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle {
+        spawn_local_abortable(fut)
+    }
+
+    fn spawn_critical_blocking(
+        &self,
+        _name: &'static str,
+        fut: BoxFuture<'static, ()>,
+    ) -> TaskHandle {
+        spawn_local_abortable(fut)
+    }
+}
+
+/// Spawns `fut` onto the browser event loop and returns an abortable [`TaskHandle`].
+///
+/// The future is wrapped in a [`futures_util::future::Abortable`] so the returned handle can
+/// cancel it. Both default and blocking task kinds map here, since wasm has no separate blocking
+/// pool.
+#[cfg(target_arch = "wasm32")]
+fn spawn_local_abortable<F>(fut: F) -> TaskHandle
+where
+    F: Future<Output = ()> + 'static,
+{
+    let (abort_handle, abort_registration) = futures_util::future::AbortHandle::new_pair();
+    let abortable = futures_util::future::Abortable::new(fut, abort_registration);
+    wasm_bindgen_futures::spawn_local(async move {
+        let _ = abortable.await;
+    });
+    TaskHandle::new(abort_handle)
 }
 
 /// Many vertex components require to spawn tasks for long-running jobs. For example network
@@ -169,6 +212,9 @@ impl TaskSpawner for TokioTaskExecutor {
 #[must_use = "TaskManager must be polled to monitor critical tasks"]
 pub struct TaskManager {
     /// Handle to the tokio runtime this task manager is associated with.
+    ///
+    /// Native only: wasm spawns onto the browser event loop and has no runtime handle.
+    #[cfg(not(target_arch = "wasm32"))]
     handle: Handle,
     /// Sender half for sending task events to this type
     task_events_tx: UnboundedSender<TaskEvent>,
@@ -194,14 +240,25 @@ impl TaskManager {
     /// # Panics
     ///
     /// This will panic if called outside the context of a Tokio runtime.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn current() -> Self {
         let handle = Handle::current();
         Self::new(handle)
     }
 
+    /// Returns a __new__ [`TaskManager`] for the wasm event loop.
+    ///
+    /// Wasm has no tokio runtime handle; tasks spawn onto the browser event loop via
+    /// [`wasm_bindgen_futures::spawn_local`].
+    #[cfg(target_arch = "wasm32")]
+    pub fn current() -> Self {
+        Self::new()
+    }
+
     /// Create a new instance connected to the given handle's tokio runtime.
     ///
     /// This also sets the global [`TaskExecutor`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(handle: Handle) -> Self {
         let (task_events_tx, task_events_rx) = unbounded_channel();
         let (signal, on_shutdown) = signal();
@@ -222,10 +279,36 @@ impl TaskManager {
         manager
     }
 
+    /// Create a new instance that spawns onto the wasm event loop.
+    ///
+    /// This also sets the global [`TaskExecutor`]. Unlike the native constructor there is no
+    /// runtime handle to pass; tasks run via [`wasm_bindgen_futures::spawn_local`].
+    #[cfg(target_arch = "wasm32")]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let (task_events_tx, task_events_rx) = unbounded_channel();
+        let (signal, on_shutdown) = signal();
+        let manager = Self {
+            task_events_tx,
+            task_events_rx,
+            signal: Some(signal),
+            on_shutdown,
+            graceful_tasks: Arc::new(GracefulShutdownCounter::new()),
+        };
+
+        let _ = GLOBAL_EXECUTOR
+            .set(manager.executor())
+            .inspect_err(|_| warn!("Global executor already set; TaskExecutor::current() will return the first instance"));
+
+        info!("TaskManager initialized");
+        manager
+    }
+
     /// Returns a new [`TaskExecutor`] that can spawn new tasks onto the tokio runtime this type is
     /// connected to.
     pub fn executor(&self) -> TaskExecutor {
         TaskExecutor {
+            #[cfg(not(target_arch = "wasm32"))]
             handle: self.handle.clone(),
             on_shutdown: self.on_shutdown.clone(),
             task_events_tx: self.task_events_tx.clone(),
@@ -329,6 +412,9 @@ enum TaskEvent {
 #[derive(Debug, Clone)]
 pub struct TaskExecutor {
     /// Handle to the tokio runtime this task manager is associated with.
+    ///
+    /// Native only: wasm spawns onto the browser event loop and has no runtime handle.
+    #[cfg(not(target_arch = "wasm32"))]
     handle: Handle,
     /// Receiver of the shutdown signal.
     on_shutdown: Shutdown,
@@ -363,6 +449,9 @@ impl TaskExecutor {
     }
 
     /// Returns the [Handle] to the tokio runtime.
+    ///
+    /// Native only: wasm spawns onto the browser event loop and exposes no runtime handle.
+    #[cfg(not(target_arch = "wasm32"))]
     pub const fn handle(&self) -> &Handle {
         &self.handle
     }
@@ -380,8 +469,11 @@ impl TaskExecutor {
         )
     }
 
-    /// Spawns a future on the tokio runtime depending on the [`TaskKind`]
-    fn spawn_on_rt<F>(&self, fut: F, task_kind: TaskKind) -> JoinHandle<()>
+    /// Spawns a future on the tokio runtime depending on the [`TaskKind`].
+    ///
+    /// This is the single spawn choke point for all public spawners on native targets.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn spawn_on_rt<F>(&self, fut: F, task_kind: TaskKind) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -394,6 +486,19 @@ impl TaskExecutor {
         }
     }
 
+    /// Spawns a future onto the wasm event loop.
+    ///
+    /// This is the single spawn choke point for all public spawners on wasm. There is no separate
+    /// blocking pool in the browser, so both [`TaskKind::Default`] and [`TaskKind::Blocking`] map
+    /// to the same non-thread [`wasm_bindgen_futures::spawn_local`] spawn.
+    #[cfg(target_arch = "wasm32")]
+    fn spawn_on_rt<F>(&self, fut: F, _task_kind: TaskKind) -> TaskHandle
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        spawn_local_abortable(fut)
+    }
+
     /// Single implementation for all regular (non-critical) tasks.
     ///
     /// Takes a pre-composed future. Callers handle shutdown composition before calling this.
@@ -403,7 +508,7 @@ impl TaskExecutor {
         task_kind: TaskKind,
         task_name: &'static str,
         graceful: bool,
-    ) -> JoinHandle<()>
+    ) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -442,7 +547,7 @@ impl TaskExecutor {
         fut: F,
         task_kind: TaskKind,
         graceful: bool,
-    ) -> JoinHandle<()>
+    ) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -483,7 +588,7 @@ impl TaskExecutor {
     /// The given future resolves as soon as the [Shutdown] signal is received.
     ///
     /// See also [`Handle::spawn`].
-    pub fn spawn<F>(&self, fut: F) -> JoinHandle<()>
+    pub fn spawn<F>(&self, fut: F) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -499,7 +604,7 @@ impl TaskExecutor {
     /// The given future resolves as soon as the [Shutdown] signal is received.
     ///
     /// See also [`Handle::spawn_blocking`].
-    pub fn spawn_blocking<F>(&self, name: &'static str, fut: F) -> JoinHandle<()>
+    pub fn spawn_blocking<F>(&self, name: &'static str, fut: F) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -515,7 +620,7 @@ impl TaskExecutor {
     /// The given future resolves as soon as the [Shutdown] signal is received.
     ///
     /// If this task panics, the [`TaskManager`] is notified.
-    pub fn spawn_critical<F>(&self, name: &'static str, fut: F) -> JoinHandle<()>
+    pub fn spawn_critical<F>(&self, name: &'static str, fut: F) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -539,7 +644,7 @@ impl TaskExecutor {
     /// The given future resolves as soon as the [Shutdown] signal is received.
     ///
     /// If this task panics, the [`TaskManager`] is notified.
-    pub fn spawn_critical_blocking<F>(&self, name: &'static str, fut: F) -> JoinHandle<()>
+    pub fn spawn_critical_blocking<F>(&self, name: &'static str, fut: F) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -575,7 +680,7 @@ impl TaskExecutor {
         &self,
         name: &'static str,
         f: impl FnOnce(GracefulShutdown) -> F,
-    ) -> JoinHandle<()>
+    ) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -607,7 +712,7 @@ impl TaskExecutor {
         &self,
         name: &'static str,
         f: impl FnOnce(GracefulShutdown) -> F,
-    ) -> JoinHandle<()>
+    ) -> TaskHandle
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -621,11 +726,7 @@ impl TaskExecutor {
     /// This is the preferred way to spawn long-running services that implement
     /// [`SpawnableTask`]. The service receives a [`GracefulShutdown`] signal and
     /// is monitored for panics.
-    pub fn spawn_service<S: SpawnableTask>(
-        &self,
-        name: &'static str,
-        service: S,
-    ) -> JoinHandle<()> {
+    pub fn spawn_service<S: SpawnableTask>(&self, name: &'static str, service: S) -> TaskHandle {
         self.spawn_critical_with_graceful_shutdown_signal(name, |shutdown| {
             service.into_task(shutdown)
         })
@@ -687,15 +788,15 @@ impl TaskExecutor {
 }
 
 impl TaskSpawner for TaskExecutor {
-    fn spawn(&self, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
+    fn spawn(&self, fut: BoxFuture<'static, ()>) -> TaskHandle {
         Self::spawn(self, fut)
     }
 
-    fn spawn_critical(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
+    fn spawn_critical(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle {
         Self::spawn_critical(self, name, fut)
     }
 
-    fn spawn_blocking(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> JoinHandle<()> {
+    fn spawn_blocking(&self, name: &'static str, fut: BoxFuture<'static, ()>) -> TaskHandle {
         Self::spawn_blocking(self, name, fut)
     }
 
@@ -703,7 +804,7 @@ impl TaskSpawner for TaskExecutor {
         &self,
         name: &'static str,
         fut: BoxFuture<'static, ()>,
-    ) -> JoinHandle<()> {
+    ) -> TaskHandle {
         Self::spawn_critical_blocking(self, name, fut)
     }
 }

--- a/crates/tasks/src/task_handle.rs
+++ b/crates/tasks/src/task_handle.rs
@@ -1,0 +1,43 @@
+//! Platform-gated handle returned by every [`TaskExecutor`](crate::TaskExecutor) spawner.
+//!
+//! On native targets a [`TaskHandle`] is exactly a [`tokio::task::JoinHandle<()>`], so the
+//! native public API is byte-identical to spawning directly onto the tokio runtime: callers can
+//! `.await` the handle to observe completion and call `abort()` to cancel.
+//!
+//! On `wasm32` there is no multi-thread tokio runtime and no [`JoinHandle`](tokio::task::JoinHandle).
+//! Tasks run on the browser event loop via [`wasm_bindgen_futures::spawn_local`], which neither
+//! yields a join future nor a cancellation token. [`TaskHandle`] is therefore a small abortable
+//! wrapper around a [`futures_util::future::AbortHandle`]: `abort()` cancels the underlying task,
+//! and the type is otherwise inert. It deliberately does not implement [`Future`](core::future::Future),
+//! because a wasm task cannot be joined.
+
+/// Native [`TaskHandle`]: a re-export of [`tokio::task::JoinHandle<()>`].
+///
+/// The native spawners return this directly, keeping the native API identical to spawning onto
+/// the tokio runtime.
+#[cfg(not(target_arch = "wasm32"))]
+pub type TaskHandle = tokio::task::JoinHandle<()>;
+
+/// Wasm [`TaskHandle`]: an abortable wrapper over a [`futures_util::future::AbortHandle`].
+///
+/// A task spawned with [`wasm_bindgen_futures::spawn_local`] cannot be joined, so this handle only
+/// supports cancellation. Dropping the handle does not cancel the task; call [`abort`](Self::abort)
+/// explicitly.
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone)]
+pub struct TaskHandle {
+    abort: futures_util::future::AbortHandle,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TaskHandle {
+    /// Wraps an [`AbortHandle`](futures_util::future::AbortHandle) for the spawned task.
+    pub(crate) const fn new(abort: futures_util::future::AbortHandle) -> Self {
+        Self { abort }
+    }
+
+    /// Aborts the spawned task. Has no effect if the task already finished.
+    pub fn abort(&self) {
+        self.abort.abort();
+    }
+}

--- a/docs/agents/wasm.md
+++ b/docs/agents/wasm.md
@@ -44,7 +44,7 @@ Native-only (must NOT pull into the wasm cone):
 
 The grey zone (must be cfg-gated):
 
-- `vertex-tasks`: the wasm client uses `wasm-bindgen-futures::spawn_local`, not multi-thread tokio. Gate the executor type.
+- `vertex-tasks`: the wasm client uses `wasm-bindgen-futures::spawn_local`, not multi-thread tokio. Done: the spawn choke point (`TaskExecutor::spawn_on_rt`) and the `TaskHandle` return type are cfg-gated (Pattern A). Native `TaskHandle` is `tokio::task::JoinHandle<()>` so the native API is byte-identical; the wasm sibling is an abortable no-op wrapper over a `futures_util::future::AbortHandle`, and both Default and Blocking task kinds map to the same `spawn_local`. The `wasm` job in CI builds `-p vertex-tasks`.
 - `vertex-observability`: tracing-subscriber works in wasm via `tracing-wasm`; Prometheus HTTP server does not. Gate the exporter and HTTP server modules.
 - Anything pulling `tokio` features: under wasm we need `rt` only, no `rt-multi-thread`, no `net`, no `signal`, no `fs`.
 - `getrandom`: three major lines coexist because different transitive deps pin different versions. The 0.3 and 0.4 lines select their browser backend through the `getrandom_backend="wasm_js"` cfg in `.cargo/config.toml`; the 0.2 line (reached transitively through `k256`/`rand_core 0.6` and the libp2p/TLS stack) selects its backend through the `js` cargo feature instead. Two crates carry hand-written `cfg(target_arch = "wasm32")` getrandom feature tables for that 0.2 line: `vertex-swarm-primitives` (the alloy-primitives `getrandom` feature plus the 0.4 `wasm_js` backend, required by alloy nonce generation) and `vertex-swarm-bandwidth-chequebook` (the 0.2 `js` feature, required by the k256 secp256k1 backend). Both are load-bearing transitive build requirements; removing either breaks the wasm build with a getrandom no-backend error. Application randomness goes through `vertex_util_runtime::rand`, not a direct getrandom dependency.
@@ -91,7 +91,7 @@ Audit `Cargo.toml` entries for `tokio` regularly. The default-features-on form (
 ### Plan to a working client-in-wasm
 
 1. Remove or rewrite `bin/swarm-wasm-lib` and `bin/wasm-playground` so they reflect the current crate graph (or delete them with a follow-up to re-add when ready).
-2. Add a `wasm32-unknown-unknown` build step to CI for the wasm-cone crates listed above. Done for the peer stack (the `wasm` job builds `vertex-swarm-peer-score` and `vertex-swarm-peer-manager`, which pulls the whole peer cone); extend the `-p` list as more cone crates become buildable.
+2. Add a `wasm32-unknown-unknown` build step to CI for the wasm-cone crates listed above. Done for the peer stack (the `wasm` job builds `vertex-swarm-peer-score` and `vertex-swarm-peer-manager`, which pulls the whole peer cone) and for `vertex-tasks`; extend the `-p` list as more cone crates become buildable.
 3. Audit tokio features in every wasm-cone crate; trim to the minimum.
 4. Add an `IndexedDb` `Database` backend (likely under `crates/storage/indexeddb`) gated on `cfg(target_arch = "wasm32")`.
 5. Add `libp2p-websocket-websys` to `crates/swarm/node`'s client variant under wasm cfg.


### PR DESCRIPTION
Cfg-gates the single spawn choke point in `vertex-tasks` so the crate compiles for `wasm32-unknown-unknown`, the first foundation piece for a browser demo node.

Native targets keep spawning onto the tokio runtime via a runtime handle and the native public API is byte-identical. Wasm spawns onto the browser event loop via `wasm_bindgen_futures::spawn_local`, mapping both `Default` and `Blocking` task kinds to the same non-thread spawn since the browser has no separate blocking pool.

A new cfg-gated `TaskHandle` carries the platform difference: native is exactly `tokio::task::JoinHandle<()>` (callers still `.await` and `abort()` as before), wasm is a small abortable wrapper over a `futures_util::future::AbortHandle` that cannot be joined and is documented as such.

The cfg follows Pattern A from `docs/agents/wasm.md`: all gating is at item level with no `#[cfg]` inside function bodies, and every native block has a wasm sibling. The gated items are the `handle` fields, `TaskManager::new`/`current`, `TaskExecutor::handle`, `spawn_on_rt`, and the `TokioTaskExecutor` trait impl.

Tokio moves into per-target dependency tables: native keeps its current features unchanged, wasm requests only `rt`, `sync`, `time`, `macros` (no `rt-multi-thread`, `net`, or `signal`). Adds `wasm-bindgen-futures` to the workspace and the wasm target table.

Verification: native `cargo test -p vertex-tasks --all-features` green, clippy clean on lib and tests, and `cargo build --target wasm32-unknown-unknown` green for both `vertex-tasks` and `vertex-swarm-peer-manager`. Adds `-p vertex-tasks` to the wasm CI job and updates the wasm cone docs.

Part of #252