### PR TITLE
feat(swarm-demo): browser wasm client with live topology monitoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,17 @@ members = [
     # "crates/manifest",
 ]
 
+# Wasm-only crates that must never enter the native default workspace build.
+# `bin/swarm-demo` is a browser `cdylib` that depends on the wasm-only client
+# launch path and never compiles for native, so it is excluded here and built
+# with the Trunk pipeline documented in its README. The legacy `bin/wasm-*` bins
+# are stale and excluded for the same reason pending their phase-4 removal.
+exclude = [
+    "bin/swarm-demo",
+    "bin/swarm-wasm-lib",
+    "bin/wasm-playground",
+]
+
 # Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
@@ -311,6 +322,14 @@ wasm-bindgen-futures = "0.4"
 ## wasm browser HTTP (fetch) and test harness
 gloo-net = { version = "0.6", default-features = false, features = ["http"] }
 wasm-bindgen-test = "0.3"
+
+## wasm-bindgen surface and browser bindings (the swarm-demo app)
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+web-sys = "0.3"
+gloo-timers = { version = "0.3", features = ["futures"] }
+console_error_panic_hook = "0.1"
+tracing-wasm = "0.2"
 
 ## atomics
 portable-atomic = { version = "1", features = ["float", "serde"] }

--- a/bin/swarm-demo/.gitignore
+++ b/bin/swarm-demo/.gitignore
@@ -1,0 +1,7 @@
+# Trunk build output.
+/dist
+# Cargo build output (this standalone wasm crate may build into its own target).
+/target
+# Resolved lockfile: the demo pins its deps through the workspace crates it
+# depends on, so the standalone lock is a build artifact, not a committed input.
+/Cargo.lock

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -1,0 +1,67 @@
+# Browser wasm demo: an ephemeral Swarm client node that dials live mainnet over
+# secure websockets and renders its Kademlia topology building up.
+#
+# This crate is wasm-only (`cdylib`) and is intentionally NOT a member of the
+# workspace `[workspace] members`: it depends on the wasm-only client launch
+# path and never builds for native, so adding it to the default workspace would
+# break `cargo build` on native CI. Build it with the documented `trunk build`
+# pipeline (see README.md) against the wasm32-unknown-unknown target.
+[package]
+name = "swarm-demo"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+# Standalone wasm-only crate: an empty workspace table keeps it out of the parent
+# native workspace so `cargo build` at the repo root never tries to compile it
+# for native. Build it with the Trunk pipeline in README.md.
+[workspace]
+
+[lints.rust]
+# The demo is exercised only on wasm32; flag any code that would not run there.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_arch, values("wasm32"))'] }
+
+[dependencies]
+# The wasm client launch path and topology monitoring surface.
+vertex-swarm-node = { path = "../../crates/swarm/node" }
+vertex-swarm-api = { path = "../../crates/swarm/api" }
+vertex-swarm-identity = { path = "../../crates/swarm/identity" }
+vertex-swarm-spec = { path = "../../crates/swarm/spec" }
+vertex-swarm-topology = { path = "../../crates/swarm/topology" }
+vertex-swarm-primitives = { path = "../../crates/swarm/primitives" }
+vertex-net-dnsaddr-doh = { path = "../../crates/net/dnsaddr-doh" }
+
+# libp2p Multiaddr only; the trimmed wasm feature set mirrors the node crate.
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798", default-features = false }
+
+# wasm-bindgen surface and browser bindings.
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = [
+    "Document",
+    "Window",
+    "Element",
+    "HtmlElement",
+    "Node",
+    "Text",
+] }
+gloo-timers = { version = "0.3", features = ["futures"] }
+console_error_panic_hook = "0.1"
+tracing = "0.1"
+tracing-wasm = "0.2"
+
+# The topology event stream is a tokio broadcast channel; only the sync feature
+# is needed in the browser (no runtime, no net).
+tokio = { version = "1", default-features = false, features = ["sync"] }
+
+# libp2p (and the alloy nonce path) pull getrandom 0.3 transitively; on wasm32
+# its browser backend needs the `wasm_js` feature. The matching
+# `getrandom_backend="wasm_js"` cfg is set in .cargo/config.toml. This is a
+# transitive build requirement, not a direct API use.
+getrandom_03 = { package = "getrandom", version = "0.3", default-features = false, features = ["wasm_js"] }

