### PR TITLE
feat(swarm-node): cfg-gate native-only behaviours out of the wasm client

### DIFF
--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -20,10 +20,9 @@ mod protocol;
 mod selection;
 mod swarm_client;
 
-pub use node::{
-    BaseNode, BootNode, BootNodeBuilder, BuiltInfrastructure, ClientNode, ClientNodeBuilder,
-    NodeBuildError, StorerNode, StorerNodeBuilder,
-};
+pub use node::{BaseNode, BuiltInfrastructure, ClientNode, ClientNodeBuilder, NodeBuildError};
+#[cfg(not(target_arch = "wasm32"))]
+pub use node::{BootNode, BootNodeBuilder, StorerNode, StorerNodeBuilder};
 
 pub use vertex_swarm_api::SwarmNodeType;
 

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -1,25 +1,38 @@
 //! Shared infrastructure for all node types.
 
 use eyre::Result;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::autonat::v2 as autonat;
 use libp2p::connection_limits::{self, ConnectionLimits};
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::mdns;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::multiaddr::Protocol;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::swarm::behaviour::toggle::Toggle;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::upnp;
 use libp2p::{Multiaddr, PeerId, Swarm, swarm::NetworkBehaviour, swarm::SwarmEvent};
 use nectar_primitives::SwarmAddress;
 use tracing::{debug, info, trace, warn};
 use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
 use vertex_swarm_net_identify as identify;
-use vertex_swarm_topology::{TopologyBehaviour, TopologyCommand, TopologyHandle};
+#[cfg(not(target_arch = "wasm32"))]
+use vertex_swarm_topology::TopologyCommand;
+use vertex_swarm_topology::{TopologyBehaviour, TopologyHandle};
 
-/// Optional NAT-traversal behaviours shared by every node type.
+/// Optional NAT-traversal behaviours shared by every native node type.
 ///
 /// AutoNAT v2 (client + server) and UPnP are wired as top-level siblings of
 /// identify so the libp2p swarm propagates verified external addresses between
 /// them automatically. Each is wrapped in a [`Toggle`] so an operator can
 /// disable it without changing the behaviour type.
+///
+/// The browser client has no NAT-traversal surface: it dials over websockets,
+/// never listens, and the `mdns`, `upnp`, and `autonat` libp2p features are
+/// dropped from the wasm dependency set. The struct and its wiring are
+/// therefore native-only.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct NatBehaviours {
     pub(crate) autonat_client: Toggle<autonat::client::Behaviour>,
     pub(crate) autonat_server: Toggle<autonat::server::Behaviour>,
