### PR TITLE
feat(ffi): expose a log-level init and a structured LogLine stream for embedding hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8370,6 +8370,8 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "vertex-node-api",
  "vertex-swarm-api",
  "vertex-swarm-builder",

--- a/crates/ffi/AGENTS.md
+++ b/crates/ffi/AGENTS.md
@@ -6,9 +6,9 @@ Root-level rules in `/AGENTS.md` apply here too, plus `docs/agents/api-surface.m
 
 ## Shape
 
-- `src/api/`: the public surface. Every reachable item is a binding-generation candidate. `client.rs` holds `VertexClient` (the opaque handle) and its build, upload, and download methods; `types.rs` holds the flat input and output shapes.
+- `src/api/`: the public surface. Every reachable item is a binding-generation candidate. `client.rs` holds `VertexClient` (the opaque handle) and its build, upload, and download methods; `types.rs` holds the flat input and output shapes; `logging.rs` holds the host logging surface (`init_logging`, `LogLine`, `LogLevel`).
 - `src/error.rs`: `FfiError`, a flat `thiserror` enum with `strum::IntoStaticStr`. It carries pre-formatted strings so a host never needs a vertex-internal error type.
-- `src/frb_generated.rs`: the flutter_rust_bridge generated glue. Committed as an empty placeholder so a plain `cargo build -p vertex-ffi` succeeds without the codegen binary. The codegen overwrites it.
+- `src/frb_generated.rs`: the flutter_rust_bridge generated glue. Committed as a minimal placeholder so a plain `cargo build -p vertex-ffi` succeeds without the codegen binary. The codegen overwrites it. The placeholder also defines a stand-in `StreamSink<T>` (a no-op `add`) so the streaming API signatures in `logging.rs` compile before the codegen has run; the codegen replaces it with the real Dart-backed sink.
 - `flutter_rust_bridge.yaml`: codegen config. `src/api` is the input; the generated Rust and the per-language bindings (Dart, C header) are the output.
 - `build.rs`: registers the `frb_expand` cfg the `#[frb]` macro emits, keeping the workspace `unexpected_cfgs` lint clean.
 
