### PR TITLE
feat(swarm-node): fluent ClientLauncher shared by native embedders and the wasm client

### DIFF
--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -20,11 +20,15 @@ mod protocol;
 mod selection;
 mod swarm_client;
 
-pub use node::{BaseNode, BuiltInfrastructure, ClientNode, ClientNodeBuilder, NodeBuildError};
+#[cfg(target_arch = "wasm32")]
+#[allow(deprecated)]
+pub use node::launch_client;
+pub use node::{
+    BaseNode, BuiltInfrastructure, ClientLauncher, ClientNode, ClientNodeBuilder, LaunchedClient,
+    NodeBuildError,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder, StorerNode, StorerNodeBuilder};
-#[cfg(target_arch = "wasm32")]
-pub use node::{WasmClientConfig, launch_client};
 
 pub use vertex_swarm_api::SwarmNodeType;
 

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -1,0 +1,314 @@
+//! Fluent launcher for an embedded Swarm client node.
+//!
+//! [`ClientLauncher`] is the lightweight entry point shared by native
+//! embedders and the browser client: no database, no chain provider, no RPC
+//! server. It composes a [`ClientNode`] from an identity and a handful of
+//! network knobs, spawns the node run loop, the client service, and the
+//! peer-manager tick on the current [`TaskExecutor`], and hands back a
+//! [`LaunchedClient`] with the handles a caller needs to observe the topology
+//! and issue chunk reads and writes. The full native stack (storage, chain,
+//! settlement, RPC) goes through `vertex-swarm-builder` instead.
+
+use std::time::Duration;
+
+use eyre::{Result, WrapErr};
+use libp2p::{Multiaddr, PeerId};
+use nectar_primitives::SwarmAddress;
+use vertex_swarm_api::{
+    DefaultPeerConfig, SwarmIdentity, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
+};
+use vertex_swarm_peer_manager::{DEFAULT_TICK_INTERVAL, spawn_peer_manager_task};
+use vertex_swarm_spec::HasSpec;
+use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
+use vertex_tasks::TaskExecutor;
+
+use super::client::ClientNode;
+use crate::ClientHandle;
+
+/// Default connection idle timeout for a launched client.
+const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Default transport-layer cap on established connections.
+///
+/// A saturated routing table sits comfortably below this; it is a resource
+/// backstop, not a topology knob.
+const DEFAULT_MAX_PEERS: usize = 400;
+
+/// Network configuration assembled from the launcher's fields.
+///
+/// A launched client is dial-only: it carries no listen addresses and leaves
+/// mDNS, UPnP, and AutoNAT off. This is the trimmed counterpart to the
+/// CLI-driven `NetworkConfig` the full native builder uses.
+struct LaunchNetworkConfig {
+    bootnodes: Vec<Multiaddr>,
+    peer: DefaultPeerConfig,
+    routing: KademliaConfig,
+    max_peers: usize,
+    idle_timeout: Duration,
+}
+
+impl SwarmNetworkConfig for LaunchNetworkConfig {
+    fn listen_addrs(&self) -> &[Multiaddr] {
+        &[]
+    }
+
+    fn bootnodes(&self) -> &[Multiaddr] {
+        &self.bootnodes
+    }
+
+    fn discovery_enabled(&self) -> bool {
+        true
+    }
+
+    fn max_peers(&self) -> usize {
+        self.max_peers
+    }
+
+    fn idle_timeout(&self) -> Duration {
+        self.idle_timeout
+    }
+
+    fn nat_auto_enabled(&self) -> bool {
+        false
+    }
+
+    fn autonat_enabled(&self) -> bool {
+        false
+    }
+
+    fn upnp_enabled(&self) -> bool {
+        false
+    }
+
+    fn mdns_enabled(&self) -> bool {
+        false
+    }
+}
+
+impl SwarmPeerConfig for LaunchNetworkConfig {
+    type Peers = DefaultPeerConfig;
+
+    fn peers(&self) -> &Self::Peers {
+        &self.peer
+    }
+}
+
+impl SwarmRoutingConfig for LaunchNetworkConfig {
+    type Routing = KademliaConfig;
+
+    fn routing(&self) -> &Self::Routing {
+        &self.routing
+    }
+}
+
+/// Fluent launcher for an embedded Swarm client node.
+///
+/// This is the lightweight entry point: no database, no chain provider, no RPC
+/// server. The full native stack goes through `vertex-swarm-builder`.
+///
+/// The launched node is dial-only on both targets: it opens no listeners and
+/// runs no NAT traversal or LAN discovery. On native that suits embedders that
+/// only read from and write to the network; in the browser it is the only
+/// possible shape.
+///
+/// # Example
+///
+/// ```ignore
+/// use vertex_swarm_node::ClientLauncher;
+///
+/// let launched = ClientLauncher::new(identity)
+///     .with_bootnodes(bootnodes)
+///     .launch()
+///     .await?;
+/// let topology = launched.topology().clone();
+/// ```
+pub struct ClientLauncher<I: SwarmIdentity + Clone> {
+    identity: I,
+    bootnodes: Vec<Multiaddr>,
+    kademlia: KademliaConfig,
+    max_peers: usize,
+    idle_timeout: Duration,
+}
+
+impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
+    /// Create a launcher for the given identity with default settings.
+    #[must_use]
+    pub fn new(identity: I) -> Self {
+        Self {
+            identity,
+            bootnodes: Vec::new(),
+            kademlia: KademliaConfig::default(),
+            max_peers: DEFAULT_MAX_PEERS,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+        }
+    }
+
+    /// Set the bootnode multiaddrs to dial at startup.
+    ///
+    /// When left empty, the launcher falls back to the bootnodes baked into
+    /// the identity's network spec. Topology resolves those per platform: the
+    /// system resolver natively, DNS-over-HTTPS in the browser.
+    #[must_use]
+    pub fn with_bootnodes(mut self, bootnodes: impl IntoIterator<Item = Multiaddr>) -> Self {
+        self.bootnodes = bootnodes.into_iter().collect();
+        self
+    }
+
+    /// Set the Kademlia routing configuration.
+    #[must_use]
+    pub fn with_kademlia(mut self, config: KademliaConfig) -> Self {
+        self.kademlia = config;
+        self
+    }
+
+    /// Set the transport-layer cap on established connections.
+    #[must_use]
+    pub fn with_max_peers(mut self, max: usize) -> Self {
+        self.max_peers = max;
+        self
+    }
+
+    /// Set the connection idle timeout.
+    #[must_use]
+    pub fn with_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.idle_timeout = timeout;
+        self
+    }
+
+    /// Build and start the client node, returning its handles.
+    ///
+    /// Assembles a [`ClientNode`] over the platform transport (TCP with DNS
+    /// natively, secure websockets in the browser), spawns the node run loop,
+    /// the client service, and the peer-manager tick on the current
+    /// [`TaskExecutor`], and returns a [`LaunchedClient`]. The node dials its
+    /// bootnodes as part of startup; from there the Kademlia routing table
+    /// fills on its own.
+    ///
+    /// The returned handles own nothing the spawned tasks need, so the client
+    /// keeps running after they are dropped. Shutdown goes through the task
+    /// executor's graceful-shutdown signal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the swarm fails to assemble (transport or behaviour
+    /// construction). Failures after spawn, including the run loop exiting
+    /// with an error, are logged by the spawned task.
+    pub async fn launch(self) -> Result<LaunchedClient<I>>
+    where
+        I: HasSpec,
+    {
+        let config = LaunchNetworkConfig {
+            bootnodes: self.bootnodes,
+            peer: DefaultPeerConfig::default(),
+            routing: self.kademlia.clone(),
+            max_peers: self.max_peers,
+            idle_timeout: self.idle_timeout,
+        };
+
+        let (node, client_service, client_handle) = ClientNode::builder(self.identity)
+            .with_kademlia_config(self.kademlia)
+            .build(&config, None)
+            .await
+            .wrap_err("failed to build client node")?;
+
+        let topology = node.topology_handle().clone();
+        let overlay = node.overlay_address();
+        let peer_id = *node.local_peer_id();
+
+        let executor = TaskExecutor::current();
+
+        // The peer manager tick is pure data and `Send`, so it goes through
+        // the ordinary spawner.
+        spawn_peer_manager_task(
+            topology.peer_manager().clone(),
+            DEFAULT_TICK_INTERVAL,
+            &executor,
+        );
+
+        // The client service drives the retrieval and pushsync request paths.
+        // It must run even for callers that never issue downloads, so the node
+        // can answer the protocols its peers speak during topology building.
+        // Its task is `Send`, so it goes through the ordinary service spawner.
+        executor.spawn_service("swarm.client_service", client_service);
+
+        // The node run loop owns the libp2p swarm. It starts listening (a
+        // no-op for a dial-only client) and then dials bootnodes and services
+        // the event loop for the session.
+        spawn_node_run_loop(&executor, node);
+
+        Ok(LaunchedClient {
+            topology,
+            client: client_handle,
+            overlay,
+            peer_id,
+        })
+    }
+}
+
+/// Spawn the node run loop on the executor.
+///
+/// The native swarm and its futures are `Send`, so the run loop spawns as a
+/// critical task on the tokio runtime and participates in graceful shutdown.
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_node_run_loop<I: SwarmIdentity + Clone>(executor: &TaskExecutor, node: ClientNode<I>) {
+    executor.spawn_critical_with_graceful_shutdown_signal(
+        "swarm.client_node",
+        move |shutdown| async move {
+            if let Err(e) = node.start_and_run(shutdown).await {
+                tracing::error!(error = %e, "client node exited with error");
+            }
+        },
+    );
+}
+
+/// Spawn the node run loop on the browser event loop.
+///
+/// The browser swarm's websocket transport futures are `!Send`, so the run
+/// loop goes through the executor's local spawner instead of the Send-bounded
+/// critical one.
+#[cfg(target_arch = "wasm32")]
+fn spawn_node_run_loop<I: SwarmIdentity + Clone>(executor: &TaskExecutor, node: ClientNode<I>) {
+    executor.spawn_local_with_graceful_shutdown_signal(
+        "swarm.client_node",
+        move |shutdown| async move {
+            if let Err(e) = node.start_and_run(shutdown).await {
+                tracing::error!(error = %e, "client node exited with error");
+            }
+        },
+    );
+}
+
+/// Handles to a running embedded client node.
+///
+/// Returned by [`ClientLauncher::launch`]. The spawned tasks do not depend on
+/// this value staying alive; dropping it leaves the node running until the
+/// executor shuts down.
+pub struct LaunchedClient<I: SwarmIdentity> {
+    topology: TopologyHandle<I>,
+    client: ClientHandle,
+    overlay: SwarmAddress,
+    peer_id: PeerId,
+}
+
+impl<I: SwarmIdentity> LaunchedClient<I> {
+    /// Topology handle for readiness polling and
+    /// [`TopologyEvent`](vertex_swarm_topology::TopologyEvent) subscription.
+    pub fn topology(&self) -> &TopologyHandle<I> {
+        &self.topology
+    }
+
+    /// Client handle for chunk retrieval and upload.
+    pub fn client(&self) -> &ClientHandle {
+        &self.client
+    }
+
+    /// The node's overlay address.
+    pub fn overlay_address(&self) -> SwarmAddress {
+        self.overlay
+    }
+
+    /// The node's libp2p peer id.
+    pub fn local_peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+}

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -17,6 +17,7 @@ mod builder;
 #[allow(unreachable_pub)]
 mod client;
 mod error;
