### PR TITLE
fix(swarm-net-identify): truncate agent_version on a char boundary and bound its metric label

### DIFF
--- a/crates/swarm/net/identify/src/metrics.rs
+++ b/crates/swarm/net/identify/src/metrics.rs
@@ -20,20 +20,68 @@ pub enum IdentifyErrorKind {
     Apply,
 }
 
+/// Bounded classification of a remote peer's agent version for metrics labels.
+///
+/// The raw `agent_version` is attacker-controlled, so it must never be used
+/// directly as a label value: an adversary could mint unlimited distinct label
+/// values and blow up metric cardinality. This enum bounds the label to a small
+/// fixed set, detected from a prefix of the agent string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum AgentKind {
+    /// The Go reference implementation (agent prefix `bee`).
+    Bee,
+    /// This implementation (agent prefix `vertex`).
+    Vertex,
+    /// Any other or empty agent string.
+    Other,
+}
+
+impl AgentKind {
+    /// Classify a raw agent version string into a bounded label value.
+    fn classify(agent_version: &str) -> Self {
+        let trimmed = agent_version.trim();
+        // Compare against fixed prefixes without slicing the input, since the
+        // input is attacker-controlled and slicing at a fixed byte offset could
+        // panic on a non-UTF-8-boundary. `as_bytes` comparison is ASCII-safe.
+        if has_ascii_prefix_ignore_case(trimmed, b"vertex") {
+            Self::Vertex
+        } else if has_ascii_prefix_ignore_case(trimmed, b"bee") {
+            Self::Bee
+        } else {
+            Self::Other
+        }
+    }
+}
+
 /// Record a received identify event with the remote peer's agent version.
 ///
