### PR TITLE
feat(swarm): wasm DoH dnsaddr resolver with snapshot fallback

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -101,7 +101,7 @@ jobs:
       # `+nightly` is load-bearing: rust-toolchain.toml pins the stable
       # channel and would otherwise override the installed nightly.
       - name: Build peer stack for wasm32
-        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager -p vertex-tasks
+        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager -p vertex-tasks -p vertex-net-dnsaddr-doh
 
   ci-success:
     name: ci success

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -482,7 +482,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -635,7 +635,7 @@ checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower 0.5.3",
@@ -1658,7 +1658,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -2102,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -2285,7 +2285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2436,7 +2436,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -2489,7 +2489,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2716,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3098,9 +3098,9 @@ checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -3173,6 +3173,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "gloo-utils",
+ "http",
+ "js-sys",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3197,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3594,7 +3620,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3905,7 +3931,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3937,6 +3963,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4745,6 +4780,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5034,7 +5079,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5941,7 +5986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5986,7 +6031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5999,7 +6044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6109,7 +6154,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6146,9 +6191,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6662,7 +6707,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7166,9 +7211,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -7436,7 +7481,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8129,7 +8174,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -8377,6 +8422,22 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "vertex-net-dnsaddr-doh"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "getrandom 0.3.4",
+ "gloo-net",
+ "libp2p",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -9515,6 +9576,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9621,7 +9721,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9771,6 +9871,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -9802,11 +9911,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9831,6 +9957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9841,6 +9973,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9855,10 +9993,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9873,6 +10023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9883,6 +10039,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9897,6 +10059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9907,6 +10075,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -10165,18 +10339,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 
     # Network (protocol-agnostic utilities)
     "crates/net/dnsaddr",
+    "crates/net/dnsaddr-doh",
     "crates/net/local",
     "crates/net/peer/backoff",
     "crates/net/peer/store",
@@ -138,6 +139,7 @@ vertex-swarm-peer = { path = "crates/swarm/peers/peer" }
 
 # network
 vertex-net-dnsaddr = { path = "crates/net/dnsaddr" }
+vertex-net-dnsaddr-doh = { path = "crates/net/dnsaddr-doh" }
 vertex-net-local = { path = "crates/net/local" }
 vertex-net-peer-backoff = { path = "crates/net/peer/backoff" }
 vertex-net-peer-store = { path = "crates/net/peer/store" }
@@ -300,6 +302,10 @@ prost = "0.13"
 futures = "0.3"
 futures-util = "0.3"
 wasm-bindgen-futures = "0.4"
+
+## wasm browser HTTP (fetch) and test harness
+gloo-net = { version = "0.6", default-features = false, features = ["http"] }
+wasm-bindgen-test = "0.3"
 
 ## atomics
 portable-atomic = { version = "1", features = ["float", "serde"] }

--- a/crates/net/AGENTS.md
+++ b/crates/net/AGENTS.md
@@ -7,6 +7,7 @@ Root-level rules in `/AGENTS.md` apply here too. The notes below are the area-sp
 ## Scope
 
 - `dnsaddr`, `local`, `utils`: address handling and IP classification.
+- `dnsaddr-doh`: wasm-only dnsaddr resolution over DNS-over-HTTPS for browser clients that have no raw DNS TXT capability. The recursion driver is generic over a `TxtFetcher` so its parsing, bounded-depth recursion, and wss-leaf filtering test natively against fixtures; the `fetch`-backed `DohClient` is `cfg(target_arch = "wasm32")`. It returns dialable leaves only and stays free of `crates/swarm/` types: the snapshot-fallback policy lives at the bootnode-selection site (`resolve_or_fallback` takes a caller-supplied snapshot slice). See `docs/agents/wasm.md`.
 - `peer/backoff`, `peer/score`, `peer/store`, `peer/registry`: peer state primitives that hold no protocol logic. Together with `local` they sit in the wasm compilation cone of the Swarm peer stack: keep them building for `wasm32-unknown-unknown` (the `wasm` CI job enforces this through `vertex-swarm-peer-manager`) and take wall clocks and monotonic time from `web-time`, not `std::time`. See `docs/agents/wasm.md`.
 - `dialer`: generic dial-request tracker with bounded queue and in-flight management.
 - `codec`: protobuf framing (`FramedProto`) plus the `protocol_error!` macro for protocol-shaped error enums.