+mod launch;
 // NAT traversal and LAN discovery only exist natively. The browser client
 // dials over websockets and never listens, so the wasm sibling exposes the
 // same item names and signatures over a no-op behaviour.
@@ -35,7 +36,9 @@ pub use bootnode::{BootNode, BootNodeBuilder};
 pub use builder::BuiltInfrastructure;
 pub use client::{ClientNode, ClientNodeBuilder};
 pub use error::NodeBuildError;
+pub use launch::{ClientLauncher, LaunchedClient};
 #[cfg(not(target_arch = "wasm32"))]
 pub use storer::{StorerNode, StorerNodeBuilder};
 #[cfg(target_arch = "wasm32")]
-pub use wasm_client::{WasmClientConfig, launch_client};
+#[allow(deprecated)]
+pub use wasm_client::launch_client;

--- a/crates/swarm/node/src/node/wasm_client.rs
+++ b/crates/swarm/node/src/node/wasm_client.rs
@@ -1,183 +1,34 @@
-//! Browser client launch entrypoint.
+//! Deprecated browser client launch entrypoint.
 //!
-//! The native launch path (`vertex-swarm-builder`) pulls the redb database, the
-//! chain provider, the SWAP settlement service, and the gRPC server, none of
-//! which build for `wasm32`. A browser client needs none of them: it mints an
-//! ephemeral identity, dials the live mainnet bootnodes over secure websockets,
-//! and watches its Kademlia topology fill. This module is the narrow,
-//! wasm-buildable assembly that does exactly that.
-//!
-//! [`launch_client`] composes a [`ClientNode`] from an identity, a resolved
-//! bootnode set, and the browser-friendly [`WasmClientConfig`], spawns the node
-//! run loop and the peer-manager tick on the wasm executor, and returns the
-//! [`TopologyHandle`] so a UI can poll readiness and stream topology events. The
-//! returned handle keeps the client alive for the session; dropping it does not
-//! stop the spawned tasks, which run until the page is torn down.
+//! The browser launch path lives in [`super::launch`] now; [`launch_client`]
+//! remains as a thin wrapper so existing callers keep compiling while they
+//! migrate to [`ClientLauncher`].
 
