### PR TITLE
feat(swarm-node): cfg-gate browser wss transport in the swarm builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -635,7 +635,7 @@ checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower 0.5.3",
@@ -2285,7 +2285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2716,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3070,7 +3070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers",
- "send_wrapper",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -3594,7 +3594,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3905,7 +3905,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3937,15 +3937,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4490,6 +4481,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-websocket-websys"
+version = "0.6.0"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+dependencies = [
+ "bytes",
+ "futures",
+ "js-sys",
+ "libp2p-core",
+ "send_wrapper 0.6.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
 source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
@@ -5027,7 +5034,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5934,7 +5941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5979,7 +5986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5992,7 +5999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6102,7 +6109,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6139,9 +6146,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6655,7 +6662,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6908,6 +6915,12 @@ name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -7423,7 +7436,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9081,6 +9094,7 @@ dependencies = [
  "futures-bounded 0.2.4",
  "libp2p",
  "libp2p-swarm-test",
+ "libp2p-websocket-websys",
  "metrics",
  "nectar-primitives",
  "parking_lot",
@@ -9605,7 +9619,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9755,15 +9769,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -9795,28 +9800,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9841,12 +9829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9857,12 +9839,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9877,22 +9853,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9907,12 +9871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9923,12 +9881,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9943,12 +9895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9959,12 +9905,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,9 @@ quick-protobuf-codec = "0.3.1"
 asynchronous-codec = "0.7.0"
 libp2p-swarm = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798" }
 libp2p-swarm-test = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798" }
+# Browser websocket transport for the wasm client. Dials the bee AutoTLS
+# `/tls/sni/<host>/ws` form; the browser performs TLS and SNI natively.
+libp2p-websocket-websys = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798" }
 quickcheck = "1.0.3"
 pb-rs = "0.10"
 walkdir = "2.5.0"

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -49,9 +49,6 @@ vertex-swarm-spec.workspace = true
 vertex-swarm-bandwidth.workspace = true
 vertex-tasks.workspace = true
 
-## p2p
-libp2p.workspace = true
-
 ## crypto
 alloy-primitives.workspace = true
 
@@ -81,6 +78,22 @@ vertex-node-api = { workspace = true, optional = true }
 vertex-swarm-bandwidth-pricing = { workspace = true, optional = true, features = ["cli"] }
 vertex-swarm-localstore = { workspace = true, optional = true }
 vertex-swarm-redistribution = { workspace = true, optional = true }
+
+# p2p: the native transport pulls tcp/dns/mdns/upnp/autonat; the browser build
+# trims to the wire-protocol features and dials over a websocket transport.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+libp2p.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798", default-features = false, features = [
+    "noise",
+    "yamux",
+    "macros",
+    "ecdsa",
+    "identify",
+    "ping",
+] }
+libp2p-websocket-websys.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -3,9 +3,7 @@
 use std::time::Duration;
 
 use eyre::{Result, WrapErr};
-use libp2p::{
-    Multiaddr, SwarmBuilder, identity::PublicKey, noise, swarm::NetworkBehaviour, tcp, yamux,
-};
+use libp2p::{Multiaddr, Swarm, identity::PublicKey, swarm::NetworkBehaviour};
 use tracing::{info, warn};
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_swarm_api::{
@@ -189,24 +187,19 @@ where
 
     let topology_cell = std::sync::Mutex::new(Some(topology_behaviour));
 
-    let swarm = SwarmBuilder::with_new_identity()
-        .with_tokio()
-        .with_tcp(
-            tcp::Config::default(),
-            noise::Config::new,
-            yamux::Config::default,
-        )?
-        .with_dns()?
-        .with_behaviour(|keypair| {
-            let topology = topology_cell
-                .lock()
-                .map_err(|_| NodeBuildError::TopologyCellPoisoned)?
-                .take()
-                .ok_or(NodeBuildError::TopologyBehaviourTaken)?;
-            Ok(behaviour_fn(keypair.public().clone(), topology))
-        })?
-        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_timeout))
-        .build();
+    let behaviour_builder = |keypair: &libp2p::identity::Keypair| {
+        let topology = topology_cell
+            .lock()
+            .map_err(|_| NodeBuildError::TopologyCellPoisoned)?
+            .take()
+            .ok_or(NodeBuildError::TopologyBehaviourTaken)?;
+        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(behaviour_fn(
+            keypair.public().clone(),
+            topology,
+        ))
+    };
+
+    let swarm = build_swarm(idle_timeout, behaviour_builder)?;
 
     let local_peer_id = *swarm.local_peer_id();
     info!(%local_peer_id, "{} peer ID", node_type_name);
@@ -222,4 +215,64 @@ where
         listen_addrs,
         topology_handle: infra.topology_handle,
     })
