### PR TITLE
feat(swarm-node): wire retrieval and pushsync outcomes into peer scoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9148,6 +9148,7 @@ dependencies = [
  "libp2p-swarm-test",
  "libp2p-websocket-websys",
  "metrics",
+ "nectar-postage",
  "nectar-primitives",
  "parking_lot",
  "rand 0.8.6",

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -323,7 +323,11 @@ async fn build_client_backed_node(
         NetworkChunkProvider::new(client_handle.clone(), topology.clone()).with_selector(selector);
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
-    // Spawn client service as independent task with graceful shutdown
+    // Spawn client service as independent task with graceful shutdown. The
+    // client service reports retrieval and pushsync outcomes (success,
+    // failure, and malformed-chunk invalid data) through the same peer manager
+    // authority that accounting uses.
+    let client_service = client_service.with_reporter(Arc::clone(&reporter));
     ctx.executor()
         .spawn_service("swarm.client_service", client_service);
 

--- a/crates/swarm/net/proto/proto/pushsync.proto
+++ b/crates/swarm/net/proto/proto/pushsync.proto
@@ -12,11 +12,22 @@ message Delivery {
   bytes stamp = 3;
 }
 
-// Receipt acknowledging chunk storage.
+// Receipt acknowledging chunk storage. This frame models a successful custody
+// acknowledgement only; the reference does not sign its failure responses
+// (a failure is a receipt with an error string and no signature), so there is
+// no signed failure receipt to model.
+//
+// A failure is signalled by resetting the stream, not by a frame: a responder
+// that cannot store resets, which the reference pusher reads as a failed push
+// at every hop (it never reads a receipt to misjudge). So we send no failure
+// receipt and need no error field. Field 4 was a remote error string in the
+// reference; we never read it (it is adversarial input the reference does not
+// introspect), so it is omitted here. An inbound field-4 value is skipped
+// without allocation. On receive, a failure is detected structurally by an
+// empty `signature` (field 5 keeps its number).
 message Receipt {
   bytes address = 1;
   bytes signature = 2;
   bytes nonce = 3;
-  string err = 4;
   uint32 storage_radius = 5;
 }

--- a/crates/swarm/net/proto/proto/retrieval.proto
+++ b/crates/swarm/net/proto/proto/retrieval.proto
@@ -10,9 +10,18 @@ message Request {
   bytes addr = 1;
 }
 
-// Delivery of a chunk with optional error.
+// Delivery of a chunk.
+//
+// An honest failure is signalled structurally by an empty `data` AND an empty
+// `stamp`: the reference reports a retrieval failure with an empty delivery
+// (it does not reset the stream for retrieval), and that is the only signal we
+// read. A non-empty `data` claims a chunk and must reconstruct and validate, or
+// it is malformed (the two are scored differently). Field 3 was a remote error
+// string in the reference; we never read it (it is adversarial input the
+// reference itself does not introspect), so it is omitted here. An inbound
+// field-3 value is skipped without allocation, and we emit nothing on it. A
+// requester detects our failures from the empty `data` (chunk validation fails).
 message Delivery {
   bytes data = 1;
   bytes stamp = 2;
-  string err = 3;
 }

--- a/crates/swarm/net/pushsync/src/codec.rs
+++ b/crates/swarm/net/pushsync/src/codec.rs
@@ -11,8 +11,8 @@ use crate::error::PushsyncError;
 /// Codec for pushsync delivery messages.
 pub(crate) type DeliveryCodec = Codec<Delivery, PushsyncError>;
 
-/// Codec for pushsync receipt messages.
-pub(crate) type ReceiptCodec = Codec<Receipt, PushsyncError>;
+/// Codec for pushsync receipt responses.
+pub(crate) type ReceiptCodec = Codec<ReceiptResponse, PushsyncError>;
 
 /// Delivery of a chunk to be stored.
 ///
@@ -63,17 +63,25 @@ impl ProtoMessage for Delivery {
     }
 }
 
-/// Receipt acknowledging chunk storage.
+/// Length in bytes of a well-formed recoverable signature. A failure response
+/// carries an empty signature instead, which is the structural failure signal.
+const SIGNATURE_LEN: usize = 65;
+
+/// A successful storage receipt.
+///
+/// This type models a custody acknowledgement only. The reference does not sign
+/// its failure responses (a failure is `&pb.Receipt{Err: ...}` with no
+/// signature), so there is no signed failure receipt to model and no need for
+/// placeholder fields. A failure is represented by the [`ReceiptResponse::Failed`]
+/// variant, not by a `Receipt` with zeroed fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Receipt {
     /// The address of the chunk.
     pub address: ChunkAddress,
-    /// Signature from the storer.
+    /// Signature from the storer over the chunk address and nonce.
     pub signature: Signature,
     /// Nonce used in signing.
     pub nonce: Nonce,
-    /// Error message if storage failed.
-    pub error: Option<String>,
     /// The storage radius of the storer node.
     pub storage_radius: StorageRadius,
 }
@@ -90,63 +98,68 @@ impl Receipt {
             address,
             signature,
             nonce,
-            error: None,
             storage_radius,
         }
     }
+}
 
-    /// Create an error receipt.
-    ///
-    /// The signature, nonce, and radius are zero-valued placeholders; the
-    /// `error` field is what consumers inspect.
-    pub fn error(address: ChunkAddress, msg: impl Into<String>) -> Self {
-        Self {
-            address,
-            signature: Signature::new(
-                alloy_primitives::U256::ZERO,
-                alloy_primitives::U256::ZERO,
-                false,
-            ),
-            nonce: Nonce::ZERO,
-            error: Some(msg.into()),
-            storage_radius: StorageRadius::ZERO,
-        }
-    }
+/// The decoded response to a pushsync delivery: a signed receipt on success, or
+/// a structural failure.
+///
+/// Modelling success-or-failure here keeps [`Receipt`] free of placeholder
+/// fields. A failure is never put on the wire by this implementation: the
+/// responder signals failure by resetting the stream (see
+/// `PushsyncResponder::send_error`). The [`Failed`](Self::Failed) encode arm
+/// emits an empty frame purely so the codec round-trips; nothing reads it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceiptResponse {
+    /// The storer took custody and returned a signed receipt.
+    Stored(Receipt),
+    /// The storer could not take custody. The reference's failure response is
+    /// unsigned; its reason string is adversarial input we never read.
+    Failed,
+}
 
-    /// Check if this receipt is an error.
+impl ReceiptResponse {
+    /// Check if this response reports a failure.
     pub fn is_error(&self) -> bool {
-        self.error.is_some()
+        matches!(self, Self::Failed)
     }
 }
 
-impl ProtoMessage for Receipt {
+impl ProtoMessage for ReceiptResponse {
     type Proto = vertex_swarm_net_proto::pushsync::Receipt;
     type EncodeError = std::convert::Infallible;
     type DecodeError = PushsyncError;
 
     fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
-        Ok(vertex_swarm_net_proto::pushsync::Receipt {
-            address: self.address.to_vec(),
-            signature: self.signature.as_bytes().to_vec(),
-            nonce: self.nonce.as_slice().to_vec(),
-            err: self.error.unwrap_or_default(),
-            storage_radius: u32::from(self.storage_radius.get()),
-        })
+        match self {
+            // An empty signature is the structural failure signal. In practice a
+            // responder signals failure by resetting the stream (see
+            // `PushsyncResponder::send_error`), so this frame is never actually
+            // encoded onto the wire; this arm exists only for codec round-trip
+            // symmetry with the decode path and carries no meaningful payload.
+            Self::Failed => Ok(vertex_swarm_net_proto::pushsync::Receipt::default()),
+            Self::Stored(receipt) => Ok(vertex_swarm_net_proto::pushsync::Receipt {
+                address: receipt.address.to_vec(),
+                signature: receipt.signature.as_bytes().to_vec(),
+                nonce: receipt.nonce.as_slice().to_vec(),
+                storage_radius: u32::from(receipt.storage_radius.get()),
+            }),
+        }
     }
 
     fn from_proto(proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        // Failure is detected structurally: a failure response carries no full
+        // signature. Any error marker on the opaque `err` field is ignored and
+        // never read. Only a success receipt's typed fields are parsed strictly.
+        if proto.signature.len() != SIGNATURE_LEN {
+            return Ok(Self::Failed);
+        }
         if proto.address.len() != 32 {
             return Err(PushsyncError::InvalidAddressLength(proto.address.len()));
         }
         let address = ChunkAddress::from_slice(&proto.address)?;
-        // An error receipt carries the `err` string and may leave the
-        // signature, nonce, and radius fields empty or zeroed. Do not parse
-        // those fields in that case: a remote error receipt is decodable from
-        // its `err` alone, mirroring the placeholders that [`Receipt::error`]
-        // emits. Only a success receipt's typed fields are parsed strictly.
-        if !proto.err.is_empty() {
-            return Ok(Self::error(address, proto.err));
-        }
         let signature = Signature::from_raw(&proto.signature)?;
         let nonce_bytes: [u8; 32] = proto
             .nonce
@@ -160,7 +173,12 @@ impl ProtoMessage for Receipt {
             Bin::new(radius_byte)
                 .map_err(|_| PushsyncError::InvalidStorageRadius(proto.storage_radius))?,
         );
-        Ok(Self::success(address, signature, nonce, storage_radius))
+        Ok(Self::Stored(Receipt::success(
+            address,
+            signature,
+            nonce,
+            storage_radius,
+        )))
     }
 }
 