-use std::time::Duration;
-
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use libp2p::Multiaddr;
-use vertex_swarm_api::{
-    DefaultPeerConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
-};
 use vertex_swarm_identity::Identity;
-use vertex_swarm_peer_manager::{DEFAULT_TICK_INTERVAL, spawn_peer_manager_task};
-use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
-use vertex_tasks::TaskExecutor;
+use vertex_swarm_topology::TopologyHandle;
 
-use super::client::ClientNode;
-
-/// Connection idle timeout for the browser client.
-const WASM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Transport-layer cap on established connections for the browser client.
-///
-/// A saturated routing table sits comfortably below this; it is a resource
-/// backstop, not a topology knob.
-const WASM_MAX_PEERS: usize = 400;
-
-/// Network configuration for a browser client node.
-///
-/// The browser cannot open listeners and has no LAN to discover peers on, so
-/// this configuration carries no listen addresses and leaves mDNS, UPnP, and
-/// AutoNAT off. It holds only the resolved bootnode multiaddrs (browser-dialable
-/// `/tls/sni/<host>/ws` leaves) plus the Kademlia routing defaults. It is the
-/// wasm counterpart to the CLI-driven `NetworkConfig` the native builder uses,
-/// trimmed to what a dial-only client needs.
-pub struct WasmClientConfig {
-    bootnodes: Vec<Multiaddr>,
-    peer: DefaultPeerConfig,
-    routing: KademliaConfig,
-}
-
-impl WasmClientConfig {
-    /// Build a browser client configuration from resolved bootnode multiaddrs.
-    ///
-    /// `bootnodes` are the browser-dialable leaves from the DoH resolver or the
-    /// embedded snapshot. Routing uses the Kademlia defaults.
-    #[must_use]
-    pub fn new(bootnodes: Vec<Multiaddr>) -> Self {
-        Self {
-            bootnodes,
-            peer: DefaultPeerConfig::default(),
-            routing: KademliaConfig::default(),
-        }
-    }
-}
-
-impl SwarmNetworkConfig for WasmClientConfig {
-    fn listen_addrs(&self) -> &[Multiaddr] {
-        &[]
-    }
-
-    fn bootnodes(&self) -> &[Multiaddr] {
-        &self.bootnodes
-    }
-
-    fn discovery_enabled(&self) -> bool {
-        true
-    }
-
-    fn max_peers(&self) -> usize {
-        WASM_MAX_PEERS
-    }
-
-    fn idle_timeout(&self) -> Duration {
-        WASM_IDLE_TIMEOUT
-    }
-
-    fn nat_auto_enabled(&self) -> bool {
-        false
-    }
-
-    fn autonat_enabled(&self) -> bool {
-        false
-    }
-
-    fn upnp_enabled(&self) -> bool {
-        false
-    }
-
-    fn mdns_enabled(&self) -> bool {
-        false
-    }
-}
-
-impl SwarmPeerConfig for WasmClientConfig {
-    type Peers = DefaultPeerConfig;
-
-    fn peers(&self) -> &Self::Peers {
-        &self.peer
-    }
-}
-
-impl SwarmRoutingConfig for WasmClientConfig {
-    type Routing = KademliaConfig;
-
-    fn routing(&self) -> &Self::Routing {
-        &self.routing
-    }
-}
+use super::launch::ClientLauncher;
 
 /// Build and start a browser client node, returning its topology handle.
 ///