--- a/bin/swarm-demo/README.md
+++ b/bin/swarm-demo/README.md
@@ -1,0 +1,65 @@
+# swarm-demo
+
+A browser WebAssembly app that runs a real Vertex Swarm client node. It mints an ephemeral identity, resolves the live mainnet bootnodes over DNS-over-HTTPS (with an embedded snapshot fallback), dials them over secure WebSockets, and renders the Kademlia topology building up: connected peer count, neighborhood depth, per-bin fill, the topology phase, and a scrolling log of topology events.
+
+This crate is wasm-only (`crate-type = ["cdylib"]`) and is intentionally **not** a member of the workspace `[workspace] members`. It depends on the wasm-only client launch path (`vertex_swarm_node::launch_client`) and never builds for native, so adding it to the default workspace would break native `cargo build`. Build it with the wasm toolchain and Trunk as below.
+
+## How it is wired
+
+The native node builder (`vertex-swarm-builder`) pulls the redb database, the chain provider, the SWAP settlement service, and the gRPC server, none of which build for `wasm32`. So the demo does not use it. Instead it calls a narrow, wasm-buildable launch entrypoint added to `vertex-swarm-node`:
+
+- `vertex_swarm_node::launch_client(identity, bootnodes)` composes a `ClientNode` (connection-limits + identify + topology + client protocols) over the browser WebSocket transport, spawns the node run loop and the peer-manager tick on the wasm executor, and returns the `TopologyHandle`.
+- The node run loop owns a `!Send` libp2p swarm (the websocket transport futures are `!Send`), so it is spawned through `TaskExecutor::spawn_local_with_graceful_shutdown_signal`, a wasm-only sibling of the Send-bounded spawner that routes through `wasm_bindgen_futures::spawn_local`.
+
+The wasm-bindgen surface in `src/lib.rs` is small: a `#[wasm_bindgen(start)]` `main` that calls the exported async `start`, plus a `SwarmDemo` handle exposing `readiness()` (a JS snapshot object) and `drainEvents()` (the buffered topology events). The UI in `src/ui.rs` renders into the document via `web-sys`, updated on a one-second poll loop.
+
+## Build
+
+The build needs a nightly toolchain (the `+atomics` target feature pulled in transitively by `nectar-primitives` is unstable), the `wasm32-unknown-unknown` target with `rust-src`, Trunk, and `wasm-bindgen-cli`. The required rustflags (`+atomics,+bulk-memory,+mutable-globals` and `getrandom_backend="wasm_js"`) live in the workspace `.cargo/config.toml` under `[target.wasm32-unknown-unknown]` and Trunk passes them through.
+
+On the project's Nix host, the whole toolchain is available through a one-off shell:
+
+```sh
+nix-shell -E '
+  let
+    rustOverlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
+    pkgs = import <nixpkgs> { overlays = [ rustOverlay ]; };
+    toolchain = pkgs.rust-bin.nightly.latest.default.override {
+      extensions = [ "rust-src" ];
+      targets = [ "wasm32-unknown-unknown" ];
+    };
+  in pkgs.mkShell {
+    buildInputs = [ toolchain pkgs.trunk pkgs.wasm-bindgen-cli pkgs.binaryen pkgs.protobuf pkgs.pkg-config pkgs.openssl ];
+  }
+'
+```
+
+Then, from this directory:
+
+```sh
+RUSTUP_TOOLCHAIN=nightly trunk build --release
+```
+
+This produces `dist/` with the wasm module, the wasm-bindgen JS glue, `index.html`, `styles.css`, and the copied `coi-serviceworker.js`.
+
+Prebuilt `wasm32-unknown-unknown` std is used (no `-Z build-std`). If your toolchain lacks prebuilt wasm std, add `rust-std` for the target; do not switch on `-Z build-std`, which rebuilds std and drags in native-only crates that do not compile for wasm.
+
+## Serve locally
+
+```sh
+RUSTUP_TOOLCHAIN=nightly trunk serve --release
+```
+
+Then open http://127.0.0.1:8080. `trunk serve` sends the `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers (see `Trunk.toml`), so the page is cross-origin isolated and SharedArrayBuffer is available.
+
+## Cross-origin isolation on GitHub Pages
+
+GitHub Pages cannot set response headers, so the vendored `coi-serviceworker.js` (referenced from `index.html` and copied into `dist/`) registers a service worker that re-serves every response with the COOP/COEP headers, making the page cross-origin isolated client-side. Locally it is a harmless no-op since Trunk already sets the headers. Wiring the Pages deploy is a later phase; this crate just ships the shim and the reference.
+
+## A note on the live connection and threaded wasm
+
+A live mainnet connection needs a real browser and network reachability to the bootnodes. The CI-able proof for this crate is the clean `trunk build` plus the wasm client-construction code compiling for `wasm32`. The live connect is verified by loading the deployed page in a browser, where peers appear over the first tens of seconds and the bins fill in.
+
+What a headless browser smoke confirmed against this build: the wasm module boots, the UI panel mounts, an ephemeral overlay address is minted, and the app reaches the bootnode-resolution step. The page is cross-origin isolated and `SharedArrayBuffer` is available.
+
+There is one open item for the fully-live in-browser run. `nectar-primitives` compiles its parallel BMT hashing on a `wasm-bindgen-rayon` Web Worker thread pool, so the module is built with `+atomics` and uses `Atomics.wait`/`waitAsync` on shared memory. Driving that to completion needs the module linked with shared, importable memory (`--shared-memory`/`--import-memory`/`--max-memory`/`--export=__heap_base` plus the TLS exports), `-Z build-std`, and a `wasm-bindgen-rayon` `initThreadPool(...)` call wired into the bootstrap before the client runs. That linker recipe builds cleanly and `wasm-bindgen` emits the worker glue, but the worker-module URL the rayon bootstrap requests did not resolve under the local static server used for the smoke, so the worker pool did not come up there. Resolving the worker-URL wiring is folded into the phase-4 GitHub Pages deploy, where the served paths are stable; this crate ships the non-threaded boot that renders the UI, and the build pipeline plus the COOP/COEP and `coi-serviceworker.js` isolation are in place for it.

--- a/bin/swarm-demo/Trunk.toml
+++ b/bin/swarm-demo/Trunk.toml
@@ -1,0 +1,25 @@
+# Trunk build/serve config for the browser Swarm client demo.
+#
+# Build (see README.md for the full toolchain setup):
+#
+#   RUSTUP_TOOLCHAIN=nightly trunk build --release
+#
+# The wasm cone is compiled with the `+atomics,+bulk-memory,+mutable-globals`
+# target features and the `getrandom_backend="wasm_js"` cfg from the workspace
+# `.cargo/config.toml` `[target.wasm32-unknown-unknown]` table, which Trunk
+# passes through to `cargo`. The atomics feature is unstable, so a nightly
+# toolchain is required.
+
+[build]
+target = "index.html"
+# Emit the wasm-bindgen glue as ES modules so the `#[wasm_bindgen(start)]`
+# entrypoint auto-runs on load.
+dist = "dist"
+
+[serve]
+address = "127.0.0.1"
+port = 8080
+# Cross-origin isolation for SharedArrayBuffer (the `+atomics` build needs it).
+# On GitHub Pages these headers cannot be set, so `coi-serviceworker.js` injects
+# the same isolation client-side; locally Trunk sets them directly.
+headers = { "Cross-Origin-Opener-Policy" = "same-origin", "Cross-Origin-Embedder-Policy" = "require-corp" }

--- a/bin/swarm-demo/coi-serviceworker.js
+++ b/bin/swarm-demo/coi-serviceworker.js
@@ -1,0 +1,140 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+// Vendored verbatim. Registers a service worker that re-serves every response
+// with the COOP `same-origin` and COEP `require-corp` headers, so a page hosted
+// where response headers cannot be set (GitHub Pages) still becomes
+// cross-origin isolated and can use SharedArrayBuffer. The `+atomics` wasm build
+// needs that isolation. Locally, `trunk serve` sets the headers directly and
+// this shim is a harmless no-op.
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then((clients) => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+        const controlling = n.serviceWorker && n.serviceWorker.controller;
+
+        // Record the failure if the page is served by serviceWorker.
+        if (controlling && !window.crossOriginIsolated) {
+            window.sessionStorage.setItem("coiCoepHasFailed", "true");
+        }
+        const coepHasFailed = window.sessionStorage.getItem("coiCoepHasFailed");
+
+        if (controlling) {
+            // Reload only on the first failure.
+            const reloadToDegrade = coi.coepDegrade() && !(
+                coepDegrading || window.crossOriginIsolated
+            );
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: (reloadToDegrade || coepHasFailed && coi.coepDegrade())
+                    ? false
+                    : coi.coepCredentialless(),
+            });
+            if (reloadToDegrade) {
+                !coi.quiet && console.log("Reloading page to degrade COEP.");
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload("coepdegrade");
+            }
+        } else if (coi.shouldRegister()) {
+            // Get the path of this script to register the service worker at the same scope.
+            if (window.crossOriginIsolated !== false || !coi.shouldRegister()) {
+                // Already isolated, nothing to do.
+            } else if (!window.isSecureContext) {
+                !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            } else if (n.serviceWorker) {
+                n.serviceWorker.register(window.document.currentScript.src).then(
+                    (registration) => {
+                        !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                        registration.addEventListener("updatefound", () => {
+                            !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                            window.sessionStorage.setItem("coiReloadedBySelf", "updatefound");
+                            coi.doReload();
+                        });
+
+                        // If the registration is active, but it's not controlling the page
+                        if (registration.active && !n.serviceWorker.controller) {
+                            !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                            window.sessionStorage.setItem("coiReloadedBySelf", "notcontrolling");
+                            coi.doReload();
+                        }
+                    },
+                    (err) => {
+                        !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+                    }
+                );
+            }
+        }
+    })();
+}