@@ -215,23 +233,25 @@ mod tests {
 
     #[test]
     fn test_receipt_success_roundtrip() {
-        let original = Receipt::success(
+        let original = ReceiptResponse::Stored(Receipt::success(
             ChunkAddress::new([0x42; 32]),
             test_signature(),
             Nonce::new([9u8; 32]),
             radius(10),
-        );
+        ));
         let proto = original.clone().into_proto().unwrap();
-        let decoded = Receipt::from_proto(proto).unwrap();
+        let decoded = ReceiptResponse::from_proto(proto).unwrap();
         assert_eq!(original, decoded);
         assert!(!decoded.is_error());
     }
 
     #[test]
     fn test_receipt_error_roundtrip() {
-        let original = Receipt::error(ChunkAddress::new([0x42; 32]), "storage failed");
+        let original = ReceiptResponse::Failed;
         let proto = original.clone().into_proto().unwrap();
-        let decoded = Receipt::from_proto(proto).unwrap();
+        // A failure is detected structurally by an empty signature.
+        assert!(proto.signature.is_empty());
+        let decoded = ReceiptResponse::from_proto(proto).unwrap();
         assert_eq!(original, decoded);
         assert!(decoded.is_error());
     }

--- a/crates/swarm/net/pushsync/src/error.rs
+++ b/crates/swarm/net/pushsync/src/error.rs
@@ -32,3 +32,40 @@ vertex_net_codec::protocol_error! {
         InvalidStorageRadius(u32),
     }
 }