@@ -27,9 +27,23 @@ Root-level rules in `/AGENTS.md` apply here too, plus `docs/agents/api-surface.m
 - Do not move domain logic here. Chunk, stamp, and address primitives live in `nectar`; node assembly lives in `vertex-swarm-builder`.
 - Do not block the calling thread on a runtime the host owns. The client owns its own native runtime and blocks on it internally.
 
+## Logging
+
+A node embedded through this crate logs through the `tracing` facade. Until a host installs a subscriber, every event hits the global no-op dispatcher and the host sees nothing. `api::logging::init_logging(level, sink)` installs a process-global subscriber that filters by `level` and forwards each surviving event to the host as a typed `LogLine` over a `StreamSink`.
+
+- `level` is an `EnvFilter`-style directive parsed by `tracing_subscriber::EnvFilter`: a bare level (`"info"`, `"debug"`, `"trace"`, `"warn"`, `"error"`) sets the global maximum, and per-target directives (`"info,vertex_topology=debug"`) tune individual modules. An unparseable directive returns `FfiError::Logging`.
+- `LogLine` is a flat struct (`timestamp_ms`, `level`, `target`, `message`, `fields`), not JSON. The host receives it as a Dart `Stream` (or the binding language's equivalent). `LogLevel` is a typed enum the host matches on instead of parsing a string. `fields` carries the event's key-value pairs flattened to strings, with the reserved `message` field hoisted out.
+- The forwarding layer is a custom `tracing_subscriber::Layer` in `logging.rs`, not `vertex-observability`'s `VertexTracer`. The custom layer targets the `LogLine` shape directly and keeps the dependency surface to `tracing` plus `tracing-subscriber` (workspace features include `env-filter`). `vertex-observability` is intentionally not a dependency: pulling even its `subscriber` slice would add `eyre` for no gain here, and the cone guard (`just check-cone`) keeps the heavier server slices out regardless.
+- `init_logging` is single-shot. `tracing` permits one global subscriber per process, so a second call returns `FfiError::LoggingAlreadyInitialized` without disturbing the installed subscriber (a `OnceLock` guard, never a panic).
+- To strip logging at compile time, a host sets a `tracing` `release_max_level_*` feature in its own `Cargo.toml`. Cargo feature unification applies it to this crate's `tracing` dependency, so events below the chosen level are compiled out and `init_logging` forwards nothing below it.
+
+## Metrics (not yet exposed)
+
+Embedded metrics are not exposed yet. The `metrics` facade the node records against is a no-op without an installed recorder, and this crate installs none (the Prometheus recorder and its HTTP server live behind `vertex-observability`'s `prometheus`/`http-server` slices, which the cone guard keeps out of the FFI build). A typed, pull-based metrics snapshot (a plain struct the host reads on demand, not JSON, per `docs/agents/api-surface.md`) is a planned follow-up. Do not reach for the Prometheus recorder or an HTTP `/metrics` endpoint here.
+
 ## Regenerating bindings
 
-Run the flutter_rust_bridge codegen against `flutter_rust_bridge.yaml` (the binary is `flutter_rust_bridge_codegen`; on this host reach it with `nix-shell -p flutter_rust_bridge_codegen --run "..."`). The crate compiles without this step, so CI does not run it.
+Run the flutter_rust_bridge codegen against `flutter_rust_bridge.yaml` (the binary is `flutter_rust_bridge_codegen`; on this host reach it with `nix-shell -p flutter_rust_bridge_codegen --run "..."`). The crate compiles without this step, so CI does not run it. The codegen regenerates `src/frb_generated.rs` including the real `StreamSink<LogLine>` glue the `init_logging` stream needs on the Dart side.
 
 ## Tests
 

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -47,7 +47,16 @@ flutter_rust_bridge.workspace = true
 thiserror.workspace = true
 strum.workspace = true
 
-# Native runtime owned by the client handle. The FFI cdylib is native-only, so
-# the multi-thread tokio runtime is unconditional here.
+# Logging surface for embedding hosts. The host installs a subscriber that
+# forwards events to a Dart stream. A custom Layer (not VertexTracer) lives in
+# `api::logging` so the event extraction targets the flat `LogLine` shape; that
+# keeps the FFI cone free of the observability server stack (no prometheus, no
+# OTLP appender) which the `just check-cone` guard asserts.
+tracing.workspace = true
+
+# Native runtime owned by the client handle plus the tracing subscriber. The FFI
+# cdylib is native-only, so both are unconditional here; the wasm cone never
+# pulls them in.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing-subscriber = { workspace = true }

--- a/crates/ffi/src/api/logging.rs
+++ b/crates/ffi/src/api/logging.rs
@@ -1,0 +1,282 @@
+//! Structured logging surface for embedding hosts.
+//!
+//! An embedded Vertex client emits its diagnostics through the `tracing`
+//! facade. Without a subscriber installed those events hit the global no-op
+//! dispatcher and the host sees nothing. [`init_logging`] installs a subscriber
+//! that filters by an `EnvFilter`-style directive and forwards every event to
+//! the host as a typed [`LogLine`] stream, so a Dart or other native host can
+//! surface node logs in its own UI or log sink.
+//!
+//! The stream carries [`LogLine`] values, not JSON: a flat struct of the
+//! timestamp, level, target, message, and a small set of flattened key-value
+//! fields. The host receives them as a Dart `Stream` (or the equivalent in its
+//! binding language) via flutter_rust_bridge's `StreamSink`.
+
+use std::fmt::Write as _;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use flutter_rust_bridge::frb;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
+use crate::error::{FfiError, FfiResult};
+use crate::frb_generated::StreamSink;
+
+/// Guards against installing the global subscriber more than once.
+///
+/// `tracing` allows exactly one global subscriber per process. A second
+/// [`init_logging`] call is a no-op error rather than a panic, so a host that
+/// double-initializes (a hot reload, a retry) does not crash the node.
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Severity of a forwarded log event.
+///
+/// A typed mirror of `tracing`'s levels so the host matches on an enum instead
+/// of parsing a string.
+#[frb(non_opaque)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    /// Most verbose: fine-grained developer tracing.
+    Trace,
+    /// Developer-facing detail.
+    Debug,
+    /// Operator-facing state changes.
+    Info,
+    /// Operator-facing, informational but noteworthy.
+    Warn,
+    /// Operator-facing, requires attention.
+    Error,
+}
+
+impl From<&Level> for LogLevel {
+    fn from(level: &Level) -> Self {
+        match *level {
+            Level::TRACE => LogLevel::Trace,
+            Level::DEBUG => LogLevel::Debug,
+            Level::INFO => LogLevel::Info,
+            Level::WARN => LogLevel::Warn,
+            Level::ERROR => LogLevel::Error,
+        }
+    }
+}
+
+/// A single structured log event crossing the FFI boundary.
+///
+/// Plain data only: every field is a primitive or a string so the bindings
+/// expose it to any host without a serde backend. `fields` carries the event's
+/// key-value pairs flattened to strings, with the special `message` field
+/// hoisted out into [`LogLine::message`].
+#[frb(non_opaque)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogLine {
+    /// Event time in milliseconds since the Unix epoch.
+    pub timestamp_ms: i64,
+    /// Severity of the event.
+    pub level: LogLevel,
+    /// The event's target (typically the emitting module path).
+    pub target: String,
+    /// The event's primary message.
+    pub message: String,
+    /// Flattened key-value fields captured from the event, message excluded.
+    pub fields: Vec<(String, String)>,
+}
+
+/// Collects an event's fields into a message and a flat key-value list.
+///
+/// `tracing` records the formatted message under the reserved `message` field;
+/// it is hoisted into `message` and every other field is rendered with its
+/// `Debug` (or string) representation into `fields`.
+#[derive(Default)]
+struct LogVisitor {
+    message: String,
+    fields: Vec<(String, String)>,
+}
+
+impl LogVisitor {
+    fn record(&mut self, field: &Field, value: String) {
+        if field.name() == "message" {
+            self.message = value;
+        } else {
+            self.fields.push((field.name().to_string(), value));
+        }
+    }
+}
+
+impl Visit for LogVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record(field, value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let mut rendered = String::new();
+        // Writing to a String is infallible; ignore the formatter result.
+        let _ = write!(rendered, "{value:?}");
+        self.record(field, rendered);
+    }
+}
+
+/// Current wall-clock time as milliseconds since the Unix epoch.
+///
+/// A clock before the epoch is not expected on a host; it clamps to zero rather
+/// than failing the event.
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Build a [`LogLine`] from a tracing event.
+fn line_from_event(event: &Event<'_>) -> LogLine {
+    let mut visitor = LogVisitor::default();
+    event.record(&mut visitor);
+
+    let metadata = event.metadata();
+    LogLine {
+        timestamp_ms: now_ms(),
+        level: metadata.level().into(),
+        target: metadata.target().to_string(),
+        message: visitor.message,
+        fields: visitor.fields,
+    }
+}
+
+/// A tracing layer that forwards each event to the host as a [`LogLine`].
+///
+/// Holds the host's [`StreamSink`]. On every event it extracts a [`LogLine`]
+/// and pushes it; a send failure (the host closed the stream) is swallowed so a
+/// dropped host listener never disturbs the node.
+struct StreamLayer {
+    sink: StreamSink<LogLine>,
+}
+
+impl<S> Layer<S> for StreamLayer
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let line = line_from_event(event);
+        // The host owns the stream lifetime; a closed sink is not our error.
+        let _ = self.sink.add(line);
+    }
+}
+
+/// Initialize logging for the embedded client.
+///
+/// Installs a process-global tracing subscriber that filters events by `level`
+/// and forwards each surviving event to `sink` as a typed [`LogLine`]. `level`
+/// is an `EnvFilter`-style directive: a bare level (`"info"`, `"debug"`) sets
+/// the global maximum, and per-target directives (`"info,vertex_topology=debug"`)
+/// tune individual modules. An unparseable directive is rejected.
+///
+/// Call once, before or just after [`super::client::VertexClient::build`]. A
+/// second call returns [`FfiError::LoggingAlreadyInitialized`] without
+/// disturbing the installed subscriber: `tracing` permits one global subscriber
+/// per process.
+///
+/// To compile logging out entirely, a host sets a `tracing` `release_max_level_*`
+/// feature in its own `Cargo.toml`; cargo feature unification then strips the
+/// filtered events at compile time and `init_logging` forwards nothing below the
+/// chosen level.
+#[frb]
+pub fn init_logging(level: String, sink: StreamSink<LogLine>) -> FfiResult<()> {
+    let filter = EnvFilter::try_new(&level).map_err(|e| FfiError::Logging {
+        reason: format!("invalid log filter {level:?}: {e}"),
+    })?;
+
+    // Reserve the init slot first so a racing second caller loses cleanly
+    // before it ever tries to install a subscriber.
+    if INIT.set(()).is_err() {
+        return Err(FfiError::LoggingAlreadyInitialized);
+    }
+
+    let layer = StreamLayer { sink };
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(layer)
+        .try_init()
+        .map_err(|e| FfiError::Logging {
+            reason: format!("install subscriber: {e}"),
+        })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visitor_hoists_message_and_collects_fields() {
+        // Capture a synthetic event by driving the same extraction `on_event`
+        // uses, through a tiny capturing subscriber. `with_default` requires a
+        // `'static` subscriber, so the capture slot is shared by `Arc`.
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+        tracing::subscriber::with_default(
+            CaptureSubscriber {
+                out: captured.clone(),
+            },
+            || {
+                tracing::error!(peer = "abcd", count = 7, "connection lost");
+            },
+        );
+
+        let line = captured.lock().unwrap().take().expect("event captured");
+        assert_eq!(line.level, LogLevel::Error);
+        assert_eq!(line.message, "connection lost");
+        // A string-valued field is recorded verbatim, without Debug quoting.
+        assert!(
+            line.fields
+                .contains(&("peer".to_string(), "abcd".to_string()))
+        );
+        assert!(
+            line.fields
+                .contains(&("count".to_string(), "7".to_string()))
+        );
+        assert!(line.timestamp_ms > 0);
+    }
+
+    #[test]
+    fn level_maps_from_tracing() {
+        assert_eq!(LogLevel::from(&Level::TRACE), LogLevel::Trace);
+        assert_eq!(LogLevel::from(&Level::ERROR), LogLevel::Error);
+    }
+
+    #[test]
+    fn double_init_guard_does_not_panic() {
+        // Drive the guard directly: the real `init_logging` installs a global
+        // subscriber, which a unit test must not do. The guard is the part that
+        // must never panic on a second call.
+        let guard: OnceLock<()> = OnceLock::new();
+        assert!(guard.set(()).is_ok());
+        assert!(guard.set(()).is_err());
+    }
+
+    /// Minimal subscriber that runs the extraction over one event and stores the
+    /// resulting [`LogLine`], so the logic is testable without a global
+    /// subscriber or a real `StreamSink`.
+    struct CaptureSubscriber {
+        out: std::sync::Arc<std::sync::Mutex<Option<LogLine>>>,
+    }
+
+    impl tracing::Subscriber for CaptureSubscriber {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+        fn event(&self, event: &Event<'_>) {
+            *self.out.lock().unwrap() = Some(line_from_event(event));
+        }
+        fn enter(&self, _: &tracing::span::Id) {}
+        fn exit(&self, _: &tracing::span::Id) {}
+    }
+}

