### PR TITLE
feat(net-local): transport-aware dial eligibility and dial-only capability pin

### DIFF
--- a/crates/net/AGENTS.md
+++ b/crates/net/AGENTS.md
@@ -6,7 +6,7 @@ Root-level rules in `/AGENTS.md` apply here too. The notes below are the area-sp
 
 ## Scope
 
-- `dnsaddr`, `local`, `utils`: address handling and IP classification.
+- `dnsaddr`, `local`, `utils`: address handling, IP classification, and dial eligibility. `local` owns `DialCapability` (IP family x transport suite): `TransportCapability::platform()` mirrors the swarm assembly in `vertex-swarm-node` (TCP natively, secure websockets on wasm32), and `LocalCapabilities::dial_only()` pins the IP half to dual-stack for nodes that never listen. See `docs/networking/address-management.md`.
 - `dnsaddr-doh`: wasm-only dnsaddr resolution over DNS-over-HTTPS for browser clients that have no raw DNS TXT capability. The recursion driver is generic over a `TxtFetcher` so its parsing, bounded-depth recursion, and wss-leaf filtering test natively against fixtures; the `fetch`-backed `DohClient` is `cfg(target_arch = "wasm32")`. It returns dialable leaves only and stays free of `crates/swarm/` types: the snapshot-fallback policy lives at the bootnode-selection site (`resolve_or_fallback` takes a caller-supplied snapshot slice). See `docs/agents/wasm.md`.
 - `peer/backoff`, `peer/score`, `peer/store`, `peer/registry`: peer state primitives that hold no protocol logic. Together with `local` they sit in the wasm compilation cone of the Swarm peer stack: keep them building for `wasm32-unknown-unknown` (the `wasm` CI job enforces this through `vertex-swarm-peer-manager`) and take wall clocks and monotonic time from `web-time`, not `std::time`. See `docs/agents/wasm.md`.
 - `dialer`: generic dial-request tracker with bounded queue and in-flight management.