--- a/crates/net/dnsaddr-doh/Cargo.toml
+++ b/crates/net/dnsaddr-doh/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "vertex-net-dnsaddr-doh"
+description = "Browser dnsaddr resolution over DNS-over-HTTPS for wasm Swarm clients"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+libp2p = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"] }
+strum = { workspace = true }
+thiserror = { workspace = true, features = ["std"] }
+tracing = { workspace = true }
+
+# Browser fetch is only available on wasm; the live DoH path is gated to wasm32.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-net = { workspace = true }
+
+# libp2p pulls getrandom 0.3 transitively; on wasm32 its browser backend needs the
+# `wasm_js` feature (the matching `getrandom_backend="wasm_js"` cfg is set in
+# .cargo/config.toml). This is a transitive build requirement, not a direct API use.
+getrandom_03 = { workspace = true, features = ["wasm_js"] }
+
+[dev-dependencies]
+futures = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true }

--- a/crates/net/dnsaddr-doh/src/doh.rs
+++ b/crates/net/dnsaddr-doh/src/doh.rs
@@ -1,0 +1,100 @@
+//! Browser `fetch`-backed DNS-over-HTTPS [`TxtFetcher`].
+//!
+//! This module is wasm-only: it issues the DoH query through the browser `fetch`
+//! API via `gloo_net`. The endpoint is configurable so an operator can point at
+//! a provider they trust. The default is Cloudflare; Google is offered as an
+//! alternate. Both answer the `application/dns-json` query shape the parser
+//! expects.
+//!
+//! # Privacy
+//!
+//! A DoH resolver sees every query the browser sends it, so the chosen provider
+//! learns that this client is resolving the Swarm bootnode names. That is an
+//! accepted tradeoff for a browser demo and is mitigated by making the endpoint
+//! configurable; a deployment with stricter requirements points [`DohClient`] at
+//! a self-hosted or otherwise trusted resolver.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use gloo_net::http::Request;
+
+use crate::error::DohError;
+use crate::resolver::TxtFetcher;
+
+/// Cloudflare DNS-over-HTTPS endpoint (`application/dns-json`).
+pub const CLOUDFLARE_DOH: &str = "https://cloudflare-dns.com/dns-query";
+
+/// Google DNS-over-HTTPS endpoint (`application/dns-json`).
+pub const GOOGLE_DOH: &str = "https://dns.google/resolve";
+
+/// A browser `fetch`-backed DoH client targeting a configurable endpoint.
+///
+/// Construct with [`DohClient::cloudflare`] or [`DohClient::google`] for the
+/// built-in providers, or [`DohClient::new`] to point at any
+/// `application/dns-json` resolver.
+#[derive(Debug, Clone)]
+pub struct DohClient {
+    endpoint: String,
+}
+
+impl Default for DohClient {
+    fn default() -> Self {
+        Self::cloudflare()
+    }
+}
+
+impl DohClient {
+    /// Create a client targeting an arbitrary `application/dns-json` endpoint.
+    #[must_use]
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+        }
+    }
+
+    /// Create a client targeting the Cloudflare DoH endpoint.
+    #[must_use]
+    pub fn cloudflare() -> Self {
+        Self::new(CLOUDFLARE_DOH)
+    }
+
+    /// Create a client targeting the Google DoH endpoint.
+    #[must_use]
+    pub fn google() -> Self {
+        Self::new(GOOGLE_DOH)
+    }
+
+    /// The configured DoH endpoint URL.
+    #[must_use]
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl TxtFetcher for DohClient {
+    fn fetch_txt(
+        &self,
+        name: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String, DohError>> + '_>> {
+        let query_name = format!("_dnsaddr.{name}");
+        let endpoint = self.endpoint.clone();
+        Box::pin(async move {
+            let response = Request::get(&endpoint)
+                .query([("name", query_name.as_str()), ("type", "TXT")])
+                .header("accept", "application/dns-json")
+                .send()
+                .await
+                .map_err(|e| DohError::Request(e.to_string()))?;
+
+            if !response.ok() {
+                return Err(DohError::Request(format!("status {}", response.status())));
+            }
+
+            response
+                .text()
+                .await
+                .map_err(|e| DohError::Request(e.to_string()))
+        })
+    }
+}

--- a/crates/net/dnsaddr-doh/src/error.rs
+++ b/crates/net/dnsaddr-doh/src/error.rs
@@ -1,0 +1,21 @@
+//! Error type for DNS-over-HTTPS dnsaddr resolution.
+
+/// Errors that can occur while resolving dnsaddr records over DoH.
+///
+/// The `reason` label for metrics is derived through `strum::IntoStaticStr` so
+/// the variant name round-trips into observability with no manual mapping.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[non_exhaustive]
+pub enum DohError {
+    /// The HTTP request to the DoH endpoint failed (network, CORS, or status).
+    #[error("DoH request failed: {0}")]
+    Request(String),
+
+    /// The DoH response body was not valid DNS-JSON.
+    #[error("DoH response parse failed: {0}")]
+    Parse(String),
+
+    /// Resolution completed but produced no browser-dialable leaves.
+    #[error("dnsaddr resolution produced no browser-dialable leaves")]
+    EmptyResolution,
+}

