### PR TITLE
refactor(topology): migrate timers to vertex_tasks::time

### DIFF
--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -2,9 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    future::Future,
     net::IpAddr,
-    pin::Pin,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -40,30 +38,12 @@ pub(crate) type ConnectionRegistry = PeerRegistry<OverlayAddress, Option<DialRea
 /// Boxed future that resolves `/dnsaddr/` bootnodes and trusted peers into
 /// dialable multiaddrs (resolved bootnodes, resolved trusted).
 ///
-/// Native resolution runs on the multi-threaded executor, so the future is
-/// `Send`. In the browser, DNS-over-HTTPS resolution is backed by `fetch`,
-/// whose future is `!Send`; the wasm swarm is single-threaded, so the `Send`
-/// bound is dropped there.
-#[cfg(not(target_arch = "wasm32"))]
+/// The `Send` bound follows the platform executor via
+/// [`vertex_tasks::MaybeSendBoxFuture`]: `Send` on native, unbounded on wasm32
+/// where DNS-over-HTTPS resolution is backed by `fetch`, whose future is
+/// `!Send`, and the swarm is single-threaded.
 pub(crate) type BootnodeResolutionFuture =
-    Pin<Box<dyn Future<Output = (Vec<Multiaddr>, Vec<Multiaddr>)> + Send>>;
-
-/// Boxed bootnode-resolution future for the browser build (see the native
-/// definition for the `Send` rationale).
-#[cfg(target_arch = "wasm32")]
-pub(crate) type BootnodeResolutionFuture =
-    Pin<Box<dyn Future<Output = (Vec<Multiaddr>, Vec<Multiaddr>)>>>;
-
-/// Boxed timer future used for the behaviour's internal pacing (dial-rate and
-/// periodic ticks). `Send` on native so the behaviour stays `Send` for the
-/// libp2p swarm; the bound is dropped on wasm32, where the browser timer future
-/// (`gloo-timers`) is `!Send` and the swarm is single-threaded.
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) type TimerFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
-
-/// Boxed timer future for the browser build (see the native definition).
-#[cfg(target_arch = "wasm32")]
-pub(crate) type TimerFuture = Pin<Box<dyn Future<Output = ()>>>;
+    vertex_tasks::MaybeSendBoxFuture<(Vec<Multiaddr>, Vec<Multiaddr>)>;
 use crate::TopologyCommand;
 use crate::builder::PendingTopologyTasks;
 use crate::composed::ProtocolBehaviours;
@@ -87,61 +67,6 @@ pub(crate) const EVENT_CHANNEL_CAPACITY: usize = 256;
 
 /// Command buffer (64 is sufficient for typical dial/disconnect rate).
 pub(crate) const COMMAND_CHANNEL_CAPACITY: usize = 64;
-
-/// Periodic interval whose underlying timer is created on first poll.
-///
-/// The tick is a re-armable `sleep` future rather than a `tokio::time::Interval`
-/// so the same behaviour runs on wasm32, where tokio's timer driver is absent.
-/// The timer is armed on first [`Self::poll_tick`] (always inside the
-/// behaviour's poll loop), so the behaviour can be constructed without a running
-/// runtime. The first tick fires immediately and subsequent ticks fire one
-/// period apart, matching `tokio::time::interval`.
-pub(crate) struct LazyInterval {
-    period: Duration,
-    timer: Option<TimerFuture>,
-    /// `tokio::time::interval` yields its first tick immediately; this flag
-    /// reproduces that so the first poll readies a tick before any wait.
-    first_tick_pending: bool,
-}
-
-impl LazyInterval {
-    /// Create a lazy interval with the given period.
-    pub(crate) fn new(period: Duration) -> Self {
-        Self {
-            period,
-            timer: None,
-            first_tick_pending: true,
-        }
-    }
-
-    /// Poll for the next tick, arming the timer on first use and re-arming it
-    /// after each fire.
-    pub(crate) fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        // The first tick is immediate, matching `tokio::time::interval`.
-        if self.first_tick_pending {
-            self.first_tick_pending = false;
-            self.timer = Some(Box::pin(vertex_tasks::time::sleep(self.period)));
-            return Poll::Ready(());
-        }
-        let period = self.period;
-        let timer = self
-            .timer
-            .get_or_insert_with(|| Box::pin(vertex_tasks::time::sleep(period)));
-        match timer.as_mut().poll(cx) {
-            Poll::Ready(()) => {
-                self.timer = Some(Box::pin(vertex_tasks::time::sleep(period)));
-                Poll::Ready(())
-            }
-            Poll::Pending => Poll::Pending,
-        }
-    }
-
-    /// The configured period (build-time pacing assertions).
-    #[cfg(test)]
-    pub(crate) fn period(&self) -> Duration {
-        self.period
-    }
-}
 
 /// Target for dialing a peer (internal).
 ///
