### PR TITLE
refactor(swarm-node): per-request response channels for outbound retrieval and pushsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 target/
+target-wasm/
 **/*.rs.bk
+
+# Playwright MCP session artifacts
+.playwright-mcp/
 *.tar.gz
 .env
 cspell.json

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -57,6 +57,11 @@ alloy-primitives.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 futures-bounded = "0.2"
+# Used for the retrieval fan-out stagger. The workspace pin enables the
+# `wasm-bindgen` feature so the browser build uses the browser clock instead
+# of the std clock, which panics on wasm32; the same feature unification keeps
+# libp2p's connection-handler delays working on wasm.
+futures-timer.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 
 ## observability
@@ -95,11 +100,6 @@ libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91f
     "ping",
 ] }
 libp2p-websocket-websys.workspace = true
-# Turn on futures-timer's browser backend so libp2p's connection-handler delays
-# use the browser clock instead of the std clock, which panics on wasm32. This
-# crate does not call futures-timer directly; the dependency exists to enable the
-# `wasm-bindgen` feature across the wasm build via feature unification.
-futures-timer = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -38,10 +38,16 @@ pub struct RetrievalResult {
     pub peer: OverlayAddress,
 }
 
-/// Error from retrieval operations.
+/// Outcome error shared by both chunk transfer operations.
+///
+/// Both [`ClientHandle::retrieve_chunk`] (get) and
+/// [`ClientHandle::push_chunk`] (put) resolve through this single type. Most
+/// variants are operation-agnostic and can surface from either path; the two
+/// operation-specific variants are called out below.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
-pub enum RetrievalError {
+pub enum ChunkTransferError {
+    // Shared variants: either a get or a put can produce these.
     /// Channel closed.
     #[error("Network channel closed")]
     ChannelClosed,
@@ -54,9 +60,13 @@ pub enum RetrievalError {
     /// Protocol error.
     #[error("Protocol error: {0}")]
     Protocol(String),
+
+    // Retrieval-specific: only a get produces this.
     /// Chunk not found.
     #[error("Chunk not found: {0}")]
     NotFound(ChunkAddress),
+
+    // Push-specific: only a put produces this.
     /// The storer rejected the chunk. Carries the storer's wire error string.
     #[error("Push rejected by storer: {0}")]
     PushRejected(String),
@@ -71,14 +81,14 @@ impl ClientHandle {
     /// Send a command to the network layer (non-blocking).
     ///
     /// Uses `try_send` because callers (e.g. the libp2p event loop) must not block.
-    pub fn send_command(&self, command: ClientCommand) -> Result<(), RetrievalError> {
+    pub fn send_command(&self, command: ClientCommand) -> Result<(), ChunkTransferError> {
         self.command_tx.try_send(command).map_err(|e| match e {
             mpsc::error::TrySendError::Full(_) => {
                 warn!("Client command channel full");
                 metrics::counter!("swarm.client.commands_dropped").increment(1);
-                RetrievalError::ChannelClosed
+                ChunkTransferError::ChannelClosed
             }
-            mpsc::error::TrySendError::Closed(_) => RetrievalError::ChannelClosed,
+            mpsc::error::TrySendError::Closed(_) => ChunkTransferError::ChannelClosed,
         })
     }
 
@@ -92,7 +102,7 @@ impl ClientHandle {
         &self,
         peer: OverlayAddress,
         address: ChunkAddress,
-    ) -> Result<RetrievalResult, RetrievalError> {
+    ) -> Result<RetrievalResult, ChunkTransferError> {
         let (tx, rx) = oneshot::channel();
 
         self.send_command(ClientCommand::RetrieveChunk {
@@ -101,7 +111,7 @@ impl ClientHandle {
             response: tx,
         })?;
 
-        rx.await.map_err(|_| RetrievalError::Cancelled)?
+        rx.await.map_err(|_| ChunkTransferError::Cancelled)?
     }
 
     /// Push a stamped chunk to a specific peer.
@@ -113,7 +123,7 @@ impl ClientHandle {
         &self,
         peer: OverlayAddress,
         chunk: StampedChunk,
-    ) -> Result<PushReceipt, RetrievalError> {
+    ) -> Result<PushReceipt, ChunkTransferError> {
         let address = *chunk.address();
         let (tx, rx) = oneshot::channel();
 
@@ -124,7 +134,7 @@ impl ClientHandle {
             response: tx,
         })?;
 
-        rx.await.map_err(|_| RetrievalError::Cancelled)?
+        rx.await.map_err(|_| ChunkTransferError::Cancelled)?
     }
 }
 

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -4,11 +4,7 @@
 //! It owns channels to communicate with `ClientBehaviour` and processes
 //! incoming events.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use nectar_primitives::ChunkAddress;
-use parking_lot::Mutex;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use vertex_swarm_api::PushReceipt;
@@ -21,24 +17,26 @@ use crate::protocol::{ClientCommand, ClientEvent};
 pub(crate) const DEFAULT_CHANNEL_CAPACITY: usize = 256;
 
 /// Handle for sending commands to the network layer.
+///
+/// Request methods ([`Self::retrieve_chunk`], [`Self::push_chunk`]) thread a
+/// response channel through the command into the per-connection handler, so
+/// each outbound request is a self-contained future: the substream that
+/// carries the request is the correlation, and no shared rendezvous state
+/// exists. Concurrent requests for the same chunk address never collide, so
+/// callers may freely race the same address across peers.
 #[derive(Clone)]
 pub struct ClientHandle {
     command_tx: mpsc::Sender<ClientCommand>,
-    pending_retrievals: Arc<Mutex<HashMap<ChunkAddress, oneshot::Sender<RetrievalResult>>>>,
-    pending_pushes: Arc<Mutex<HashMap<ChunkAddress, oneshot::Sender<PushOutcome>>>>,
 }
 
 /// Result of a chunk retrieval.
+#[derive(Debug)]
 pub struct RetrievalResult {
     /// The retrieved chunk and its postage stamp.
     pub chunk: StampedChunk,
     /// The peer that served the chunk.
     pub peer: OverlayAddress,
 }
-
-/// Outcome delivered to a pending push: a [`PushReceipt`] on success or an error
-/// describing why the storer rejected the chunk.
-type PushOutcome = Result<PushReceipt, RetrievalError>;
 
 /// Error from retrieval operations.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
@@ -47,6 +45,9 @@ pub enum RetrievalError {
     /// Channel closed.
     #[error("Network channel closed")]
     ChannelClosed,
+    /// The target peer has no active connection.
+    #[error("Peer not connected")]
+    NotConnected,
     /// Request cancelled.
     #[error("Request cancelled")]
     Cancelled,
@@ -64,11 +65,7 @@ pub enum RetrievalError {
 impl ClientHandle {
     /// Create a new client handle.
     pub fn new(command_tx: mpsc::Sender<ClientCommand>) -> Self {
-        Self {
-            command_tx,
-            pending_retrievals: Arc::new(Mutex::new(HashMap::new())),
-            pending_pushes: Arc::new(Mutex::new(HashMap::new())),
-        }
+        Self { command_tx }
     }
 
     /// Send a command to the network layer (non-blocking).
@@ -87,7 +84,10 @@ impl ClientHandle {
 
     /// Retrieve a chunk from a specific peer.
     ///
-    /// This sends a retrieval command and waits for the response.
+    /// Sends a retrieval command carrying the response channel and waits for
+    /// the outcome. The request is self-contained: any failure on the path
+    /// (peer not connected, queue overflow, substream error, disconnect)
+    /// resolves or drops the channel, so this future never hangs.
     pub async fn retrieve_chunk(
         &self,
         peer: OverlayAddress,
@@ -95,39 +95,20 @@ impl ClientHandle {
     ) -> Result<RetrievalResult, RetrievalError> {
         let (tx, rx) = oneshot::channel();
 
-        // Register the pending retrieval
-        {
-            let mut pending = self.pending_retrievals.lock();
-            pending.insert(address, tx);
-        }
+        self.send_command(ClientCommand::RetrieveChunk {
+            peer,
+            address,
+            response: tx,
+        })?;
 
-        // Send the retrieval command
-        self.send_command(ClientCommand::RetrieveChunk { peer, address })?;
-
-        // Wait for the response
-        rx.await.map_err(|_| RetrievalError::Cancelled)
-    }
-
-    /// Complete a pending retrieval with a result.
-    ///
-    /// Called by the event processor when a chunk is received.
-    pub(crate) fn complete_retrieval(&self, address: ChunkAddress, result: RetrievalResult) {
-        let mut pending = self.pending_retrievals.lock();
-        if let Some(tx) = pending.remove(&address) {
-            let _ = tx.send(result);
-        }
-    }
-
-    /// Fail a pending retrieval with an error.
-    pub(crate) fn fail_retrieval(&self, address: ChunkAddress, _error: String) {
-        let mut pending = self.pending_retrievals.lock();
-        pending.remove(&address);
-        // The oneshot will be dropped, causing the receiver to get Cancelled
+        rx.await.map_err(|_| RetrievalError::Cancelled)?
     }
 
     /// Push a stamped chunk to a specific peer.
     ///
-    /// This sends a push command and waits for the storer's [`PushReceipt`].
+    /// Sends a push command carrying the response channel and waits for the
+    /// storer's [`PushReceipt`]. Same failure semantics as
+    /// [`Self::retrieve_chunk`]: the future never hangs.
     pub async fn push_chunk(
         &self,
         peer: OverlayAddress,
@@ -136,39 +117,14 @@ impl ClientHandle {
         let address = *chunk.address();
         let (tx, rx) = oneshot::channel();
 
-        // Register the pending push
-        {
-            let mut pending = self.pending_pushes.lock();
-            pending.insert(address, tx);
-        }
-
-        // Send the push command
         self.send_command(ClientCommand::PushChunk {
             peer,
             address,
             chunk,
+            response: tx,
         })?;
 
-        // Wait for the receipt or a failure report.
         rx.await.map_err(|_| RetrievalError::Cancelled)?
-    }
-
-    /// Complete a pending push with a receipt.
-    ///
-    /// Called by the event processor when a receipt is received.
-    pub(crate) fn complete_push(&self, address: ChunkAddress, receipt: PushReceipt) {
-        let mut pending = self.pending_pushes.lock();
-        if let Some(tx) = pending.remove(&address) {
-            let _ = tx.send(Ok(receipt));
-        }
-    }
-
-    /// Fail a pending push, surfacing the storer's rejection reason to the caller.
-    pub(crate) fn fail_push(&self, address: ChunkAddress, error: String) {
-        let mut pending = self.pending_pushes.lock();
-        if let Some(tx) = pending.remove(&address) {
-            let _ = tx.send(Err(RetrievalError::PushRejected(error)));
-        }
     }
 }
 
@@ -272,11 +228,12 @@ impl ClientService {
             ClientEvent::ChunkReceived {
                 peer,
                 address,
-                chunk,
+                chunk: _,
             } => {
+                // The requester is resolved directly by the handler; this
+                // event exists for accounting and peer scoring.
                 debug!(%peer, %address, "Chunk received");
-                self.handle
-                    .complete_retrieval(address, RetrievalResult { chunk, peer });
+                // TODO: Record bandwidth usage and report RetrievalSuccess
             }
 
             ClientEvent::ChunkRequested {
@@ -311,19 +268,13 @@ impl ClientService {
                 nonce,
                 storage_radius,
             } => {
+                // The pusher is resolved directly by the handler; this event
+                // exists for accounting and peer scoring.
                 debug!(
                     %peer, %address, %storage_radius, %nonce,
                     sig = %signature, "Receipt received"
                 );
-                self.handle.complete_push(
-                    address,
-                    PushReceipt {
-                        storer: peer,
-                        signature,
-                        nonce,
-                        storage_radius,
-                    },
-                );
+                // TODO: Record bandwidth usage and report PushSuccess
             }
 
             ClientEvent::PeerDisconnected { peer_id, overlay } => {
@@ -352,8 +303,10 @@ impl ClientService {
                 address,
                 error,
             } => {
+                // The requester is resolved directly by the handler; this
+                // event exists for peer scoring.
                 warn!(%peer, %address, %error, "Retrieval failed");
-                self.handle.fail_retrieval(address, error);
+                // TODO: Report RetrievalFailure to peer scoring
             }
 
             ClientEvent::PushFailed {
@@ -361,8 +314,10 @@ impl ClientService {
                 address,
                 error,
             } => {
+                // The pusher is resolved directly by the handler; this event
+                // exists for peer scoring.
                 warn!(%peer, %address, %error, "Push failed");
-                self.handle.fail_push(address, error);
+                // TODO: Report PushFailure to peer scoring
             }
 
             ClientEvent::SettlementNeeded { peer, balance } => {

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -29,7 +29,7 @@ pub use node::{BootNode, BootNodeBuilder, StorerNode, StorerNodeBuilder};
 
 pub use vertex_swarm_api::SwarmNodeType;
 
-pub use client_service::{ClientHandle, ClientService, RetrievalError, RetrievalResult};
+pub use client_service::{ChunkTransferError, ClientHandle, ClientService, RetrievalResult};
 #[cfg(feature = "swap")]
 pub use protocol::SwapEvent;
 pub use protocol::{

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -32,7 +32,9 @@ pub use vertex_swarm_api::SwarmNodeType;
 pub use client_service::{ClientHandle, ClientService, RetrievalError, RetrievalResult};
 #[cfg(feature = "swap")]
 pub use protocol::SwapEvent;
-pub use protocol::{ClientCommand, ClientEvent, PseudosettleEvent};
+pub use protocol::{
+    ClientCommand, ClientEvent, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
+};
 
 pub use selection::{AccountingSettlement, PeerScores, PeerSelector, SettlementTrigger};
 pub use swarm_client::{BootnodeClient, Client, FullClient};

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -175,7 +175,7 @@ impl ClientBehaviour {
                     });
                 } else {
                     debug!(%peer, "Unknown peer for retrieval");
-                    let _ = response.send(Err(crate::RetrievalError::NotConnected));
+                    let _ = response.send(Err(crate::ChunkTransferError::NotConnected));
                 }
             }
             ClientCommand::PushChunk {
@@ -193,7 +193,7 @@ impl ClientBehaviour {
                     });
                 } else {
                     debug!(%peer, "Unknown peer for push");
-                    let _ = response.send(Err(crate::RetrievalError::NotConnected));
+                    let _ = response.send(Err(crate::ChunkTransferError::NotConnected));
                 }
             }
             ClientCommand::ServeChunk {

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -161,32 +161,39 @@ impl ClientBehaviour {
                     debug!(%peer, "Unknown peer for pricing announcement");
                 }
             }
-            ClientCommand::RetrieveChunk { peer, address } => {
+            ClientCommand::RetrieveChunk {
+                peer,
+                address,
+                response,
+            } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %address, "Retrieving chunk");
                     self.push_event(ToSwarm::NotifyHandler {
                         peer_id,
                         handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::RetrieveChunk { address },
+                        event: HandlerCommand::RetrieveChunk { address, response },
                     });
                 } else {
                     debug!(%peer, "Unknown peer for retrieval");
+                    let _ = response.send(Err(crate::RetrievalError::NotConnected));
                 }
             }
             ClientCommand::PushChunk {
                 peer,
                 address,
                 chunk,
+                response,
             } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %address, "Pushing chunk");
                     self.push_event(ToSwarm::NotifyHandler {
                         peer_id,
                         handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::PushChunk { chunk },
+                        event: HandlerCommand::PushChunk { chunk, response },
                     });
                 } else {
                     debug!(%peer, "Unknown peer for push");
+                    let _ = response.send(Err(crate::RetrievalError::NotConnected));
                 }
             }
             ClientCommand::ServeChunk {
@@ -360,6 +367,28 @@ impl ClientBehaviour {
                     signature,
                     nonce,
                     storage_radius,
+                }));
+            }
+            HandlerEvent::RetrievalFailed {
+                overlay,
+                address,
+                error,
+            } => {
+                self.push_event(ToSwarm::GenerateEvent(ClientEvent::RetrievalFailed {
+                    peer: overlay,
+                    address,
+                    error,
+                }));
+            }
+            HandlerEvent::PushFailed {
+                overlay,
+                address,
+                error,
+            } => {
+                self.push_event(ToSwarm::GenerateEvent(ClientEvent::PushFailed {
+                    peer: overlay,
+                    address,
+                    error,
                 }));
             }
             HandlerEvent::Error {

--- a/crates/swarm/node/src/protocol/events.rs
+++ b/crates/swarm/node/src/protocol/events.rs
@@ -25,21 +25,21 @@ use vertex_swarm_net_pseudosettle::PaymentAck;
 use vertex_swarm_net_swap::SignedCheque;
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk, StorageRadius, SwarmNodeType};
 
-use crate::client_service::{RetrievalError, RetrievalResult};
+use crate::client_service::{ChunkTransferError, RetrievalResult};
 
 /// Channel on which an outbound retrieval request resolves.
 ///
 /// The sender travels with the request from the caller through the behaviour
 /// and handler into the outbound substream state, so the response (or any
 /// failure along the way) resolves the caller directly. Dropping the sender
-/// anywhere on that path surfaces as [`RetrievalError::Cancelled`].
-pub type RetrievalResponseTx = oneshot::Sender<Result<RetrievalResult, RetrievalError>>;
+/// anywhere on that path surfaces as [`ChunkTransferError::Cancelled`].
+pub type RetrievalResponseTx = oneshot::Sender<Result<RetrievalResult, ChunkTransferError>>;
 
 /// Channel on which an outbound chunk push resolves.
 ///
 /// Same lifecycle as [`RetrievalResponseTx`]: the storer's receipt or the
 /// failure that prevented it resolves the caller directly.
-pub type PushResponseTx = oneshot::Sender<Result<PushReceipt, RetrievalError>>;
+pub type PushResponseTx = oneshot::Sender<Result<PushReceipt, ChunkTransferError>>;
 
 /// Events emitted by the client behaviour.
 #[derive(Debug, Clone)]

--- a/crates/swarm/node/src/protocol/events.rs
+++ b/crates/swarm/node/src/protocol/events.rs
@@ -18,10 +18,28 @@
 use alloy_primitives::{Signature, U256};
 use libp2p::PeerId;
 use nectar_primitives::{ChunkAddress, Nonce};
+use tokio::sync::oneshot;
+use vertex_swarm_api::PushReceipt;
 use vertex_swarm_net_pseudosettle::PaymentAck;
 #[cfg(feature = "swap")]
 use vertex_swarm_net_swap::SignedCheque;
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk, StorageRadius, SwarmNodeType};
+
+use crate::client_service::{RetrievalError, RetrievalResult};
+
+/// Channel on which an outbound retrieval request resolves.
+///
+/// The sender travels with the request from the caller through the behaviour
+/// and handler into the outbound substream state, so the response (or any
+/// failure along the way) resolves the caller directly. Dropping the sender
+/// anywhere on that path surfaces as [`RetrievalError::Cancelled`].
+pub type RetrievalResponseTx = oneshot::Sender<Result<RetrievalResult, RetrievalError>>;
+
+/// Channel on which an outbound chunk push resolves.
+///
+/// Same lifecycle as [`RetrievalResponseTx`]: the storer's receipt or the
+/// failure that prevented it resolves the caller directly.
+pub type PushResponseTx = oneshot::Sender<Result<PushReceipt, RetrievalError>>;
 
 /// Events emitted by the client behaviour.
 #[derive(Debug, Clone)]
@@ -211,7 +229,11 @@ pub enum ClientEvent {
 }
 
 /// Commands accepted by the client behaviour.
-#[derive(Debug, Clone)]
+///
+/// Request commands ([`Self::RetrieveChunk`], [`Self::PushChunk`]) carry the
+/// response channel for their outcome, so the enum is intentionally not
+/// `Clone`.
+#[derive(Debug)]
 pub enum ClientCommand {
     /// Activate the handler for a peer after handshake completes.
     ///
@@ -243,6 +265,8 @@ pub enum ClientCommand {
         peer: OverlayAddress,
         /// The chunk address to retrieve.
         address: ChunkAddress,
+        /// Resolves with the retrieved chunk or the failure.
+        response: RetrievalResponseTx,
     },
 
     /// Serve a chunk to a peer (response to ChunkRequested).
@@ -265,6 +289,8 @@ pub enum ClientCommand {
         address: ChunkAddress,
         /// The chunk and its postage stamp to push.
         chunk: StampedChunk,
+        /// Resolves with the storer's receipt or the failure.
+        response: PushResponseTx,
     },
 
     /// Send a receipt to a peer (response to ChunkPushReceived).

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -48,7 +48,7 @@ use super::upgrade::{
     ClientInboundOutput, ClientInboundUpgrade, ClientOutboundInfo, ClientOutboundOutput,
     ClientOutboundUpgrade,
 };
-use crate::client_service::{RetrievalError, RetrievalResult};
+use crate::client_service::{ChunkTransferError, RetrievalResult};
 
 const DEFAULT_MAX_PENDING_COMMANDS: usize = 256;
 const DEFAULT_MAX_PENDING_EVENTS: usize = 256;
@@ -527,11 +527,11 @@ impl ClientHandler {
                         error: err.clone(),
                     });
                 }
-                let _ = response.send(Err(RetrievalError::Protocol(err)));
+                let _ = response.send(Err(ChunkTransferError::Protocol(err)));
             }
             vertex_swarm_net_retrieval::Delivery::Chunk(chunk) => {
                 let Some(overlay) = overlay else {
-                    let _ = response.send(Err(RetrievalError::Protocol(
+                    let _ = response.send(Err(ChunkTransferError::Protocol(
                         "handler not active".to_string(),
                     )));
                     return;
@@ -566,10 +566,10 @@ impl ClientHandler {
                     error: err.clone(),
                 });
             }
-            let _ = response.send(Err(RetrievalError::PushRejected(err)));
+            let _ = response.send(Err(ChunkTransferError::PushRejected(err)));
         } else {
             let Some(overlay) = overlay else {
-                let _ = response.send(Err(RetrievalError::Protocol(
+                let _ = response.send(Err(ChunkTransferError::Protocol(
                     "handler not active".to_string(),
                 )));
                 return;
@@ -853,7 +853,7 @@ impl ConnectionHandler for ClientHandler {
                                 error: error.clone(),
                             });
                         }
-                        let _ = response.send(Err(RetrievalError::Protocol(error)));
+                        let _ = response.send(Err(ChunkTransferError::Protocol(error)));
                     }
                     ClientOutboundInfo::Pushsync { address, response } => {
                         warn!(protocol = "pushsync", %address, %error, "Client dial upgrade error");
@@ -864,7 +864,7 @@ impl ConnectionHandler for ClientHandler {
                                 error: error.clone(),
                             });
                         }
-                        let _ = response.send(Err(RetrievalError::Protocol(error)));
+                        let _ = response.send(Err(ChunkTransferError::Protocol(error)));
                     }
                     ClientOutboundInfo::Pseudosettle { .. } => {
                         warn!(protocol = "pseudosettle", %error, "Client dial upgrade error");

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -37,15 +37,18 @@ use libp2p::swarm::{
 };
 use nectar_primitives::{ChunkAddress, Nonce};
 use tracing::{debug, warn};
+use vertex_swarm_api::PushReceipt;
 use vertex_swarm_net_pseudosettle::PaymentAck;
 #[cfg(feature = "swap")]
 use vertex_swarm_net_swap::SignedCheque;
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk, StorageRadius, SwarmNodeType};
 
+use super::events::{PushResponseTx, RetrievalResponseTx};
 use super::upgrade::{
     ClientInboundOutput, ClientInboundUpgrade, ClientOutboundInfo, ClientOutboundOutput,
     ClientOutboundUpgrade,
 };
+use crate::client_service::{RetrievalError, RetrievalResult};
 
 const DEFAULT_MAX_PENDING_COMMANDS: usize = 256;
 const DEFAULT_MAX_PENDING_EVENTS: usize = 256;
@@ -111,11 +114,15 @@ pub(crate) enum HandlerCommand {
     RetrieveChunk {
         /// The address of the chunk to retrieve.
         address: ChunkAddress,
+        /// Resolves with the retrieved chunk or the failure.
+        response: RetrievalResponseTx,
     },
     /// Push a chunk to the peer for storage.
     PushChunk {
         /// The chunk and its postage stamp.
         chunk: StampedChunk,
+        /// Resolves with the storer's receipt or the failure.
+        response: PushResponseTx,
     },
     /// Send a pseudosettle payment to the peer.
     SendPseudosettle {
@@ -218,6 +225,30 @@ pub(crate) enum HandlerEvent {
         nonce: Nonce,
         /// The storer's storage radius.
         storage_radius: StorageRadius,
+    },
+    /// An outbound retrieval request failed.
+    ///
+    /// The requester has already been resolved through its response channel;
+    /// this event feeds peer scoring and metrics.
+    RetrievalFailed {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// The requested chunk address.
+        address: ChunkAddress,
+        /// Error description.
+        error: String,
+    },
+    /// An outbound chunk push failed.
+    ///
+    /// The pusher has already been resolved through its response channel;
+    /// this event feeds peer scoring and metrics.
+    PushFailed {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// The chunk address.
+        address: ChunkAddress,
+        /// Error description.
+        error: String,
     },
     /// Protocol error occurred.
     Error {
@@ -478,55 +509,85 @@ impl ClientHandler {
         }
     }
 
-    /// Handle retrieval response.
+    /// Handle retrieval response, resolving the caller's response channel.
     fn on_retrieval_response(
         &mut self,
         delivery: vertex_swarm_net_retrieval::Delivery,
         address: ChunkAddress,
+        response: RetrievalResponseTx,
     ) {
-        if let Some(overlay) = self.overlay() {
-            match delivery {
-                vertex_swarm_net_retrieval::Delivery::Error(err) => {
-                    debug!(%overlay, error = %err, "Retrieval failed");
-                    self.push_event(HandlerEvent::Error {
-                        overlay: Some(overlay),
-                        protocol: "retrieval",
-                        error: err,
-                    });
-                }
-                vertex_swarm_net_retrieval::Delivery::Chunk(chunk) => {
-                    debug!(%overlay, %address, "Received chunk");
-                    self.push_event(HandlerEvent::ChunkReceived {
+        let overlay = self.overlay();
+        match delivery {
+            vertex_swarm_net_retrieval::Delivery::Error(err) => {
+                debug!(?overlay, %address, error = %err, "Retrieval failed");
+                if let Some(overlay) = overlay {
+                    self.push_event(HandlerEvent::RetrievalFailed {
                         overlay,
                         address,
-                        chunk: *chunk,
+                        error: err.clone(),
                     });
                 }
+                let _ = response.send(Err(RetrievalError::Protocol(err)));
+            }
+            vertex_swarm_net_retrieval::Delivery::Chunk(chunk) => {
+                let Some(overlay) = overlay else {
+                    let _ = response.send(Err(RetrievalError::Protocol(
+                        "handler not active".to_string(),
+                    )));
+                    return;
+                };
+                debug!(%overlay, %address, "Received chunk");
+                self.push_event(HandlerEvent::ChunkReceived {
+                    overlay,
+                    address,
+                    chunk: (*chunk).clone(),
+                });
+                let _ = response.send(Ok(RetrievalResult {
+                    chunk: *chunk,
+                    peer: overlay,
+                }));
             }
         }
     }
 
-    /// Handle pushsync receipt.
-    fn on_pushsync_receipt(&mut self, receipt: vertex_swarm_net_pushsync::Receipt) {
-        if let Some(overlay) = self.overlay() {
-            if let Some(ref err) = receipt.error {
-                debug!(%overlay, error = %err, "Pushsync failed");
-                self.push_event(HandlerEvent::Error {
-                    overlay: Some(overlay),
-                    protocol: "pushsync",
+    /// Handle pushsync receipt, resolving the caller's response channel.
+    fn on_pushsync_receipt(
+        &mut self,
+        receipt: vertex_swarm_net_pushsync::Receipt,
+        response: PushResponseTx,
+    ) {
+        let overlay = self.overlay();
+        if let Some(err) = receipt.error {
+            debug!(?overlay, address = %receipt.address, error = %err, "Pushsync failed");
+            if let Some(overlay) = overlay {
+                self.push_event(HandlerEvent::PushFailed {
+                    overlay,
+                    address: receipt.address,
                     error: err.clone(),
                 });
-            } else {
-                debug!(%overlay, address = %receipt.address, "Received receipt");
-                self.pending_events
-                    .push_back(HandlerEvent::ReceiptReceived {
-                        overlay,
-                        address: receipt.address,
-                        signature: receipt.signature,
-                        nonce: receipt.nonce,
-                        storage_radius: receipt.storage_radius,
-                    });
             }
+            let _ = response.send(Err(RetrievalError::PushRejected(err)));
+        } else {
+            let Some(overlay) = overlay else {
+                let _ = response.send(Err(RetrievalError::Protocol(
+                    "handler not active".to_string(),
+                )));
+                return;
+            };
+            debug!(%overlay, address = %receipt.address, "Received receipt");
+            self.push_event(HandlerEvent::ReceiptReceived {
+                overlay,
+                address: receipt.address,
+                signature: receipt.signature,
+                nonce: receipt.nonce,
+                storage_radius: receipt.storage_radius,
+            });
+            let _ = response.send(Ok(PushReceipt {
+                storer: overlay,
+                signature: receipt.signature,
+                nonce: receipt.nonce,
+                storage_radius: receipt.storage_radius,
+            }));
         }
     }
 }
@@ -614,24 +675,24 @@ impl ConnectionHandler for ClientHandler {
                         });
                     }
                 }
-                HandlerCommand::RetrieveChunk { address } => {
+                HandlerCommand::RetrieveChunk { address, response } => {
                     let upgrade = ClientOutboundUpgrade::retrieval(address);
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
                         protocol: SubstreamProtocol::new(
                             upgrade,
-                            ClientOutboundInfo::Retrieval { address },
+                            ClientOutboundInfo::Retrieval { address, response },
                         )
                         .with_timeout(self.config.timeout),
                     });
                 }
-                HandlerCommand::PushChunk { chunk } => {
+                HandlerCommand::PushChunk { chunk, response } => {
                     let address = *chunk.address();
                     let delivery = vertex_swarm_net_pushsync::Delivery::new(chunk);
                     let upgrade = ClientOutboundUpgrade::pushsync(delivery);
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
                         protocol: SubstreamProtocol::new(
                             upgrade,
-                            ClientOutboundInfo::Pushsync { address },
+                            ClientOutboundInfo::Pushsync { address, response },
                         )
                         .with_timeout(self.config.timeout),
                     });
@@ -772,23 +833,57 @@ impl ConnectionHandler for ClientHandler {
             }
 
             ConnectionEvent::DialUpgradeError(e) => {
-                let protocol = match &e.info {
+                let error = e.error.to_string();
+                match e.info {
                     ClientOutboundInfo::Pricing => {
                         self.pricing_outbound_pending = false;
-                        "pricing"
+                        warn!(protocol = "pricing", %error, "Client dial upgrade error");
+                        self.push_event(HandlerEvent::Error {
+                            overlay: self.overlay(),
+                            protocol: "pricing",
+                            error,
+                        });
                     }
-                    ClientOutboundInfo::Retrieval { .. } => "retrieval",
-                    ClientOutboundInfo::Pushsync { .. } => "pushsync",
-                    ClientOutboundInfo::Pseudosettle { .. } => "pseudosettle",
+                    ClientOutboundInfo::Retrieval { address, response } => {
+                        warn!(protocol = "retrieval", %address, %error, "Client dial upgrade error");
+                        if let Some(overlay) = self.overlay() {
+                            self.push_event(HandlerEvent::RetrievalFailed {
+                                overlay,
+                                address,
+                                error: error.clone(),
+                            });
+                        }
+                        let _ = response.send(Err(RetrievalError::Protocol(error)));
+                    }
+                    ClientOutboundInfo::Pushsync { address, response } => {
+                        warn!(protocol = "pushsync", %address, %error, "Client dial upgrade error");
+                        if let Some(overlay) = self.overlay() {
+                            self.push_event(HandlerEvent::PushFailed {
+                                overlay,
+                                address,
+                                error: error.clone(),
+                            });
+                        }
+                        let _ = response.send(Err(RetrievalError::Protocol(error)));
+                    }
+                    ClientOutboundInfo::Pseudosettle { .. } => {
+                        warn!(protocol = "pseudosettle", %error, "Client dial upgrade error");
+                        self.push_event(HandlerEvent::Error {
+                            overlay: self.overlay(),
+                            protocol: "pseudosettle",
+                            error,
+                        });
+                    }
                     #[cfg(feature = "swap")]
-                    ClientOutboundInfo::Swap => "swap",
-                };
-                warn!(protocol, error = %e.error, "Client dial upgrade error");
-                self.push_event(HandlerEvent::Error {
-                    overlay: self.overlay(),
-                    protocol,
-                    error: e.error.to_string(),
-                });
+                    ClientOutboundInfo::Swap => {
+                        warn!(protocol = "swap", %error, "Client dial upgrade error");
+                        self.push_event(HandlerEvent::Error {
+                            overlay: self.overlay(),
+                            protocol: "swap",
+                            error,
+                        });
+                    }
+                }
             }
 
             ConnectionEvent::ListenUpgradeError(e) => {
@@ -858,15 +953,16 @@ impl ClientHandler {
             }
             (
                 ClientOutboundOutput::Retrieval(delivery),
-                ClientOutboundInfo::Retrieval { address },
+                ClientOutboundInfo::Retrieval { address, response },
             ) => {
-                self.on_retrieval_response(delivery, address);
+                self.on_retrieval_response(delivery, address, response);
             }
-            (ClientOutboundOutput::Pushsync(receipt), ClientOutboundInfo::Pushsync { address }) => {
-                if let Some(overlay) = self.overlay() {
-                    debug!(%overlay, %address, "Received pushsync receipt");
-                    self.on_pushsync_receipt(receipt);
-                }
+            (
+                ClientOutboundOutput::Pushsync(receipt),
+                ClientOutboundInfo::Pushsync { address, response },
+            ) => {
+                debug!(%address, "Received pushsync receipt");
+                self.on_pushsync_receipt(receipt, response);
             }
             (
                 ClientOutboundOutput::Pseudosettle(ack),

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -70,4 +70,6 @@ pub(crate) mod upgrade;
 pub(crate) use behaviour::{ClientBehaviour, Config as BehaviourConfig};
 #[cfg(feature = "swap")]
 pub use events::SwapEvent;
-pub use events::{ClientCommand, ClientEvent, PseudosettleEvent};
+pub use events::{
+    ClientCommand, ClientEvent, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
+};

--- a/crates/swarm/node/src/protocol/upgrade.rs
+++ b/crates/swarm/node/src/protocol/upgrade.rs
@@ -417,14 +417,25 @@ impl OutboundUpgrade<Stream> for ClientOutboundUpgrade {
 }
 
 /// Information about an outbound request, used for correlating responses.
-#[derive(Debug, Clone)]
+///
+/// Travels with the outbound substream and comes back with its completion
+/// (or failure), so it is the natural per-request correlation: retrieval and
+/// pushsync carry their caller's response channel here, and the handler
+/// resolves it from whichever path terminates the request.
+#[derive(Debug)]
 pub(crate) enum ClientOutboundInfo {
     /// Pricing announcement.
     Pricing,
-    /// Retrieval request with chunk address.
-    Retrieval { address: ChunkAddress },
-    /// Pushsync request with chunk address.
-    Pushsync { address: ChunkAddress },
+    /// Retrieval request with chunk address and the caller's response channel.
+    Retrieval {
+        address: ChunkAddress,
+        response: super::events::RetrievalResponseTx,
+    },
+    /// Pushsync request with chunk address and the caller's response channel.
+    Pushsync {
+        address: ChunkAddress,
+        response: super::events::PushResponseTx,
+    },
     /// Pseudosettle payment with amount.
     Pseudosettle { amount: U256 },
     /// Swap cheque emission.

--- a/crates/swarm/node/src/swarm_client.rs
+++ b/crates/swarm/node/src/swarm_client.rs
@@ -258,7 +258,7 @@ mod tests {
         assert!(peers.is_empty());
     }
 
-    use crate::RetrievalError;
+    use crate::ChunkTransferError;
     use alloy_primitives::{B256, Signature};
     use nectar_primitives::{ContentChunk, Nonce};
     use vertex_swarm_api::{PushReceipt, Stamp};
@@ -473,7 +473,9 @@ mod tests {
         match rx.recv().await.expect("command emitted") {
             ClientCommand::PushChunk { response, .. } => {
                 response
-                    .send(Err(RetrievalError::PushRejected("rejected".to_string())))
+                    .send(Err(ChunkTransferError::PushRejected(
+                        "rejected".to_string(),
+                    )))
                     .expect("receiver alive");
             }
             other => panic!("unexpected command: {other:?}"),
@@ -481,7 +483,7 @@ mod tests {
 
         let result = push.await.unwrap();
         match result {
-            Err(RetrievalError::PushRejected(reason)) => assert_eq!(reason, "rejected"),
+            Err(ChunkTransferError::PushRejected(reason)) => assert_eq!(reason, "rejected"),
             other => panic!("expected PushRejected, got {other:?}"),
         }
     }
@@ -528,7 +530,7 @@ mod tests {
         responses
             .remove(&peer_a)
             .unwrap()
-            .send(Err(RetrievalError::Protocol("missing".to_string())))
+            .send(Err(ChunkTransferError::Protocol("missing".to_string())))
             .expect("receiver alive");
         responses
             .remove(&peer_b)
@@ -540,7 +542,7 @@ mod tests {
             .expect("receiver alive");
 
         let err = retrieval_a.await.unwrap().unwrap_err();
-        assert!(matches!(err, RetrievalError::Protocol(_)));
+        assert!(matches!(err, ChunkTransferError::Protocol(_)));
         let result = retrieval_b.await.unwrap().expect("b resolves");
         assert_eq!(result.peer, peer_b);
     }
@@ -572,7 +574,7 @@ mod tests {
             ClientCommand::RetrieveChunk { peer, response, .. } => {
                 assert_eq!(peer, peer_a);
                 response
-                    .send(Err(RetrievalError::Protocol("missing".to_string())))
+                    .send(Err(ChunkTransferError::Protocol("missing".to_string())))
                     .expect("receiver alive");
             }
             other => panic!("unexpected command: {other:?}"),

--- a/crates/swarm/node/src/swarm_client.rs
+++ b/crates/swarm/node/src/swarm_client.rs
@@ -1,8 +1,10 @@
 //! Unified client for Swarm nodes.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
+use futures_timer::Delay;
 use nectar_primitives::{AnyChunk, ChunkAddress};
 use vertex_swarm_api::{
     BootnodeComponents, ClientComponents, HasAccounting, HasTopology, StampedChunk, SwarmClient,
@@ -12,8 +14,16 @@ use vertex_swarm_primitives::OverlayAddress;
 
 use crate::{ClientHandle, PeerSelector};
 
-/// Number of closest peers to try, in order, for a retrieval.
+/// Number of closest peers raced for a retrieval (and walked for a push).
 const CLOSEST_PEER_COUNT: usize = 3;
+
+/// Delay before each additional retrieval candidate joins the race.
+///
+/// Staggering bounds the cost of the fan-out: every raced attempt the remote
+/// answers is paid for in accounting units, so further candidates only start
+/// while no response has arrived. A failed attempt starts the next candidate
+/// immediately instead of waiting out the stagger.
+const RETRIEVAL_STAGGER: Duration = Duration::from_millis(500);
 
 /// Unified client for all Swarm node types.
 ///
@@ -109,35 +119,56 @@ where
             .closest_to(address, CLOSEST_PEER_COUNT);
         let closest = self.select(closest, address);
         let attempts = closest.len();
+        let mut candidates = closest.into_iter();
 
-        // Walk the closest peers in order and return the first response. The
-        // codec reconstructs the chunk against the requested address, so the
+        // Race the candidates with a staggered start: the best candidate is
+        // queried immediately and each stagger tick (or failed attempt) adds
+        // the next one, resolving on the first response. The codec
+        // reconstructs the chunk against the requested address, so the
         // retrieved chunk is already address-validated; no re-verification is
-        // needed here. Retrieval cannot yet be raced across peers for the same
-        // chunk: the client handle correlates a response to a pending request by
-        // chunk address alone, so two in-flight requests for one address would
-        // alias. Fanning out needs a per-request correlation id in the handle
-        // and handler, tracked as a follow-up; until then this is sequential.
-        //
-        // The seed error covers the no-candidates case; each failed attempt
-        // replaces it, so the value after the loop is always the last failure.
-        let mut outcome = Err(SwarmError::NoStorer {
-            chunk_address: *address,
-        });
-        for peer in closest {
-            match self.client_handle.retrieve_chunk(peer, *address).await {
-                Ok(result) => return Ok(result.chunk.into_parts().0),
-                Err(e) => {
-                    outcome = Err(SwarmError::AllPeersFailed {
-                        address: *address,
-                        attempts,
-                        source: Box::new(e),
-                    });
-                }
+        // needed here. Each request carries its own response channel, so
+        // concurrent requests for one address never collide, and losing
+        // attempts are simply dropped when this future returns.
+        let mut in_flight = FuturesUnordered::new();
+        match candidates.next() {
+            Some(peer) => in_flight.push(self.client_handle.retrieve_chunk(peer, *address)),
+            None => {
+                return Err(SwarmError::NoStorer {
+                    chunk_address: *address,
+                });
             }
         }
 
-        outcome
+        let mut stagger = Delay::new(RETRIEVAL_STAGGER).fuse();
+
+        loop {
+            futures::select! {
+                result = in_flight.select_next_some() => match result {
+                    Ok(result) => return Ok(result.chunk.into_parts().0),
+                    Err(error) => {
+                        // A failed attempt frees its slot: start the next
+                        // candidate immediately. Once no candidates and no
+                        // attempts remain, the race ends with the error of
+                        // the last attempt to fail.
+                        if let Some(peer) = candidates.next() {
+                            in_flight.push(self.client_handle.retrieve_chunk(peer, *address));
+                        } else if in_flight.is_empty() {
+                            return Err(SwarmError::AllPeersFailed {
+                                address: *address,
+                                attempts,
+                                source: Box::new(error),
+                            });
+                        }
+                    }
+                },
+                _ = stagger => {
+                    if let Some(peer) = candidates.next() {
+                        in_flight.push(self.client_handle.retrieve_chunk(peer, *address));
+                        stagger = Delay::new(RETRIEVAL_STAGGER).fuse();
+                    }
+                }
+            }
+        }
     }
 
     async fn put(&self, chunk: StampedChunk) -> SwarmResult<()> {
@@ -147,16 +178,32 @@ where
             .topology()
             .closest_to(&address, CLOSEST_PEER_COUNT);
         let closest = self.select(closest, &address);
+        let attempts = closest.len();
 
-        let peer = closest.into_iter().next().ok_or(SwarmError::NoStorer {
+        // Walk the candidates in order. Pushes are not raced: a race would
+        // deliver and charge for the chunk on every branch. Failures resolve
+        // promptly through the per-request response channel, so a dead
+        // candidate cannot stall the walk.
+        //
+        // The seed error covers the no-candidates case; each failed attempt
+        // replaces it, so the value after the loop is always the last failure.
+        let mut outcome = Err(SwarmError::NoStorer {
             chunk_address: address,
-        })?;
+        });
+        for peer in closest {
+            match self.client_handle.push_chunk(peer, chunk.clone()).await {
+                Ok(_receipt) => return Ok(()),
+                Err(error) => {
+                    outcome = Err(SwarmError::AllPeersFailed {
+                        address,
+                        attempts,
+                        source: Box::new(error),
+                    });
+                }
+            }
+        }
 
-        self.client_handle
-            .push_chunk(peer, chunk)
-            .await
-            .map(|_receipt| ())
-            .map_err(|e| SwarmError::network_msg(e.to_string()))
+        outcome
     }
 }
 
@@ -292,29 +339,31 @@ mod tests {
 
         // The handle must have emitted a PushChunk command for the target peer.
         let cmd = rx.recv().await.expect("command emitted");
-        match cmd {
+        let response = match cmd {
             ClientCommand::PushChunk {
                 peer: p,
                 address: a,
                 chunk,
+                response,
             } => {
                 assert_eq!(p, peer);
                 assert_eq!(a, address);
                 assert_eq!(*chunk.address(), address);
+                response
             }
             other => panic!("unexpected command: {other:?}"),
-        }
+        };
 
-        // Simulate the event processor delivering a typed receipt.
-        handle.complete_push(
-            address,
-            PushReceipt {
+        // Resolve the request through its own response channel, as the
+        // handler does when the receipt arrives on the request's substream.
+        response
+            .send(Ok(PushReceipt {
                 storer: peer,
                 signature: test_signature(),
                 nonce: Nonce::from([9u8; 32]),
                 storage_radius: StorageRadius::new(Bin::new(5).unwrap()),
-            },
-        );
+            }))
+            .expect("receiver alive");
 
         let receipt = push.await.unwrap().expect("push resolves");
         assert_eq!(receipt.storer, peer);
@@ -389,17 +438,16 @@ mod tests {
         // candidate is closer in proximity order.
         let cmd = rx.recv().await.expect("command emitted");
         match cmd {
-            ClientCommand::PushChunk { peer, address, .. } => {
+            ClientCommand::PushChunk { peer, response, .. } => {
                 assert_eq!(peer, affordable);
-                handle.complete_push(
-                    address,
-                    PushReceipt {
+                response
+                    .send(Ok(PushReceipt {
                         storer: affordable,
                         signature: test_signature(),
                         nonce: Nonce::from([9u8; 32]),
                         storage_radius: StorageRadius::new(Bin::new(5).unwrap()),
-                    },
-                );
+                    }))
+                    .expect("receiver alive");
             }
             other => panic!("unexpected command: {other:?}"),
         }
@@ -414,22 +462,179 @@ mod tests {
 
         let peer = test_peer();
         let stamped = test_stamped_chunk();
-        let address = test_address();
 
         let push = {
             let handle = handle.clone();
             tokio::spawn(async move { handle.push_chunk(peer, stamped).await })
         };
 
-        let _ = rx.recv().await.expect("command emitted");
-
-        // The event processor reports a storer rejection.
-        handle.fail_push(address, "rejected".to_string());
+        // The handler reports a storer rejection through the request's
+        // response channel.
+        match rx.recv().await.expect("command emitted") {
+            ClientCommand::PushChunk { response, .. } => {
+                response
+                    .send(Err(RetrievalError::PushRejected("rejected".to_string())))
+                    .expect("receiver alive");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
 
         let result = push.await.unwrap();
         match result {
             Err(RetrievalError::PushRejected(reason)) => assert_eq!(reason, "rejected"),
             other => panic!("expected PushRejected, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn concurrent_retrievals_for_same_address_resolve_independently() {
+        use crate::RetrievalResult;
+
+        let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+        let handle = ClientHandle::new(tx);
+
+        let address = test_address();
+        let peer_a = OverlayAddress::from([1u8; 32]);
+        let peer_b = OverlayAddress::from([2u8; 32]);
+
+        let retrieval_a = {
+            let handle = handle.clone();
+            tokio::spawn(async move { handle.retrieve_chunk(peer_a, address).await })
+        };
+        let retrieval_b = {
+            let handle = handle.clone();
+            tokio::spawn(async move { handle.retrieve_chunk(peer_b, address).await })
+        };
+
+        // Both requests for the same address are in flight; collect their
+        // response channels keyed by peer.
+        let mut responses = std::collections::HashMap::new();
+        for _ in 0..2 {
+            match rx.recv().await.expect("command emitted") {
+                ClientCommand::RetrieveChunk {
+                    peer,
+                    address: requested,
+                    response,
+                } => {
+                    assert_eq!(requested, address);
+                    responses.insert(peer, response);
+                }
+                other => panic!("unexpected command: {other:?}"),
+            }
+        }
+        assert_eq!(responses.len(), 2, "requests must not alias");
+
+        // Fail A and succeed B: each request resolves through its own channel.
+        responses
+            .remove(&peer_a)
+            .unwrap()
+            .send(Err(RetrievalError::Protocol("missing".to_string())))
+            .expect("receiver alive");
+        responses
+            .remove(&peer_b)
+            .unwrap()
+            .send(Ok(RetrievalResult {
+                chunk: test_stamped_chunk(),
+                peer: peer_b,
+            }))
+            .expect("receiver alive");
+
+        let err = retrieval_a.await.unwrap().unwrap_err();
+        assert!(matches!(err, RetrievalError::Protocol(_)));
+        let result = retrieval_b.await.unwrap().expect("b resolves");
+        assert_eq!(result.peer, peer_b);
+    }
+
+    #[tokio::test]
+    async fn get_starts_next_candidate_on_failure_and_returns_first_success() {
+        use crate::RetrievalResult;
+
+        let peer_a = OverlayAddress::from([1u8; 32]);
+        let peer_b = OverlayAddress::from([2u8; 32]);
+
+        let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+        let handle = ClientHandle::new(tx);
+        let topology = MockTopology::default().with_closest(vec![peer_a, peer_b]);
+        let bandwidth = Arc::new(Accounting::new(
+            DefaultBandwidthConfig::default(),
+            test_identity(),
+        ));
+        let pricer = FixedPricer::new(10_000, vertex_swarm_spec::init_mainnet());
+        let accounting = ClientAccounting::new(bandwidth, pricer);
+        let client = Client::client(topology, accounting, handle);
+
+        let address = test_address();
+        let get = tokio::spawn(async move { client.get(&address).await });
+
+        // First candidate fails; the next must start immediately (well before
+        // the stagger interval).
+        match rx.recv().await.expect("first command") {
+            ClientCommand::RetrieveChunk { peer, response, .. } => {
+                assert_eq!(peer, peer_a);
+                response
+                    .send(Err(RetrievalError::Protocol("missing".to_string())))
+                    .expect("receiver alive");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+        match rx.recv().await.expect("second command") {
+            ClientCommand::RetrieveChunk { peer, response, .. } => {
+                assert_eq!(peer, peer_b);
+                response
+                    .send(Ok(RetrievalResult {
+                        chunk: test_stamped_chunk(),
+                        peer: peer_b,
+                    }))
+                    .expect("receiver alive");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        let chunk = get.await.unwrap().expect("get resolves");
+        assert_eq!(*chunk.address(), test_address());
+    }
+
+    #[tokio::test]
+    async fn get_staggers_in_a_second_candidate_while_the_first_is_silent() {
+        use crate::RetrievalResult;
+
+        let peer_a = OverlayAddress::from([1u8; 32]);
+        let peer_b = OverlayAddress::from([2u8; 32]);
+
+        let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+        let handle = ClientHandle::new(tx);
+        let topology = MockTopology::default().with_closest(vec![peer_a, peer_b]);
+        let bandwidth = Arc::new(Accounting::new(
+            DefaultBandwidthConfig::default(),
+            test_identity(),
+        ));
+        let pricer = FixedPricer::new(10_000, vertex_swarm_spec::init_mainnet());
+        let accounting = ClientAccounting::new(bandwidth, pricer);
+        let client = Client::client(topology, accounting, handle);
+
+        let address = test_address();
+        let get = tokio::spawn(async move { client.get(&address).await });
+
+        // Leave the first candidate unanswered; the stagger must bring in the
+        // second, and its response must resolve the race.
+        match rx.recv().await.expect("first command") {
+            ClientCommand::RetrieveChunk { peer, .. } => assert_eq!(peer, peer_a),
+            other => panic!("unexpected command: {other:?}"),
+        }
+        match rx.recv().await.expect("second command after stagger") {
+            ClientCommand::RetrieveChunk { peer, response, .. } => {
+                assert_eq!(peer, peer_b);
+                response
+                    .send(Ok(RetrievalResult {
+                        chunk: test_stamped_chunk(),
+                        peer: peer_b,
+                    }))
+                    .expect("receiver alive");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        let chunk = get.await.unwrap().expect("get resolves");
+        assert_eq!(*chunk.address(), test_address());
     }
 }


### PR DESCRIPTION
## Problem

Outbound retrieval and pushsync correlated responses to callers through `ClientHandle` maps keyed by chunk address alone (`pending_retrievals`, `pending_pushes`). Three consequences:

- Two in-flight requests for the same address overwrote each other's channel, and a failure from one peer evicted another peer's pending entry, so fan-out was impossible and `SwarmClient::get` walked peers sequentially (#178).
- `ClientEvent::RetrievalFailed` / `PushFailed` were never emitted by any code path: handler failures surfaced only as generic `ProtocolError`, which nothing routed back to the pending maps. Any wire-level failure (delivery error, receipt rejection, dial upgrade error, timeout) left the caller's channel in the map forever, so both `get` and `put` could hang indefinitely (#177, and the same bug class on the retrieval side).
- `SwarmClient::put` only ever tried the single closest candidate.

## Change

Thread the caller's oneshot sender through `ClientCommand` and `HandlerCommand` into `ClientOutboundInfo`. The info travels with the outbound substream and returns with its completion (`FullyNegotiatedOutbound`) or failure (`DialUpgradeError`), so the substream is the correlation and no shared rendezvous state exists. The pending maps and their `complete_*`/`fail_*` plumbing are deleted.

Every termination path now resolves the caller: chunk delivery, wire-level delivery error, receipt and receipt rejection, dial upgrade error, unknown peer (new `RetrievalError::NotConnected`), queue overflow, and connection teardown (channel drop surfaces as `Cancelled`). The handler emits typed `RetrievalFailed`/`PushFailed` events carrying peer and address, which the behaviour forwards as the previously dead `ClientEvent` variants, ready for peer scoring (#287).

With requests self-contained, `SwarmClient::get` races the closest candidates with a staggered start: the best candidate is queried immediately, each 500ms tick (or an attempt failure, instantly) adds the next, and the first verified chunk wins; losing branches are dropped with their channels. The stagger bounds the accounting cost of the race, pending the self-throttle work (#130/#132). `SwarmClient::put` now walks all candidates sequentially instead of giving up after the first; pushes are deliberately not raced since every branch would deliver and be charged for the chunk.

`futures-timer` (already pinned workspace-wide with the `wasm-bindgen` feature for the browser clock) moves from the wasm-only section to a regular dependency for the stagger timer, keeping `vertex-swarm-node` wasm-clean.

## Tests

- `concurrent_retrievals_for_same_address_resolve_independently`: the exact aliasing failure of the old design.
- `get_starts_next_candidate_on_failure_and_returns_first_success`: failure frees a slot immediately.
- `get_staggers_in_a_second_candidate_while_the_first_is_silent`: stagger brings in candidate two and its response resolves the race.
- `push_chunk_fails_when_push_is_rejected` reworked as the #177 regression test: rejection resolves the caller instead of hanging.
- Existing selector/affordability and failure-path tests reworked onto the response channels.

Closes #177
Closes #178