-/// Increments `identify_received_total` with `purpose` and `agent_version`
-/// labels so that the distribution of agent versions can be queried per-swarm
-/// via `sum by (agent_version) (identify_received_total{purpose="topology"})`.
+/// Increments `identify_received_total` with `purpose` and a bounded
+/// `agent_kind` label so that the distribution of agent kinds can be queried
+/// per-swarm via `sum by (agent_kind) (identify_received_total{purpose="topology"})`.
+/// The label is a fixed enum rather than the raw, peer-controlled string so that
+/// an adversarial peer cannot inflate metric cardinality.
 pub(crate) fn record_received(
     purpose: &'static str,
     agent_version: &str,
     duration: std::time::Duration,
 ) {
+    let kind = AgentKind::classify(agent_version);
+
+    // The full agent_version is attacker-controlled, so it never becomes a label
+    // value. It is still useful for developers, so emit a length-bounded,
+    // char-boundary-safe copy on the debug log only.
+    tracing::debug!(
+        purpose,
+        agent_kind = kind.label_value(),
+        agent_version = truncate_on_char_boundary(agent_version.trim(), 64),
+        "identify received",
+    );
+
     counter!(
         "identify_received_total",
         "purpose" => purpose,
-        "agent_version" => normalize_agent_version(agent_version),
+        "agent_kind" => kind.label_value(),
     )
     .increment(1);
 
@@ -78,21 +126,35 @@ pub(crate) fn record_error(
     .record(duration.as_secs_f64());
 }
 
-/// Normalize agent version strings to a bounded set of label values.
+/// Return whether `s` starts with the ASCII `prefix`, case-insensitively.
 ///
-/// High-cardinality labels can cause memory issues in Prometheus. This function
-/// caps the label length and replaces empty values with "unknown".
-fn normalize_agent_version(agent_version: &str) -> String {
-    let trimmed = agent_version.trim();
-    if trimmed.is_empty() {
-        return "unknown".to_string();
+/// Operates on bytes so it never slices `s` at a non-UTF-8 char boundary, which
+/// matters because `s` is attacker-controlled. Only the fixed ASCII `prefix`
+/// bytes are inspected.
+fn has_ascii_prefix_ignore_case(s: &str, prefix: &[u8]) -> bool {
+    s.as_bytes()
+        .get(..prefix.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+}
+
+/// Truncate `s` to at most `max` bytes without splitting a UTF-8 character.
+///
+/// Returns the longest prefix of `s` whose byte length is `<= max` and that ends
+/// on a char boundary. Slicing `&s[..max]` directly would panic when `max` lands
+/// in the middle of a multi-byte character, and `s` is attacker-controlled, so
+/// this floor-to-char-boundary form is used instead. `str::floor_char_boundary`
+/// is still unstable on the workspace MSRV, so the boundary is found by hand.
+fn truncate_on_char_boundary(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
     }
-    // Cap at 64 characters to bound cardinality from adversarial peers.
-    if trimmed.len() > 64 {
-        trimmed[..64].to_string()
-    } else {
-        trimmed.to_string()
-    }
+    let end = s
+        .char_indices()
+        .map(|(i, _)| i)
+        .take_while(|&i| i <= max)
+        .last()
+        .unwrap_or(0);
+    s.get(..end).unwrap_or("")
 }
 
 #[cfg(test)]
@@ -100,24 +162,58 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalize_empty_agent_version() {
-        assert_eq!(normalize_agent_version(""), "unknown");
-        assert_eq!(normalize_agent_version("  "), "unknown");
+    fn classify_known_agents() {
+        assert_eq!(AgentKind::classify("vertex/0.1.0"), AgentKind::Vertex);
+        assert_eq!(AgentKind::classify("Vertex/0.1.0"), AgentKind::Vertex);
+        assert_eq!(AgentKind::classify("bee/2.3.0-abc123"), AgentKind::Bee);
+        assert_eq!(AgentKind::classify("  bee/2.3.0  "), AgentKind::Bee);
     }
 
     #[test]
-    fn normalize_normal_agent_version() {
-        assert_eq!(normalize_agent_version("vertex/0.1.0"), "vertex/0.1.0");
-        assert_eq!(
-            normalize_agent_version("bee/2.3.0-abc123"),
-            "bee/2.3.0-abc123"
-        );
+    fn classify_unknown_agents() {
+        assert_eq!(AgentKind::classify(""), AgentKind::Other);
+        assert_eq!(AgentKind::classify("   "), AgentKind::Other);
+        assert_eq!(AgentKind::classify("go-ipfs/0.4"), AgentKind::Other);
+        // A short string that cannot match any prefix must not panic.
+        assert_eq!(AgentKind::classify("be"), AgentKind::Other);
     }
 
     #[test]
-    fn normalize_long_agent_version() {
-        let long = "a".repeat(100);
-        let normalized = normalize_agent_version(&long);
-        assert_eq!(normalized.len(), 64);
+    fn classify_label_values_are_bounded() {
+        assert_eq!(AgentKind::Bee.label_value(), "bee");
+        assert_eq!(AgentKind::Vertex.label_value(), "vertex");
+        assert_eq!(AgentKind::Other.label_value(), "other");
+    }
+
+    #[test]
+    fn classify_does_not_panic_on_multibyte_straddling_offset() {
+        // 63 ASCII bytes followed by a 4-byte emoji so a multi-byte character
+        // straddles byte offset 64. An adversarial agent_version of this shape
+        // must classify without panicking.
+        let adversarial = format!("{}\u{1F600}", "a".repeat(63));
+        assert_eq!(AgentKind::classify(&adversarial), AgentKind::Other);
+
+        // The same shape carrying a known prefix still classifies cleanly.
+        let bee_like = format!("bee/{}\u{1F600}", "a".repeat(60));
+        assert_eq!(AgentKind::classify(&bee_like), AgentKind::Bee);
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_never_splits_a_character() {
+        // A multi-byte character straddling the cap must not be split, and the
+        // call must not panic.
+        let s = format!("{}\u{1F600}", "a".repeat(63));
+        let truncated = truncate_on_char_boundary(&s, 64);
+        // The emoji begins at byte 63 and is 4 bytes wide, so the floor boundary
+        // is byte 63: the leading run of "a" is kept, the emoji is dropped whole.
+        assert_eq!(truncated.len(), 63);
+        assert!(truncated.is_char_boundary(truncated.len()));
+        assert_eq!(truncated, "a".repeat(63));
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_passes_short_strings_through() {
+        assert_eq!(truncate_on_char_boundary("bee/2.3.0", 64), "bee/2.3.0");
+        assert_eq!(truncate_on_char_boundary("", 64), "");
     }
 }


### PR DESCRIPTION
## Problem

The remote peer's `agent_version` from the libp2p identify protocol is attacker-controlled. Two bugs flowed from treating it as trusted in `crates/swarm/net/identify/src/metrics.rs`.

1. Remote DoS panic. `normalize_agent_version` truncated with `trimmed[..64].to_string()`. Slicing a `&str` at byte index 64 panics whenever byte 64 is not a UTF-8 char boundary. A peer sending 63 ASCII bytes followed by a multi-byte character (an emoji, an accented letter) straddling offset 64 panicked the identify event handler inside the swarm event loop.
2. Metric cardinality bomb. The normalized string was used as the `agent_version` label value on `identify_received_total`. Bounded only by length, an adversary could mint unlimited distinct label values, one time series and one allocation each. This violates the observability label rules (no dynamic string label values; label enums derive `strum::IntoStaticStr`).

## Fix

Classify `agent_version` into a bounded `AgentKind` enum (`Bee`, `Vertex`, `Other`) by an ASCII-case-insensitive prefix that never slices the input, so it cannot panic. The `identify_received_total` counter now carries a fixed `agent_kind` label from this `strum::IntoStaticStr` enum, not the raw peer-controlled string, so cardinality is bounded.

The full agent string is no longer normalized for the label path. A length-bounded, char-boundary-safe copy is emitted on the debug log only, via a new `truncate_on_char_boundary` helper (`str::floor_char_boundary` is unstable on the MSRV, so the boundary is found by hand).

## Tests

Added unit tests in the crate covering a multi-byte character straddling byte 64 (no panic, sane truncation), and the classifier mapping representative bee/vertex/unknown agent strings to the expected bounded label.

`cargo fmt --all`, `cargo clippy -p vertex-swarm-net-identify --all-targets -- -D warnings`, and `cargo test -p vertex-swarm-net-identify` all pass locally.