--- a/crates/net/local/src/capabilities.rs
+++ b/crates/net/local/src/capabilities.rs
@@ -52,13 +52,29 @@ pub fn advertise_filter<'a>(
 pub struct LocalCapabilities {
     listen_addrs: RwLock<Vec<Multiaddr>>,
     capability: RwLock<IpCapability>,
+    /// Pin the reported capability to [`IpCapability::Dual`] regardless of
+    /// listen addresses. Set for dial-only nodes, which never listen and so
+    /// can never derive a capability from listeners, yet can dial whatever
+    /// address family their host stack routes.
+    dial_only: bool,
 }
 
 impl LocalCapabilities {
     pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Capabilities for a dial-only node: no listeners will ever register,
+    /// so the IP capability is pinned to [`IpCapability::Dual`].
+    ///
+    /// This is the same reasoning the browser target applies globally (see
+    /// [`Self::capability`]): an outbound-only node is not limited by what
+    /// it listens on, and a dial into an unroutable family fails fast at
+    /// the socket rather than poisoning the routing table.
+    pub fn dial_only() -> Self {
         Self {
-            listen_addrs: RwLock::new(Vec::new()),
-            capability: RwLock::new(IpCapability::default()),
+            dial_only: true,
+            ..Self::default()
         }
     }
 
@@ -110,21 +126,27 @@ impl LocalCapabilities {
     /// The locally observed IP dial capability.
     ///
     /// On native targets this is derived from the node's own listen addresses
-    /// (a node with no IPv6 listener does not dial IPv6 peers, and so on). A
-    /// browser client has no listeners, so the listen-address heuristic would
-    /// leave it at [`IpCapability::None`] and reject every dial. The browser can
-    /// in fact open outbound connections to either address family through its
-    /// own network stack, so on wasm32 the capability is fixed at
-    /// [`IpCapability::Dual`].
-    #[cfg(not(target_arch = "wasm32"))]
+    /// (a node with no IPv6 listener does not dial IPv6 peers, and so on),
+    /// except for dial-only nodes ([`Self::dial_only`]), which have no
+    /// listeners by construction and report [`IpCapability::Dual`]. A
+    /// browser client has no listeners either, so on wasm32 the capability is
+    /// always [`IpCapability::Dual`]: the browser opens outbound connections
+    /// to either address family through its own network stack.
     pub fn capability(&self) -> IpCapability {
+        if cfg!(target_arch = "wasm32") || self.dial_only {
+            return IpCapability::Dual;
+        }
         *self.capability.read()
     }
 
-    /// Browser dial capability: see the native definition for the rationale.
-    #[cfg(target_arch = "wasm32")]
-    pub fn capability(&self) -> IpCapability {
-        IpCapability::Dual
+    /// The combined dial filter for this node: the current IP capability
+    /// plus the transport suites this build target's swarm assembly can
+    /// dial ([`crate::TransportCapability::platform`]).
+    pub fn dial_capability(&self) -> crate::DialCapability {
+        crate::DialCapability {
+            ip: self.capability(),
+            transport: crate::TransportCapability::platform(),
+        }
     }
 
     /// Get a clone of listen addresses.
@@ -179,6 +201,18 @@ mod tests {
         assert_eq!(addrs.len(), 1);
         assert!(!addrs.contains(&addr1));
         assert!(addrs.contains(&addr2));
+    }
+
+    #[test]
+    fn dial_only_pins_capability_to_dual() {
+        let cap = LocalCapabilities::dial_only();
+        assert_eq!(cap.capability(), IpCapability::Dual);
+        assert!(cap.capability().is_known());
+
+        // Listen events never arrive for a dial-only node, but even if one
+        // did the pin holds: capability stays Dual.
+        cap.on_new_listen_addr(parse_addr("/ip4/127.0.0.1/tcp/1634"));
+        assert_eq!(cap.capability(), IpCapability::Dual);
     }
 
     #[test]

--- a/crates/net/local/src/lib.rs
+++ b/crates/net/local/src/lib.rs
@@ -1,12 +1,14 @@
 //! Protocol-agnostic local network utilities for libp2p.
 //!
 //! - [`scope`] - IP address classification (loopback, private, link-local, public)
+//! - [`transport`] - Transport-suite classification and combined dial eligibility
 //! - [`system`] - System interface queries for subnet detection
 //! - [`capabilities`] - Local node network capabilities tracking
 
 pub mod capabilities;
 pub mod scope;
 pub mod system;
+pub mod transport;
 
 pub use capabilities::{LocalCapabilities, advertise_filter};
 pub use scope::{
@@ -14,3 +16,4 @@ pub use scope::{
     is_dialable,
 };
 pub use system::{add_subnet, remove_subnet, same_subnet};
+pub use transport::{DialCapability, TransportCapability, TransportRequirement};

--- a/crates/net/local/src/transport.rs
+++ b/crates/net/local/src/transport.rs
@@ -1,0 +1,229 @@
+//! Transport-suite classification for dial eligibility.
+//!
+//! IP capability ([`crate::IpCapability`]) answers "can this host route to
+//! that address family"; the types here answer "can the assembled libp2p
+//! transport stack open that kind of connection at all". A browser client
+//! dials only secure websockets, so a peer advertising nothing but raw TCP
+//! multiaddrs is undialable for it no matter how routable the IP is, and
+//! vice versa for a native stack without a websocket client. Filtering on
+//! both halves up front avoids dials that can only fail inside the
+//! transport.
+
+use libp2p::Multiaddr;
+use libp2p::multiaddr::Protocol;
+
+/// The transport suite a multiaddr requires from the dialer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportRequirement {
+    /// Raw TCP (optionally behind `/dns*` resolution), no upgrade encoded
+    /// in the address.
+    Tcp,
+    /// Plain (non-TLS) websocket.
+    Websocket,
+    /// TLS websocket: `/tls/ws` (with or without `/sni`) or the legacy
+    /// `/wss` form.
+    SecureWebsocket,
+    /// Anything else (QUIC, memory, relay-only); dialable by no transport
+    /// stack vertex currently assembles.
+    Other,
+}
+
+impl TransportRequirement {
+    /// Classify the transport suite `addr` requires.
+    ///
+    /// A websocket component dominates the TCP it rides on, so
+    /// `/ip4/../tcp/../tls/ws` classifies as [`Self::SecureWebsocket`],
+    /// not [`Self::Tcp`].
+    pub fn of(addr: &Multiaddr) -> Self {
+        let mut saw_tcp = false;
+        let mut saw_tls = false;
+
+        for proto in addr.iter() {
+            match proto {
+                Protocol::Tcp(_) => saw_tcp = true,
+                Protocol::Tls => saw_tls = true,
+                Protocol::Wss(_) => return Self::SecureWebsocket,
+                Protocol::Ws(_) => {
+                    return if saw_tls {
+                        Self::SecureWebsocket
+                    } else {
+                        Self::Websocket
+                    };
+                }
+                _ => {}
+            }
+        }
+
+        if saw_tcp { Self::Tcp } else { Self::Other }
+    }
+}
+
+/// The transport suites the local node's assembled libp2p stack can dial.
+///
+/// Mirrors the swarm assembly in `vertex-swarm-node`: the native stack is
+/// TCP with DNS resolution and no websocket client; the browser stack is
+/// `libp2p-websocket-websys`, which dials secure websockets only (both the
+/// `/dns4/<host>/../tls/ws` and the AutoTLS `/ip4/../tls/sni/<host>/ws`
+/// shapes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportCapability {
+    /// TCP with DNS resolution; no websocket client.
+    Tcp,
+    /// Secure websockets only.
+    SecureWebsocket,
+}
+
+impl TransportCapability {
+    /// The capability matching the swarm this build target assembles.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub const fn platform() -> Self {
+        Self::Tcp
+    }
+
+    /// The capability matching the swarm this build target assembles.
+    #[cfg(target_arch = "wasm32")]
+    pub const fn platform() -> Self {
+        Self::SecureWebsocket
+    }
+
+    /// Whether this stack can dial `addr` at the transport layer.
+    pub fn can_dial(&self, addr: &Multiaddr) -> bool {
+        matches!(
+            (self, TransportRequirement::of(addr)),
+            (Self::Tcp, TransportRequirement::Tcp)
+                | (Self::SecureWebsocket, TransportRequirement::SecureWebsocket)
+        )
+    }
+}
+
+/// Combined dial eligibility: IP-family reachability and transport support.
+///
+/// This is the one filter dial preparation and gossip intake share, so the
+/// set of peers admitted to the known table and the set of addresses handed
+/// to the dialer can never disagree about what is dialable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DialCapability {
+    /// IP-family reachability (listen-derived, or pinned for dial-only
+    /// nodes).
+    pub ip: crate::IpCapability,
+    /// Transport suites the assembled stack can dial.
+    pub transport: TransportCapability,
+}
+
+impl DialCapability {
+    /// Whether `addr` is dialable: the transport stack supports it and
+    /// [`crate::is_dialable`] passes for the IP half.
+    pub fn can_dial(&self, addr: &Multiaddr) -> bool {
+        self.transport.can_dial(addr) && crate::is_dialable(addr, self.ip)
+    }
+
+    /// Whether at least one of `addrs` is dialable.
+    pub fn can_dial_any<'a>(&self, addrs: impl IntoIterator<Item = &'a Multiaddr>) -> bool {
+        addrs.into_iter().any(|addr| self.can_dial(addr))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::IpCapability;
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().expect("valid multiaddr")
+    }
+
+    #[test]
+    fn classifies_live_network_shapes() {
+        // The shapes that appear in mainnet hive gossip and dnsaddr leaves.
+        let cases = [
+            ("/ip4/1.2.3.4/tcp/1634", TransportRequirement::Tcp),
+            ("/dns4/bee.example.org/tcp/1634", TransportRequirement::Tcp),
+            ("/ip6/2001:db8::1/tcp/1634", TransportRequirement::Tcp),
+            (
+                "/dns4/host.example.org/tcp/443/tls/ws",
+                TransportRequirement::SecureWebsocket,
+            ),
+            (
+                "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws",
+                TransportRequirement::SecureWebsocket,
+            ),
+            (
+                "/dns4/host.example.org/tcp/443/wss",
+                TransportRequirement::SecureWebsocket,
+            ),
+            ("/ip4/1.2.3.4/tcp/1634/ws", TransportRequirement::Websocket),
+            ("/ip4/1.2.3.4/udp/1634/quic-v1", TransportRequirement::Other),
+        ];
+        for (s, expected) in cases {
+            assert_eq!(TransportRequirement::of(&addr(s)), expected, "{s}");
+        }
+    }
+
+    #[test]
+    fn classification_survives_p2p_suffix() {
+        let wss = addr(
+            "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg",
+        );
+        assert_eq!(
+            TransportRequirement::of(&wss),
+            TransportRequirement::SecureWebsocket
+        );
+        let tcp = addr("/ip4/1.2.3.4/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg");
+        assert_eq!(TransportRequirement::of(&tcp), TransportRequirement::Tcp);
+    }
+
+    #[test]
+    fn tcp_stack_rejects_websockets() {
+        let cap = TransportCapability::Tcp;
+        assert!(cap.can_dial(&addr("/ip4/8.8.8.8/tcp/1634")));
+        assert!(cap.can_dial(&addr("/dns4/bee.example.org/tcp/1634")));
+        assert!(!cap.can_dial(&addr(
+            "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws"
+        )));
+        assert!(!cap.can_dial(&addr("/ip4/8.8.8.8/tcp/1634/ws")));
+    }
+
+    #[test]
+    fn secure_websocket_stack_rejects_tcp_and_plain_ws() {
+        let cap = TransportCapability::SecureWebsocket;
+        assert!(cap.can_dial(&addr(
+            "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws"
+        )));
+        assert!(cap.can_dial(&addr("/dns4/host.example.org/tcp/443/tls/ws")));
+        assert!(!cap.can_dial(&addr("/ip4/8.8.8.8/tcp/1634")));
+        assert!(!cap.can_dial(&addr("/ip4/8.8.8.8/tcp/1634/ws")));
+    }
+
+    #[test]
+    fn dial_capability_combines_ip_and_transport() {
+        // A browser-shaped capability: dual-stack IP, wss-only transport.
+        let browser = DialCapability {
+            ip: IpCapability::Dual,
+            transport: TransportCapability::SecureWebsocket,
+        };
+        let wss = addr("/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws");
+        let tcp = addr("/ip4/8.8.8.8/tcp/1634");
+        assert!(browser.can_dial(&wss));
+        assert!(!browser.can_dial(&tcp));
+        assert!(browser.can_dial_any([&tcp, &wss]));
+        assert!(!browser.can_dial_any([&tcp]));
+
+        // A v4-only native node rejects a v6 TCP address on the IP half.
+        let native_v4 = DialCapability {
+            ip: IpCapability::V4Only,
+            transport: TransportCapability::Tcp,
+        };
+        assert!(native_v4.can_dial(&tcp));
+        assert!(!native_v4.can_dial(&addr("/ip6/2001:db8::1/tcp/1634")));
+        assert!(!native_v4.can_dial(&wss));
+    }
+
+    #[test]
+    fn dial_capability_unknown_ip_rejects_everything() {
+        let cap = DialCapability {
+            ip: IpCapability::None,
+            transport: TransportCapability::Tcp,
+        };
+        assert!(!cap.can_dial(&addr("/ip4/8.8.8.8/tcp/1634")));
+    }
+}

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -61,6 +61,9 @@ pub struct TopologyBehaviourBuilder<I: SwarmIdentity + Clone> {
     bootnodes: Vec<Multiaddr>,
     trusted_peers: Vec<Multiaddr>,
     nat_addrs: Vec<Multiaddr>,
+    /// No listen addresses configured: the node is dial-only, so its IP
+    /// capability is pinned instead of listener-derived.
+    dial_only: bool,
     trust_local_peers: bool,
     scoring_config: SwarmScoringConfig,
     max_per_bin: usize,
@@ -84,6 +87,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             bootnodes: network_config.bootnodes().to_vec(),
             trusted_peers: network_config.trusted_peers().to_vec(),
             nat_addrs: network_config.nat_addrs().to_vec(),
+            dial_only: network_config.listen_addrs().is_empty(),
             trust_local_peers: network_config.trust_local_peers(),
             scoring_config: SwarmScoringConfig::builder()
                 .ban_threshold(peer_config.ban_threshold())
@@ -170,7 +174,16 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             .unwrap_or(pacing.evaluation_interval);
         let dial_quota = self.config.dial_quota.unwrap_or(pacing.dial_quota);
 
-        let local_capabilities = Arc::new(LocalCapabilities::new());
+        // A dial-only node never registers a listen address, so the
+        // listener-derived IP capability would stay unknown and the dial
+        // filter would reject every ip4/dns4 address. Pin it to dual-stack
+        // instead: an outbound-only node dials whatever its host stack
+        // routes (the browser target applies the same pin globally).
+        let local_capabilities = Arc::new(if self.dial_only {
+            LocalCapabilities::dial_only()
+        } else {
+            LocalCapabilities::new()
+        });
 
         // LocalAddressManager handles NAT address advertisement
         // Note: We no longer track peer-observed addresses - they contain
@@ -328,7 +341,7 @@ mod tests {
         peers: DefaultPeerConfig,
         routing: KademliaConfig,
         bootnodes: Vec<Multiaddr>,
-        empty_addrs: Vec<Multiaddr>,
+        listen_addrs: Vec<Multiaddr>,
         connection_profile: Option<ConnectionProfile>,
     }
 
@@ -338,7 +351,7 @@ mod tests {
                 peers: DefaultPeerConfig::default(),
                 routing: KademliaConfig::default(),
                 bootnodes: vec!["/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr")],
-                empty_addrs: Vec::new(),
+                listen_addrs: Vec::new(),
                 connection_profile: None,
             }
         }