--- a/crates/ffi/src/api/mod.rs
+++ b/crates/ffi/src/api/mod.rs
@@ -6,4 +6,5 @@
 //! from these signatures, never hand-maintained alongside them.
 
 pub mod client;
+pub mod logging;
 pub mod types;

--- a/crates/ffi/src/error.rs
+++ b/crates/ffi/src/error.rs
@@ -60,6 +60,22 @@ pub enum FfiError {
         /// Why the download failed.
         reason: String,
     },
+
+    /// Installing the logging subscriber failed.
+    #[error("logging setup failed: {reason}")]
+    Logging {
+        /// Why logging setup failed (an unparseable filter or a subscriber that
+        /// could not be installed).
+        reason: String,
+    },
+
+    /// Logging was already initialized for this process.
+    ///
+    /// A process has exactly one global tracing subscriber, so the first
+    /// `init_logging` call wins and a later call is rejected without disturbing
+    /// the installed subscriber.
+    #[error("logging is already initialized for this process")]
+    LoggingAlreadyInitialized,
 }
 
 /// Convenience alias for results crossing the FFI boundary.

--- a/crates/ffi/src/frb_generated.rs
+++ b/crates/ffi/src/frb_generated.rs
@@ -1,11 +1,45 @@
 //! Generated flutter_rust_bridge glue.
 //!
 //! This file is normally produced by the flutter_rust_bridge codegen from the