--- a/bin/swarm-demo/index.html
+++ b/bin/swarm-demo/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vertex Swarm browser client</title>
+
+    <!--
+      Cross-origin isolation shim for GitHub Pages.
+
+      The wasm build is compiled with the `+atomics` target feature, so the
+      module needs SharedArrayBuffer, which the browser only grants on a
+      cross-origin-isolated page (COOP `same-origin` + COEP `require-corp`).
+      `trunk serve` sets those headers locally (see Trunk.toml). On GitHub Pages
+      response headers cannot be set, so this service worker injects them on the
+      client. It must load before the wasm bootstrap, so it is referenced here as
+      a plain unbundled script and copied verbatim into `dist/`.
+    -->
+    <script src="coi-serviceworker.js"></script>
+
+    <link data-trunk rel="rust" data-type="main" />
+    <link data-trunk rel="copy-file" href="coi-serviceworker.js" />
+    <link data-trunk rel="css" href="styles.css" />
+  </head>
+  <body>
+    <noscript>This demo needs JavaScript and WebAssembly.</noscript>
+  </body>
+</html>

--- a/bin/swarm-demo/src/lib.rs
+++ b/bin/swarm-demo/src/lib.rs
@@ -1,0 +1,386 @@
+//! Browser Swarm client demo.
+//!
+//! This wasm-bindgen app mints an ephemeral Swarm client identity, resolves the
+//! live mainnet bootnodes over DNS-over-HTTPS (falling back to an embedded
+//! snapshot), starts a browser client node over secure websockets, and renders
+//! its Kademlia topology building up: connected peer count, neighborhood depth,
+//! per-bin fill, the topology phase, and a scrolling log of topology events.
+//!
+//! The exported surface is small and JS-facing:
+//!
+//! - [`start`] is the entrypoint: it installs the panic hook and console
+//!   tracing, builds the client, and returns a [`SwarmDemo`] handle.
+//! - [`SwarmDemo::readiness`] returns a plain JS object with the current
+//!   readiness snapshot fields, polled by the UI on an interval.
+//! - [`SwarmDemo::drain_events`] returns the topology events seen since the last
+//!   call as an array of JS objects, so the UI can append them to its log.
+//!
+//! The UI itself is driven from this module via `web-sys` so the app is a single
+//! wasm artifact with a minimal HTML shell.
+
+mod ui;
+
+use std::collections::VecDeque;
+
+use tracing::info;
+use vertex_net_dnsaddr_doh::{DohClient, resolve_mainnet_wss_bootnodes};
+use vertex_swarm_api::SwarmIdentity;
+use vertex_swarm_identity::Identity;
+use vertex_swarm_node::{SwarmNodeType, launch_client};
+use vertex_swarm_spec::{init_mainnet, mainnet_wss_bootnodes};
+use vertex_swarm_topology::{TopologyEvent, TopologyHandle};
+use wasm_bindgen::prelude::*;
+
+/// Maximum topology events buffered between UI drains.
+///
+/// The UI drains on a one-second interval; a burst beyond this drops the oldest
+/// events, which only affects the scrolling log, never the live counters (those
+/// come from [`SwarmDemo::readiness`]).
+const EVENT_BUFFER_CAP: usize = 256;
+
+/// A running browser Swarm client, exposed to JS.
+///
+/// Holds the [`TopologyHandle`] for the live node plus a rolling buffer of
+/// recent [`TopologyEvent`]s. The node tasks run on the browser event loop; this
+/// handle is the read surface the UI polls.
+#[wasm_bindgen]
+pub struct SwarmDemo {
+    topology: TopologyHandle<Identity>,
+    events: std::rc::Rc<std::cell::RefCell<VecDeque<TopologyEvent>>>,
+    overlay: String,
+}
+
+#[wasm_bindgen]
+impl SwarmDemo {
+    /// The node's ephemeral overlay address as a hex string.
+    #[wasm_bindgen(getter)]
+    pub fn overlay(&self) -> String {
+        self.overlay.clone()
+    }
+
+    /// Snapshot the current readiness state as a plain JS object.
+    ///
+    /// Fields: `connectedPeers`, `connectedStorers`, `depth`,
+    /// `neighborhoodConnected`, `saturationThreshold`, `binsAtTarget`, `phase`
+    /// (a string), `isRoutable`, `isSaturated`, and `bins` (an array of
+    /// `{ bin, connected, target, deficit }`, where `target` is `null` for
+    /// neighborhood bins).
+    #[wasm_bindgen]
+    pub fn readiness(&self) -> JsValue {
+        let snap = self.topology.readiness();
+        let obj = js_sys::Object::new();
+        set_u32(&obj, "connectedPeers", snap.connected_peers as u32);
+        set_u32(&obj, "connectedStorers", snap.connected_storers as u32);
+        set_u32(&obj, "depth", u32::from(snap.depth.get()));
+        set_u32(
+            &obj,
+            "neighborhoodConnected",
+            snap.neighborhood_connected as u32,
+        );
+        set_u32(
+            &obj,
+            "saturationThreshold",
+            snap.saturation_threshold as u32,
+        );
+        set_u32(&obj, "binsAtTarget", snap.bins_at_target as u32);
+        set_str(&obj, "phase", snap.phase.into());
+        set_bool(&obj, "isRoutable", snap.is_routable());
+        set_bool(&obj, "isSaturated", snap.is_saturated());
+
+        let bins = js_sys::Array::new();
+        for bin in &snap.bins {
+            let entry = js_sys::Object::new();
+            set_u32(&entry, "bin", u32::from(bin.bin.get()));
+            set_u32(&entry, "connected", bin.connected as u32);
+            match bin.target {
+                Some(t) => set_u32(&entry, "target", t as u32),
+                None => set_null(&entry, "target"),
+            }
+            set_u32(&entry, "deficit", bin.deficit as u32);
+            bins.push(&entry);
+        }
+        set_value(&obj, "bins", &bins);
+
+        obj.into()
+    }
+
+    /// Drain the topology events seen since the last call.
+    ///
+    /// Returns a JS array of `{ kind, detail }` objects, oldest first, and
+    /// clears the buffer. `kind` is a short event label; `detail` is a
+    /// human-readable summary.
+    #[wasm_bindgen(js_name = drainEvents)]
+    pub fn drain_events(&self) -> js_sys::Array {
+        let out = js_sys::Array::new();
+        let mut buf = self.events.borrow_mut();
+        for event in buf.drain(..) {
+            let obj = js_sys::Object::new();
+            let (kind, detail) = describe_event(&event);
+            set_str(&obj, "kind", kind);
+            set_str(&obj, "detail", &detail);
+            out.push(&obj);
+        }
+        out
+    }
+}
+
+/// wasm entrypoint: start the client and keep the handle alive for the session.
+///
+/// Trunk's bootstrap calls this exported `main` automatically. It spawns
+/// [`start`] on the browser event loop and leaks the returned [`SwarmDemo`] so
+/// the node tasks keep running; the page session owns it for its lifetime.
+#[wasm_bindgen(start)]
+pub fn main() {
+    wasm_bindgen_futures::spawn_local(async {
+        match start().await {
+            Ok(demo) => {
+                // Keep the client alive for the page session.
+                std::mem::forget(demo);
+            }
+            Err(e) => {
+                tracing::error!(?e, "failed to start Swarm client demo");
+                ui::set_status("failed to start, see console");
+            }
+        }
+    });
+}
+
+/// Start the browser Swarm client and mount the topology UI.
+///
+/// Installs the panic hook and console tracing, mints an ephemeral mainnet
+/// client identity, resolves the live mainnet bootnodes over DNS-over-HTTPS
+/// (with the embedded wss snapshot as fallback), starts the client node, mounts
+/// the UI into the document, and begins the one-second poll loop. Returns the
+/// [`SwarmDemo`] handle, which keeps the node alive for the page session.
+///
+/// # Errors
+///
+/// Returns a JS error if the client node fails to build or start. Bootnode
+/// resolution never fails: it always falls back to the embedded snapshot.
+#[wasm_bindgen]
+pub async fn start() -> Result<SwarmDemo, JsValue> {
+    console_error_panic_hook::set_once();
+    tracing_wasm::set_as_global_default();
+
+    info!("starting browser Swarm client demo");
+
+    let spec = init_mainnet();
+    let identity = Identity::random(spec, SwarmNodeType::Client);
+    let overlay = identity.overlay_address().to_string();
+
+    ui::mount(&overlay);
+    ui::set_status("resolving bootnodes...");
+
+    let bootnodes =
+        resolve_mainnet_wss_bootnodes(&DohClient::cloudflare(), mainnet_wss_bootnodes()).await;
+    info!(count = bootnodes.len(), "resolved bootnodes");
+    ui::set_status(&format!(
+        "dialing {} bootnodes over wss...",
+        bootnodes.len()
+    ));
+
+    let topology = launch_client(identity, bootnodes)
+        .await
+        .map_err(|e| JsValue::from_str(&format!("failed to launch client: {e}")))?;
+
+    let events = std::rc::Rc::new(std::cell::RefCell::new(VecDeque::with_capacity(
+        EVENT_BUFFER_CAP,
+    )));
+    spawn_event_pump(topology.clone(), events.clone());
+    spawn_render_loop(topology.clone());
+
+    ui::set_status("connecting...");
+
+    let demo = SwarmDemo {
+        topology,
+        events,
+        overlay,
+    };
+    Ok(demo)
+}
+
+/// Forward topology events from the broadcast subscription to both consumers.
+///
+/// Each event is appended to the scrolling DOM log (the live UI) and pushed onto
+/// the `events` buffer that the JS [`SwarmDemo::drain_events`] accessor reads, so
+/// the two consumers never compete for the same event. Runs on the browser event
+/// loop for the session. The subscription can lag under a burst; a lagged
+/// receiver skips ahead and keeps going rather than stalling, since the live
+/// counters come from `readiness`, not this stream.
+fn spawn_event_pump(
+    topology: TopologyHandle<Identity>,
+    events: std::rc::Rc<std::cell::RefCell<VecDeque<TopologyEvent>>>,
+) {
+    use tokio::sync::broadcast::error::RecvError;
+
+    wasm_bindgen_futures::spawn_local(async move {
+        let mut rx = topology.subscribe();
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let (kind, detail) = describe_event(&event);
+                    ui::append_event(kind, &escape_html(&detail));
+
+                    let mut buf = events.borrow_mut();
+                    if buf.len() >= EVENT_BUFFER_CAP {
+                        buf.pop_front();
+                    }
+                    buf.push_back(event);
+                }
+                Err(RecvError::Lagged(_)) => continue,
+                Err(RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
+/// Drive the topology UI on a one-second interval.
+///
+/// Each tick snapshots readiness into the stats grid and per-bin table. The
+/// scrolling event log is updated by the event pump as events arrive, not here.
+/// Runs on the browser event loop for the session.
+fn spawn_render_loop(topology: TopologyHandle<Identity>) {
+    use gloo_timers::future::TimeoutFuture;
+
+    wasm_bindgen_futures::spawn_local(async move {
+        loop {
+            render_once(&topology);
+            TimeoutFuture::new(1_000).await;
+        }
+    });
+}
+
+/// Render a single frame: the status line, stats grid, and per-bin table.
+fn render_once(topology: &TopologyHandle<Identity>) {
+    let snap = topology.readiness();
+
+    if snap.connected_peers == 0 {
+        ui::set_status("connecting...");
+    } else if snap.is_routable() {
+        ui::set_status("connected, building topology");
+    } else {
+        ui::set_status("connected to peers, awaiting a storer");
+    }
+
+    ui::render_stats(&ui::Stats {
+        connected_peers: snap.connected_peers as u32,
+        connected_storers: snap.connected_storers as u32,
+        depth: u32::from(snap.depth.get()),
+        neighborhood_connected: snap.neighborhood_connected as u32,
+        saturation_threshold: snap.saturation_threshold as u32,
+        bins_at_target: snap.bins_at_target as u32,
+        phase: snap.phase.into(),
+        is_routable: snap.is_routable(),
+        is_saturated: snap.is_saturated(),
+    });
+
+    let rows: Vec<(u32, u32, Option<u32>, u32)> = snap
+        .bins
+        .iter()
+        .map(|b| {
+            (
+                u32::from(b.bin.get()),
+                b.connected as u32,
+                b.target.map(|t| t as u32),
+                b.deficit as u32,
+            )
+        })
+        .collect();
+    ui::render_bins(&rows);
+}
+
+/// Escape the HTML-special characters in event detail text.
+///
+/// Event details embed peer-supplied data (overlay addresses, error strings), so
+/// they are escaped before going into `innerHTML`.
+fn escape_html(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// A short label and a human-readable summary for a topology event.
+fn describe_event(event: &TopologyEvent) -> (&'static str, String) {
+    match event {
+        TopologyEvent::PeerReady {
+            overlay, node_type, ..
+        } => (
+            "peer_ready",
+            format!("{node_type} {}", short_overlay(&overlay.to_string())),
+        ),
+        TopologyEvent::PeerRejected {
+            overlay, reason, ..
+        } => (
+            "peer_rejected",
+            format!("{} ({reason:?})", short_overlay(&overlay.to_string())),
+        ),
+        TopologyEvent::PeerDisconnected {
+            overlay, reason, ..
+        } => (
+            "peer_disconnected",
+            format!("{} ({reason:?})", short_overlay(&overlay.to_string())),
+        ),
+        TopologyEvent::DepthChanged {
+            old_depth,
+            new_depth,
+        } => ("depth_changed", format!("{old_depth} -> {new_depth}")),
+        TopologyEvent::PhaseChanged { from, to, depth } => {
+            ("phase_changed", format!("{from} -> {to} (depth {depth})"))
+        }
+        TopologyEvent::DialFailed { overlay, error, .. } => (
+            "dial_failed",
+            match overlay {
+                Some(o) => format!("{} ({error})", short_overlay(&o.to_string())),
+                None => format!("{error}"),
+            },
+        ),
+        TopologyEvent::PingCompleted { overlay, rtt } => (
+            "ping",
+            format!(
+                "{} {}ms",
+                short_overlay(&overlay.to_string()),
+                rtt.as_millis()
+            ),
+        ),
+    }
+}
+
+/// Abbreviate a hex overlay address to its first and last few characters.
+fn short_overlay(overlay: &str) -> String {
+    let trimmed = overlay.strip_prefix("0x").unwrap_or(overlay);
+    if trimmed.len() <= 12 {
+        return trimmed.to_string();
+    }
+    format!("{}..{}", &trimmed[..6], &trimmed[trimmed.len() - 4..])
+}
+
+fn set_u32(obj: &js_sys::Object, key: &str, value: u32) {
+    set_value(obj, key, &JsValue::from_f64(f64::from(value)));
+}
+
+fn set_bool(obj: &js_sys::Object, key: &str, value: bool) {
+    set_value(obj, key, &JsValue::from_bool(value));
+}
+
+fn set_str(obj: &js_sys::Object, key: &str, value: &str) {
+    set_value(obj, key, &JsValue::from_str(value));
+}
+
+fn set_null(obj: &js_sys::Object, key: &str) {
+    set_value(obj, key, &JsValue::NULL);
+}
+
+fn set_value(obj: &js_sys::Object, key: &str, value: &JsValue) {
+    // The key is a static identifier and the object is freshly constructed, so
+    // the reflect set cannot fail; ignore the result.
+    let _ = js_sys::Reflect::set(obj, &JsValue::from_str(key), value);
+}

--- a/bin/swarm-demo/src/ui.rs
+++ b/bin/swarm-demo/src/ui.rs
@@ -1,0 +1,164 @@
+//! Minimal DOM UI for the topology demo, driven through `web-sys`.
+//!
+//! [`mount`] builds the static panel once (header, status line, a stats grid, a
+//! per-bin table, and a scrolling event log). The render helpers
+//! ([`set_status`], [`render_stats`], [`render_bins`], [`append_event`]) update
+//! the live regions by id. Keeping the structure static and updating text and
+//! rows in place avoids rebuilding the tree on every one-second tick.
+
+use web_sys::{Document, Element};
+
+/// Element id of the status line.
+const STATUS_ID: &str = "status";
+/// Element id of the stats grid container.
+const STATS_ID: &str = "stats";
+/// Element id of the per-bin table body.
+const BINS_ID: &str = "bins";
+/// Element id of the scrolling event log container.
+const LOG_ID: &str = "log";
+/// Maximum log rows kept in the DOM before the oldest are trimmed.
+const MAX_LOG_ROWS: usize = 200;
+
+/// The document, or a panic: the app only runs in a browser with a document.
+fn document() -> Document {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .expect("browser document is available")
+}
+
+fn by_id(id: &str) -> Option<Element> {
+    document().get_element_by_id(id)
+}
+
+/// Build the static panel and mount it into the document body.
+///
+/// `overlay` is the node's ephemeral overlay address, shown in the header so the
+/// session identity is visible.
+pub fn mount(overlay: &str) {
+    let doc = document();
+    let body = doc.body().expect("document has a body");
+
+    let root = doc.create_element("div").expect("create div");
+    root.set_class_name("panel");
+    root.set_inner_html(&format!(
+        "<h1>Vertex Swarm browser client</h1>\
+         <p class=\"overlay\">overlay <code>{overlay}</code></p>\
+         <p id=\"{STATUS_ID}\" class=\"status\">starting...</p>\
+         <div id=\"{STATS_ID}\" class=\"stats\"></div>\
+         <h2>Bins</h2>\
+         <table class=\"bins\"><thead><tr>\
+           <th>bin</th><th>connected</th><th>target</th><th>deficit</th>\
+         </tr></thead><tbody id=\"{BINS_ID}\"></tbody></table>\
+         <h2>Events</h2>\
+         <div id=\"{LOG_ID}\" class=\"log\"></div>"
+    ));
+
+    body.append_child(&root).expect("append panel");
+}
+
+/// Update the status line text.
+pub fn set_status(text: &str) {
+    if let Some(el) = by_id(STATUS_ID) {
+        el.set_text_content(Some(text));
+    }
+}
+
+/// The headline topology counters rendered in the stats grid.
+pub struct Stats<'a> {
+    /// Total connected peers.
+    pub connected_peers: u32,
+    /// Connected peers whose handshake-confirmed type stores chunks.
+    pub connected_storers: u32,
+    /// Neighborhood depth.
+    pub depth: u32,
+    /// Connected peers in bins at or beyond the depth boundary.
+    pub neighborhood_connected: u32,
+    /// Per-bin saturation target the neighborhood aims for.
+    pub saturation_threshold: u32,
+    /// Bins with a finite target whose connected count meets it.
+    pub bins_at_target: u32,
+    /// Current topology phase label.
+    pub phase: &'a str,
+    /// Whether a push or retrieval has a storer to ask.
+    pub is_routable: bool,
+    /// Whether the neighborhood is saturated.
+    pub is_saturated: bool,
+}
+
+/// Render the headline counters: connected peers, storers, depth, phase, and
+/// the saturation and routability flags.
+pub fn render_stats(stats: &Stats) {
+    let Some(el) = by_id(STATS_ID) else {
+        return;
+    };
+    let routable = if stats.is_routable { "yes" } else { "no" };
+    let saturated = if stats.is_saturated { "yes" } else { "no" };
+    let Stats {
+        connected_peers,
+        connected_storers,
+        depth,
+        neighborhood_connected,
+        saturation_threshold,
+        bins_at_target,
+        phase,
+        ..
+    } = *stats;
+    el.set_inner_html(&format!(
+        "<div class=\"stat\"><span class=\"k\">peers</span><span class=\"v\">{connected_peers}</span></div>\
+         <div class=\"stat\"><span class=\"k\">storers</span><span class=\"v\">{connected_storers}</span></div>\
+         <div class=\"stat\"><span class=\"k\">depth</span><span class=\"v\">{depth}</span></div>\
+         <div class=\"stat\"><span class=\"k\">phase</span><span class=\"v\">{phase}</span></div>\
+         <div class=\"stat\"><span class=\"k\">neighborhood</span><span class=\"v\">{neighborhood_connected} / {saturation_threshold}</span></div>\
+         <div class=\"stat\"><span class=\"k\">bins at target</span><span class=\"v\">{bins_at_target}</span></div>\
+         <div class=\"stat\"><span class=\"k\">routable</span><span class=\"v\">{routable}</span></div>\
+         <div class=\"stat\"><span class=\"k\">saturated</span><span class=\"v\">{saturated}</span></div>"
+    ));
+}
+
+/// Replace the per-bin table body with the current per-bin fill.
+///
+/// `rows` is `(bin, connected, target, deficit)` where `target` is `None` for
+/// neighborhood bins, which connect to every available peer.
+pub fn render_bins(rows: &[(u32, u32, Option<u32>, u32)]) {
+    let Some(el) = by_id(BINS_ID) else {
+        return;
+    };
+    let mut html = String::new();
+    for (bin, connected, target, deficit) in rows {
+        let target_cell = match target {
+            Some(t) => t.to_string(),
+            None => "all".to_string(),
+        };
+        let filled = target.is_none() || *deficit == 0;
+        let class = if filled { "filled" } else { "" };
+        html.push_str(&format!(
+            "<tr class=\"{class}\"><td>{bin}</td><td>{connected}</td><td>{target_cell}</td><td>{deficit}</td></tr>"
+        ));
+    }
+    el.set_inner_html(&html);
+}
+
+/// Append one event row to the scrolling log, trimming the oldest rows.
+pub fn append_event(kind: &str, detail: &str) {
+    let Some(log) = by_id(LOG_ID) else {
+        return;
+    };
+    let doc = document();
+    let row = doc.create_element("div").expect("create row");
+    row.set_class_name(&format!("event {kind}"));
+    let row_el: &Element = &row;
+    row_el.set_inner_html(&format!(
+        "<span class=\"kind\">{kind}</span><span class=\"detail\">{detail}</span>"
+    ));
+    log.append_child(&row).expect("append event row");
+
+    while log.child_element_count() as usize > MAX_LOG_ROWS {
+        if let Some(first) = log.first_element_child() {
+            let _ = log.remove_child(&first);
+        } else {
+            break;
+        }
+    }
+
+    log.set_scroll_top(log.scroll_height());
+}

--- a/bin/swarm-demo/styles.css
+++ b/bin/swarm-demo/styles.css
@@ -1,0 +1,147 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f1115;
+  --panel: #171a21;
+  --line: #262b36;
+  --text: #d7dce4;
+  --muted: #8b93a1;
+  --accent: #4ea1ff;
+  --good: #51cf66;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.panel {
+  max-width: 860px;
+  margin: 2rem auto;
+  padding: 0 1.25rem;
+}
+
+h1 {
+  font-size: 1.3rem;
+  margin: 0 0 0.25rem;
+}
+
+h2 {
+  font-size: 1rem;
+  margin: 1.5rem 0 0.5rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.overlay {
+  margin: 0 0 0.5rem;
+  color: var(--muted);
+}
+
+.overlay code {
+  color: var(--accent);
+  word-break: break-all;
+}
+
+.status {
+  margin: 0.25rem 0 1rem;
+  padding: 0.4rem 0.7rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--accent);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
+}
+
+.stat {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0.7rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.stat .k {
+  color: var(--muted);
+}
+
+.stat .v {
+  font-weight: 600;
+}
+
+table.bins {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+table.bins th,
+table.bins td {
+  padding: 0.3rem 0.6rem;
+  text-align: right;
+  border-bottom: 1px solid var(--line);
+}
+
+table.bins th:first-child,
+table.bins td:first-child {
+  text-align: left;
+}
+
+table.bins th {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+table.bins tr.filled td {
+  color: var(--good);
+}
+
+.log {
+  height: 260px;
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+}
+
+.event {
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.1rem 0;
+  border-bottom: 1px solid transparent;
+}
+
+.event .kind {
+  flex: 0 0 9rem;
+  color: var(--muted);
+}
+
+.event.peer_ready .kind {
+  color: var(--good);
+}
+
+.event.dial_failed .kind,
+.event.peer_rejected .kind {
+  color: #ff8787;
+}
+
+.event .detail {
+  color: var(--text);
+  word-break: break-all;
+}

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -23,6 +23,8 @@ mod swarm_client;
 pub use node::{BaseNode, BuiltInfrastructure, ClientNode, ClientNodeBuilder, NodeBuildError};
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder, StorerNode, StorerNodeBuilder};
+#[cfg(target_arch = "wasm32")]
+pub use node::{WasmClientConfig, launch_client};
 
 pub use vertex_swarm_api::SwarmNodeType;
 

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -18,8 +18,10 @@ use tracing::{debug, info, trace, warn};
 use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
 use vertex_swarm_net_identify as identify;
 #[cfg(not(target_arch = "wasm32"))]
+use vertex_swarm_topology::TopologyBehaviour;
+#[cfg(not(target_arch = "wasm32"))]
 use vertex_swarm_topology::TopologyCommand;
-use vertex_swarm_topology::{TopologyBehaviour, TopologyHandle};
+use vertex_swarm_topology::TopologyHandle;
 
 /// Optional NAT-traversal behaviours shared by every native node type.
 ///

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -21,6 +21,8 @@ pub(crate) mod stats;
 #[cfg(not(target_arch = "wasm32"))]
 mod storer;
 pub(crate) mod task;
+#[cfg(target_arch = "wasm32")]
+mod wasm_client;
 
 pub use base::BaseNode;
 #[cfg(not(target_arch = "wasm32"))]
@@ -30,3 +32,5 @@ pub use client::{ClientNode, ClientNodeBuilder};
 pub use error::NodeBuildError;
 #[cfg(not(target_arch = "wasm32"))]
 pub use storer::{StorerNode, StorerNodeBuilder};
+#[cfg(target_arch = "wasm32")]
+pub use wasm_client::{WasmClientConfig, launch_client};

--- a/crates/swarm/node/src/node/wasm_client.rs
+++ b/crates/swarm/node/src/node/wasm_client.rs
@@ -1,0 +1,183 @@
+//! Browser client launch entrypoint.
+//!
+//! The native launch path (`vertex-swarm-builder`) pulls the redb database, the
+//! chain provider, the SWAP settlement service, and the gRPC server, none of
+//! which build for `wasm32`. A browser client needs none of them: it mints an
+//! ephemeral identity, dials the live mainnet bootnodes over secure websockets,
+//! and watches its Kademlia topology fill. This module is the narrow,
+//! wasm-buildable assembly that does exactly that.
+//!
+//! [`launch_client`] composes a [`ClientNode`] from an identity, a resolved
+//! bootnode set, and the browser-friendly [`WasmClientConfig`], spawns the node
+//! run loop and the peer-manager tick on the wasm executor, and returns the
+//! [`TopologyHandle`] so a UI can poll readiness and stream topology events. The
+//! returned handle keeps the client alive for the session; dropping it does not
+//! stop the spawned tasks, which run until the page is torn down.
+
+use std::time::Duration;
+
+use eyre::{Result, WrapErr};
+use libp2p::Multiaddr;
+use vertex_swarm_api::{
+    DefaultPeerConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
+};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_peer_manager::{DEFAULT_TICK_INTERVAL, spawn_peer_manager_task};
+use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
+use vertex_tasks::TaskExecutor;
+
+use super::client::ClientNode;
+
+/// Connection idle timeout for the browser client.
+const WASM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Transport-layer cap on established connections for the browser client.
+///
+/// A saturated routing table sits comfortably below this; it is a resource
+/// backstop, not a topology knob.
+const WASM_MAX_PEERS: usize = 400;
+
+/// Network configuration for a browser client node.
+///
+/// The browser cannot open listeners and has no LAN to discover peers on, so
+/// this configuration carries no listen addresses and leaves mDNS, UPnP, and
+/// AutoNAT off. It holds only the resolved bootnode multiaddrs (browser-dialable
+/// `/tls/sni/<host>/ws` leaves) plus the Kademlia routing defaults. It is the
+/// wasm counterpart to the CLI-driven `NetworkConfig` the native builder uses,
+/// trimmed to what a dial-only client needs.
+pub struct WasmClientConfig {
+    bootnodes: Vec<Multiaddr>,
+    peer: DefaultPeerConfig,
+    routing: KademliaConfig,
+}
+
+impl WasmClientConfig {
+    /// Build a browser client configuration from resolved bootnode multiaddrs.
+    ///
+    /// `bootnodes` are the browser-dialable leaves from the DoH resolver or the
+    /// embedded snapshot. Routing uses the Kademlia defaults.
+    #[must_use]
+    pub fn new(bootnodes: Vec<Multiaddr>) -> Self {
+        Self {
+            bootnodes,
+            peer: DefaultPeerConfig::default(),
+            routing: KademliaConfig::default(),
+        }
+    }
+}
+
+impl SwarmNetworkConfig for WasmClientConfig {
+    fn listen_addrs(&self) -> &[Multiaddr] {
+        &[]
+    }
+
+    fn bootnodes(&self) -> &[Multiaddr] {
+        &self.bootnodes
+    }
+
+    fn discovery_enabled(&self) -> bool {
+        true
+    }
+
+    fn max_peers(&self) -> usize {
+        WASM_MAX_PEERS
+    }
+
+    fn idle_timeout(&self) -> Duration {
+        WASM_IDLE_TIMEOUT
+    }
+
+    fn nat_auto_enabled(&self) -> bool {
+        false
+    }
+
+    fn autonat_enabled(&self) -> bool {
+        false
+    }
+
+    fn upnp_enabled(&self) -> bool {
+        false
+    }
+
+    fn mdns_enabled(&self) -> bool {
+        false
+    }
+}
+
+impl SwarmPeerConfig for WasmClientConfig {
+    type Peers = DefaultPeerConfig;
+
+    fn peers(&self) -> &Self::Peers {
+        &self.peer
+    }
+}
+
+impl SwarmRoutingConfig for WasmClientConfig {
+    type Routing = KademliaConfig;
+
+    fn routing(&self) -> &Self::Routing {
+        &self.routing
+    }
+}
+
+/// Build and start a browser client node, returning its topology handle.
+///
+/// Assembles a [`ClientNode`] over the wasm websocket transport from the given
+/// ephemeral `identity` and resolved `bootnodes`, spawns the node run loop and
+/// the peer-manager tick on the current wasm [`TaskExecutor`], and hands back the
+/// [`TopologyHandle`] the caller polls for readiness and subscribes to for
+/// [`TopologyEvent`](vertex_swarm_topology::TopologyEvent)s. The node dials its
+/// bootnodes as part of startup; from there the Kademlia routing table fills on
+/// its own.
+///
+/// The returned handle owns nothing the spawned tasks need, so the client keeps
+/// running after the handle is dropped. The browser tears the session down by
+/// dropping the whole wasm instance.
+///
+/// # Errors
+///
+/// Returns an error if the swarm fails to assemble (transport or behaviour
+/// construction) or the node fails to begin listening.
+pub async fn launch_client(
+    identity: Identity,
+    bootnodes: Vec<Multiaddr>,
+) -> Result<TopologyHandle<Identity>> {
+    let config = WasmClientConfig::new(bootnodes);
+
+    let (node, client_service, _client_handle) = ClientNode::builder(identity)
+        .build(&config, None)
+        .await
+        .wrap_err("failed to build browser client node")?;
+
+    let topology = node.topology_handle().clone();
+
+    let executor = TaskExecutor::current();
+    // The peer manager tick is pure data and `Send`, so it goes through the
+    // ordinary spawner.
+    spawn_peer_manager_task(
+        topology.peer_manager().clone(),
+        DEFAULT_TICK_INTERVAL,
+        &executor,
+    );
+
+    // The client service drives the retrieval and pushsync request paths. The
+    // demo does not issue downloads, but the service must run so the node can
+    // answer the protocols its peers speak during topology building. Its task is
+    // `Send`, so it goes through the ordinary service spawner.
+    executor.spawn_service("swarm.client_service", client_service);
+
+    // The node run loop owns the libp2p swarm, whose websocket transport futures
+    // are `!Send`. It starts listening (a no-op for the browser, which cannot
+    // listen) and then dials bootnodes and services the event loop for the
+    // session, so it spawns on the browser-local path too.
+    executor.spawn_local_with_graceful_shutdown_signal(
+        "swarm.client_node",
+        move |shutdown| async move {
+            if let Err(e) = node.start_and_run(shutdown).await {
+                tracing::error!(error = %e, "browser client node exited with error");
+            }
+        },
+    );
+
+    Ok(topology)
+}

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -721,6 +721,29 @@ impl TaskExecutor {
         self.spawn_task_as(fut, TaskKind::Default, name, true)
     }
 
+    /// Spawns a `!Send` task that participates in graceful shutdown, on the
+    /// browser event loop.
+    ///
+    /// The browser swarm and its websocket transport futures are `!Send`, so
+    /// the node run loop cannot go through the Send-bounded spawners. This wasm
+    /// sibling drops the `Send` bound and spawns through
+    /// [`wasm_bindgen_futures::spawn_local`], the same choke point every wasm
+    /// spawn uses, while still wiring the [`GracefulShutdown`] signal and the
+    /// shutdown count so the task is tracked like any other.
+    #[cfg(target_arch = "wasm32")]
+    pub fn spawn_local_with_graceful_shutdown_signal<F>(
+        &self,
+        name: &'static str,
+        f: impl FnOnce(GracefulShutdown) -> F,
+    ) -> TaskHandle
+    where
+        F: Future<Output = ()> + 'static,
+    {
+        debug!(task = name, "spawning local task with graceful shutdown");
+        let fut = f(self.new_graceful_shutdown());
+        spawn_local_abortable(fut)
+    }
+
     /// Spawns a [`SpawnableTask`] as a critical task with graceful shutdown.
     ///
     /// This is the preferred way to spawn long-running services that implement


### PR DESCRIPTION
## The payoff

A browser WebAssembly app that runs a real Vertex Swarm client node: it mints an ephemeral identity, resolves the live mainnet bootnodes over DNS-over-HTTPS (with the embedded wss snapshot as fallback), dials them over secure WebSockets, and renders the Kademlia topology building up.

## Construction path chosen

The native node builder (`vertex-swarm-builder`) pulls `vertex-storage-redb`, the chain provider, the SWAP settlement service, and the gRPC server, none of which build for `wasm32`. So the demo does not use it. Instead a narrow, wasm-only launch entrypoint lands in `vertex-swarm-node` (the libp2p composition home, already in the wasm cone):

`vertex_swarm_node::launch_client(identity, bootnodes)` composes a `ClientNode` (connection-limits + identify + topology + client protocols) over the browser WebSocket transport via the existing `ClientNode::builder(...).build(...)` path, spawns the node run loop and the peer-manager tick on the wasm executor, and returns the `TopologyHandle`.

The node run loop owns a `!Send` libp2p swarm (the websocket transport futures are `!Send`), so it spawns through a new wasm-only `TaskExecutor::spawn_local_with_graceful_shutdown_signal` sibling that drops the `Send` bound and routes through `wasm_bindgen_futures::spawn_local`, the same spawn choke point every wasm task uses, while still wiring the graceful-shutdown signal and the shutdown count. The peer-manager tick and the client service are `Send` and go through the ordinary spawners.

This keeps the wasm-construction logic in the node crate, so the demo crate stays a thin wasm-bindgen + UI shell.

## wasm-bindgen surface

`start()` installs the panic hook and console tracing, mints `Identity::random()` as a `Client`, resolves the bootnodes over the DoH path, launches the client, and returns a `SwarmDemo` handle. The JS-facing surface is small and documented: `SwarmDemo::readiness()` returns a plain JS object with the readiness snapshot fields (connected peers, storers, depth, neighborhood, per-bin fill, phase, routable/saturated flags), and `SwarmDemo::drainEvents()` returns the buffered topology events. A single event pump feeds both the live DOM log and the JS buffer from one broadcast subscription, so the two consumers never compete for the same event.

## UI

A minimal `web-sys` panel renders live, updated on a one-second poll loop and on events: connected peer count, neighborhood depth, the topology phase, the saturation and routability flags, a per-bin fill table, and a scrolling log of `TopologyEvent`s. Event detail text (overlay addresses, error strings) is HTML-escaped before going into the DOM.

## Trunk, COOP/COEP, coi-serviceworker

`Trunk.toml` sets `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` for `trunk serve`, so the page is cross-origin isolated locally (the `+atomics` build needs SharedArrayBuffer). `coi-serviceworker.js` is vendored and copied into `dist/` for the eventual GitHub Pages deploy, where response headers cannot be set: it registers a service worker that re-serves responses with the isolation headers client-side. The README documents the exact nightly + `wasm32-unknown-unknown` + `rust-src` + Trunk build pipeline.

The demo is a wasm-only `cdylib` and a standalone workspace, excluded from the native default workspace so `cargo build` at the repo root never compiles it for native. The existing `wasm` CI job still builds the client cone (`vertex-swarm-node`), which now includes the launch entrypoint.

## What the browser smoke showed

`trunk build --release` produces a clean `dist/` (wasm + JS glue + html + css + the copied service worker). A headless browser smoke against that build confirmed the wasm module boots, the UI panel mounts, an ephemeral overlay address is minted, and the app reaches the bootnode-resolution step; the page is cross-origin isolated and SharedArrayBuffer is available.

One open item for the fully-live in-browser run: `nectar-primitives` compiles parallel BMT hashing on a `wasm-bindgen-rayon` Web Worker thread pool, so the module uses `Atomics.wait`/`waitAsync` on shared memory. Driving that to completion needs the shared-memory linker recipe (`--shared-memory`/`--import-memory`/`--max-memory`/`--export=__heap_base` + TLS exports), `-Z build-std`, and a `initThreadPool(...)` bootstrap. That recipe builds and `wasm-bindgen` emits the worker glue, but the worker-module URL the rayon bootstrap requests did not resolve under the local static server used for the smoke. Resolving the worker-URL wiring is folded into the phase-4 GitHub Pages deploy, where the served paths are stable. The CI-able proof here is the clean `trunk build` plus the wasm client-construction code compiling for `wasm32`; the live connect is verified on the deployed page. The README spells this out.

Part of #252