@@ -346,7 +359,7 @@ mod tests {
 
     impl SwarmNetworkConfig for TestConfig {
         fn listen_addrs(&self) -> &[Multiaddr] {
-            &self.empty_addrs
+            &self.listen_addrs
         }
         fn bootnodes(&self) -> &[Multiaddr] {
             &self.bootnodes
@@ -438,6 +451,33 @@ mod tests {
 
     fn identity_of(node_type: SwarmNodeType) -> Identity {
         Identity::random(vertex_swarm_spec::init_testnet(), node_type)
+    }
+
+    /// A configuration without listen addresses builds a dial-only node:
+    /// the IP capability is pinned to dual-stack so bootnode and discovery
+    /// dials are never filtered for lack of a listener-derived capability.
+    #[test]
+    fn no_listen_addrs_pins_dial_capability_to_dual() {
+        use vertex_net_local::IpCapability;
+
+        let (behaviour, _handle) =
+            TopologyBehaviourBuilder::new(test_identity(), &TestConfig::new())
+                .try_build()
+                .expect("build without runtime");
+        assert_eq!(behaviour.nat_discovery.capability(), IpCapability::Dual);
+
+        let listening = TestConfig {
+            listen_addrs: vec!["/ip4/0.0.0.0/tcp/1634".parse().expect("valid multiaddr")],
+            ..TestConfig::new()
+        };
+        let (behaviour, _handle) = TopologyBehaviourBuilder::new(test_identity(), &listening)
+            .try_build()
+            .expect("build without runtime");
+        assert_eq!(
+            behaviour.nat_discovery.capability(),
+            IpCapability::None,
+            "a listening node derives capability from its listeners, not the pin"
+        );
     }
 
     /// Assert that a built behaviour carries the pacing numbers of `profile`.

--- a/crates/swarm/topology/src/dialing.rs
+++ b/crates/swarm/topology/src/dialing.rs
@@ -77,14 +77,18 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             return;
         }
 
-        // One call: filter addresses, build DialOpts, register in-flight
-        let capability = self.nat_discovery.capability();
+        // One call: filter addresses, build DialOpts, register in-flight.
+        // The filter covers both halves of dialability: IP-family
+        // reachability and whether the assembled transport stack supports
+        // the address shape at all (TCP natively, secure websockets in the
+        // browser).
+        let capability = self.nat_discovery.dial_capability();
         let opts = match self.dial_tracker.prepare_and_start(
             target.overlay(),
             peer_id,
             target.addrs(),
             reason,
-            |addr| vertex_net_local::is_dialable(addr, capability),
+            |addr| capability.can_dial(addr),
         ) {
             Ok(opts) => opts,
             Err(PrepareError::NoReachableAddresses) => {

--- a/crates/swarm/topology/src/nat_discovery.rs
+++ b/crates/swarm/topology/src/nat_discovery.rs
@@ -121,6 +121,12 @@ impl LocalAddressManager {
         self.local.capability()
     }
 
+    /// The combined dial filter (IP capability plus platform transport
+    /// suites); see [`LocalCapabilities::dial_capability`].
+    pub fn dial_capability(&self) -> vertex_net_local::DialCapability {
+        self.local.dial_capability()
+    }
+
     /// Check if we have any public addresses to advertise.
     pub fn is_reachable(&self) -> bool {
         // Check static NAT addresses

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use libp2p::PeerId;
 use libp2p::ping;
 use libp2p::swarm::{ConnectionId, ToSwarm};
-use metrics::gauge;
+use metrics::{counter, gauge};
 use tracing::{debug, info, trace, warn};
 use vertex_net_local::{AddressScope, classify_multiaddr};
 use vertex_net_peer_registry::ActivateResult;
@@ -382,29 +382,25 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             return;
         }
 
-        // Filter peers we can't reach based on our IP capability.
-        let local_capability = self.nat_discovery.capability();
-        let peers: Vec<vertex_swarm_peer::SwarmPeer> = if local_capability.is_known() {
-            peers
-                .into_iter()
-                .filter(|peer| {
-                    let peer_cap = peer.ip_capability();
-                    let reachable = local_capability.can_reach(&peer_cap);
-                    if !reachable {
-                        trace!(
-                            overlay = %peer.overlay(),
-                            ?local_capability,
-                            ?peer_cap,
-                            "filtering unreachable gossiped peer"
-                        );
-                    }
-                    reachable
-                })
-                .collect()
-        } else {
-            // Capability unknown (no listen addrs yet) -- let all through
-            peers
-        };
+        // Filter records this node cannot dial, so they never enter the
+        // known table as dial candidates.
+        let dial_capability = self.nat_discovery.dial_capability();
+        let peers: Vec<vertex_swarm_peer::SwarmPeer> = peers
+            .into_iter()
+            .filter(|peer| {
+                let dialable = record_dialable(peer, dial_capability);
+                if !dialable {
+                    trace!(
+                        overlay = %peer.overlay(),
+                        ?dial_capability,
+                        "filtering undialable gossiped peer"
+                    );
+                    counter!("topology_gossip_rejected_total", "reason" => "not_dialable")
+                        .increment(1);
+                }
+                dialable
+            })
+            .collect();
 
         if peers.is_empty() {
             return;
@@ -469,6 +465,30 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     }
 }
 
+/// Whether a gossiped record carries at least one multiaddr this node can
+/// dial.
+///
+/// The transport half of the capability is static (the assembled stack
+/// never changes), so it always applies: a secure-websocket-only client
+/// drops records carrying nothing but raw TCP multiaddrs instead of
+/// queuing dials that can only fail inside the transport. The IP half
+/// applies once the capability is known; while it is unknown (no listen
+/// addresses registered yet) only the transport check runs, so a briefly
+/// capability-less node does not permanently reject otherwise good
+/// records.
+fn record_dialable(
+    peer: &vertex_swarm_peer::SwarmPeer,
+    capability: vertex_net_local::DialCapability,
+) -> bool {
+    if capability.ip.is_known() {
+        capability.can_dial_any(peer.multiaddrs())
+    } else {
+        peer.multiaddrs()
+            .iter()
+            .any(|addr| capability.transport.can_dial(addr))
+    }
+}
+
 /// Classify a handshake error: only protocol violations the peer is solely
 /// responsible for should feed the reachability tracker. Timeouts, IO
 /// errors, and bare connection-close events can be caused by our own side
@@ -489,4 +509,78 @@ fn is_peer_fault(error: &vertex_swarm_net_handshake::HandshakeError) -> bool {
             | E::InvalidObservedAddress
             | E::Protobuf(_)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, B256, Signature, U256};
+    use vertex_net_local::{DialCapability, IpCapability, TransportCapability};
+    use vertex_swarm_peer::SwarmPeer;
+
+    fn record_with_addrs(addrs: &[&str]) -> SwarmPeer {
+        let multiaddrs = addrs
+            .iter()
+            .map(|s| s.parse().expect("valid multiaddr"))
+            .collect();
+        SwarmPeer::from_parts(
+            multiaddrs,
+            Signature::new(U256::from(1u64), U256::from(1u64), false),
+            B256::repeat_byte(0x42).into(),
+            vertex_swarm_primitives::Nonce::ZERO,
+            vertex_swarm_peer::Timestamp::from_seconds(1),
+            None,
+            Address::ZERO,
+        )
+    }
+
+    const TCP: &str = "/ip4/8.8.8.8/tcp/1634";
+    const WSS: &str = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws";
+
+    #[test]
+    fn wss_only_client_rejects_tcp_only_records() {
+        // The browser shape: dual-stack IP, secure-websocket-only transport.
+        let capability = DialCapability {
+            ip: IpCapability::Dual,
+            transport: TransportCapability::SecureWebsocket,
+        };
+        assert!(!record_dialable(&record_with_addrs(&[TCP]), capability));
+        assert!(record_dialable(&record_with_addrs(&[WSS]), capability));
+        assert!(record_dialable(&record_with_addrs(&[TCP, WSS]), capability));
+    }
+
+    #[test]
+    fn tcp_client_rejects_wss_only_records() {
+        let capability = DialCapability {
+            ip: IpCapability::Dual,
+            transport: TransportCapability::Tcp,
+        };
+        assert!(record_dialable(&record_with_addrs(&[TCP]), capability));
+        assert!(!record_dialable(&record_with_addrs(&[WSS]), capability));
+        assert!(record_dialable(&record_with_addrs(&[TCP, WSS]), capability));
+    }
+
+    #[test]
+    fn unknown_ip_capability_applies_only_the_transport_half() {
+        // A listening native node before its first listener registers: the
+        // IP half must not reject records, but the transport half still
+        // filters websocket-only ones.
+        let capability = DialCapability {
+            ip: IpCapability::None,
+            transport: TransportCapability::Tcp,
+        };
+        assert!(record_dialable(&record_with_addrs(&[TCP]), capability));
+        assert!(!record_dialable(&record_with_addrs(&[WSS]), capability));
+    }
+
+    #[test]
+    fn known_ip_capability_filters_by_family() {
+        let capability = DialCapability {
+            ip: IpCapability::V4Only,
+            transport: TransportCapability::Tcp,
+        };
+        let v6_only = record_with_addrs(&["/ip6/2001:db8::1/tcp/1634"]);
+        assert!(!record_dialable(&v6_only, capability));
+        assert!(record_dialable(&record_with_addrs(&[TCP]), capability));
+    }
 }

--- a/docs/networking/address-management.md
+++ b/docs/networking/address-management.md
@@ -20,6 +20,18 @@ Classifies IP addresses into scopes for smart address selection:
 
 `IpCapability` tracks dual-stack support (IPv4, IPv6, or both) and filters peer addresses we can actually dial.
 
+## Dial Eligibility (`DialCapability`)
+
+Whether an address is dialable has two independent halves, combined in `DialCapability`:
+
+- **IP half** (`IpCapability`): derived from the node's own listen addresses. A dial-only node (no listen addresses configured, including every `ClientLauncher` node and the browser client) never registers a listener, so its capability is pinned to dual-stack instead: an outbound-only node dials whatever address family its host stack routes.
+- **Transport half** (`TransportCapability`): what the assembled libp2p stack can open, mirroring the swarm assembly in `vertex-swarm-node`. Native builds dial TCP (with DNS resolution) and no websockets; the browser build dials secure websockets only (`/dns4/<host>/../tls/ws` and the AutoTLS `/ip4/../tls/sni/<host>/ws` shapes).
+
+`DialCapability` is applied in two places, which therefore can never disagree:
+
+- **Dial preparation** (`vertex-swarm-topology::dialing`): per-address filter before `DialOpts` are built; a target with no surviving address is released without a dial attempt.
+- **Hive gossip receipt** (`on_hive_peers_received`): records carrying no locally-dialable multiaddr are dropped before they enter the known table (`topology_gossip_rejected_total{reason="not_dialable"}`), so the candidate supply never queues dials that can only fail inside the transport. While the IP half is still unknown (a listening node before its first listener registers) only the transport half applies.
+
 ## Local Network Detection
 
 `LocalCapabilities` queries system network interfaces to determine subnet membership. This enables accurate "same subnet" checks without hardcoding subnet sizes.


### PR DESCRIPTION
Closes #270

## Problem

Dial eligibility covered only the IP-family half: `is_dialable` filtered on `IpCapability`, derived from the node's listen addresses. That broke two ways.

A native dial-only node launched through `ClientLauncher` never listens, so its capability stayed `None` and the dial filter rejected every ip4/dns4 bootnode leaf (#270). The wasm client was unaffected only because the browser target pins `Dual` globally.

The pinned-`Dual` browser had the opposite problem: nothing modelled what the assembled transport stack can actually open. The browser dials only secure websockets (`/dns4/<host>/../tls/ws` and the AutoTLS `/ip4/../tls/sni/<host>/ws` shapes), yet gossiped records carrying nothing but raw TCP multiaddrs passed the IP filter, entered the known table as dial candidates, and produced guaranteed-failing dials that burned dial-rate budget and backoff state. Symmetrically, a native node would attempt wss-only dnsaddr leaves its TCP transport cannot open.

## Change

`vertex-net-local` now models both halves of dialability:

- `TransportRequirement::of(addr)` classifies the suite a multiaddr needs: tcp, plain websocket, secure websocket (`/tls/ws` with or without `/sni`, legacy `/wss`), or other (quic and friends).
- `TransportCapability::platform()` mirrors the swarm assembly in `vertex-swarm-node`: TCP with DNS resolution natively, secure websockets only on wasm32.
- `DialCapability` combines the transport check with the existing `is_dialable` IP check, and is the one filter shared by dial preparation and gossip receipt, so the candidate supply and the dialer can never disagree about what is dialable.
- `LocalCapabilities::dial_only()` pins the IP half to `Dual` for nodes that never listen: an outbound-only node dials whatever address family its host stack routes, the same reasoning the browser target already applied globally.

Wiring:

- The topology builder constructs dial-only capabilities whenever the network configuration carries no listen addresses, which covers every `ClientLauncher` node. A native `ClientLauncher::launch()` with default spec bootnodes now passes the dial filter (the #270 acceptance).
- Dial preparation filters each address through `DialCapability::can_dial`, so the browser only ever dials tls/sni/ws leaves and a native node drops wss-only leaves instead of failing inside the transport.
- Hive receipt drops records with no locally dialable multiaddr before they enter the known table, observable as `topology_gossip_rejected_total{reason="not_dialable"}`. This replaces the previous record-declared-capability `can_reach` pre-filter with a per-address check that also covers transport. While the IP half is still unknown (a listening node before its first listener registers) only the static transport half applies, preserving the previous leniency.

## Testing

- New unit tests: transport classification over live-network address shapes, capability matrices, the dial-only pin, the builder wiring, and the per-record gossip filter under browser-shaped and native-shaped capabilities.
- `cargo test --workspace` green, `cargo clippy --all-features -D warnings` clean, wasm client cone (`cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`) builds.