### PR TITLE
fix(deps): pin rust-libp2p fork with the websocket-websys browser flush fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -635,7 +635,7 @@ checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower 0.5.3",
@@ -2285,7 +2285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2716,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3632,7 +3632,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3943,7 +3943,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3975,15 +3975,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4158,7 +4149,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "bytes",
  "either",
@@ -4190,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4200,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4223,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4233,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "either",
  "fnv",
@@ -4257,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4271,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4311,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4329,7 +4320,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4345,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4367,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4382,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4397,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4418,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "futures-bounded 0.3.0",
@@ -4433,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "either",
  "fnv",
@@ -4456,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "heck",
  "quote",
@@ -4466,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "async-trait",
  "futures",
@@ -4483,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4498,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4516,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4530,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket-websys"
 version = "0.6.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "bytes",
  "futures",
@@ -4546,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "either",
  "futures",
@@ -4894,7 +4885,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "bytes",
  "futures",
@@ -5094,7 +5085,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6001,7 +5992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6017,7 +6008,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6046,7 +6037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6059,7 +6050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6169,7 +6160,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6206,9 +6197,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6722,7 +6713,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6781,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=3e72d4c071d5ec8815d2f6f7ee3602600ff51798#3e72d4c071d5ec8815d2f6f7ee3602600ff51798"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
 dependencies = [
  "futures",
  "pin-project",
@@ -7496,7 +7487,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9741,7 +9732,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9891,15 +9882,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -9931,28 +9913,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9977,12 +9942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9993,12 +9952,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10013,22 +9966,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10043,12 +9984,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10059,12 +9994,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10079,12 +10008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10095,12 +10018,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,9 +270,14 @@ opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-proto",
 opentelemetry-appender-tracing = { version = "0.31", features = ["experimental_use_tracing_span_context"] }
 
 ## p2p
-# Pinned to rust-libp2p master to pick up libp2p-dns 0.45.0 against hickory 0.26.1
-# (RUSTSEC-2026-0119 / RUSTSEC-2026-0118). Revisit when libp2p 0.57 is released.
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798", features = [
+# Pinned to the nxm-rs rust-libp2p fork, branched from upstream rev
+# 3e72d4c071d5ec8815d2f6f7ee3602600ff51798 (master, for libp2p-dns 0.45.0 against
+# hickory 0.26.1, RUSTSEC-2026-0119 / RUSTSEC-2026-0118). The fork carries a single
+# fix on top: `libp2p-websocket-websys` no longer blocks `poll_flush` on the browser
+# WebSocket `bufferedAmount` draining to zero, which stalled the wasm client mid
+# handshake and tore the connection down with `BrokenPipe`. Revisit when the fix is
+# upstreamed and libp2p 0.57 is released.
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", features = [
     "tokio",
     "noise",
     "tcp",
@@ -289,11 +294,13 @@ libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8
 quick-protobuf = "0.8"
 quick-protobuf-codec = "0.3.1"
 asynchronous-codec = "0.7.0"
-libp2p-swarm = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798" }
-libp2p-swarm-test = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798" }
+libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133" }
+libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133" }
 # Browser websocket transport for the wasm client. Dials the bee AutoTLS
-# `/tls/sni/<host>/ws` form; the browser performs TLS and SNI natively.
-libp2p-websocket-websys = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798" }
+# `/tls/sni/<host>/ws` form; the browser performs TLS and SNI natively. Pinned to
+# the nxm-rs fork for the `poll_flush` browser WebSocket flush fix (see the `libp2p`
+# entry above).
+libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133" }
 quickcheck = "1.0.3"
 pb-rs = "0.10"
 walkdir = "2.5.0"

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -41,7 +41,7 @@ vertex-net-dnsaddr-doh = { path = "../../crates/net/dnsaddr-doh" }
 vertex-tasks = { path = "../../crates/tasks" }
 
 # libp2p Multiaddr only; the trimmed wasm feature set mirrors the node crate.
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798", default-features = false }
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", default-features = false }
 
 # wasm-bindgen surface and browser bindings.
 wasm-bindgen = "0.2"

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -86,7 +86,7 @@ vertex-swarm-redistribution = { workspace = true, optional = true }
 libp2p.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -81,7 +81,7 @@ vertex-net-dnsaddr.workspace = true
 # `vertex-net-dnsaddr-doh` (DNS-over-HTTPS) with the embedded wss snapshot as
 # the fallback.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e72d4c071d5ec8815d2f6f7ee3602600ff51798", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/deny.toml
+++ b/deny.toml
@@ -31,4 +31,8 @@ highlight = "all"
 unknown-registry = "deny"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/nxm-rs/nectar"]
+allow-git = [
+    "https://github.com/nxm-rs/nectar",
+    # rust-libp2p fork carrying the websocket-websys browser flush/send fix.
+    "https://github.com/nxm-rs/rust-libp2p",
+]


### PR DESCRIPTION
## What

The wasm browser client (`bin/swarm-demo`) could not complete a libp2p handshake against a live mainnet bee node. The browser secure WebSocket opened and the remote answered, but the connection was torn down mid-handshake with `BrokenPipe`. This PR pins every libp2p dependency to the [nxm-rs/rust-libp2p](https://github.com/nxm-rs/rust-libp2p) fork that fixes the transport, and regenerates `Cargo.lock`.

It builds on #262 (the `Version::V1Lazy` negotiation change); base it there.

## Root cause

The browser path layers libp2p Noise + yamux on top of a browser-native TLS WebSocket (`wss://`). The browser does TLS and SNI; Noise is the libp2p peer-auth handshake inside the encrypted byte stream. A hand-driven raw `WebSocket` confirmed the live node completes multistream-select and answers, so the network path and protocol IDs were all correct. The fault was entirely in `libp2p-websocket-websys`:

- `poll_write` handed `WebSocket.send` a `Uint8Array` view built directly over the caller's slice. Under the threaded (`SharedArrayBuffer`) wasm build that view is shared memory, and browsers reject sending a shared-memory view with "The provided ArrayBufferView value must not be shared". The throw surfaced as `BrokenPipe` right as the first Noise message went out. Confirmed in-page: sending a `SharedArrayBuffer`-backed view throws `TypeError`, a normal view succeeds.
- `poll_flush` blocked until the browser `bufferedAmount` drained to zero, observed only by a 100ms interval timer, so a flush issued mid-handshake parked until that timer fired and, under the wasm executor, the remote dropped the connection.
- `extract_websocket_url` did not parse the AutoTLS `/ip4|dns/<host>/tcp/<port>/tls/sni/<sni-host>/ws` form, so peers discovered via hive gossip were rejected with `MultiaddrNotSupported` and never dialed.

## The fork fix

Single commit in nxm-rs/rust-libp2p, branched from the exact upstream rev vertex already pinned (`3e72d4c0...`):

https://github.com/nxm-rs/rust-libp2p/commit/6454fdf3450f91fdbb6e3306daa7a9a4e633c133

- `poll_write` copies the payload into a fresh JS-heap `Uint8Array` (`new_with_length` + `copy_from`) before sending, valid whether or not wasm memory is shared.
- `poll_flush` returns ready once the socket is open; backpressure stays bounded by the existing `MAX_BUFFER` check in `poll_write`.
- `extract_websocket_url` understands `/tls/sni/<host>/ws`: it dials the SNI host (so DNS resolves the `*.libp2p.direct` name and TLS presents the matching cert) while keeping the `/tcp` port. Covered by new unit tests.

## The repoint

Every libp2p git dependency (`libp2p`, `libp2p-swarm`, `libp2p-swarm-test`, `libp2p-websocket-websys`, and the wasm-target `libp2p` entries in `swarm-node`, `topology`, and `swarm-demo`) moves from the upstream URL/rev to the fork URL/rev, and `Cargo.lock` is regenerated. The fork branches from the same upstream rev, so native behaviour is unchanged; only the wasm-only `websocket-websys` transport differs. Native `cargo build --all-features` and `cargo test -p vertex-swarm-node --all-features` stay green, and the wasm client cone builds.

## Confirmed live connection

Yes. The browser demo, built against the fork and loaded headless with cross-origin isolation, connects to live mainnet and builds its Kademlia topology: **peers 61, storers 61, depth 4, routable yes, phase converging**, with per-bin connected counts filling in. Before the fix the connection died at `BrokenPipe` in the Noise handshake; after it, the full stack completes (Noise, yamux, identify, `/swarm/handshake/15.0.0`, `/swarm/hive/2.0.0/peers`) and the routing table populates from gossiped AutoTLS peers. Screenshot captured during verification.

Part of #252