-//! signatures under [`crate::api`]. It is committed as an empty placeholder so a
-//! plain `cargo build -p vertex-ffi` succeeds without running the external
+//! signatures under [`crate::api`]. It is committed as a minimal placeholder so
+//! a plain `cargo build -p vertex-ffi` succeeds without running the external
 //! codegen binary. Running the codegen (see `flutter_rust_bridge.yaml`)
-//! overwrites this file with the real C ABI dispatch table and the wire codecs
-//! the host bindings call into.
+//! overwrites this file with the real C ABI dispatch table, the wire codecs, and
+//! the `StreamSink` type the host bindings call into.
 //!
 //! Do not hand-edit the regenerated contents; edit the API under [`crate::api`]
 //! and regenerate.
+//!
+//! The codegen emits a `StreamSink<T>` type here (via flutter_rust_bridge's
+//! `frb_generated_stream_sink!` macro) that the streaming API signatures in
+//! [`crate::api`] reference. So those signatures compile before the codegen has
+//! ever run, the placeholder below stands in a structurally compatible
+//! `StreamSink<T>`: an opaque handle with an `add` method that is a no-op until
+//! the codegen replaces it with the real Dart-backed sink. A host that has not
+//! run the codegen gets a node that logs nowhere; a host that has gets the live
+//! Dart stream.
+
+use std::marker::PhantomData;
+
+/// Placeholder stand-in for the codegen-emitted `StreamSink<T>`.
+///
+/// Carries no channel: [`StreamSink::add`] drops its value. The flutter_rust_bridge
+/// codegen overwrites this type with one backed by a Dart message port, at which
+/// point `add` delivers each value to the host stream.
+pub struct StreamSink<T> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T> StreamSink<T> {
+    /// Push a value to the host stream.
+    ///
+    /// The placeholder discards the value and reports success; the codegen
+    /// replacement delivers it to Dart and reports a closed-stream send error.
+    pub fn add(&self, _value: T) -> Result<(), StreamSinkError> {
+        Ok(())
+    }
+}
+
+/// Placeholder stand-in for the codegen send-error type.
+#[derive(Debug)]
+pub struct StreamSinkError;

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -13,6 +13,8 @@
 //! then drives uploads and downloads through it. Inputs and outputs cross the
 //! boundary as flat byte vectors, strings, and primitives; the strong domain
 //! types are reconstructed immediately inside Rust and never leak outward.