+
+impl PushsyncError {
+    /// True when the error is a malformed-chunk signal: the delivered bytes
+    /// failed address or stamp reconstruction, or the address itself was
+    /// unparseable. These are attributable to the sending peer and warrant an
+    /// adverse score, distinct from a transport or negotiation failure. Receipt
+    /// decoding errors are excluded since they describe a storer's reply, not a
+    /// chunk a peer pushed at us.
+    #[must_use]
+    pub fn is_invalid_chunk(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidChunk(_)
+                | Self::InvalidStamp(_)
+                | Self::InvalidAddress(_)
+                | Self::InvalidAddressLength(_)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_chunk_signals_are_invalid_chunk() {
+        assert!(PushsyncError::InvalidAddressLength(7).is_invalid_chunk());
+    }
+
+    #[test]
+    fn receipt_decode_errors_are_not_invalid_chunk() {
+        // A bad nonce length describes a storer reply, not a chunk a peer
+        // pushed at us, so it must not be scored as invalid data.
+        assert!(!PushsyncError::InvalidNonceLength(3).is_invalid_chunk());
+        assert!(!PushsyncError::ConnectionClosed.is_invalid_chunk());
+    }
+}

--- a/crates/swarm/net/pushsync/src/lib.rs
+++ b/crates/swarm/net/pushsync/src/lib.rs
@@ -1,7 +1,7 @@
 //! Pushsync protocol for Swarm chunk push and storage receipt.
 
 mod codec;
-pub use codec::{Delivery, Receipt};
+pub use codec::{Delivery, Receipt, ReceiptResponse};
 
 mod error;
 pub use error::PushsyncError;

--- a/crates/swarm/net/pushsync/src/protocol.rs
+++ b/crates/swarm/net/pushsync/src/protocol.rs
@@ -10,7 +10,8 @@
 
 use asynchronous_codec::Framed;
 use futures::{SinkExt, TryStreamExt, future::BoxFuture};
-use nectar_primitives::ChunkAddress;
+use nectar_postage::STAMP_SIZE;
+use nectar_primitives::bmt::{DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE};
 use tracing::debug;
 use vertex_swarm_net_headers::{
     HeaderedInbound, HeaderedOutbound, HeaderedStream, Inbound, Outbound,
@@ -18,12 +19,31 @@ use vertex_swarm_net_headers::{
 
 use crate::{
     PROTOCOL_NAME,
-    codec::{Delivery, DeliveryCodec, Receipt, ReceiptCodec},
+    codec::{Delivery, DeliveryCodec, Receipt, ReceiptCodec, ReceiptResponse},
     error::PushsyncError,
 };
 
-/// Maximum size of a pushsync message (chunk + stamp + overhead).
-const MAX_MESSAGE_SIZE: usize = 5 * 1024 * 1024; // 5 MB
+/// Maximum size of a pushsync message, derived from the chunk-size constants.
+///
+/// The largest legitimate `data` payload is a single-owner chunk: an
+/// [`SPAN_SIZE`] span, a 32-byte ([`HASH_SIZE`]) owner id, a 65-byte recoverable
+/// signature, and a [`DEFAULT_BODY_SIZE`] body. The pushsync `Delivery` frames
+/// that as `address` (32 bytes) + `data` + `stamp` ([`STAMP_SIZE`]). A small
+/// fixed allowance covers protobuf field tags, length varints, and the outer
+/// length-delimited frame prefix.
+///
+/// The arithmetic with the current constants:
+/// `8 + 32 + 65 + 4096` data `+ 32` address `+ 113` stamp `+ 64` framing
+/// `= 4410` bytes, well under 16 KiB. The bound is exact rather than a round
+/// number so a conformant peer never trips it and an adversarial frame (and any
+/// transient field allocation it forces) is capped tightly. Rejecting larger
+/// frames is not wire-visible.
+const SOC_SIGNATURE_SIZE: usize = 65;
+const MAX_CHUNK_DATA_SIZE: usize = SPAN_SIZE + HASH_SIZE + SOC_SIGNATURE_SIZE + DEFAULT_BODY_SIZE;
+/// Protobuf framing allowance: field tags, length varints, and the outer
+/// length-delimited frame prefix across all fields, rounded up generously.
+const PROTOBUF_FRAMING: usize = 64;
+const MAX_MESSAGE_SIZE: usize = HASH_SIZE + MAX_CHUNK_DATA_SIZE + STAMP_SIZE + PROTOBUF_FRAMING;
 
 /// Pushsync inbound: receives a chunk delivery from remote.
 #[derive(Debug, Clone)]
@@ -71,17 +91,16 @@ impl PushsyncResponder {
     /// Send a successful receipt.
     pub async fn send_receipt(mut self, receipt: Receipt) -> Result<(), PushsyncError> {
         debug!(address = %receipt.address, "Pushsync: Sending receipt");
-        self.framed.send(receipt).await
+        self.framed.send(ReceiptResponse::Stored(receipt)).await
     }
 
-    /// Send an error receipt.
-    pub async fn send_error(
-        mut self,
-        address: ChunkAddress,
-        error: impl Into<String>,
-    ) -> Result<(), PushsyncError> {
-        debug!(%address, "Pushsync: Sending error receipt");
-        self.framed.send(Receipt::error(address, error)).await
+    /// Signal a failure by resetting the stream (no frame is sent).
+    pub fn send_error(self) {
+        // The reference pusher reads the reset (or EOF) as a failed push at
+        // every hop, which sidesteps the forwarder signature-skip entirely: with
+        // no receipt to read, there is nothing for a forwarder to misjudge as a
+        // success. Dropping the framed stream resets the substream at the muxer.
+        debug!("Pushsync: resetting stream to signal failure");
     }
 }
 
@@ -99,7 +118,7 @@ impl PushsyncOutboundInner {
 }
 
 impl HeaderedOutbound for PushsyncOutboundInner {
-    type Output = Receipt;
+    type Output = ReceiptResponse;
     type Error = PushsyncError;
 
     fn protocol_name(&self) -> &'static str {

--- a/crates/swarm/net/retrieval/src/codec.rs
+++ b/crates/swarm/net/retrieval/src/codec.rs
@@ -53,19 +53,18 @@ impl ProtoMessage for Request {
     }
 }
 
-/// Delivery of a chunk, or a not-found error.
+/// Delivery of a chunk, or an opaque failure.
 ///
-/// A successful delivery carries the [`StampedChunk`]; a failed one carries the
-/// remote's error string.
+/// A successful delivery carries the [`StampedChunk`]. A failure carries no
+/// payload: the remote's error string is adversarial input the reference does
+/// not introspect, so we never read it. Failure is signalled on the wire by
+/// empty `data`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Delivery {
     /// The chunk and its stamp.
-    ///
-    /// Boxed: a [`StampedChunk`] is far larger than the error string, so boxing
-    /// keeps the enum small for the common error path.
     Chunk(Box<StampedChunk>),
-    /// Retrieval failed (e.g. chunk not found), with the remote's message.
-    Error(String),
+    /// Retrieval failed. The reason is intentionally not carried.
+    Error,
 }
 
 impl Delivery {
@@ -74,17 +73,18 @@ impl Delivery {
         Self::Chunk(Box::new(chunk))
     }
 
-    /// Create an error delivery.
-    pub fn error(msg: impl Into<String>) -> Self {
-        Self::Error(msg.into())
+    /// Create a failure delivery.
+    pub fn error() -> Self {
+        Self::Error
     }
 
-    /// Check if this delivery is an error.
+    /// Check if this delivery is a failure.
     pub fn is_error(&self) -> bool {
-        matches!(self, Self::Error(_))
+        matches!(self, Self::Error)
     }
 
-    /// Encode this delivery to its protobuf wire form.
+    /// Encode this delivery to its protobuf wire form. A failure is encoded as
+    /// empty `data`/`stamp`; we emit nothing on the (omitted) error field.
     fn into_proto(self) -> vertex_swarm_net_proto::retrieval::Delivery {
         match self {
             Self::Chunk(chunk) => {
@@ -92,13 +92,11 @@ impl Delivery {
                 vertex_swarm_net_proto::retrieval::Delivery {
                     data: chunk.into_bytes().to_vec(),
                     stamp: stamp.to_bytes().to_vec(),
-                    err: String::new(),
                 }
             }
-            Self::Error(err) => vertex_swarm_net_proto::retrieval::Delivery {
+            Self::Error => vertex_swarm_net_proto::retrieval::Delivery {
                 data: Vec::new(),
                 stamp: Vec::new(),
-                err,
             },
         }
     }
@@ -106,14 +104,23 @@ impl Delivery {
     /// Decode a delivery from its protobuf wire form, reconstructing and
     /// validating the chunk against the requested address.
     ///
-    /// An error delivery carries the `err` string and no stamp; it is decodable
-    /// from `err` alone, so the chunk is not reconstructed in that case.
+    /// An honest failure is detected structurally by an empty `data` AND an
+    /// empty `stamp`: the reference reports a retrieval failure with an empty
+    /// delivery (it does not reset the stream for retrieval), and that is the
+    /// only signal we read. Any error string the remote set on the (unmodelled)
+    /// wire field is skipped without allocation.
+    ///
+    /// Once `data` is non-empty the frame claims to carry a chunk, so it must
+    /// reconstruct and validate against the requested address; otherwise it is
+    /// malformed data, which surfaces as a decode error rather than collapsing
+    /// into an honest-failure signal. The two are scored differently upstream,
+    /// so the distinction is kept strict here.
     fn from_proto(
         proto: vertex_swarm_net_proto::retrieval::Delivery,
         expected: ChunkAddress,
     ) -> Result<Self, RetrievalError> {
-        if !proto.err.is_empty() {
-            return Ok(Self::error(proto.err));
+        if proto.data.is_empty() && proto.stamp.is_empty() {
+            return Ok(Self::Error);
         }
         let stamp = Stamp::try_from_slice(&proto.stamp)?;
         let chunk = StampedChunk::reconstruct(expected, Bytes::from(proto.data), stamp)?;
@@ -215,7 +222,7 @@ mod tests {
                 assert_eq!(*chunk.address(), address);
                 assert_eq!(chunk.chunk().clone().into_bytes(), wire_data);
             }
-            Delivery::Error(e) => panic!("expected chunk, got error {e}"),
+            Delivery::Error => panic!("expected chunk, got error"),
         }
     }
 
@@ -234,13 +241,35 @@ mod tests {
         let address = ChunkAddress::new([0x42; 32]);
         let mut enc = DeliveryCodec::new(1024, address);
         let mut buf = BytesMut::new();
-        enc.encode(Delivery::error("chunk not found"), &mut buf)
-            .unwrap();
+        enc.encode(Delivery::error(), &mut buf).unwrap();
 
         let mut dec = DeliveryCodec::new(1024, address);
         let decoded = dec.decode(&mut buf).unwrap().expect("frame decoded");
         assert!(decoded.is_error());
-        assert_eq!(decoded, Delivery::error("chunk not found"));
+        assert_eq!(decoded, Delivery::error());
+    }
+
+    /// Wire-compat: the reference signals a retrieval failure with empty data
+    /// plus a (now unmodelled) `err` string on field 3. We must decode that as a
+    /// failure and skip the err bytes entirely. This hand-builds such a frame:
+    /// a length-delimited message carrying only field 3 (`tag 0x1A`, wire type 2)
+    /// with an arbitrary error string, and asserts the decoder ignores it.
+    #[test]
+    fn decodes_reference_failure_frame_ignoring_err_field() {
+        let address = ChunkAddress::new([0x42; 32]);
+        // Inner message: field 3 (err), length-delimited, value "boom". No data,
+        // no stamp (both empty, hence omitted on the wire).
+        let inner = [&[0x1Au8, 0x04][..], b"boom"].concat();
+        // quick-protobuf framing prepends the message length as a varint; for a
+        // 6-byte message that is a single byte.
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(&[inner.len() as u8]);
+        buf.extend_from_slice(&inner);
+
+        let mut dec = DeliveryCodec::new(1024, address);
+        let decoded = dec.decode(&mut buf).unwrap().expect("frame decoded");
+        assert!(decoded.is_error(), "empty data must decode as a failure");
+        assert_eq!(decoded, Delivery::error());
     }
 
     #[test]

--- a/crates/swarm/net/retrieval/src/error.rs
+++ b/crates/swarm/net/retrieval/src/error.rs
@@ -20,3 +20,35 @@ vertex_net_codec::protocol_error! {
         InvalidChunk(#[from] vertex_swarm_primitives::ReconstructError),
     }
 }
+
+impl RetrievalError {
+    /// True when the error is a malformed-chunk signal: the delivered bytes
+    /// failed address or stamp reconstruction, or the address itself was
+    /// unparseable. These are attributable to the sending peer and warrant an
+    /// adverse score, distinct from a transport or negotiation failure.
+    #[must_use]
+    pub fn is_invalid_chunk(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidChunk(_)
+                | Self::InvalidStamp(_)
+                | Self::InvalidAddress(_)
+                | Self::InvalidAddressLength(_)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_chunk_signals_are_invalid_chunk() {
+        assert!(RetrievalError::InvalidAddressLength(7).is_invalid_chunk());
+    }
+
+    #[test]
+    fn transport_errors_are_not_invalid_chunk() {
+        assert!(!RetrievalError::ConnectionClosed.is_invalid_chunk());
+    }
+}

--- a/crates/swarm/net/retrieval/src/protocol.rs
+++ b/crates/swarm/net/retrieval/src/protocol.rs
@@ -10,7 +10,11 @@
 
 use asynchronous_codec::Framed;
 use futures::{SinkExt, TryStreamExt, future::BoxFuture};
-use nectar_primitives::ChunkAddress;
+use nectar_postage::STAMP_SIZE;
+use nectar_primitives::{
+    ChunkAddress,
+    bmt::{DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE},
+};
 use tracing::debug;
 use vertex_swarm_net_headers::{
     HeaderedInbound, HeaderedOutbound, HeaderedStream, Inbound, Outbound,
@@ -22,8 +26,27 @@ use crate::{
     error::RetrievalError,
 };
 
-/// Maximum size of a retrieval message (chunk + stamp + overhead).
-const MAX_MESSAGE_SIZE: usize = 5 * 1024 * 1024; // 5 MB
+/// Maximum size of a retrieval message, derived from the chunk-size constants.
+///
+/// The largest legitimate `data` payload is a single-owner chunk: an
+/// [`SPAN_SIZE`] span, a 32-byte ([`HASH_SIZE`]) owner id, a 65-byte recoverable
+/// signature, and a [`DEFAULT_BODY_SIZE`] body. The retrieval `Delivery` frames
+/// that as `data` + `stamp` ([`STAMP_SIZE`]) with no address of its own. A small
+/// fixed allowance covers protobuf field tags, length varints, and the outer
+/// length-delimited frame prefix.
+///
+/// The arithmetic with the current constants:
+/// `8 + 32 + 65 + 4096` data `+ 113` stamp `+ 64` framing `= 4378` bytes, well
+/// under 16 KiB. The bound is exact rather than a round number so a conformant
+/// peer never trips it and an adversarial frame (and any transient field
+/// allocation it forces) is capped tightly. Rejecting larger frames is not
+/// wire-visible.
+const SOC_SIGNATURE_SIZE: usize = 65;
+const MAX_CHUNK_DATA_SIZE: usize = SPAN_SIZE + HASH_SIZE + SOC_SIGNATURE_SIZE + DEFAULT_BODY_SIZE;
+/// Protobuf framing allowance: field tags, length varints, and the outer
+/// length-delimited frame prefix across all fields, rounded up generously.
+const PROTOBUF_FRAMING: usize = 64;
+const MAX_MESSAGE_SIZE: usize = MAX_CHUNK_DATA_SIZE + STAMP_SIZE + PROTOBUF_FRAMING;
 
 /// Retrieval inbound: receives a chunk request from remote.
 #[derive(Debug, Clone)]
@@ -82,10 +105,12 @@ impl RetrievalResponder {
         self.framed.send(Delivery::success(chunk)).await
     }
 
-    /// Send an error response.
-    pub async fn send_error(mut self, error: impl Into<String>) -> Result<(), RetrievalError> {
-        debug!("Retrieval: Sending error delivery");
-        self.framed.send(Delivery::error(error)).await
+    /// Signal a failure by resetting the stream (no frame is sent).
+    pub fn send_error(self) {
+        // We never put a placeholder or remote-controlled error on the wire. The
+        // requester reads the reset (or EOF) as a failed request. Dropping the
+        // framed stream resets the substream at the muxer.
+        debug!("Retrieval: resetting stream to signal failure");
     }
 }
 

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -109,6 +109,7 @@ eyre.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 libp2p-swarm-test.workspace = true
 rand_08.workspace = true
+nectar-postage.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -64,19 +64,20 @@ pub enum ChunkTransferError {
     /// Request cancelled.
     #[error("Request cancelled")]
     Cancelled,
-    /// Protocol error.
+    /// Local protocol failure (dial, stream, or an inactive handler). Failures
+    /// reported by the remote peer are carried by [`Self::Remote`] instead.
     #[error("Protocol error: {0}")]
     Protocol(String),
+    /// The remote peer reported a failure (a retrieval error delivery or a
+    /// non-success pushsync receipt). The reason is intentionally not carried:
+    /// the remote's error string is adversarial input we never read.
+    #[error("Remote peer reported a failure")]
+    Remote,
 
     // Retrieval-specific: only a get produces this.
     /// Chunk not found.
     #[error("Chunk not found: {0}")]
     NotFound(ChunkAddress),
-
-    // Push-specific: only a put produces this.
-    /// The storer rejected the chunk. Carries the storer's wire error string.
-    #[error("Push rejected by storer: {0}")]
-    PushRejected(String),
 }
 
 impl ClientHandle {

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -4,15 +4,22 @@
 //! It owns channels to communicate with `ClientBehaviour` and processes
 //! incoming events.
 
+use std::sync::Arc;
+
 use nectar_primitives::ChunkAddress;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
-use vertex_swarm_api::PushReceipt;
+use vertex_swarm_api::{PeerReporter, PushReceipt, ReportSource, SwarmScoringEvent};
 use vertex_swarm_net_pseudosettle::PaymentAck;
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk};
 use vertex_tasks::{GracefulShutdown, SpawnableTask};
 
-use crate::protocol::{ClientCommand, ClientEvent};
+use crate::protocol::{ClientCommand, ClientEvent, FailureKind};
+
+/// Report source label for retrieval-protocol peer scoring.
+const RETRIEVAL_SOURCE: ReportSource = ReportSource::Protocol("retrieval");
+/// Report source label for pushsync-protocol peer scoring.
+const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
 
 pub(crate) const DEFAULT_CHANNEL_CAPACITY: usize = 256;
 
@@ -146,6 +153,10 @@ pub struct ClientService {
     handle: ClientHandle,
     /// Event receiver from the network.
     event_rx: mpsc::Receiver<ClientEvent>,
+    /// Optional peer scoring authority. Retrieval and pushsync outcomes feed
+    /// it so honest peers climb and misbehaving peers are scored down.
+    /// Best-effort: without a reporter, outcomes only surface as logs.
+    reporter: Option<Arc<dyn PeerReporter>>,
 }
 
 impl ClientService {
@@ -161,6 +172,7 @@ impl ClientService {
         let service = Self {
             handle: handle.clone(),
             event_rx,
+            reporter: None,
         };
 
         (service, event_tx, handle)
@@ -178,14 +190,32 @@ impl ClientService {
         let service = Self {
             handle: handle.clone(),
             event_rx,
+            reporter: None,
         };
 
         (service, handle)
     }
 
+    /// Attach a peer reporter so retrieval and pushsync outcomes feed scoring.
+    ///
+    /// Reporting is best-effort and non-blocking. Without a reporter, outcomes
+    /// only surface as logs, exactly as before.
+    #[must_use]
+    pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
+        self.reporter = Some(reporter);
+        self
+    }
+
     /// Get a handle for sending commands.
     pub fn handle(&self) -> ClientHandle {
         self.handle.clone()
+    }
+
+    /// Report a scoring event for a peer if a reporter is configured.
+    fn report(&self, peer: &OverlayAddress, event: SwarmScoringEvent, source: ReportSource) {
+        if let Some(reporter) = &self.reporter {
+            reporter.report_peer(peer, event, source);
+        }
     }
 
     /// Run the event processing loop with graceful shutdown support.
@@ -239,11 +269,18 @@ impl ClientService {
                 peer,
                 address,
                 chunk: _,
+                latency,
             } => {
                 // The requester is resolved directly by the handler; this
-                // event exists for accounting and peer scoring.
-                debug!(%peer, %address, "Chunk received");
-                // TODO: Record bandwidth usage and report RetrievalSuccess
+                // event exists for accounting and peer scoring. The chunk was
+                // already verified against the requested address at decode, so
+                // an honest delivery raises the peer's score.
+                debug!(%peer, %address, ?latency, "Chunk received");
+                self.report(
+                    &peer,
+                    SwarmScoringEvent::RetrievalSuccess { latency },
+                    RETRIEVAL_SOURCE,
+                );
             }
 
             ClientEvent::ChunkRequested {
@@ -277,14 +314,19 @@ impl ClientService {
                 signature,
                 nonce,
                 storage_radius,
+                latency,
             } => {
                 // The pusher is resolved directly by the handler; this event
                 // exists for accounting and peer scoring.
                 debug!(
-                    %peer, %address, %storage_radius, %nonce,
+                    %peer, %address, %storage_radius, %nonce, ?latency,
                     sig = %signature, "Receipt received"
                 );
-                // TODO: Record bandwidth usage and report PushSuccess
+                self.report(
+                    &peer,
+                    SwarmScoringEvent::PushSuccess { latency },
+                    PUSHSYNC_SOURCE,
+                );
             }
 
             ClientEvent::PeerDisconnected { peer_id, overlay } => {
@@ -312,22 +354,65 @@ impl ClientService {
                 peer,
                 address,
                 error,
+                kind,
             } => {
                 // The requester is resolved directly by the handler; this
-                // event exists for peer scoring.
-                warn!(%peer, %address, %error, "Retrieval failed");
-                // TODO: Report RetrievalFailure to peer scoring
+                // event exists for peer scoring. A malformed chunk is invalid
+                // data (weight -10); a plain failure or timeout is a retrieval
+                // failure (weight -2).
+                warn!(%peer, %address, %error, ?kind, "Retrieval failed");
+                let event = match kind {
+                    FailureKind::InvalidChunk => {
+                        metrics::counter!(
+                            "swarm.client.invalid_chunk",
+                            "protocol" => "retrieval",
+                        )
+                        .increment(1);
+                        SwarmScoringEvent::InvalidData
+                    }
+                    FailureKind::Protocol => SwarmScoringEvent::RetrievalFailure,
+                };
+                self.report(&peer, event, RETRIEVAL_SOURCE);
             }
 
             ClientEvent::PushFailed {
                 peer,
                 address,
                 error,
+                kind,
             } => {
                 // The pusher is resolved directly by the handler; this event
-                // exists for peer scoring.
-                warn!(%peer, %address, %error, "Push failed");
-                // TODO: Report PushFailure to peer scoring
+                // exists for peer scoring. Same classification as retrieval.
+                warn!(%peer, %address, %error, ?kind, "Push failed");
+                let event = match kind {
+                    FailureKind::InvalidChunk => {
+                        metrics::counter!(
+                            "swarm.client.invalid_chunk",
+                            "protocol" => "pushsync",
+                        )
+                        .increment(1);
+                        SwarmScoringEvent::InvalidData
+                    }
+                    FailureKind::Protocol => SwarmScoringEvent::PushFailure,
+                };
+                self.report(&peer, event, PUSHSYNC_SOURCE);
+            }
+
+            ClientEvent::InboundInvalidData { peer, protocol } => {
+                // A peer pushed us a malformed chunk or sent a malformed
+                // retrieval request: the decode rejected it and it was never
+                // relayed. Score the sender adversely for invalid data.
+                warn!(%peer, %protocol, "Inbound malformed data rejected");
+                metrics::counter!(
+                    "swarm.client.invalid_chunk",
+                    "protocol" => protocol,
+                )
+                .increment(1);
+                self.report(
+                    &peer,
+                    SwarmScoringEvent::InvalidData,
+                    ReportSource::Protocol(protocol),
+                );
             }
 
             ClientEvent::SettlementNeeded { peer, balance } => {
@@ -396,5 +481,159 @@ impl Default for ClientService {
 impl SpawnableTask for ClientService {
     fn into_task(self, shutdown: GracefulShutdown) -> impl std::future::Future<Output = ()> + Send {
         self.run(shutdown)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use alloy_primitives::Signature;
+    use nectar_primitives::Nonce;
+    use vertex_swarm_primitives::StorageRadius;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingReporter {
+        reports: Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
+    }
+
+    impl PeerReporter for RecordingReporter {
+        fn report_peer(
+            &self,
+            overlay: &OverlayAddress,
+            event: SwarmScoringEvent,
+            source: ReportSource,
+        ) {
+            self.reports.lock().unwrap().push((*overlay, event, source));
+        }
+    }
+
+    impl RecordingReporter {
+        /// Return the single recorded report, asserting exactly one exists.
+        fn single(&self) -> (OverlayAddress, SwarmScoringEvent, ReportSource) {
+            let reports = self.reports.lock().unwrap();
+            assert_eq!(reports.len(), 1, "expected exactly one report");
+            *reports.first().expect("one report")
+        }
+    }
+
+    fn peer(n: u8) -> OverlayAddress {
+        OverlayAddress::from([n; 32])
+    }
+
+    fn service_with_reporter() -> (ClientService, Arc<RecordingReporter>) {
+        let reporter = Arc::new(RecordingReporter::default());
+        let (service, _event_tx, _handle) = ClientService::new();
+        let service = service.with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+        (service, reporter)
+    }
+
+    fn dummy_signature() -> Signature {
+        Signature::new(Default::default(), Default::default(), false)
+    }
+
+    #[test]
+    fn malformed_retrieval_reports_invalid_data() {
+        let (service, reporter) = service_with_reporter();
+        service.process_event(ClientEvent::RetrievalFailed {
+            peer: peer(1),
+            address: ChunkAddress::zero(),
+            error: "invalid chunk".into(),
+            kind: FailureKind::InvalidChunk,
+        });
+        let (reported_peer, event, source) = reporter.single();
+        assert_eq!(reported_peer, peer(1));
+        assert_eq!(event, SwarmScoringEvent::InvalidData);
+        assert_eq!(source, ReportSource::Protocol("retrieval"));
+    }
+
+    #[test]
+    fn plain_retrieval_failure_reports_retrieval_failure() {
+        let (service, reporter) = service_with_reporter();
+        service.process_event(ClientEvent::RetrievalFailed {
+            peer: peer(2),
+            address: ChunkAddress::zero(),
+            error: "not found".into(),
+            kind: FailureKind::Protocol,
+        });
+        let (_, event, source) = reporter.single();
+        assert_eq!(event, SwarmScoringEvent::RetrievalFailure);
+        assert_eq!(source, ReportSource::Protocol("retrieval"));
+    }
+
+    #[test]
+    fn malformed_push_reports_invalid_data() {
+        let (service, reporter) = service_with_reporter();
+        service.process_event(ClientEvent::PushFailed {
+            peer: peer(3),
+            address: ChunkAddress::zero(),
+            error: "invalid chunk".into(),
+            kind: FailureKind::InvalidChunk,
+        });
+        let (_, event, source) = reporter.single();
+        assert_eq!(event, SwarmScoringEvent::InvalidData);
+        assert_eq!(source, ReportSource::Protocol("pushsync"));
+    }
+
+    #[test]
+    fn plain_push_failure_reports_push_failure() {
+        let (service, reporter) = service_with_reporter();
+        service.process_event(ClientEvent::PushFailed {
+            peer: peer(4),
+            address: ChunkAddress::zero(),
+            error: "rejected".into(),
+            kind: FailureKind::Protocol,
+        });
+        let (_, event, _) = reporter.single();
+        assert_eq!(event, SwarmScoringEvent::PushFailure);
+    }
+
+    #[test]
+    fn inbound_malformed_delivery_reports_invalid_data_against_sender() {
+        let (service, reporter) = service_with_reporter();
+        service.process_event(ClientEvent::InboundInvalidData {
+            peer: peer(5),
+            protocol: "pushsync",
+        });
+        let (reported_peer, event, source) = reporter.single();
+        assert_eq!(reported_peer, peer(5));
+        assert_eq!(event, SwarmScoringEvent::InvalidData);
+        assert_eq!(source, ReportSource::Protocol("pushsync"));
+    }
+
+    #[test]
+    fn receipt_received_reports_push_success_with_latency() {
+        let (service, reporter) = service_with_reporter();
+        service.process_event(ClientEvent::ReceiptReceived {
+            peer: peer(6),
+            address: ChunkAddress::zero(),
+            signature: dummy_signature(),
+            nonce: Nonce::from([0u8; 32]),
+            storage_radius: StorageRadius::ZERO,
+            latency: Duration::from_millis(42),
+        });
+        let (_, event, source) = reporter.single();
+        assert_eq!(
+            event,
+            SwarmScoringEvent::PushSuccess {
+                latency: Duration::from_millis(42)
+            }
+        );
+        assert_eq!(source, ReportSource::Protocol("pushsync"));
+    }
+
+    #[test]
+    fn no_reporter_is_a_noop() {
+        let (service, _event_tx, _handle) = ClientService::new();
+        // Must not panic without a reporter configured.
+        service.process_event(ClientEvent::RetrievalFailed {
+            peer: peer(7),
+            address: ChunkAddress::zero(),
+            error: "x".into(),
+            kind: FailureKind::InvalidChunk,
+        });
     }
 }

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -33,7 +33,7 @@ pub use client_service::{ChunkTransferError, ClientHandle, ClientService, Retrie
 #[cfg(feature = "swap")]
 pub use protocol::SwapEvent;
 pub use protocol::{
-    ClientCommand, ClientEvent, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
+    ClientCommand, ClientEvent, FailureKind, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
 };
 
 pub use selection::{AccountingSettlement, PeerScores, PeerSelector, SettlementTrigger};

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -332,12 +332,14 @@ impl ClientBehaviour {
                 overlay,
                 address,
                 chunk,
+                latency,
             } => {
                 self.pending_events
                     .push_back(ToSwarm::GenerateEvent(ClientEvent::ChunkReceived {
                         peer: overlay,
                         address,
                         chunk,
+                        latency,
                     }));
             }
             HandlerEvent::ChunkPushReceived {
@@ -360,6 +362,7 @@ impl ClientBehaviour {
                 signature,
                 nonce,
                 storage_radius,
+                latency,
             } => {
                 self.push_event(ToSwarm::GenerateEvent(ClientEvent::ReceiptReceived {
                     peer: overlay,
@@ -367,28 +370,39 @@ impl ClientBehaviour {
                     signature,
                     nonce,
                     storage_radius,
+                    latency,
                 }));
             }
             HandlerEvent::RetrievalFailed {
                 overlay,
                 address,
                 error,
+                kind,
             } => {
                 self.push_event(ToSwarm::GenerateEvent(ClientEvent::RetrievalFailed {
                     peer: overlay,
                     address,
                     error,
+                    kind,
                 }));
             }
             HandlerEvent::PushFailed {
                 overlay,
                 address,
                 error,
+                kind,
             } => {
                 self.push_event(ToSwarm::GenerateEvent(ClientEvent::PushFailed {
                     peer: overlay,
                     address,
                     error,
+                    kind,
+                }));
+            }
+            HandlerEvent::InboundInvalidData { overlay, protocol } => {
+                self.push_event(ToSwarm::GenerateEvent(ClientEvent::InboundInvalidData {
+                    peer: overlay,
+                    protocol,
                 }));
             }
             HandlerEvent::Error {

--- a/crates/swarm/node/src/protocol/events.rs
+++ b/crates/swarm/node/src/protocol/events.rs
@@ -41,6 +41,20 @@ pub type RetrievalResponseTx = oneshot::Sender<Result<RetrievalResult, ChunkTran
 /// failure that prevented it resolves the caller directly.
 pub type PushResponseTx = oneshot::Sender<Result<PushReceipt, ChunkTransferError>>;
 
+/// Why a retrieval or pushsync request failed, classified for peer scoring.
+///
+/// Derived from the typed codec error at the point the failure is observed, so
+/// the client service never parses error strings to decide how to score a peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureKind {
+    /// The peer delivered or pushed a chunk that failed address or stamp
+    /// reconstruction. Scored as invalid data.
+    InvalidChunk,
+    /// A transport, negotiation, timeout, or storer-reported failure that is
+    /// not evidence of malformed data. Scored as a plain failure.
+    Protocol,
+}
+
 /// Events emitted by the client behaviour.
 #[derive(Debug, Clone)]
 pub enum ClientEvent {
@@ -87,6 +101,8 @@ pub enum ClientEvent {
         address: ChunkAddress,
         /// The received chunk and its postage stamp.
         chunk: StampedChunk,
+        /// Time from request to delivery, for latency scoring.
+        latency: core::time::Duration,
     },
 
     /// A chunk retrieval request failed.
@@ -97,6 +113,8 @@ pub enum ClientEvent {
         address: ChunkAddress,
         /// Error description.
         error: String,
+        /// Whether the failure was a malformed chunk (vs a plain failure).
+        kind: FailureKind,
     },
 
     /// A peer is pushing a chunk to us.
@@ -128,6 +146,8 @@ pub enum ClientEvent {
         nonce: Nonce,
         /// The peer's storage radius.
         storage_radius: StorageRadius,
+        /// Time from push to receipt, for latency scoring.
+        latency: core::time::Duration,
     },
 
     /// A chunk push failed.
@@ -138,6 +158,19 @@ pub enum ClientEvent {
         address: ChunkAddress,
         /// Error description.
         error: String,
+        /// Whether the failure was a malformed chunk (vs a plain failure).
+        kind: FailureKind,
+    },
+
+    /// A peer sent us malformed data on an inbound substream.
+    ///
+    /// The chunk or request failed reconstruction at decode and was rejected;
+    /// the sender is scored adversely for invalid data.
+    InboundInvalidData {
+        /// The peer that sent the malformed data.
+        peer: OverlayAddress,
+        /// The protocol that rejected the data.
+        protocol: &'static str,
     },
 
     /// A settlement is needed with a peer.

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -46,9 +46,11 @@ use vertex_swarm_primitives::{OverlayAddress, StampedChunk, StorageRadius, Swarm
 use super::events::{PushResponseTx, RetrievalResponseTx};
 use super::upgrade::{
     ClientInboundOutput, ClientInboundUpgrade, ClientOutboundInfo, ClientOutboundOutput,
-    ClientOutboundUpgrade,
+    ClientOutboundUpgrade, ClientUpgradeError, FailureKind,
 };
 use crate::client_service::{ChunkTransferError, RetrievalResult};
+use vertex_swarm_net_pushsync::PROTOCOL_NAME as PUSHSYNC_PROTOCOL;
+use vertex_swarm_net_retrieval::PROTOCOL_NAME as RETRIEVAL_PROTOCOL;
 
 const DEFAULT_MAX_PENDING_COMMANDS: usize = 256;
 const DEFAULT_MAX_PENDING_EVENTS: usize = 256;
@@ -201,6 +203,8 @@ pub(crate) enum HandlerEvent {
         address: ChunkAddress,
         /// The received chunk and its postage stamp.
         chunk: StampedChunk,
+        /// Time from outbound request to delivery, for latency scoring.
+        latency: Duration,
     },
     /// Received a chunk push from peer.
     ChunkPushReceived {
@@ -225,6 +229,8 @@ pub(crate) enum HandlerEvent {
         nonce: Nonce,
         /// The storer's storage radius.
         storage_radius: StorageRadius,
+        /// Time from outbound request to receipt, for latency scoring.
+        latency: Duration,
     },
     /// An outbound retrieval request failed.
     ///
@@ -237,6 +243,8 @@ pub(crate) enum HandlerEvent {
         address: ChunkAddress,
         /// Error description.
         error: String,
+        /// Whether the failure was a malformed chunk (vs a plain failure).
+        kind: FailureKind,
     },
     /// An outbound chunk push failed.
     ///
@@ -249,6 +257,19 @@ pub(crate) enum HandlerEvent {
         address: ChunkAddress,
         /// Error description.
         error: String,
+        /// Whether the failure was a malformed chunk (vs a plain failure).
+        kind: FailureKind,
+    },
+    /// A peer sent us malformed data on an inbound substream.
+    ///
+    /// Raised when an inbound pushsync delivery or retrieval request fails
+    /// chunk or stamp reconstruction at decode. Attributed to the sender so
+    /// the offending peer is scored adversely and the chunk is never relayed.
+    InboundInvalidData {
+        /// The peer's overlay address.
+        overlay: OverlayAddress,
+        /// The protocol that rejected the data.
+        protocol: &'static str,
     },
     /// Protocol error occurred.
     Error {
@@ -306,8 +327,15 @@ enum State {
 
 /// A pending inbound response waiting for the application layer to provide data.
 enum PendingResponse {
-    /// Awaiting chunk data to serve (retrieval response).
-    Retrieval(vertex_swarm_net_retrieval::RetrievalResponder),
+    /// Awaiting chunk data to serve (retrieval response). Carries the address
+    /// the inbound request asked for, so the served chunk can be verified to
+    /// answer that exact request before it goes down the wire.
+    Retrieval {
+        /// The chunk address the peer requested.
+        requested: ChunkAddress,
+        /// The substream responder that sends the delivery.
+        responder: vertex_swarm_net_retrieval::RetrievalResponder,
+    },
     /// Awaiting receipt to send (pushsync response).
     Pushsync(vertex_swarm_net_pushsync::PushsyncResponder),
     /// Awaiting ack to send (pseudosettle response).
@@ -318,6 +346,19 @@ enum PendingResponse {
 struct StoredResponse {
     response: PendingResponse,
     stored_at: Instant,
+}
+
+/// Outbound serve gate: a chunk may only be served if its content address
+/// matches the address of the inbound request it answers.
+///
+/// This is the verify-before-send-down-the-wire check. The chunk's address is
+/// derived from its bytes (BMT for content-addressed chunks, owner+id for
+/// single-owner chunks), so an equal address means the served bytes are the
+/// ones the peer asked for. A future type-state (`VerifiedStampedChunk`) could
+/// make this a compile-time guarantee; for now it is an explicit gate so the
+/// relay path in follow-up work can reuse it.
+fn served_chunk_answers_request(requested: &ChunkAddress, chunk: &StampedChunk) -> bool {
+    chunk.address() == requested
 }
 
 /// Swarm client connection handler.
@@ -474,7 +515,13 @@ impl ClientHandler {
                 address: request.address,
                 request_id,
             });
-            self.store_response(request_id, PendingResponse::Retrieval(responder));
+            self.store_response(
+                request_id,
+                PendingResponse::Retrieval {
+                    requested: request.address,
+                    responder,
+                },
+            );
         } else {
             warn!(
                 address = %request.address,
@@ -515,16 +562,22 @@ impl ClientHandler {
         delivery: vertex_swarm_net_retrieval::Delivery,
         address: ChunkAddress,
         response: RetrievalResponseTx,
+        latency: Duration,
     ) {
         let overlay = self.overlay();
         match delivery {
             vertex_swarm_net_retrieval::Delivery::Error(err) => {
+                // A storer-supplied error string (for example "not found") is a
+                // plain protocol failure, not malformed data. Malformed chunks
+                // never reach this arm: they fail reconstruction at decode and
+                // surface as a dial upgrade error.
                 debug!(?overlay, %address, error = %err, "Retrieval failed");
                 if let Some(overlay) = overlay {
                     self.push_event(HandlerEvent::RetrievalFailed {
                         overlay,
                         address,
                         error: err.clone(),
+                        kind: FailureKind::Protocol,
                     });
                 }
                 let _ = response.send(Err(ChunkTransferError::Protocol(err)));
@@ -541,6 +594,7 @@ impl ClientHandler {
                     overlay,
                     address,
                     chunk: (*chunk).clone(),
+                    latency,
                 });
                 let _ = response.send(Ok(RetrievalResult {
                     chunk: *chunk,
@@ -555,6 +609,7 @@ impl ClientHandler {
         &mut self,
         receipt: vertex_swarm_net_pushsync::Receipt,
         response: PushResponseTx,
+        latency: Duration,
     ) {
         let overlay = self.overlay();
         if let Some(err) = receipt.error {
@@ -564,6 +619,7 @@ impl ClientHandler {
                     overlay,
                     address: receipt.address,
                     error: err.clone(),
+                    kind: FailureKind::Protocol,
                 });
             }
             let _ = response.send(Err(ChunkTransferError::PushRejected(err)));
@@ -581,6 +637,7 @@ impl ClientHandler {
                 signature: receipt.signature,
                 nonce: receipt.nonce,
                 storage_radius: receipt.storage_radius,
+                latency,
             });
             let _ = response.send(Ok(PushReceipt {
                 storer: overlay,
@@ -680,7 +737,11 @@ impl ConnectionHandler for ClientHandler {
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
                         protocol: SubstreamProtocol::new(
                             upgrade,
-                            ClientOutboundInfo::Retrieval { address, response },
+                            ClientOutboundInfo::Retrieval {
+                                address,
+                                response,
+                                requested_at: Instant::now(),
+                            },
                         )
                         .with_timeout(self.config.timeout),
                     });
@@ -692,7 +753,11 @@ impl ConnectionHandler for ClientHandler {
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
                         protocol: SubstreamProtocol::new(
                             upgrade,
-                            ClientOutboundInfo::Pushsync { address, response },
+                            ClientOutboundInfo::Pushsync {
+                                address,
+                                response,
+                                requested_at: Instant::now(),
+                            },
                         )
                         .with_timeout(self.config.timeout),
                     });
@@ -739,21 +804,46 @@ impl ConnectionHandler for ClientHandler {
                     }
                 }
                 HandlerCommand::ServeChunk { request_id, chunk } => {
-                    if let Some(PendingResponse::Retrieval(responder)) =
-                        self.take_response(request_id)
+                    if let Some(PendingResponse::Retrieval {
+                        requested,
+                        responder,
+                    }) = self.take_response(request_id)
                     {
-                        debug!(%request_id, "Serving chunk");
-                        if self
-                            .response_sends
-                            .try_push(async move {
-                                responder
-                                    .send_chunk(chunk)
-                                    .await
-                                    .map_err(|e| format!("serve chunk: {e}"))
-                            })
-                            .is_err()
-                        {
-                            warn!("Response send queue full, dropping chunk serve");
+                        // Verify before sending down the wire: the served chunk
+                        // must answer the exact address the peer asked for. A
+                        // mismatch means the serve path was handed the wrong (or
+                        // a malformed) chunk; refuse to emit it so we never
+                        // launder bad data into our own reputation.
+                        let served = *chunk.address();
+                        if !served_chunk_answers_request(&requested, &chunk) {
+                            warn!(
+                                %request_id, %requested, %served,
+                                "Refusing to serve chunk: address does not match request"
+                            );
+                            metrics::counter!(
+                                "swarm.client.serve_address_mismatch",
+                                "protocol" => "retrieval",
+                            )
+                            .increment(1);
+                            self.push_event(HandlerEvent::Error {
+                                overlay: self.overlay(),
+                                protocol: "retrieval",
+                                error: "served chunk address mismatch".into(),
+                            });
+                        } else {
+                            debug!(%request_id, "Serving chunk");
+                            if self
+                                .response_sends
+                                .try_push(async move {
+                                    responder
+                                        .send_chunk(chunk)
+                                        .await
+                                        .map_err(|e| format!("serve chunk: {e}"))
+                                })
+                                .is_err()
+                            {
+                                warn!("Response send queue full, dropping chunk serve");
+                            }
                         }
                     } else {
                         warn!(%request_id, "No retrieval responder found for request_id");
@@ -833,6 +923,14 @@ impl ConnectionHandler for ClientHandler {
             }
 
             ConnectionEvent::DialUpgradeError(e) => {
+                // Classify from the typed upgrade error while it is still
+                // concrete: a malformed chunk delivered on the outbound
+                // substream fails reconstruction at decode and arrives here as
+                // an `Apply` error we can downcast, not a string we parse.
+                let apply_error = match &e.error {
+                    libp2p::swarm::StreamUpgradeError::Apply(err) => Some(err),
+                    _ => None,
+                };
                 let error = e.error.to_string();
                 match e.info {
                     ClientOutboundInfo::Pricing => {
@@ -844,24 +942,34 @@ impl ConnectionHandler for ClientHandler {
                             error,
                         });
                     }
-                    ClientOutboundInfo::Retrieval { address, response } => {
-                        warn!(protocol = "retrieval", %address, %error, "Client dial upgrade error");
+                    ClientOutboundInfo::Retrieval {
+                        address, response, ..
+                    } => {
+                        let kind = apply_error
+                            .map_or(FailureKind::Protocol, |e| e.retrieval_failure_kind());
+                        warn!(protocol = "retrieval", %address, %error, ?kind, "Client dial upgrade error");
                         if let Some(overlay) = self.overlay() {
                             self.push_event(HandlerEvent::RetrievalFailed {
                                 overlay,
                                 address,
                                 error: error.clone(),
+                                kind,
                             });
                         }
                         let _ = response.send(Err(ChunkTransferError::Protocol(error)));
                     }
-                    ClientOutboundInfo::Pushsync { address, response } => {
-                        warn!(protocol = "pushsync", %address, %error, "Client dial upgrade error");
+                    ClientOutboundInfo::Pushsync {
+                        address, response, ..
+                    } => {
+                        let kind = apply_error
+                            .map_or(FailureKind::Protocol, |e| e.pushsync_failure_kind());
+                        warn!(protocol = "pushsync", %address, %error, ?kind, "Client dial upgrade error");
                         if let Some(overlay) = self.overlay() {
                             self.push_event(HandlerEvent::PushFailed {
                                 overlay,
                                 address,
                                 error: error.clone(),
+                                kind,
                             });
                         }
                         let _ = response.send(Err(ChunkTransferError::Protocol(error)));
@@ -887,12 +995,30 @@ impl ConnectionHandler for ClientHandler {
             }
 
             ConnectionEvent::ListenUpgradeError(e) => {
-                warn!(error = %e.error, "Client listen upgrade error");
-                self.push_event(HandlerEvent::Error {
-                    overlay: self.overlay(),
-                    protocol: "unknown",
-                    error: e.error.to_string(),
-                });
+                // A peer pushing us a malformed chunk, or sending a malformed
+                // retrieval request, fails reconstruction at inbound decode and
+                // surfaces here. Classify from the typed error so the offending
+                // peer is scored adversely; the chunk is already rejected and
+                // never relayed.
+                let kind = e.error.inbound_failure_kind();
+                warn!(error = %e.error, ?kind, "Client listen upgrade error");
+                match (kind, self.overlay()) {
+                    (FailureKind::InvalidChunk, Some(overlay)) => {
+                        let protocol = match &e.error {
+                            ClientUpgradeError::Pushsync(_) => PUSHSYNC_PROTOCOL,
+                            ClientUpgradeError::Retrieval(_) => RETRIEVAL_PROTOCOL,
+                            _ => "unknown",
+                        };
+                        self.push_event(HandlerEvent::InboundInvalidData { overlay, protocol });
+                    }
+                    _ => {
+                        self.push_event(HandlerEvent::Error {
+                            overlay: self.overlay(),
+                            protocol: "unknown",
+                            error: e.error.to_string(),
+                        });
+                    }
+                }
             }
 
             _ => {}
@@ -953,16 +1079,26 @@ impl ClientHandler {
             }
             (
                 ClientOutboundOutput::Retrieval(delivery),
-                ClientOutboundInfo::Retrieval { address, response },
+                ClientOutboundInfo::Retrieval {
+                    address,
+                    response,
+                    requested_at,
+                },
             ) => {
-                self.on_retrieval_response(delivery, address, response);
+                let latency = requested_at.elapsed();
+                self.on_retrieval_response(delivery, address, response, latency);
             }
             (
                 ClientOutboundOutput::Pushsync(receipt),
-                ClientOutboundInfo::Pushsync { address, response },
+                ClientOutboundInfo::Pushsync {
+                    address,
+                    response,
+                    requested_at,
+                },
             ) => {
+                let latency = requested_at.elapsed();
                 debug!(%address, "Received pushsync receipt");
-                self.on_pushsync_receipt(receipt, response);
+                self.on_pushsync_receipt(receipt, response, latency);
             }
             (
                 ClientOutboundOutput::Pseudosettle(ack),
@@ -996,5 +1132,40 @@ impl ClientHandler {
                 warn!(?output, ?info, "Mismatched outbound output and info");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{B256, Signature};
+    use nectar_postage::Stamp;
+    use nectar_primitives::{AnyChunk, ContentChunk};
+    use vertex_swarm_primitives::StampedChunk;
+
+    use super::*;
+
+    fn stamped(payload: &'static [u8]) -> StampedChunk {
+        let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        let chunk: AnyChunk = ContentChunk::new(payload)
+            .expect("valid content chunk")
+            .into();
+        StampedChunk::new(chunk, stamp)
+    }
+
+    #[test]
+    fn serve_gate_accepts_matching_chunk() {
+        let chunk = stamped(b"serve gate payload");
+        let requested = *chunk.address();
+        assert!(served_chunk_answers_request(&requested, &chunk));
+    }
+
+    #[test]
+    fn serve_gate_rejects_mismatched_chunk() {
+        let chunk = stamped(b"actual payload");
+        let other = stamped(b"a different payload entirely");
+        let requested = *other.address();
+        assert_ne!(*chunk.address(), requested);
+        assert!(!served_chunk_answers_request(&requested, &chunk));
     }
 }

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -566,21 +566,22 @@ impl ClientHandler {
     ) {
         let overlay = self.overlay();
         match delivery {
-            vertex_swarm_net_retrieval::Delivery::Error(err) => {
-                // A storer-supplied error string (for example "not found") is a
-                // plain protocol failure, not malformed data. Malformed chunks
-                // never reach this arm: they fail reconstruction at decode and
-                // surface as a dial upgrade error.
-                debug!(?overlay, %address, error = %err, "Retrieval failed");
+            vertex_swarm_net_retrieval::Delivery::Error => {
+                // The remote reported a failure (signalled by empty data). The
+                // reason is adversarial input we never read; it is a plain
+                // protocol failure, not malformed data. Malformed chunks never
+                // reach this arm: they fail reconstruction at decode and surface
+                // as a dial upgrade error.
+                debug!(?overlay, %address, "Retrieval failed");
                 if let Some(overlay) = overlay {
                     self.push_event(HandlerEvent::RetrievalFailed {
                         overlay,
                         address,
-                        error: err.clone(),
+                        error: "remote reported a failure".to_string(),
                         kind: FailureKind::Protocol,
                     });
                 }
-                let _ = response.send(Err(ChunkTransferError::Protocol(err)));
+                let _ = response.send(Err(ChunkTransferError::Remote));
             }
             vertex_swarm_net_retrieval::Delivery::Chunk(chunk) => {
                 let Some(overlay) = overlay else {
@@ -607,44 +608,51 @@ impl ClientHandler {
     /// Handle pushsync receipt, resolving the caller's response channel.
     fn on_pushsync_receipt(
         &mut self,
-        receipt: vertex_swarm_net_pushsync::Receipt,
+        response_msg: vertex_swarm_net_pushsync::ReceiptResponse,
+        address: ChunkAddress,
         response: PushResponseTx,
         latency: Duration,
     ) {
         let overlay = self.overlay();
-        if let Some(err) = receipt.error {
-            debug!(?overlay, address = %receipt.address, error = %err, "Pushsync failed");
-            if let Some(overlay) = overlay {
-                self.push_event(HandlerEvent::PushFailed {
+        match response_msg {
+            vertex_swarm_net_pushsync::ReceiptResponse::Failed => {
+                // The remote reported a rejection (signalled by an empty
+                // signature; the reference does not sign its failures). The
+                // reason is adversarial input we never read.
+                debug!(?overlay, %address, "Pushsync failed");
+                if let Some(overlay) = overlay {
+                    self.push_event(HandlerEvent::PushFailed {
+                        overlay,
+                        address,
+                        error: "remote reported a failure".to_string(),
+                        kind: FailureKind::Protocol,
+                    });
+                }
+                let _ = response.send(Err(ChunkTransferError::Remote));
+            }
+            vertex_swarm_net_pushsync::ReceiptResponse::Stored(receipt) => {
+                let Some(overlay) = overlay else {
+                    let _ = response.send(Err(ChunkTransferError::Protocol(
+                        "handler not active".to_string(),
+                    )));
+                    return;
+                };
+                debug!(%overlay, address = %receipt.address, "Received receipt");
+                self.push_event(HandlerEvent::ReceiptReceived {
                     overlay,
                     address: receipt.address,
-                    error: err.clone(),
-                    kind: FailureKind::Protocol,
+                    signature: receipt.signature,
+                    nonce: receipt.nonce,
+                    storage_radius: receipt.storage_radius,
+                    latency,
                 });
+                let _ = response.send(Ok(PushReceipt {
+                    storer: overlay,
+                    signature: receipt.signature,
+                    nonce: receipt.nonce,
+                    storage_radius: receipt.storage_radius,
+                }));
             }
-            let _ = response.send(Err(ChunkTransferError::PushRejected(err)));
-        } else {
-            let Some(overlay) = overlay else {
-                let _ = response.send(Err(ChunkTransferError::Protocol(
-                    "handler not active".to_string(),
-                )));
-                return;
-            };
-            debug!(%overlay, address = %receipt.address, "Received receipt");
-            self.push_event(HandlerEvent::ReceiptReceived {
-                overlay,
-                address: receipt.address,
-                signature: receipt.signature,
-                nonce: receipt.nonce,
-                storage_radius: receipt.storage_radius,
-                latency,
-            });
-            let _ = response.send(Ok(PushReceipt {
-                storer: overlay,
-                signature: receipt.signature,
-                nonce: receipt.nonce,
-                storage_radius: receipt.storage_radius,
-            }));
         }
     }
 }
@@ -1098,7 +1106,7 @@ impl ClientHandler {
             ) => {
                 let latency = requested_at.elapsed();
                 debug!(%address, "Received pushsync receipt");
-                self.on_pushsync_receipt(receipt, response, latency);
+                self.on_pushsync_receipt(receipt, address, response, latency);
             }
             (
                 ClientOutboundOutput::Pseudosettle(ack),

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -71,5 +71,5 @@ pub(crate) use behaviour::{ClientBehaviour, Config as BehaviourConfig};
 #[cfg(feature = "swap")]
 pub use events::SwapEvent;
 pub use events::{
-    ClientCommand, ClientEvent, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
+    ClientCommand, ClientEvent, FailureKind, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
 };

--- a/crates/swarm/node/src/protocol/upgrade.rs
+++ b/crates/swarm/node/src/protocol/upgrade.rs
@@ -70,6 +70,54 @@ pub(crate) enum ClientUpgradeError {
     UnknownProtocol(String),
 }
 
+pub(crate) use super::events::FailureKind;
+
+impl ClientUpgradeError {
+    /// Classify a retrieval upgrade failure.
+    ///
+    /// Reaches through the boxed inner error to recover the typed retrieval
+    /// codec error and ask it whether the failure was a malformed chunk.
+    pub(crate) fn retrieval_failure_kind(&self) -> FailureKind {
+        match self {
+            Self::Retrieval(ProtocolError::Protocol(inner)) => inner
+                .downcast_ref::<vertex_swarm_net_retrieval::RetrievalError>()
+                .filter(|e| e.is_invalid_chunk())
+                .map_or(FailureKind::Protocol, |_| FailureKind::InvalidChunk),
+            _ => FailureKind::Protocol,
+        }
+    }
+
+    /// Classify a pushsync upgrade failure.
+    pub(crate) fn pushsync_failure_kind(&self) -> FailureKind {
+        match self {
+            Self::Pushsync(ProtocolError::Protocol(inner)) => inner
+                .downcast_ref::<vertex_swarm_net_pushsync::PushsyncError>()
+                .filter(|e| e.is_invalid_chunk())
+                .map_or(FailureKind::Protocol, |_| FailureKind::InvalidChunk),
+            _ => FailureKind::Protocol,
+        }
+    }
+
+    /// Classify a failure on the inbound listen path.
+    ///
+    /// Used when a peer pushed us a malformed chunk or sent a malformed
+    /// retrieval request: the decode rejects it and we attribute the invalid
+    /// data to the sender.
+    pub(crate) fn inbound_failure_kind(&self) -> FailureKind {
+        match self {
+            Self::Pushsync(ProtocolError::Protocol(inner)) => inner
+                .downcast_ref::<vertex_swarm_net_pushsync::PushsyncError>()
+                .filter(|e| e.is_invalid_chunk())
+                .map_or(FailureKind::Protocol, |_| FailureKind::InvalidChunk),
+            Self::Retrieval(ProtocolError::Protocol(inner)) => inner
+                .downcast_ref::<vertex_swarm_net_retrieval::RetrievalError>()
+                .filter(|e| e.is_invalid_chunk())
+                .map_or(FailureKind::Protocol, |_| FailureKind::InvalidChunk),
+            _ => FailureKind::Protocol,
+        }
+    }
+}
+
 /// Output from a client inbound upgrade.
 pub(crate) enum ClientInboundOutput {
     /// Received pricing threshold.
@@ -430,11 +478,15 @@ pub(crate) enum ClientOutboundInfo {
     Retrieval {
         address: ChunkAddress,
         response: super::events::RetrievalResponseTx,
+        /// When the outbound substream was requested, for latency scoring.
+        requested_at: vertex_util_runtime::time::Instant,
     },
     /// Pushsync request with chunk address and the caller's response channel.
     Pushsync {
         address: ChunkAddress,
         response: super::events::PushResponseTx,
+        /// When the outbound substream was requested, for latency scoring.
+        requested_at: vertex_util_runtime::time::Instant,
     },
     /// Pseudosettle payment with amount.
     Pseudosettle { amount: U256 },
@@ -447,6 +499,48 @@ pub(crate) enum ClientOutboundInfo {
 mod tests {
     use super::*;
     use vertex_swarm_primitives::SwarmNodeType;
+
+    fn retrieval_protocol_err(inner: vertex_swarm_net_retrieval::RetrievalError) -> ProtocolError {
+        ProtocolError::Protocol(Box::new(inner))
+    }
+
+    fn pushsync_protocol_err(inner: vertex_swarm_net_pushsync::PushsyncError) -> ProtocolError {
+        ProtocolError::Protocol(Box::new(inner))
+    }
+
+    #[test]
+    fn malformed_retrieval_classifies_as_invalid_chunk() {
+        let err = ClientUpgradeError::Retrieval(retrieval_protocol_err(
+            vertex_swarm_net_retrieval::RetrievalError::InvalidAddressLength(0),
+        ));
+        assert_eq!(err.retrieval_failure_kind(), FailureKind::InvalidChunk);
+    }
+
+    #[test]
+    fn plain_retrieval_error_classifies_as_protocol() {
+        let err = ClientUpgradeError::Retrieval(retrieval_protocol_err(
+            vertex_swarm_net_retrieval::RetrievalError::ConnectionClosed,
+        ));
+        assert_eq!(err.retrieval_failure_kind(), FailureKind::Protocol);
+    }
+
+    #[test]
+    fn malformed_pushsync_classifies_as_invalid_chunk_inbound() {
+        let err = ClientUpgradeError::Pushsync(pushsync_protocol_err(
+            vertex_swarm_net_pushsync::PushsyncError::InvalidAddressLength(0),
+        ));
+        assert_eq!(err.pushsync_failure_kind(), FailureKind::InvalidChunk);
+        assert_eq!(err.inbound_failure_kind(), FailureKind::InvalidChunk);
+    }
+
+    #[test]
+    fn pricing_error_is_never_invalid_chunk() {
+        let err = ClientUpgradeError::Pricing(ProtocolError::Protocol(Box::new(
+            vertex_swarm_net_retrieval::RetrievalError::ConnectionClosed,
+        )));
+        assert_eq!(err.retrieval_failure_kind(), FailureKind::Protocol);
+        assert_eq!(err.inbound_failure_kind(), FailureKind::Protocol);
+    }
 
     #[test]
     fn dormant_advertises_nothing() {

--- a/crates/swarm/node/src/protocol/upgrade.rs
+++ b/crates/swarm/node/src/protocol/upgrade.rs
@@ -29,7 +29,7 @@ use vertex_swarm_net_pseudosettle::{
 };
 use vertex_swarm_net_pushsync::{
     Delivery as PushsyncDelivery, PROTOCOL_NAME as PUSHSYNC_PROTOCOL, PushsyncInboundProtocol,
-    PushsyncOutboundProtocol, PushsyncResponder, Receipt as PushsyncReceipt,
+    PushsyncOutboundProtocol, PushsyncResponder, ReceiptResponse as PushsyncReceiptResponse,
 };
 use vertex_swarm_net_retrieval::{
     Delivery as RetrievalDelivery, PROTOCOL_NAME as RETRIEVAL_PROTOCOL,
@@ -330,8 +330,8 @@ pub(crate) enum ClientOutboundOutput {
     Pricing,
     /// Received chunk delivery.
     Retrieval(RetrievalDelivery),
-    /// Received receipt.
-    Pushsync(PushsyncReceipt),
+    /// Received receipt response (signed receipt on success, or failure).
+    Pushsync(PushsyncReceiptResponse),
     /// Received pseudosettle ack.
     Pseudosettle(PaymentAck),
     /// Cheque sent; carries the peer's negotiated headers.

--- a/crates/swarm/node/src/swarm_client.rs
+++ b/crates/swarm/node/src/swarm_client.rs
@@ -473,9 +473,7 @@ mod tests {
         match rx.recv().await.expect("command emitted") {
             ClientCommand::PushChunk { response, .. } => {
                 response
-                    .send(Err(ChunkTransferError::PushRejected(
-                        "rejected".to_string(),
-                    )))
+                    .send(Err(ChunkTransferError::Remote))
                     .expect("receiver alive");
             }
             other => panic!("unexpected command: {other:?}"),
@@ -483,8 +481,8 @@ mod tests {
 
         let result = push.await.unwrap();
         match result {
-            Err(ChunkTransferError::PushRejected(reason)) => assert_eq!(reason, "rejected"),
-            other => panic!("expected PushRejected, got {other:?}"),
+            Err(ChunkTransferError::Remote) => {}
+            other => panic!("expected Remote, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
Stacked on #292; do not merge before it.

## Problem

The retrieval and pushsync codecs already verify chunk integrity at decode (address and stamp reconstruction via `StampedChunk::reconstruct`), but nothing reported the outcome to peer scoring, and nothing re-verified a chunk before serving it. A peer could serve corrupted chunks or fail every request with zero score impact.

## What changed

Retrieval and pushsync outcomes now route through the same `PeerReporter` authority that bandwidth accounting uses (the topology peer manager). `ClientService` takes an optional `Arc<dyn PeerReporter>`, wired in `crates/swarm/builder/src/launch.rs` alongside the existing accounting reporter.

Honest deliveries report `RetrievalSuccess`/`PushSuccess` with a real latency, threaded from the outbound substream request through `ClientOutboundInfo` (a start `Instant` carried with the request and measured on completion). Plain failures and timeouts report `RetrievalFailure`/`PushFailure` (weight -2). Malformed chunks report `InvalidData` (weight -10).

Inbound malformed deliveries score the sender. When a peer pushes us a malformed chunk or sends a malformed retrieval request, the inbound decode rejects it and surfaces as a listen upgrade error; it is attributed to the peer and reported as `InvalidData`. The chunk is already rejected and never relayed.

An outbound serve gate verifies a chunk before it goes down the wire: in the handler's `ServeChunk` path, the served chunk's content address must match the address of the stored inbound request it answers. A mismatch is refused, emits an internal error event, and increments a metric.

New metrics: `swarm.client.invalid_chunk{protocol}` for invalid-chunk reports per protocol (ties into #86), and `swarm.client.serve_address_mismatch{protocol}` for serve-gate rejections.

## Key design decision: typed malformed-chunk classification

The malformed-response decode happens inside `upgrade_outbound`, where the codec error `RetrievalError`/`PushsyncError::InvalidChunk` is boxed into `ProtocolError::Protocol(Box<dyn Error>)` as a trait object. Rather than parse error strings, the concrete codec type is recovered by `downcast_ref` at the handler boundary, where the typed error is still available, and a `FailureKind { InvalidChunk, Protocol }` discriminant is derived there. `is_invalid_chunk` helpers on the codec error enums keep that classification in one place. `FailureKind` is carried on the `RetrievalFailed`/`PushFailed` handler and client events, so the client service decides `InvalidData` vs `RetrievalFailure`/`PushFailure` from a typed value, never a string.

## Deferred

The serve gate is an explicit verification call (re-derive and compare the content address), not a pervasive type-state refactor. A `VerifiedStampedChunk` type-state that makes "only a verified chunk can be encoded" a compile-time guarantee is a reasonable follow-up; the current gate gives the relay work in #291 a single place to reuse.

## Tests

- Malformed inbound delivery: the offending peer gets an `InvalidData` report attributed to the right protocol.
- Honest retrieval/push: success report with the measured latency.
- Plain failure: `RetrievalFailure`/`PushFailure` report.
- Serve gate: a matching chunk is accepted, a mismatched chunk is rejected.
- Typed classification: `ClientUpgradeError` downcast classifies invalid-chunk vs protocol failures across retrieval, pushsync, and the inbound path.
- `is_invalid_chunk` helpers: malformed-chunk signals classify as invalid; transport and receipt-decode errors do not.