--- a/crates/net/dnsaddr-doh/src/lib.rs
+++ b/crates/net/dnsaddr-doh/src/lib.rs
@@ -1,0 +1,161 @@
+//! Browser dnsaddr resolution over DNS-over-HTTPS (DoH).
+//!
+//! A browser cannot perform raw DNS TXT lookups, so the `/dnsaddr/mainnet.ethswarm.org`
+//! indirection the live network relies on cannot be resolved the way the native
+//! `vertex-net-dnsaddr` resolver does. This crate restores that indirection on
+//! `wasm32` by resolving the dnsaddr tree over DoH: a `fetch` to a DoH endpoint
+//! (`application/dns-json`) returns the TXT records, the resolver recurses through
+//! the nested `/dnsaddr/` entries, and the browser-dialable secure-WebSocket
+//! leaves fall out.
+//!
+//! # Design
+//!
+//! - The DoH path is the primary, live source of mainnet bootnodes in the browser.
+//! - This crate stays protocol-agnostic: it resolves a dnsaddr tree to dialable
+//!   leaves and nothing more. The "fall back to the embedded snapshot when DoH
+//!   yields nothing" policy belongs at the bootnode-selection site, which already
+//!   knows the network spec, not in this net-layer util. [`resolve_or_fallback`]
+//!   is the helper that composes the two given a caller-supplied snapshot.
+//! - The recursion driver ([`resolve_dnsaddr`]) is generic over a [`TxtFetcher`],
+//!   so its parsing, bounded-depth recursion, de-duplication, and wss-leaf
+//!   filtering are unit-tested natively against captured fixtures with no network.
+//!   The live browser fetcher ([`DohClient`], wasm-only) supplies the same trait.
+//!
+//! # Targets
+//!
+//! The pure logic (parsing, recursion, filtering, [`resolve_or_fallback`]) builds
+//! and is tested on every target. The `fetch`-backed [`DohClient`] and the live
+//! [`resolve_mainnet_wss_bootnodes`] entrypoint are `wasm32`-only, since `fetch`
+//! exists only in the browser. Native clients keep using `vertex-net-dnsaddr`
+//! over the system resolver and never link this crate.
+
+pub mod error;
+pub mod parse;
+pub mod resolver;
+
+#[cfg(target_arch = "wasm32")]
+pub mod doh;
+
+pub use error::DohError;
+pub use resolver::{DEFAULT_MAX_DEPTH, TxtFetcher, resolve_dnsaddr};
+
+#[cfg(target_arch = "wasm32")]
+pub use doh::{CLOUDFLARE_DOH, DohClient, GOOGLE_DOH};
+
+use libp2p::Multiaddr;
+
+/// The mainnet dnsaddr root name (without the `_dnsaddr.` query prefix).
+pub const MAINNET_DNSADDR_NAME: &str = "mainnet.ethswarm.org";
+
+/// Resolve `name` over a [`TxtFetcher`], falling back to a snapshot when empty.
+///
+/// Runs the DoH recursion through `fetcher` and returns its browser-dialable wss
+/// leaves. When the live resolution yields nothing (network error, CORS rejection,
+/// parse failure, or a genuinely empty tree), the caller-supplied `snapshot` of
+/// multiaddr strings is parsed and returned instead, so the caller always receives
+/// a dialable set. The chosen path is logged.
+///
+/// The snapshot is taken as raw strings rather than a hard dependency on a network
+/// spec so this net-layer crate stays free of `crates/swarm/` types; the
+/// bootnode-selection site passes `vertex_swarm_spec::mainnet_wss_bootnodes()`.
+pub async fn resolve_or_fallback<F: TxtFetcher>(
+    fetcher: &F,
+    name: &str,
+    snapshot: &[&str],
+) -> Vec<Multiaddr> {
+    let resolved = resolve_dnsaddr(fetcher, name, DEFAULT_MAX_DEPTH).await;
+
+    if resolved.is_empty() {
+        tracing::warn!(
+            %name,
+            "DoH dnsaddr resolution yielded no leaves, using embedded snapshot"
+        );
+        snapshot.iter().filter_map(|s| s.parse().ok()).collect()
+    } else {
+        tracing::info!(
+            %name,
+            count = resolved.len(),
+            "resolved bootnodes over DoH"
+        );
+        resolved
+    }
+}
+
+/// Resolve mainnet bootnodes for a browser client, preferring live DoH.
+///
+/// Resolves the `mainnet.ethswarm.org` dnsaddr tree over DoH through `client`,
+/// falling back to `snapshot` (typically `vertex_swarm_spec::mainnet_wss_bootnodes()`)
+/// when the live path yields nothing. See [`resolve_or_fallback`].
+#[cfg(target_arch = "wasm32")]
+pub async fn resolve_mainnet_wss_bootnodes(
+    client: &DohClient,
+    snapshot: &[&str],
+) -> Vec<Multiaddr> {
+    resolve_or_fallback(client, MAINNET_DNSADDR_NAME, snapshot).await
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    use std::future::Future;
+    use std::pin::Pin;
+
+    use futures::executor::block_on;
+
+    use super::*;
+
+    struct EmptyFetcher;
+
+    impl TxtFetcher for EmptyFetcher {
+        fn fetch_txt(
+            &self,
+            _name: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, DohError>> + '_>> {
+            Box::pin(async { Err(DohError::EmptyResolution) })
+        }
+    }
+
+    struct OneLeafFetcher;
+
+    const LEAF: &str = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+
+    impl TxtFetcher for OneLeafFetcher {
+        fn fetch_txt(
+            &self,
+            _name: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, DohError>> + '_>> {
+            let body = format!(r#"{{"Answer": [{{"type": 16, "data": "dnsaddr={LEAF}"}}]}}"#);
+            Box::pin(async move { Ok(body) })
+        }
+    }
+
+    #[test]
+    fn falls_back_to_snapshot_when_resolution_empty() {
+        let snap = [LEAF];
+        let leaves = block_on(resolve_or_fallback(
+            &EmptyFetcher,
+            "mainnet.ethswarm.org",
+            &snap,
+        ));
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].to_string(), LEAF);
+    }
+
+    #[test]
+    fn prefers_live_resolution_over_snapshot() {
+        // Snapshot is a different, stale address; live resolution must win.
+        let stale = "/ip4/1.2.3.4/tcp/1635/tls/sni/stale.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+        let snap = [stale];
+        let leaves = block_on(resolve_or_fallback(
+            &OneLeafFetcher,
+            "mainnet.ethswarm.org",
+            &snap,
+        ));
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(
+            leaves[0].to_string(),
+            LEAF,
+            "live leaf must take precedence"
+        );
+    }
+}