-/// Assembles a [`ClientNode`] over the wasm websocket transport from the given
-/// ephemeral `identity` and resolved `bootnodes`, spawns the node run loop and
-/// the peer-manager tick on the current wasm [`TaskExecutor`], and hands back the
-/// [`TopologyHandle`] the caller polls for readiness and subscribes to for
-/// [`TopologyEvent`](vertex_swarm_topology::TopologyEvent)s. The node dials its
-/// bootnodes as part of startup; from there the Kademlia routing table fills on
-/// its own.
-///
-/// The returned handle owns nothing the spawned tasks need, so the client keeps
-/// running after the handle is dropped. The browser tears the session down by
-/// dropping the whole wasm instance.
+/// Thin wrapper over [`ClientLauncher`] kept for callers that predate it. The
+/// returned handle keeps the client alive for the session; dropping it does
+/// not stop the spawned tasks, which run until the page is torn down.
 ///
 /// # Errors
 ///
 /// Returns an error if the swarm fails to assemble (transport or behaviour
-/// construction) or the node fails to begin listening.
+/// construction).
+#[deprecated(note = "use ClientLauncher")]
 pub async fn launch_client(
     identity: Identity,
     bootnodes: Vec<Multiaddr>,
 ) -> Result<TopologyHandle<Identity>> {
-    let config = WasmClientConfig::new(bootnodes);
-
-    let (node, client_service, _client_handle) = ClientNode::builder(identity)
-        .build(&config, None)
-        .await
-        .wrap_err("failed to build browser client node")?;
-
-    let topology = node.topology_handle().clone();
-
-    let executor = TaskExecutor::current();
-    // The peer manager tick is pure data and `Send`, so it goes through the
-    // ordinary spawner.
-    spawn_peer_manager_task(
-        topology.peer_manager().clone(),
-        DEFAULT_TICK_INTERVAL,
-        &executor,
-    );
-
-    // The client service drives the retrieval and pushsync request paths. The
-    // demo does not issue downloads, but the service must run so the node can
-    // answer the protocols its peers speak during topology building. Its task is
-    // `Send`, so it goes through the ordinary service spawner.
-    executor.spawn_service("swarm.client_service", client_service);
-
-    // The node run loop owns the libp2p swarm, whose websocket transport futures
-    // are `!Send`. It starts listening (a no-op for the browser, which cannot
-    // listen) and then dials bootnodes and services the event loop for the
-    // session, so it spawns on the browser-local path too.
-    executor.spawn_local_with_graceful_shutdown_signal(
-        "swarm.client_node",
-        move |shutdown| async move {
-            if let Err(e) = node.start_and_run(shutdown).await {
-                tracing::error!(error = %e, "browser client node exited with error");
-            }
-        },
-    );
-
-    Ok(topology)
+    let launched = ClientLauncher::new(identity)
+        .with_bootnodes(bootnodes)
+        .launch()
+        .await?;
+    Ok(launched.topology().clone())
 }