+}
+
+/// Assemble the libp2p [`Swarm`] for native targets over a TCP transport with
+/// DNS resolution, Noise authentication, and Yamux multiplexing.
+#[cfg(not(target_arch = "wasm32"))]
+fn build_swarm<B, F>(idle_timeout: Duration, behaviour_builder: F) -> Result<Swarm<B>>
+where
+    B: NetworkBehaviour,
+    F: FnOnce(
+        &libp2p::identity::Keypair,
+    ) -> std::result::Result<B, Box<dyn std::error::Error + Send + Sync>>,
+{
+    use libp2p::{SwarmBuilder, noise, tcp, yamux};
+
+    let swarm = SwarmBuilder::with_new_identity()
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )?
+        .with_dns()?
+        .with_behaviour(behaviour_builder)?
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_timeout))
+        .build();
+
+    Ok(swarm)
+}
+
+/// Assemble the libp2p [`Swarm`] for the browser over a websocket transport.
+///
+/// The browser cannot open listeners, so this path only dials. It builds the
+/// websocket transport from `libp2p-websocket-websys`, which dials the bee
+/// AutoTLS `/tls/sni/<host>/ws` multiaddrs (the browser performs TLS and SNI
+/// natively), then upgrades it with Noise and Yamux to match the native
+/// authentication and multiplexing.
+#[cfg(target_arch = "wasm32")]
+fn build_swarm<B, F>(idle_timeout: Duration, behaviour_builder: F) -> Result<Swarm<B>>
+where
+    B: NetworkBehaviour,
+    F: FnOnce(
+        &libp2p::identity::Keypair,
+    ) -> std::result::Result<B, Box<dyn std::error::Error + Send + Sync>>,
+{
+    use libp2p::{SwarmBuilder, Transport as _, core::upgrade::Version, noise, yamux};
+
+    let swarm = SwarmBuilder::with_new_identity()
+        .with_wasm_bindgen()
+        .with_other_transport(|keypair| {
+            let transport = libp2p_websocket_websys::Transport::default()
+                .upgrade(Version::V1)
+                .authenticate(noise::Config::new(keypair)?)
+                .multiplex(yamux::Config::default());
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(transport)
+        })?
+        .with_behaviour(behaviour_builder)?
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_timeout))
+        .build();
+
+    Ok(swarm)
 }


### PR DESCRIPTION
Part of #252.

## What

Cfg-gate the swarm transport in `build_base_node` so the browser client can dial over websockets while the native node keeps its existing TCP transport.

The swarm-assembly block is hoisted into two item-level cfg-gated `build_swarm` implementations (Pattern A from `docs/agents/wasm.md`; no in-body `#[cfg]`). Both return the built `Swarm<B>` from the same behaviour-builder closure.

The native path is byte-identical to before: `with_tokio().with_tcp(Noise, Yamux).with_dns()`.

The wasm32 sibling uses `with_wasm_bindgen()` and `with_other_transport`, building `libp2p_websocket_websys::Transport::default()` upgraded with Noise and Yamux. It dials the AutoTLS `/tls/sni/<host>/ws` multiaddrs the mainnet bootnodes advertise; the browser performs TLS and SNI natively. There is no `with_tcp`/`with_dns`, and the browser cannot open listeners, so this path only dials.

## Cargo feature split

The `libp2p` dependency in `vertex-swarm-node` is now declared per target. The non-wasm table keeps the full native feature set (inherited from the workspace dep, unchanged). The wasm table trims to the wire-protocol features (`noise`, `yamux`, `macros`, `ecdsa`, `identify`, `ping`) and drops `tcp`, `dns`, `mdns`, `upnp`, `autonat`. `libp2p-websocket-websys` is added to the workspace and pulled only under the wasm target.

## What compiles now vs after the behaviour PR

The behaviour-composite gating for `wasm32` is a separate sibling unit. This PR does not touch the behaviour struct, so the full wasm build of `vertex-swarm-node` completes only after that lands (the topology composite still pulls native-only NAT discovery paths).

Verified now:

- Native: `cargo test -p vertex-swarm-node --all-features` passes; `cargo build --all-features` builds the workspace and `bin/vertex`; clippy clean. Native behaviour is unchanged.
- Wasm: `cargo build --target wasm32-unknown-unknown -p libp2p-websocket-websys` succeeds, and the exact `with_wasm_bindgen` + `with_other_transport` (websys upgraded with Noise and Yamux) + `with_behaviour` chain from the wasm `build_swarm` typechecks for `wasm32-unknown-unknown` in an isolated reproduction.

After the behaviour PR lands, the whole crate's wasm build completes and the wasm `build_swarm` path is reachable end to end.