### PR TITLE
refactor(node): route stray timer call sites through vertex_tasks::time

### DIFF
--- a/crates/node/commands/src/lib.rs
+++ b/crates/node/commands/src/lib.rs
@@ -88,7 +88,9 @@ where
             info!("Received Ctrl+C, initiating graceful shutdown...");
             match executor.initiate_graceful_shutdown() {
                 Ok(graceful_shutdown) => {
-                    match tokio::time::timeout(GRACEFUL_SHUTDOWN_TIMEOUT, graceful_shutdown).await {
+                    match vertex_tasks::time::timeout(GRACEFUL_SHUTDOWN_TIMEOUT, graceful_shutdown)
+                        .await
+                    {
                         Ok(_guard) => info!("Graceful shutdown complete"),
                         Err(_) => warn!(
                             "Graceful shutdown timed out after {:?}, forcing exit",

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -95,7 +95,7 @@ fn spawn_db_metrics_task(ctx: &dyn InfrastructureContext, db: Arc<RedbDatabase>)
     ctx.executor()
         .spawn_with_graceful_shutdown_signal("db.metrics", move |shutdown| async move {
             let mut shutdown = std::pin::pin!(shutdown);
-            let mut interval = tokio::time::interval(DB_METRICS_INTERVAL);
+            let mut interval = vertex_tasks::time::interval(DB_METRICS_INTERVAL);
 
             loop {
                 tokio::select! {

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -283,7 +283,7 @@ mod tests {
                 }
             }
         };
-        let cause = tokio::time::timeout(Duration::from_secs(10), denial)
+        let cause = vertex_tasks::time::timeout(Duration::from_secs(10), denial)
             .await
             .expect("listener denies the second connection");
 


### PR DESCRIPTION
Migrates the remaining direct `tokio::time` calls in production code to the canonical `vertex_tasks::time` abstraction so wasm-cone code can never hit a tokio-timer panic.

## Changes

- `crates/swarm/builder/src/launch.rs`: the db metrics task now builds its ticker with `vertex_tasks::time::interval(DB_METRICS_INTERVAL)`. The select arm is unchanged: `Interval::tick` is cancel-safe because the armed timer lives in the `Interval` itself and is re-armed only when a tick fires, so a cancelled tick future does not lose the armed timer. Missed-tick semantics change from tokio's burst to delay, which is preferable for metrics collection: a late loop iteration re-arms a full period after the fire instead of bursting to catch up.
- `crates/node/commands/src/lib.rs`: the graceful shutdown timeout goes through `vertex_tasks::time::timeout`. Native-only CLI crate, migrated for consistency; the match arms already used `Err(_)` so the switch to `Elapsed` is unobservable.
- `crates/swarm/node/src/node/base.rs`: the `tokio::time::timeout` here turned out to be inside the `#[cfg(test)]` module (the connection-limits cap test), so it was never a runtime wasm panic risk; migrated anyway for consistency per the unit brief.

## Audit of remaining `tokio::time` usage

`rg "tokio::time" crates/ -t rust` after this change leaves only the expected survivors: vertex-tasks internals (the abstraction itself, plus its own tests and doc comments), test code (`#[cfg(test)]` modules, `tests/` dirs, and `vertex-swarm-test-utils`), and doc comments. One production site remains in `crates/swarm/topology/src/kademlia/routing.rs` (`use tokio::time::Instant`); topology is owned by another in-flight worker so it is not touched here. Note that on native `vertex_tasks::time::Instant` is the same tokio clock, so that site is already semantically aligned and is a one-line import swap whenever topology picks it up.

All three crates already had `vertex-tasks` as a workspace dependency, so no `Cargo.toml` changes were needed.

## Verification

`cargo fmt --all` clean, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo test -p vertex-swarm-node -p vertex-node-commands -p vertex-swarm-builder` green, and the wasm cone builds: `cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node`.

Zero behaviour change beyond the documented missed-tick semantics in the metrics loop.