--- a/crates/swarm/node/tests/client_launcher.rs
+++ b/crates/swarm/node/tests/client_launcher.rs
@@ -1,0 +1,52 @@
+//! Smoke test: [`ClientLauncher`] brings up an embedded client node and
+//! returns working handles.
+//!
+//! Hermetic by construction: the spec carries no bootnodes and the launcher is
+//! given none, so the spec fallback resolves to nothing and the node never
+//! dials off-host. The point under test is the launch wiring (swarm assembly,
+//! task spawning, handle plumbing), not connectivity; the cluster tests cover
+//! the connected paths.
+
+use std::sync::Arc;
+
+use eyre::Result;
+use vertex_swarm_api::{SwarmIdentity as _, SwarmNodeType, SwarmTopologyStats as _};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_node::ClientLauncher;
+use vertex_swarm_spec::SpecBuilder;
+use vertex_swarm_test_utils::TEST_NETWORK_ID;
+use vertex_tasks::{TaskExecutor, TaskManager};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn launcher_brings_up_client_node() -> Result<()> {
+    // The launch path spawns onto the global TaskExecutor; install one if the
+    // test process has not already done so. Held so the executor outlives the
+    // launched node.
+    let _task_manager = match TaskExecutor::try_current() {
+        Ok(_) => None,
+        Err(_) => Some(TaskManager::current()),
+    };
+
+    let spec = Arc::new(
+        SpecBuilder::testnet()
+            .network_id(TEST_NETWORK_ID)
+            .bootnodes(Vec::new())
+            .build(),
+    );
+    let identity = Identity::random(spec, SwarmNodeType::Client);
+    let overlay = identity.overlay_address();
+
+    let launched = ClientLauncher::new(identity)
+        .with_max_peers(16)
+        .launch()
+        .await?;
+
+    assert_eq!(launched.overlay_address(), overlay);
+    assert_eq!(launched.topology().connected_peers_count(), 0);
+    // The accessors hand out live handles: the peer id is the swarm's and the
+    // client handle is clonable for embedding.
+    let _peer_id = launched.local_peer_id();
+    let _client = launched.client().clone();
+
+    Ok(())
+}