--- a/crates/net/dnsaddr-doh/src/parse.rs
+++ b/crates/net/dnsaddr-doh/src/parse.rs
@@ -1,0 +1,194 @@
+//! Parsing of DNS-over-HTTPS JSON responses and dnsaddr TXT records.
+//!
+//! Both Cloudflare (`https://cloudflare-dns.com/dns-query`) and Google
+//! (`https://dns.google/resolve`) answer a `type=TXT` query with the same JSON
+//! shape when asked with the `accept: application/dns-json` header: an `Answer`
+//! array whose entries carry a numeric `type` and a string `data` field. For TXT
+//! records `type` is `16` and `data` is the record text, usually wrapped in the
+//! surrounding double quotes that the DNS presentation format uses.
+
+use libp2p::Multiaddr;
+use serde::Deserialize;
+
+/// DNS resource-record type for TXT records.
+const DNS_TYPE_TXT: u16 = 16;
+
+/// A decoded DNS-over-HTTPS JSON response.
+///
+/// Only the `Answer` section is modelled; the status and question sections are
+/// not needed to extract dnsaddr records.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DnsJsonResponse {
+    /// Answer records, absent when the name has no matching records.
+    #[serde(default, rename = "Answer")]
+    pub answer: Vec<DnsJsonAnswer>,
+}
+
+/// A single answer record from a DNS-over-HTTPS response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DnsJsonAnswer {
+    /// Numeric DNS record type (16 for TXT).
+    #[serde(rename = "type")]
+    pub record_type: u16,
+    /// Record payload. For TXT records this is the text, normally double-quoted.
+    pub data: String,
+}
+
+/// Parse a DNS-over-HTTPS JSON body into its answer records.
+///
+/// # Errors
+///
+/// Returns the underlying `serde_json` error when the body is not the expected
+/// DNS-JSON object.
+pub fn parse_dns_json(body: &str) -> Result<DnsJsonResponse, serde_json::Error> {
+    serde_json::from_str(body)
+}
+
+/// Strip a single layer of surrounding ASCII double quotes from a TXT record.
+///
+/// DNS presentation format wraps TXT data in double quotes; some providers
+/// return them and some do not, so the strip is best-effort.
+fn unquote(data: &str) -> &str {
+    data.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(data)
+}
+
+/// Extract the multiaddr text from every `dnsaddr=<multiaddr>` TXT answer.
+///
+/// Non-TXT answers and TXT answers that do not start with the `dnsaddr=` prefix
+/// are skipped. The returned strings are the raw multiaddr text; parsing into a
+/// [`Multiaddr`] happens in the resolver so it can recurse on `/dnsaddr/` entries.
+pub fn extract_dnsaddr_values(response: &DnsJsonResponse) -> Vec<String> {
+    response
+        .answer
+        .iter()
+        .filter(|a| a.record_type == DNS_TYPE_TXT)
+        .filter_map(|a| {
+            unquote(a.data.trim())
+                .strip_prefix("dnsaddr=")
+                .map(|v| v.trim().to_string())
+        })
+        .collect()
+}
+
+/// Whether a multiaddr is a browser-dialable secure-WebSocket leaf.
+///
+/// A browser can only dial WebSocket transports, and the live network advertises
+/// its browser leaves as `/tls/.../ws` (secure WebSocket). Plain `/ws` without
+/// TLS and the bare `tcp/1634` siblings are not dialable from a browser, so they
+/// are filtered out. The leaf must also carry a `/p2p/` peer id to be dialable.
+#[must_use]
+pub fn is_browser_dialable_wss(addr: &Multiaddr) -> bool {
+    use libp2p::multiaddr::Protocol;
+
+    let mut has_plain_ws = false;
+    let mut has_wss = false;
+    let mut has_tls = false;
+    let mut has_p2p = false;
+
+    for protocol in addr.iter() {
+        match protocol {
+            Protocol::Ws(_) => has_plain_ws = true,
+            Protocol::Wss(_) => has_wss = true,
+            Protocol::Tls => has_tls = true,
+            Protocol::P2p(_) => has_p2p = true,
+            _ => {}
+        }
+    }
+
+    // `/wss` is TLS-implied; `/tls/.../ws` is the explicit form the network uses.
+    let secure_ws = has_wss || (has_plain_ws && has_tls);
+    secure_ws && has_p2p
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    use super::*;
+
+    /// A captured Cloudflare DNS-JSON response for the dnsaddr root, with the
+    /// double-quoted `data` field the provider returns.
+    const ROOT_RESPONSE: &str = r#"{
+        "Status": 0,
+        "Answer": [
+            {"name": "_dnsaddr.mainnet.ethswarm.org", "type": 16, "TTL": 300,
+             "data": "\"dnsaddr=/dnsaddr/apac.mainnet.ethswarm.org\""},
+            {"name": "_dnsaddr.mainnet.ethswarm.org", "type": 16, "TTL": 300,
+             "data": "\"dnsaddr=/dnsaddr/emea.mainnet.ethswarm.org\""}
+        ]
+    }"#;
+
+    /// A captured Google DNS-JSON leaf response with concrete multiaddrs: a
+    /// browser-dialable wss leaf and the plain tcp/1634 sibling to be filtered.
+    const LEAF_RESPONSE: &str = r#"{
+        "Status": 0,
+        "Answer": [
+            {"name": "_dnsaddr.city.mainnet.ethswarm.org", "type": 16,
+             "data": "dnsaddr=/ip4/5.78.94.214/tcp/1635/tls/sni/5-78-94-214.k2k4r8pobzefjwtmnob5hb4aw8idrmzh8epsvcjo007e79s2hf8073z3.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg"},
+            {"name": "_dnsaddr.city.mainnet.ethswarm.org", "type": 16,
+             "data": "dnsaddr=/ip4/5.78.94.214/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg"}
+        ]
+    }"#;
+
+    #[test]
+    fn parses_quoted_root_records() {
+        let parsed = parse_dns_json(ROOT_RESPONSE).expect("valid json");
+        let values = extract_dnsaddr_values(&parsed);
+        assert_eq!(
+            values,
+            vec![
+                "/dnsaddr/apac.mainnet.ethswarm.org",
+                "/dnsaddr/emea.mainnet.ethswarm.org",
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_unquoted_leaf_records() {
+        let parsed = parse_dns_json(LEAF_RESPONSE).expect("valid json");
+        let values = extract_dnsaddr_values(&parsed);
+        assert_eq!(values.len(), 2);
+        assert!(values[0].contains("/ws/p2p/"));
+        assert!(values[1].contains("/tcp/1634/p2p/"));
+    }
+
+    #[test]
+    fn empty_answer_yields_no_values() {
+        let parsed = parse_dns_json(r#"{"Status": 0}"#).expect("valid json");
+        assert!(extract_dnsaddr_values(&parsed).is_empty());
+    }
+
+    #[test]
+    fn non_txt_answers_are_skipped() {
+        let body = r#"{"Answer": [{"type": 1, "data": "5.78.94.214"}]}"#;
+        let parsed = parse_dns_json(body).expect("valid json");
+        assert!(extract_dnsaddr_values(&parsed).is_empty());
+    }
+
+    #[test]
+    fn malformed_json_errors() {
+        assert!(parse_dns_json("not json").is_err());
+    }
+
+    #[test]
+    fn wss_leaf_is_browser_dialable() {
+        let addr: Multiaddr = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg".parse().unwrap();
+        assert!(is_browser_dialable_wss(&addr));
+    }
+
+    #[test]
+    fn plain_tcp_leaf_is_not_dialable() {
+        let addr: Multiaddr =
+            "/ip4/5.78.94.214/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg"
+                .parse()
+                .unwrap();
+        assert!(!is_browser_dialable_wss(&addr));
+    }
+
+    #[test]
+    fn ws_without_tls_or_p2p_is_not_dialable() {
+        let plain_ws: Multiaddr = "/ip4/5.78.94.214/tcp/1635/ws".parse().unwrap();
+        assert!(!is_browser_dialable_wss(&plain_ws));
+    }
+}

--- a/crates/net/dnsaddr-doh/src/resolver.rs
+++ b/crates/net/dnsaddr-doh/src/resolver.rs
@@ -1,0 +1,311 @@
+//! The transport-agnostic dnsaddr recursion driver.
+//!
+//! The driver is generic over a [`TxtFetcher`], so the recursion, de-duplication,
+//! bounded depth, and wss-leaf filtering can be exercised natively against a
+//! fixture fetcher with no network access. The live browser path supplies a
+//! `fetch`-backed fetcher (see the crate root and `doh` module).
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+
+use libp2p::Multiaddr;
+use libp2p::multiaddr::Protocol;
+use tracing::{debug, warn};
+
+use crate::error::DohError;
+use crate::parse::{extract_dnsaddr_values, is_browser_dialable_wss, parse_dns_json};
+
+/// Default maximum dnsaddr recursion depth.
+///
+/// The live tree is root -> region -> city -> concrete leaf, which is three hops.
+/// Four bounds that with one hop of slack while still cutting off any
+/// CNAME-style loop quickly.
+pub const DEFAULT_MAX_DEPTH: u8 = 4;
+
+/// Fetches the TXT records for a `_dnsaddr.<name>` query as a raw DNS-JSON body.
+///
+/// The resolver only needs the JSON string back; parsing and recursion are owned
+/// by the driver. Implementors decide the transport: the browser path issues a
+/// DoH `fetch`, and tests return a captured fixture body.
+pub trait TxtFetcher {
+    /// Fetch the DNS-JSON body for a TXT query of `name`.
+    ///
+    /// `name` is the bare domain (for example `apac.mainnet.ethswarm.org`); the
+    /// implementor is responsible for prefixing `_dnsaddr.` and selecting the
+    /// query transport. The returned `String` is the JSON body to be parsed by
+    /// [`parse_dns_json`].
+    fn fetch_txt(&self, name: &str)
+    -> Pin<Box<dyn Future<Output = Result<String, DohError>> + '_>>;
+}
+
+/// Resolve `/dnsaddr/<name>` to its browser-dialable wss leaves via a fetcher.
+///
+/// Recurses through nested `/dnsaddr/` entries up to `max_depth`, de-duplicates
+/// visited names and produced leaves, and keeps only the secure-WebSocket leaves
+/// a browser can dial (see [`is_browser_dialable_wss`]). A fetch or parse failure
+/// at any node is logged and treated as an empty branch rather than aborting the
+/// whole resolution, so one unreachable region does not sink the others.
+///
+/// Returns the collected wss leaves, which may be empty when nothing resolved.
+pub async fn resolve_dnsaddr<F: TxtFetcher>(
+    fetcher: &F,
+    name: &str,
+    max_depth: u8,
+) -> Vec<Multiaddr> {
+    let mut seen_names = HashSet::new();
+    let mut leaves = Vec::new();
+    let mut seen_leaves = HashSet::new();
+
+    resolve_into(
+        fetcher,
+        name.to_string(),
+        0,
+        max_depth,
+        &mut seen_names,
+        &mut leaves,
+        &mut seen_leaves,
+    )
+    .await;
+
+    leaves
+}
+
+/// Recursive worker: boxed because the recursion makes the future self-referential.
+fn resolve_into<'a, F: TxtFetcher>(
+    fetcher: &'a F,
+    name: String,
+    depth: u8,
+    max_depth: u8,
+    seen_names: &'a mut HashSet<String>,
+    leaves: &'a mut Vec<Multiaddr>,
+    seen_leaves: &'a mut HashSet<String>,
+) -> Pin<Box<dyn Future<Output = ()> + 'a>> {
+    Box::pin(async move {
+        if depth > max_depth {
+            warn!(%name, depth, "dnsaddr recursion depth exceeded, stopping branch");
+            return;
+        }
+        if !seen_names.insert(name.clone()) {
+            debug!(%name, "skipping already-seen dnsaddr name");
+            return;
+        }
+
+        let body = match fetcher.fetch_txt(&name).await {
+            Ok(body) => body,
+            Err(e) => {
+                warn!(%name, error = %e, "dnsaddr DoH fetch failed for branch");
+                return;
+            }
+        };
+
+        let response = match parse_dns_json(&body) {
+            Ok(response) => response,
+            Err(e) => {
+                warn!(%name, error = %e, "dnsaddr DoH response parse failed for branch");
+                return;
+            }
+        };
+
+        for value in extract_dnsaddr_values(&response) {
+            let addr: Multiaddr = match value.parse() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    warn!(%value, error = %e, "failed to parse dnsaddr multiaddr");
+                    continue;
+                }
+            };
+
+            if let Some(nested) = nested_dnsaddr_name(&addr) {
+                resolve_into(
+                    fetcher,
+                    nested,
+                    depth + 1,
+                    max_depth,
+                    seen_names,
+                    leaves,
+                    seen_leaves,
+                )
+                .await;
+            } else if is_browser_dialable_wss(&addr) && seen_leaves.insert(addr.to_string()) {
+                leaves.push(addr);
+            }
+        }
+    })
+}
+
+/// Extract the domain from the first `/dnsaddr/<domain>` component, if any.
+fn nested_dnsaddr_name(addr: &Multiaddr) -> Option<String> {
+    addr.iter().find_map(|p| match p {
+        Protocol::Dnsaddr(domain) => Some(domain.to_string()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    use std::collections::HashMap;
+
+    use futures::executor::block_on;
+
+    use super::*;
+
+    /// A fixture fetcher backed by a name -> JSON-body map. Missing names return
+    /// an error, mirroring an NXDOMAIN or network failure.
+    struct FixtureFetcher {
+        bodies: HashMap<String, String>,
+    }
+
+    impl TxtFetcher for FixtureFetcher {
+        fn fetch_txt(
+            &self,
+            name: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, DohError>> + '_>> {
+            let result = self
+                .bodies
+                .get(name)
+                .cloned()
+                .ok_or(DohError::EmptyResolution);
+            Box::pin(async move { result })
+        }
+    }
+
+    fn leaf_body(wss: &str, tcp: &str) -> String {
+        format!(
+            r#"{{"Answer": [
+                {{"type": 16, "data": "dnsaddr={wss}"}},
+                {{"type": 16, "data": "dnsaddr={tcp}"}}
+            ]}}"#
+        )
+    }
+
+    fn region_body(city: &str) -> String {
+        format!(r#"{{"Answer": [{{"type": 16, "data": "dnsaddr=/dnsaddr/{city}"}}]}}"#)
+    }
+
+    #[test]
+    fn resolves_full_tree_to_wss_leaves() {
+        let wss = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+        let tcp = "/ip4/5.78.94.214/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+
+        let mut bodies = HashMap::new();
+        bodies.insert(
+            "mainnet.ethswarm.org".to_string(),
+            region_body("apac.mainnet.ethswarm.org"),
+        );
+        bodies.insert(
+            "apac.mainnet.ethswarm.org".to_string(),
+            region_body("tokyo.mainnet.ethswarm.org"),
+        );
+        bodies.insert(
+            "tokyo.mainnet.ethswarm.org".to_string(),
+            leaf_body(wss, tcp),
+        );
+
+        let fetcher = FixtureFetcher { bodies };
+        let leaves = block_on(resolve_dnsaddr(
+            &fetcher,
+            "mainnet.ethswarm.org",
+            DEFAULT_MAX_DEPTH,
+        ));
+
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].to_string(), wss);
+    }
+
+    #[test]
+    fn deduplicates_repeated_leaves() {
+        let wss = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+        let tcp = "/ip4/5.78.94.214/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+
+        // Two regions both pointing at the same city, which has one wss leaf.
+        let mut bodies = HashMap::new();
+        bodies.insert(
+            "mainnet.ethswarm.org".to_string(),
+            r#"{"Answer": [
+                {"type": 16, "data": "dnsaddr=/dnsaddr/apac.mainnet.ethswarm.org"},
+                {"type": 16, "data": "dnsaddr=/dnsaddr/emea.mainnet.ethswarm.org"}
+            ]}"#
+            .to_string(),
+        );
+        bodies.insert(
+            "apac.mainnet.ethswarm.org".to_string(),
+            region_body("tokyo.mainnet.ethswarm.org"),
+        );
+        bodies.insert(
+            "emea.mainnet.ethswarm.org".to_string(),
+            region_body("tokyo.mainnet.ethswarm.org"),
+        );
+        bodies.insert(
+            "tokyo.mainnet.ethswarm.org".to_string(),
+            leaf_body(wss, tcp),
+        );
+
+        let fetcher = FixtureFetcher { bodies };
+        let leaves = block_on(resolve_dnsaddr(
+            &fetcher,
+            "mainnet.ethswarm.org",
+            DEFAULT_MAX_DEPTH,
+        ));
+
+        assert_eq!(leaves.len(), 1, "duplicate leaves should collapse");
+    }
+
+    #[test]
+    fn depth_bound_stops_runaway_recursion() {
+        // A self-referential name would loop forever without the seen-set; the
+        // depth bound is the secondary guard. Point a name at itself.
+        let mut bodies = HashMap::new();
+        bodies.insert(
+            "loop.ethswarm.org".to_string(),
+            region_body("loop.ethswarm.org"),
+        );
+        let fetcher = FixtureFetcher { bodies };
+        let leaves = block_on(resolve_dnsaddr(&fetcher, "loop.ethswarm.org", 2));
+        assert!(leaves.is_empty());
+    }
+
+    #[test]
+    fn missing_branch_does_not_sink_siblings() {
+        let wss = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+        let tcp = "/ip4/5.78.94.214/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg";
+
+        // apac resolves, emea is missing (fetch error). The wss leaf still lands.
+        let mut bodies = HashMap::new();
+        bodies.insert(
+            "mainnet.ethswarm.org".to_string(),
+            r#"{"Answer": [
+                {"type": 16, "data": "dnsaddr=/dnsaddr/apac.mainnet.ethswarm.org"},
+                {"type": 16, "data": "dnsaddr=/dnsaddr/emea.mainnet.ethswarm.org"}
+            ]}"#
+            .to_string(),
+        );
+        bodies.insert("apac.mainnet.ethswarm.org".to_string(), leaf_body(wss, tcp));
+
+        let fetcher = FixtureFetcher { bodies };
+        let leaves = block_on(resolve_dnsaddr(
+            &fetcher,
+            "mainnet.ethswarm.org",
+            DEFAULT_MAX_DEPTH,
+        ));
+
+        assert_eq!(leaves.len(), 1);
+    }
+
+    #[test]
+    fn empty_response_yields_no_leaves() {
+        let mut bodies = HashMap::new();
+        bodies.insert(
+            "mainnet.ethswarm.org".to_string(),
+            r#"{"Status": 0}"#.to_string(),
+        );
+        let fetcher = FixtureFetcher { bodies };
+        let leaves = block_on(resolve_dnsaddr(
+            &fetcher,
+            "mainnet.ethswarm.org",
+            DEFAULT_MAX_DEPTH,
+        ));
+        assert!(leaves.is_empty());
+    }
+}