@@ -29,6 +42,7 @@ pub(crate) struct NatBehaviours {
     pub(crate) mdns_enabled: bool,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl NatBehaviours {
     /// Build the NAT behaviours from a network configuration.
     ///
@@ -92,8 +106,9 @@ pub(crate) fn build_connection_limits(
 /// than alongside the config-only NAT behaviours. A bind failure never aborts
 /// node startup: the behaviour is logged and left disabled.
 ///
-/// A future browser/wasm client would gate this off, since mDNS has no
-/// `wasm32-unknown-unknown` transport; the node crate is not in the wasm cone.
+/// mDNS has no `wasm32-unknown-unknown` transport, so this is native-only; the
+/// browser client composite drops the mDNS field entirely.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn build_mdns_toggle(enabled: bool, peer_id: PeerId) -> Toggle<mdns::tokio::Behaviour> {
     if !enabled {
         return Toggle::from(None);
@@ -113,6 +128,7 @@ pub(crate) fn build_mdns_toggle(enabled: bool, peer_id: PeerId) -> Toggle<mdns::
 /// Otherwise appends `/p2p/<peer_id>` when the address lacks a peer component
 /// so the dial resolves to a concrete peer; an address that already carries a
 /// `/p2p/` is returned unchanged.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn mdns_dial_addr(
     local_peer_id: &PeerId,
     peer_id: PeerId,
@@ -135,6 +151,7 @@ pub(crate) fn mdns_dial_addr(
 /// the overlay address is learned at the Swarm handshake. `Expired` is only
 /// logged: an mDNS TTL lapse is not connection state and must not tear down a
 /// live connection.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_mdns_event<I: SwarmIdentity + Clone>(
     local_peer_id: PeerId,
     topology: &mut TopologyBehaviour<I>,
@@ -161,6 +178,7 @@ pub(crate) fn handle_mdns_event<I: SwarmIdentity + Clone>(
 ///
 /// A successful dial-back proves the `client` peer accepts inbound
 /// connections, so we forward it into the topology reachability tracker.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_autonat_server_event<I: SwarmIdentity + Clone>(
     topology: &TopologyBehaviour<I>,
     event: autonat::server::Event,
@@ -181,6 +199,7 @@ pub(crate) fn handle_autonat_server_event<I: SwarmIdentity + Clone>(
 /// On success the swarm marks the address confirmed and broadcasts
 /// `FromSwarm::ExternalAddrConfirmed`, which the topology behaviour consumes to
 /// flip public connectivity. Here we only log the outcome.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_autonat_client_event(event: autonat::client::Event) {
     match event.result {
         Ok(()) => debug!(
@@ -200,6 +219,7 @@ pub(crate) fn handle_autonat_client_event(event: autonat::client::Event) {
 /// Handle a UPnP event. Port-map confirmations reach the topology behaviour as
 /// `FromSwarm::ExternalAddrConfirmed`; here we only surface operator-facing
 /// gateway diagnostics.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn handle_upnp_event(event: upnp::Event) {
     match event {
         upnp::Event::NewExternalAddr { external_addr, .. } => {

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -10,10 +10,14 @@ use std::sync::Arc;
 
 use eyre::Result;
 use futures::StreamExt;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::autonat::v2 as autonat;
 use libp2p::connection_limits;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::mdns;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::swarm::behaviour::toggle::Toggle;
+#[cfg(not(target_arch = "wasm32"))]
 use libp2p::upnp;
 use libp2p::{Multiaddr, PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
 use nectar_primitives::SwarmAddress;
@@ -28,7 +32,9 @@ use vertex_swarm_topology::{
 use vertex_tasks::GracefulShutdown;
 use vertex_tasks::TaskExecutor;
 
-use super::base::{BaseNode, NatBehaviours};
+use super::base::BaseNode;
+#[cfg(not(target_arch = "wasm32"))]
+use super::base::NatBehaviours;
 use super::builder::BuiltInfrastructure;
 use crate::protocol::{
     BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, ClientCommand, ClientEvent,
@@ -45,14 +51,23 @@ pub(crate) struct ClientNodeBehaviour<I: SwarmIdentity + Clone> {
     /// allocate per-connection state.
     pub(crate) connection_limits: connection_limits::Behaviour,
     pub(crate) identify: identify::Behaviour,
+    // NAT traversal (AutoNAT v2, UPnP) and LAN discovery (mDNS) are native-only.
+    // The browser client dials over websockets, never listens, and the wasm
+    // dependency set drops the `autonat`, `upnp`, and `mdns` libp2p features, so
+    // these fields are absent from the wasm composite.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) autonat_client: Toggle<autonat::client::Behaviour>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) autonat_server: Toggle<autonat::server::Behaviour>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) upnp: Toggle<upnp::tokio::Behaviour>,
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) mdns: Toggle<mdns::tokio::Behaviour>,
     pub(crate) topology: TopologyBehaviour<I>,
     pub(crate) client: ClientBehaviour,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
     pub(crate) fn from_parts(
         local_public_key: PublicKey,
@@ -67,8 +82,9 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
             // Identify advertises addresses scoped to each peer (see
             // `addresses_for_remote`), so a public peer never receives our
             // private or loopback addresses. A NAT'd node with no public address
-            // sends an empty listen set to public peers; bee tolerates this
-            // (it falls back to the connection's remote multiaddr).
+            // sends an empty listen set to public peers; the reference peer
+            // tolerates this (it falls back to the connection's remote
+            // multiaddr).
             identify: identify::Behaviour::new(
                 identify::Config::new(local_public_key),
                 agent_versions,
@@ -83,13 +99,78 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
     }
 }
 
+/// The browser client composite has no NAT-traversal behaviours: it dials over
+/// websockets, never listens, and the `autonat`, `upnp`, and `mdns` libp2p
+/// features are dropped from the wasm dependency set.
+#[cfg(target_arch = "wasm32")]
+impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
+    pub(crate) fn from_parts(
+        local_public_key: PublicKey,
+        topology: TopologyBehaviour<I>,
+        connection_limits: connection_limits::Behaviour,
+    ) -> Self {
+        let agent_versions = topology.agent_versions();
+        Self {
+            connection_limits,
+            identify: identify::Behaviour::new(
+                identify::Config::new(local_public_key),
+                agent_versions,
+            ),
+            topology,
+            client: ClientBehaviour::new(ClientBehaviourConfig::default()),
+        }
+    }
+}
+
+/// Assemble the client base node natively, wiring the NAT-traversal behaviours
+/// (AutoNAT v2, UPnP) and LAN discovery (mDNS) into the composite.
+#[cfg(not(target_arch = "wasm32"))]
+async fn build_client_base<I, C>(
+    infra: BuiltInfrastructure<I>,
+    network_config: &C,
+) -> Result<BaseNode<I, ClientNodeBehaviour<I>>>
+where
+    I: SwarmIdentity + Clone,
+    C: SwarmNetworkConfig,
+{
+    let nat = NatBehaviours::from_config(network_config);
+    let connection_limits = super::base::build_connection_limits(network_config);
+    super::builder::build_base_node(infra, network_config, "Client node", move |pk, topology| {
+        ClientNodeBehaviour::from_parts(pk, topology, nat, connection_limits)
+    })
+    .await
+}
+
+/// Assemble the browser client base node. The wasm composite carries only the
+/// connection-limits gate, identify, topology, and the client protocols; the
+/// NAT-traversal behaviours are absent.
+#[cfg(target_arch = "wasm32")]
+async fn build_client_base<I, C>(
+    infra: BuiltInfrastructure<I>,
+    network_config: &C,
+) -> Result<BaseNode<I, ClientNodeBehaviour<I>>>
+where
+    I: SwarmIdentity + Clone,
+    C: SwarmNetworkConfig,
+{
+    let connection_limits = super::base::build_connection_limits(network_config);
+    super::builder::build_base_node(infra, network_config, "Client node", move |pk, topology| {
+        ClientNodeBehaviour::from_parts(pk, topology, connection_limits)
+    })
+    .await
+}
+
 /// Events from the client node behaviour.
 #[allow(clippy::large_enum_variant)]
 pub enum ClientNodeEvent {
     Identify(Box<identify::Event>),
+    #[cfg(not(target_arch = "wasm32"))]
     AutonatClient(autonat::client::Event),
+    #[cfg(not(target_arch = "wasm32"))]
     AutonatServer(autonat::server::Event),
+    #[cfg(not(target_arch = "wasm32"))]
     Upnp(upnp::Event),
+    #[cfg(not(target_arch = "wasm32"))]
     Mdns(mdns::Event),
     Topology(()),
     Client(ClientEvent),
@@ -108,24 +189,28 @@ impl From<identify::Event> for ClientNodeEvent {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<autonat::client::Event> for ClientNodeEvent {
     fn from(event: autonat::client::Event) -> Self {
         ClientNodeEvent::AutonatClient(event)
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<autonat::server::Event> for ClientNodeEvent {
     fn from(event: autonat::server::Event) -> Self {
         ClientNodeEvent::AutonatServer(event)
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<upnp::Event> for ClientNodeEvent {
     fn from(event: upnp::Event) -> Self {
         ClientNodeEvent::Upnp(event)
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<mdns::Event> for ClientNodeEvent {
     fn from(event: mdns::Event) -> Self {
         ClientNodeEvent::Mdns(event)
@@ -258,18 +343,22 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
             ClientNodeEvent::Identify(event) => {
                 self.handle_identify_event(*event);
             }
+            #[cfg(not(target_arch = "wasm32"))]
             ClientNodeEvent::AutonatServer(event) => {
                 super::base::handle_autonat_server_event(
                     &self.base.swarm.behaviour().topology,
                     event,
                 );
             }
+            #[cfg(not(target_arch = "wasm32"))]
             ClientNodeEvent::AutonatClient(event) => {
                 super::base::handle_autonat_client_event(event);
             }
+            #[cfg(not(target_arch = "wasm32"))]
             ClientNodeEvent::Upnp(event) => {
                 super::base::handle_upnp_event(event);
             }
+            #[cfg(not(target_arch = "wasm32"))]
             ClientNodeEvent::Mdns(event) => {
                 let local_peer_id = *self.base.swarm.local_peer_id();
                 super::base::handle_mdns_event(
@@ -417,17 +506,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
             }
         };
 
-        let nat = NatBehaviours::from_config(network_config);
-        let connection_limits = super::base::build_connection_limits(network_config);
-        let mut base = super::builder::build_base_node(
-            infra,
-            network_config,
-            "Client node",
-            move |pk, topology| {
-                ClientNodeBehaviour::from_parts(pk, topology, nat, connection_limits)
-            },
-        )
-        .await?;
+        let mut base = build_client_base(infra, network_config).await?;
 
         // Register the local PeerId for address advertisement in handshakes
         base.swarm

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -1,10 +1,16 @@
 //! Node types for Swarm network participation.
 //!
-//! - [`BootNode`] - Topology only (bootnode servers)
-//! - [`ClientNode`] - Topology + client protocols (chunk read/write)
-//! - [`StorerNode`] - Client + storage protocols (chunk storage and staking)
+//! - [`BootNode`] - Topology only (bootnode servers); native-only.
+//! - [`ClientNode`] - Topology + client protocols (chunk read/write).
+//! - [`StorerNode`] - Client + storage protocols (chunk storage and staking);
+//!   native-only.
+//!
+//! The browser client target builds only the [`ClientNode`] path. Bootnode and
+//! storer are out of scope for `wasm32-unknown-unknown` (they need listeners,
+//! NAT traversal, and native storage), so their modules are native-only.
 
 mod base;
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(unreachable_pub)]
 mod bootnode;
 mod builder;
@@ -12,12 +18,15 @@ mod builder;
 mod client;
 mod error;
 pub(crate) mod stats;
+#[cfg(not(target_arch = "wasm32"))]
 mod storer;
 pub(crate) mod task;
 
 pub use base::BaseNode;
+#[cfg(not(target_arch = "wasm32"))]
 pub use bootnode::{BootNode, BootNodeBuilder};
 pub use builder::BuiltInfrastructure;
 pub use client::{ClientNode, ClientNodeBuilder};
 pub use error::NodeBuildError;
+#[cfg(not(target_arch = "wasm32"))]
 pub use storer::{StorerNode, StorerNodeBuilder};


### PR DESCRIPTION
Part of #252.

## What

Cfg-gate the native-only behaviours out of the browser client composite so the `ClientNodeBehaviour` carries only the wire surface a browser can actually run.

On `wasm32` the composite keeps `connection_limits`, `identify`, `topology`, and `client`. The AutoNAT v2 (client + server), UPnP, and mDNS fields are gated out, matching the wasm libp2p feature table from #256 which already drops `tcp`, `dns`, `mdns`, `upnp`, and `autonat`. The native composite is byte-identical to before.

## How

Pattern A (`target_arch = "wasm32"`) per `docs/agents/wasm.md`, hoisted to item level wherever a function body would otherwise branch:

- `ClientNodeBehaviour` cfg-gates the four NAT fields with `#[cfg(not(target_arch = "wasm32"))]`. The `#[derive(NetworkBehaviour)]` macro is correct here because the compiler strips cfg-disabled fields from the token stream before the derive expands, so the generated select / `on_swarm_event` / `poll` / event wiring is built only from the surviving fields.
- The `ClientNodeEvent` variants, their `From` impls, and the `handle_behaviour_event` match arms for the four NAT events are gated to match.
- `ClientNodeBehaviour::from_parts` has native and wasm siblings: the wasm one drops the `nat` parameter. A new `build_client_base` helper has native and wasm siblings too, so the builder body has no in-body cfg; the two differ only in whether `NatBehaviours` is constructed and threaded in.
- In `base.rs`, the shared NAT plumbing (`NatBehaviours` and its `from_config`, `build_mdns_toggle`, `mdns_dial_addr`, and the `handle_autonat_*` / `handle_upnp_event` / `handle_mdns_event` handlers) is native-only. `BaseNode`, `build_connection_limits`, and `handle_identify_event` stay shared.
- Bootnode and storer are out of scope for the browser target (they need listeners, NAT traversal, and native storage), so the `bootnode` and `storer` modules and their re-exports are native-only.

## What compiles for wasm now

The behaviour composite (`ClientNodeBehaviour`, its events, `from_parts`, and `build_client_base`) is now wasm-shaped: every native-only behaviour has a wasm sibling or is cleanly absent, and the only libp2p features the wasm composite references are the ones #256 keeps. Combined with #256's websocket transport and #254's wasm task executor, the client behaviour stack is ready to build for `wasm32` once the remaining transitive blockers below are gated.

## Remaining phase-2 blockers

The full `vertex-swarm-node` crate does not yet build for `wasm32-unknown-unknown`. The build stops in `mio` (pulled by `tokio`'s `net` feature) and in native-only libp2p code, both reached transitively through the topology cone, not through anything in this PR:

- `vertex-observability` pulls `axum` and `tokio` with `net`, dragging in `mio`. It is a dependency of `vertex-swarm-net-handshake`, hence of `vertex-swarm-topology`.
- `vertex-swarm-topology` depends on the native `libp2p` feature set and on `vertex-net-dialer` and `vertex-net-dnsaddr`, which `docs/agents/wasm.md` lists as native-only.

Gating the topology / observability / dialer cone for wasm is a separate phase-2 unit; the `wasm` CI job in `.github/workflows/unit.yml` builds the peer stack and `vertex-tasks`, not `vertex-swarm-node`, so it is unaffected.

## Verification

- `cargo build -p vertex-swarm-node --all-features`: green.
- `cargo test -p vertex-swarm-node --all-features`: 52 + integration + doctests pass.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean across the workspace.
- `cargo build --all-features` (workspace + `bin/vertex`): green.