--- a/docs/agents/wasm.md
+++ b/docs/agents/wasm.md
@@ -128,6 +128,6 @@ Deploy: `.github/workflows/pages.yml` builds the demo with `--public-url /vertex
 3. Audit tokio features in every wasm-cone crate; trim to the minimum.
 4. Add an `IndexedDb` `Database` backend (likely under `crates/storage/indexeddb`) gated on `cfg(target_arch = "wasm32")`.
 5. Done: `libp2p-websocket-websys` is wired into `crates/swarm/node`'s client variant under wasm cfg (`build_swarm`).
-6. Build a richer browser client on top of `vertex_swarm_node::launch_client` that adds the IndexedDB backend and upload/download flows.
+6. Build a richer browser client on top of `vertex_swarm_node::ClientLauncher` (the fluent launcher shared by native embedders and the browser; the deprecated `launch_client` wrapper remains until the demo migrates) that adds the IndexedDB backend and upload/download flows.
 
 Each step is its own PR. Do not bundle.


### PR DESCRIPTION
## Summary

Gives the wasm client real builder ergonomics: a fluent `ClientLauncher` in `vertex-swarm-node`, compiled on both targets, replaces the standalone `launch_client()` path so the browser demo and native embedders share one lightweight entry point (no database, no chain provider, no RPC server; the full native stack stays in `vertex-swarm-builder`).

## What changed

- New `crates/swarm/node/src/node/launch.rs`, compiled on both targets with no module-level cfg. `ClientLauncher::new(identity)` plus `with_bootnodes`, `with_kademlia`, `with_max_peers` (default 400), `with_idle_timeout` (default 60s), and `launch()`, which builds through the existing `ClientNode::builder(...).build(...)` path and spawns the peer-manager tick, the client service, and the node run loop on the current `TaskExecutor`. It returns `LaunchedClient` with `topology()`, `client()`, `overlay_address()`, and `local_peer_id()` accessors.
- The only cfg in the file is one Pattern A pair for spawning the run loop: `spawn_critical_with_graceful_shutdown_signal` natively (the node future is Send there) and `spawn_local_with_graceful_shutdown_signal` on wasm (the websocket-websys swarm is not Send). Both siblings have identical signatures.
- `WasmClientConfig` moved into launch.rs as the private `LaunchNetworkConfig` (same trait impls, fields fed from the launcher; nothing platform-specific remains in it). Empty bootnodes fall back to the spec set, which topology resolves per platform (system resolver natively, DoH in the browser); documented on `with_bootnodes`.
- `wasm_client.rs` shrinks to a thin `#[deprecated]` wrapper: `launch_client(identity, bootnodes)` delegates to the launcher and still returns the topology handle, so `bin/swarm-demo` and the Pages build stay green. The demo migrates in a later unit and is untouched here.
- `ClientLauncher` and `LaunchedClient` are exported unconditionally from `vertex_swarm_node`; the deprecated `launch_client` re-export stays wasm-only behind `#[allow(deprecated)]`.
- `docs/agents/wasm.md` plan step 6 now names `ClientLauncher`.

## Behaviour

Runtime behaviour on wasm is identical to today's `launch_client`: same defaults (400 max peers, 60s idle timeout, Kademlia defaults), same build path, same spawn order and task names. No native node path changes (`vertex-swarm-builder`, `bin/vertex`, storer untouched).

Known pre-existing limitation worth a follow-up: a native dial-only launcher node has no listen addresses, so the listen-address-derived `IpCapability` stays unknown and `is_dialable` filters ip4/dns4 bootnode leaves (wasm pins capability to `Dual`). Out of scope here since this unit changes no native dial policy.

## Testing

- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo test -p vertex-swarm-node` passes, including a new hermetic smoke test (`tests/client_launcher.rs`): launcher brings up a client node on a no-bootnode isolated spec and returns working handles. The connected paths stay covered by the cluster tests.
- `cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node` (the CI wasm job invocation) builds clean.
- `bin/swarm-demo` builds for wasm against the deprecated wrapper (deprecation warning only, as intended).