+//! [`api::logging::init_logging`] installs a tracing subscriber that streams the
+//! node's diagnostics to the host as typed [`api::logging::LogLine`] events.
 //!
 //! # Bindings
 //!


### PR DESCRIPTION
## What

Give an embedding host a real logging surface on the native FFI crate. Before this change `crates/ffi` installed no tracing subscriber, so every `tracing` event from the running node hit the global no-op dispatcher and a host embedding Vertex (a Dart/Flutter app, for example) could not see a single log line. Field-debugging an embedded client was impossible.

This PR adds:

- `api::logging::init_logging(level, sink)`: installs a process-global tracing subscriber that filters events by an `EnvFilter`-style directive and forwards each surviving event to the host as a typed `LogLine` over a flutter_rust_bridge `StreamSink`. The host consumes them as a Dart `Stream` (or the binding language equivalent).
- `LogLine`: a flat typed struct (`timestamp_ms: i64`, `level: LogLevel`, `target: String`, `message: String`, `fields: Vec<(String, String)>`). Not JSON, no serde backend, per the FFI cone rules in `docs/agents/api-surface.md`.
- `LogLevel`: a typed enum mirroring `tracing`'s levels so the host matches on a variant instead of parsing a string.
- Two `FfiError` variants: `Logging { reason }` (unparseable filter or subscriber install failure) and `LoggingAlreadyInitialized`.