@@ -300,7 +225,7 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
     pub(crate) gossip: GossipHandle,
 
     // Periodic dial interval
-    pub(crate) dial_interval: LazyInterval,
+    pub(crate) dial_interval: vertex_tasks::time::Interval,
 
     /// GCRA bucket shaping the discovery dial rate. Bursts after a candidate
     /// influx drain immediately up to the bucket size; beyond it, candidates
@@ -309,9 +234,8 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
 
     /// Armed when the dial-rate bucket refused a candidate: fires when the
     /// next token is available so the drain resumes without waiting for the
-    /// evaluation tick. A boxed `sleep` future rather than a
-    /// `tokio::time::Sleep` so the timer runs on wasm32 too.
-    pub(crate) dial_rate_timer: Option<TimerFuture>,
+    /// evaluation tick.
+    pub(crate) dial_rate_timer: Option<vertex_tasks::time::BoxTimerFuture>,
 
     // Pending dnsaddr resolution for bootnodes (resolved_bootnodes, resolved_trusted)
     pub(crate) pending_bootnode_resolution: Option<BootnodeResolutionFuture>,
@@ -517,7 +441,8 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 Err(RateLimitedErr::TooSoon(wait)) => {
                     metrics::counter!("topology_dials_throttled_total").increment(1);
                     self.routing.requeue_candidate(overlay);
-                    let mut timer: TimerFuture = Box::pin(vertex_tasks::time::sleep(wait));
+                    let mut timer: vertex_tasks::time::BoxTimerFuture =
+                        Box::pin(vertex_tasks::time::sleep(wait));
                     if timer.as_mut().poll(cx).is_ready() {
                         // Sub-millisecond wait already elapsed; keep draining.
                         continue;

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -21,7 +21,7 @@ use vertex_swarm_peer_manager::{PeerManager, PeerManagerConfig};
 use vertex_swarm_peer_score::SwarmScoringConfig;
 
 use crate::behaviour::{
-    COMMAND_CHANNEL_CAPACITY, ConnectionRegistry, EVENT_CHANNEL_CAPACITY, LazyInterval, PeerStore,
+    COMMAND_CHANNEL_CAPACITY, ConnectionRegistry, EVENT_CHANNEL_CAPACITY, PeerStore,
     TopologyBehaviour, TopologyConfig,
 };
 use crate::composed::ProtocolBehaviours;
@@ -226,7 +226,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             event_tx,
             pending_actions: VecDeque::new(),
             gossip,
-            dial_interval: LazyInterval::new(evaluation_interval),
+            dial_interval: vertex_tasks::time::interval(evaluation_interval),
             dial_rate: RateLimiter::new(dial_quota),
             dial_rate_timer: None,
             pending_bootnode_resolution: None,

--- a/crates/swarm/topology/src/gossip/tasks.rs
+++ b/crates/swarm/topology/src/gossip/tasks.rs
@@ -1,8 +1,6 @@
 //! Gossip exchange coordinator task.
 
 use std::collections::{HashMap, HashSet};
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,15 +40,12 @@ struct PendingExchange {
     node_type: SwarmNodeType,
 }
 
-/// Boxed delayed-exchange future. `Send` on native so the gossip task spawns
-/// through the Send-bounded spawner; the bound is dropped on wasm32, where the
-/// browser timer future is `!Send` and the task runs on the browser event loop.
-#[cfg(not(target_arch = "wasm32"))]
-type PendingExchangeFuture = Pin<Box<dyn Future<Output = PendingExchange> + Send>>;
-
-/// Boxed delayed-exchange future for the browser build (see the native one).
-#[cfg(target_arch = "wasm32")]
-type PendingExchangeFuture = Pin<Box<dyn Future<Output = PendingExchange>>>;
+/// Boxed delayed-exchange future. The `Send` bound follows the platform
+/// executor via [`vertex_tasks::MaybeSendBoxFuture`]: `Send` on native so the
+/// gossip task spawns through the Send-bounded spawner, unbounded on wasm32
+/// where the browser timer future is `!Send` and the task runs on the browser
+/// event loop.
+type PendingExchangeFuture = vertex_tasks::MaybeSendBoxFuture<PendingExchange>;
 
 /// Gossip exchange coordinator task.
 struct GossipTask<I: SwarmIdentity> {
@@ -74,10 +69,8 @@ struct GossipTask<I: SwarmIdentity> {
     gossip_dial_peers: HashSet<PeerId>,
     health_check_delay: Duration,
     refresh_interval: Duration,
-    /// Re-armable periodic tick. tokio's timer driver does not run on wasm32, so
-    /// the cadence is a `sleep` future that is recreated after each fire rather
-    /// than a `tokio::time::Interval`.
-    gossip_tick: crate::behaviour::TimerFuture,
+    /// Periodic refresh tick; first fire one full period after spawn.
+    gossip_tick: vertex_tasks::time::Interval,
 
     // Delayed gossip exchange
     pending_exchanges: FuturesUnordered<PendingExchangeFuture>,
@@ -94,8 +87,7 @@ impl<I: SwarmIdentity> GossipTask<I> {
                 Some(input) = self.input_rx.recv() => {
                     self.handle_input(input);
                 }
-                _ = &mut self.gossip_tick => {
-                    self.gossip_tick = Box::pin(sleep(self.refresh_interval));
+                _ = self.gossip_tick.tick() => {
                     self.on_tick();
                 }
                 Some(exchange) = self.pending_exchanges.next() => {
@@ -531,7 +523,10 @@ pub(crate) fn spawn_gossip_task<I: SwarmIdentity>(
         gossip_dial_peers: HashSet::new(),
         health_check_delay: config.health_check_delay,
         refresh_interval: config.refresh_interval,
-        gossip_tick: Box::pin(sleep(config.refresh_interval)),
+        gossip_tick: vertex_tasks::time::interval_after(
+            config.refresh_interval,
+            config.refresh_interval,
+        ),
         pending_exchanges: FuturesUnordered::new(),
         cancelled_exchanges: HashSet::new(),
         evaluator_handle,

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -17,13 +17,6 @@ use super::{
 use crate::metrics::{phase, record_phase_transition, record_topology_phase_change};
 use nectar_primitives::{ChunkAddress, recompute_neighborhood_depth};
 use parking_lot::{Mutex, RwLock};
-// The neighborhood stability clock is a `tokio::time::Instant` on native so the
-// paused-time tests can advance it deterministically. tokio's clock reaches the
-// std monotonic clock, which panics on wasm32-unknown-unknown, so the browser
-// build uses the `web-time` clock instead. Both expose `now`, `elapsed`, and the
-// duration arithmetic this module uses.
-#[cfg(not(target_arch = "wasm32"))]
-use tokio::time::Instant;
 use tracing::{debug, info, trace};
 use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use vertex_swarm_peer_manager::{PeerManager, ProximityIndex};
@@ -31,8 +24,9 @@ use vertex_swarm_primitives::{
     Bin, NeighborhoodDepth, OverlayAddress, ProximityOrder, SwarmNodeType, all_bins, balanced_bins,
     neighborhood_bins,
 };
-#[cfg(target_arch = "wasm32")]
-use vertex_util_runtime::time::Instant;
+// The neighborhood stability clock is the timer-coherent monotonic clock from
+// `vertex_tasks::time` on both targets.
+use vertex_tasks::time::Instant;
 use vertex_util_runtime::time::Instant as PhaseInstant;
 
 /// Connection phase for capacity tracking.


### PR DESCRIPTION
Part of the batch reorganizing the wasm32 work so timer code stops growing per-crate cfg pairs and flows through the canonical `vertex_tasks::time` abstraction added in #264.

Changes in `vertex-swarm-topology`:

- Delete the private `LazyInterval`; its logic was ported verbatim into `vertex_tasks::time::Interval`. The dial interval is now built with `vertex_tasks::time::interval(evaluation_interval)`, which has the same immediate-first-tick semantics.

- Delete the cfg-gated `TimerFuture` alias pair. `dial_rate_timer` holds an `Option<vertex_tasks::time::BoxTimerFuture>` instead.

- `BootnodeResolutionFuture` and `PendingExchangeFuture` collapse to single un-cfg'd aliases over `vertex_tasks::MaybeSendBoxFuture`, which reproduces the same `Send`-on-native / unbounded-on-wasm32 pair.

- The gossip refresh tick is a `vertex_tasks::time::Interval` built with `interval_after(refresh_interval, refresh_interval)`, preserving the one-full-period delay before the first fire; the manual re-arm in the select loop is gone.

- `kademlia/routing.rs` imports `vertex_tasks::time::Instant` instead of the cfg-gated tokio/web-time dual import. The alias resolves to the same type on each target, so the paused-time test coherence is unchanged.

The `dialing.rs` bootnode-resolution cfg pair of functions stays: that is the sanctioned pattern for the native-vs-DoH DNS divergence; only its boxed-future type alias changed.

Zero behavior change: same tick cadence, same first-fire timing, same Send bounds per target. The paused-time regression tests in `handle.rs` and `kademlia/routing.rs` pass unchanged, and the wasm32 client cone (`-p vertex-swarm-topology -p vertex-swarm-node`) builds clean.