### PR DESCRIPTION
Browsers cannot perform raw DNS TXT lookups, so the `/dnsaddr/mainnet.ethswarm.org` indirection the live network relies on cannot be resolved the way the native `vertex-net-dnsaddr` resolver does. This adds `vertex-net-dnsaddr-doh`, a wasm-cone crate that restores that indirection over DNS-over-HTTPS.

## Design

The DoH path is the primary, live source of mainnet bootnodes in the browser. A `fetch` to a DoH endpoint with `accept: application/dns-json` returns the TXT records, the resolver recurses through the nested `/dnsaddr/` entries (bounded depth, de-duplicated), and the browser-dialable secure-WebSocket (`/tls/.../ws`) leaves fall out. The plain `tcp/1634` siblings and any leaf without a `/p2p/` peer id are filtered.

The embedded snapshot in `vertex-swarm-spec` (`mainnet_wss_bootnodes`, from #255) is the fallback used whenever DoH fails: network error, CORS rejection, parse failure, or an empty result. To keep this net-layer crate free of `crates/swarm/` types, `resolve_or_fallback` takes a caller-supplied snapshot slice rather than depending on the spec; the bootnode-selection site (which already holds the network spec) passes `vertex_swarm_spec::mainnet_wss_bootnodes()`.

## Configurable endpoint

`DohClient` targets a configurable endpoint, defaulting to Cloudflare (`https://cloudflare-dns.com/dns-query`) with Google (`https://dns.google/resolve`) as a built-in alternate, or any `application/dns-json` resolver via `DohClient::new`. A DoH resolver sees every query the browser sends it, so the chosen provider learns that this client is resolving the Swarm bootnode names. That privacy tradeoff is documented in the rustdoc and is acceptable for a demo, mitigated by the configurable endpoint.

## Testing

The recursion driver is generic over a `TxtFetcher`, so the DNS-JSON parsing, bounded-depth recursion, de-duplication, and wss-leaf filtering are unit-tested natively against captured fixture responses with no live network. Tests cover quoted and unquoted TXT records, full-tree resolution, leaf de-duplication, depth bounding, one branch failing without sinking its siblings, and the snapshot fallback on empty resolution.

The `fetch`-backed `DohClient` and the live `resolve_mainnet_wss_bootnodes` entrypoint are `cfg(target_arch = "wasm32")`; native clients keep using `vertex-net-dnsaddr` over the system resolver and never link this crate. The crate is added to the wasm CI job so it stays wasm-clean.

Part of #252