## Design

- The forwarding layer is a custom `tracing_subscriber::Layer` (`StreamLayer`) in `crates/ffi/src/api/logging.rs`. Its `on_event` runs a `tracing_subscriber::field::Visit` implementation (`LogVisitor`) that hoists the reserved `message` field into `LogLine::message` and flattens every other field to a `(name, value)` string pair. String-valued fields are recorded verbatim; everything else is rendered with `Debug`.
- The level param is parsed with `tracing_subscriber::EnvFilter::try_new`, so a bare level (`"info"`) and per-target directives (`"info,vertex_topology=debug"`) both work. The filter and the stream layer compose through `tracing_subscriber::registry()`.
- Double-init guard: a `OnceLock<()>` is claimed before the subscriber is installed. A second `init_logging` returns `FfiError::LoggingAlreadyInitialized` rather than panicking, matching `tracing`'s one-global-subscriber-per-process rule. A send to a closed `StreamSink` (host dropped its listener) is swallowed so a dead Dart listener never disturbs the node.

### vertex-observability vs a custom layer

A custom layer was cleaner than reusing `vertex-observability`'s `subscriber` slice. `VertexTracer` is wired to its own fmt/stdout layer and returns its own `TracingGuard`; it does not expose a hook to forward events into a `StreamSink<LogLine>`. Reusing it would mean depending on `vertex-observability` (pulling `eyre`) for no gain, then still hand-writing the field extraction. The custom layer keeps the dependency surface to `tracing` plus `tracing-subscriber` (the workspace already enables its `env-filter` feature) and targets the `LogLine` shape directly. The `just check-cone` guard, which asserts `vertex-ffi` does not pull `metrics-exporter-prometheus` or `opentelemetry-appender-tracing`, still passes; no axum or OTLP enters the FFI cone.

### StreamSink and the codegen placeholder

`StreamSink<T>` is normally emitted by the flutter_rust_bridge codegen into `src/frb_generated.rs`. So the streaming API signatures compile before the codegen has ever run (the crate ships a placeholder `frb_generated.rs` for exactly this reason), the placeholder now also defines a structurally compatible stand-in `StreamSink<T>` whose `add` is a no-op. A host that has not run the codegen gets a node that logs nowhere; a host that has gets the live Dart stream. The codegen overwrites the whole file, replacing the stand-in with the real Dart-backed sink and the `LogLine` wire glue.

## Codegen

The Rust side compiles and tests on its own. `flutter_rust_bridge_codegen` must be run against `crates/ffi/flutter_rust_bridge.yaml` to regenerate the Dart bindings (and the real `StreamSink<LogLine>` glue) before a host can call `init_logging` from Dart. CI does not run the codegen, consistent with the existing crate convention. No generated files were hand-edited.

## Scope

Logging only. Embedded metrics are explicitly out of scope and documented as a follow-up in `crates/ffi/AGENTS.md`: the `metrics` facade is a no-op without a recorder, this crate installs none (the Prometheus recorder and HTTP server stay behind `vertex-observability` slices the cone guard keeps out), and a typed pull-based metrics snapshot (not JSON) is planned. `AGENTS.md` also documents the host-side option to compile logs out entirely via a `tracing` `release_max_level_*` feature in the host's own `Cargo.toml`.

## Tests

`crates/ffi/src/api/logging.rs` adds unit tests:

- `visitor_hoists_message_and_collects_fields`: drives the extraction over a synthetic `tracing::error!(peer = "abcd", count = 7, "connection lost")` and asserts the message is hoisted, the fields are flattened, the level maps, and the timestamp is set.
- `level_maps_from_tracing`: the `LogLevel` mapping.
- `double_init_guard_does_not_panic`: the `OnceLock` guard rejects a second claim without panicking.

## Verification

- `cargo build -p vertex-ffi`: clean.
- `cargo fmt --all`: clean.
- `cargo clippy -p vertex-ffi --all-targets -- -D warnings`: clean.
- `cargo test -p vertex-ffi`: 9 passed.
- `just check-cone`: passes (FFI cone free of the observability server stack).
