### PR TITLE
refactor(swarm-net): stop processing the adversarial retrieval/pushsync error string

### DIFF
--- a/crates/swarm/net/proto/proto/pushsync.proto
+++ b/crates/swarm/net/proto/proto/pushsync.proto
@@ -12,11 +12,22 @@ message Delivery {
   bytes stamp = 3;
 }
 
-// Receipt acknowledging chunk storage.
+// Receipt acknowledging chunk storage. This frame models a successful custody
+// acknowledgement only; the reference does not sign its failure responses
+// (a failure is a receipt with an error string and no signature), so there is
+// no signed failure receipt to model.
+//
+// A failure is signalled by resetting the stream, not by a frame: a responder
+// that cannot store resets, which the reference pusher reads as a failed push
+// at every hop (it never reads a receipt to misjudge). So we send no failure
+// receipt and need no error field. Field 4 was a remote error string in the
+// reference; we never read it (it is adversarial input the reference does not
+// introspect), so it is omitted here. An inbound field-4 value is skipped
+// without allocation. On receive, a failure is detected structurally by an
+// empty `signature` (field 5 keeps its number).
 message Receipt {
   bytes address = 1;
   bytes signature = 2;
   bytes nonce = 3;
-  string err = 4;
   uint32 storage_radius = 5;
 }

--- a/crates/swarm/net/proto/proto/retrieval.proto
+++ b/crates/swarm/net/proto/proto/retrieval.proto
@@ -10,9 +10,18 @@ message Request {
   bytes addr = 1;
 }
 
-// Delivery of a chunk with optional error.
+// Delivery of a chunk.
+//
+// An honest failure is signalled structurally by an empty `data` AND an empty
+// `stamp`: the reference reports a retrieval failure with an empty delivery
+// (it does not reset the stream for retrieval), and that is the only signal we
+// read. A non-empty `data` claims a chunk and must reconstruct and validate, or
+// it is malformed (the two are scored differently). Field 3 was a remote error
+// string in the reference; we never read it (it is adversarial input the
+// reference itself does not introspect), so it is omitted here. An inbound
+// field-3 value is skipped without allocation, and we emit nothing on it. A
+// requester detects our failures from the empty `data` (chunk validation fails).
 message Delivery {
   bytes data = 1;
   bytes stamp = 2;
-  string err = 3;
 }

--- a/crates/swarm/net/pushsync/src/codec.rs
+++ b/crates/swarm/net/pushsync/src/codec.rs
@@ -11,8 +11,8 @@ use crate::error::PushsyncError;
 /// Codec for pushsync delivery messages.
 pub(crate) type DeliveryCodec = Codec<Delivery, PushsyncError>;
 
-/// Codec for pushsync receipt messages.
-pub(crate) type ReceiptCodec = Codec<Receipt, PushsyncError>;
+/// Codec for pushsync receipt responses.
+pub(crate) type ReceiptCodec = Codec<ReceiptResponse, PushsyncError>;
 
 /// Delivery of a chunk to be stored.
 ///
@@ -63,17 +63,25 @@ impl ProtoMessage for Delivery {
     }
 }
 
-/// Receipt acknowledging chunk storage.
+/// Length in bytes of a well-formed recoverable signature. A failure response
+/// carries an empty signature instead, which is the structural failure signal.
+const SIGNATURE_LEN: usize = 65;
+
+/// A successful storage receipt.
+///
+/// This type models a custody acknowledgement only. The reference does not sign
+/// its failure responses (a failure is `&pb.Receipt{Err: ...}` with no
+/// signature), so there is no signed failure receipt to model and no need for
+/// placeholder fields. A failure is represented by the [`ReceiptResponse::Failed`]
+/// variant, not by a `Receipt` with zeroed fields.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Receipt {
     /// The address of the chunk.
     pub address: ChunkAddress,
-    /// Signature from the storer.
+    /// Signature from the storer over the chunk address and nonce.
     pub signature: Signature,
     /// Nonce used in signing.
     pub nonce: Nonce,
-    /// Error message if storage failed.
-    pub error: Option<String>,
     /// The storage radius of the storer node.
     pub storage_radius: StorageRadius,
 }
@@ -90,63 +98,68 @@ impl Receipt {
             address,
             signature,
             nonce,
-            error: None,
             storage_radius,
         }
     }
+}
 
-    /// Create an error receipt.
-    ///
-    /// The signature, nonce, and radius are zero-valued placeholders; the
-    /// `error` field is what consumers inspect.
-    pub fn error(address: ChunkAddress, msg: impl Into<String>) -> Self {
-        Self {
-            address,
-            signature: Signature::new(
-                alloy_primitives::U256::ZERO,
-                alloy_primitives::U256::ZERO,
-                false,
-            ),
-            nonce: Nonce::ZERO,
-            error: Some(msg.into()),
-            storage_radius: StorageRadius::ZERO,
-        }
-    }
+/// The decoded response to a pushsync delivery: a signed receipt on success, or
+/// a structural failure.
+///
+/// Modelling success-or-failure here keeps [`Receipt`] free of placeholder
+/// fields. A failure is never put on the wire by this implementation: the
+/// responder signals failure by resetting the stream (see
+/// `PushsyncResponder::send_error`). The [`Failed`](Self::Failed) encode arm
+/// emits an empty frame purely so the codec round-trips; nothing reads it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceiptResponse {
+    /// The storer took custody and returned a signed receipt.
+    Stored(Receipt),
+    /// The storer could not take custody. The reference's failure response is
+    /// unsigned; its reason string is adversarial input we never read.
+    Failed,
+}
 
-    /// Check if this receipt is an error.
+impl ReceiptResponse {
+    /// Check if this response reports a failure.
     pub fn is_error(&self) -> bool {
-        self.error.is_some()
+        matches!(self, Self::Failed)
     }
 }
 
-impl ProtoMessage for Receipt {
+impl ProtoMessage for ReceiptResponse {
     type Proto = vertex_swarm_net_proto::pushsync::Receipt;
     type EncodeError = std::convert::Infallible;
     type DecodeError = PushsyncError;
 
     fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
-        Ok(vertex_swarm_net_proto::pushsync::Receipt {
-            address: self.address.to_vec(),
-            signature: self.signature.as_bytes().to_vec(),
-            nonce: self.nonce.as_slice().to_vec(),
-            err: self.error.unwrap_or_default(),
-            storage_radius: u32::from(self.storage_radius.get()),
-        })
+        match self {
+            // An empty signature is the structural failure signal. In practice a
+            // responder signals failure by resetting the stream (see
+            // `PushsyncResponder::send_error`), so this frame is never actually
+            // encoded onto the wire; this arm exists only for codec round-trip
+            // symmetry with the decode path and carries no meaningful payload.
+            Self::Failed => Ok(vertex_swarm_net_proto::pushsync::Receipt::default()),
+            Self::Stored(receipt) => Ok(vertex_swarm_net_proto::pushsync::Receipt {
+                address: receipt.address.to_vec(),
+                signature: receipt.signature.as_bytes().to_vec(),
+                nonce: receipt.nonce.as_slice().to_vec(),
+                storage_radius: u32::from(receipt.storage_radius.get()),
+            }),
+        }
     }
 
     fn from_proto(proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        // Failure is detected structurally: a failure response carries no full
+        // signature. Any error marker on the opaque `err` field is ignored and
+        // never read. Only a success receipt's typed fields are parsed strictly.
+        if proto.signature.len() != SIGNATURE_LEN {
+            return Ok(Self::Failed);
+        }
         if proto.address.len() != 32 {
             return Err(PushsyncError::InvalidAddressLength(proto.address.len()));
         }
         let address = ChunkAddress::from_slice(&proto.address)?;
-        // An error receipt carries the `err` string and may leave the
-        // signature, nonce, and radius fields empty or zeroed. Do not parse
-        // those fields in that case: a remote error receipt is decodable from
-        // its `err` alone, mirroring the placeholders that [`Receipt::error`]
-        // emits. Only a success receipt's typed fields are parsed strictly.
-        if !proto.err.is_empty() {
-            return Ok(Self::error(address, proto.err));
-        }
         let signature = Signature::from_raw(&proto.signature)?;
         let nonce_bytes: [u8; 32] = proto
             .nonce
@@ -160,7 +173,12 @@ impl ProtoMessage for Receipt {
             Bin::new(radius_byte)
                 .map_err(|_| PushsyncError::InvalidStorageRadius(proto.storage_radius))?,
         );
-        Ok(Self::success(address, signature, nonce, storage_radius))
+        Ok(Self::Stored(Receipt::success(
+            address,
+            signature,
+            nonce,
+            storage_radius,
+        )))
     }
 }
 
@@ -215,23 +233,25 @@ mod tests {
 
     #[test]
     fn test_receipt_success_roundtrip() {
-        let original = Receipt::success(
+        let original = ReceiptResponse::Stored(Receipt::success(
             ChunkAddress::new([0x42; 32]),
             test_signature(),
             Nonce::new([9u8; 32]),
             radius(10),
-        );
+        ));
         let proto = original.clone().into_proto().unwrap();
-        let decoded = Receipt::from_proto(proto).unwrap();
+        let decoded = ReceiptResponse::from_proto(proto).unwrap();
         assert_eq!(original, decoded);
         assert!(!decoded.is_error());
     }
 
     #[test]
     fn test_receipt_error_roundtrip() {
-        let original = Receipt::error(ChunkAddress::new([0x42; 32]), "storage failed");
+        let original = ReceiptResponse::Failed;
         let proto = original.clone().into_proto().unwrap();
-        let decoded = Receipt::from_proto(proto).unwrap();
+        // A failure is detected structurally by an empty signature.
+        assert!(proto.signature.is_empty());
+        let decoded = ReceiptResponse::from_proto(proto).unwrap();
         assert_eq!(original, decoded);
         assert!(decoded.is_error());
     }

--- a/crates/swarm/net/pushsync/src/lib.rs
+++ b/crates/swarm/net/pushsync/src/lib.rs
@@ -1,7 +1,7 @@
 //! Pushsync protocol for Swarm chunk push and storage receipt.
 
 mod codec;
-pub use codec::{Delivery, Receipt};
+pub use codec::{Delivery, Receipt, ReceiptResponse};
 
 mod error;
 pub use error::PushsyncError;

--- a/crates/swarm/net/pushsync/src/protocol.rs
+++ b/crates/swarm/net/pushsync/src/protocol.rs
@@ -10,7 +10,8 @@
 
 use asynchronous_codec::Framed;
 use futures::{SinkExt, TryStreamExt, future::BoxFuture};
-use nectar_primitives::ChunkAddress;
+use nectar_postage::STAMP_SIZE;
+use nectar_primitives::bmt::{DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE};
 use tracing::debug;
 use vertex_swarm_net_headers::{
     HeaderedInbound, HeaderedOutbound, HeaderedStream, Inbound, Outbound,
@@ -18,12 +19,31 @@ use vertex_swarm_net_headers::{
 
 use crate::{
     PROTOCOL_NAME,
-    codec::{Delivery, DeliveryCodec, Receipt, ReceiptCodec},
+    codec::{Delivery, DeliveryCodec, Receipt, ReceiptCodec, ReceiptResponse},
     error::PushsyncError,
 };
 
-/// Maximum size of a pushsync message (chunk + stamp + overhead).
-const MAX_MESSAGE_SIZE: usize = 5 * 1024 * 1024; // 5 MB
+/// Maximum size of a pushsync message, derived from the chunk-size constants.
+///
+/// The largest legitimate `data` payload is a single-owner chunk: an
+/// [`SPAN_SIZE`] span, a 32-byte ([`HASH_SIZE`]) owner id, a 65-byte recoverable
+/// signature, and a [`DEFAULT_BODY_SIZE`] body. The pushsync `Delivery` frames
+/// that as `address` (32 bytes) + `data` + `stamp` ([`STAMP_SIZE`]). A small
+/// fixed allowance covers protobuf field tags, length varints, and the outer
+/// length-delimited frame prefix.
+///
+/// The arithmetic with the current constants:
+/// `8 + 32 + 65 + 4096` data `+ 32` address `+ 113` stamp `+ 64` framing
+/// `= 4410` bytes, well under 16 KiB. The bound is exact rather than a round
+/// number so a conformant peer never trips it and an adversarial frame (and any
+/// transient field allocation it forces) is capped tightly. Rejecting larger
+/// frames is not wire-visible.
+const SOC_SIGNATURE_SIZE: usize = 65;
+const MAX_CHUNK_DATA_SIZE: usize = SPAN_SIZE + HASH_SIZE + SOC_SIGNATURE_SIZE + DEFAULT_BODY_SIZE;
+/// Protobuf framing allowance: field tags, length varints, and the outer
+/// length-delimited frame prefix across all fields, rounded up generously.
+const PROTOBUF_FRAMING: usize = 64;
+const MAX_MESSAGE_SIZE: usize = HASH_SIZE + MAX_CHUNK_DATA_SIZE + STAMP_SIZE + PROTOBUF_FRAMING;
 
 /// Pushsync inbound: receives a chunk delivery from remote.
 #[derive(Debug, Clone)]
@@ -71,17 +91,16 @@ impl PushsyncResponder {
     /// Send a successful receipt.
     pub async fn send_receipt(mut self, receipt: Receipt) -> Result<(), PushsyncError> {
         debug!(address = %receipt.address, "Pushsync: Sending receipt");
-        self.framed.send(receipt).await
+        self.framed.send(ReceiptResponse::Stored(receipt)).await
     }
 
-    /// Send an error receipt.
-    pub async fn send_error(
-        mut self,
-        address: ChunkAddress,
-        error: impl Into<String>,
-    ) -> Result<(), PushsyncError> {
-        debug!(%address, "Pushsync: Sending error receipt");
-        self.framed.send(Receipt::error(address, error)).await
+    /// Signal a failure by resetting the stream (no frame is sent).
+    pub fn send_error(self) {
+        // The reference pusher reads the reset (or EOF) as a failed push at
+        // every hop, which sidesteps the forwarder signature-skip entirely: with
+        // no receipt to read, there is nothing for a forwarder to misjudge as a
+        // success. Dropping the framed stream resets the substream at the muxer.
+        debug!("Pushsync: resetting stream to signal failure");
     }
 }
 
@@ -99,7 +118,7 @@ impl PushsyncOutboundInner {
 }
 
 impl HeaderedOutbound for PushsyncOutboundInner {
-    type Output = Receipt;
+    type Output = ReceiptResponse;
     type Error = PushsyncError;
 
     fn protocol_name(&self) -> &'static str {

--- a/crates/swarm/net/retrieval/src/codec.rs
+++ b/crates/swarm/net/retrieval/src/codec.rs
@@ -53,19 +53,18 @@ impl ProtoMessage for Request {
     }
 }
 
-/// Delivery of a chunk, or a not-found error.
+/// Delivery of a chunk, or an opaque failure.
 ///
-/// A successful delivery carries the [`StampedChunk`]; a failed one carries the
-/// remote's error string.
+/// A successful delivery carries the [`StampedChunk`]. A failure carries no
+/// payload: the remote's error string is adversarial input the reference does
+/// not introspect, so we never read it. Failure is signalled on the wire by
+/// empty `data`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Delivery {
     /// The chunk and its stamp.
-    ///
-    /// Boxed: a [`StampedChunk`] is far larger than the error string, so boxing
-    /// keeps the enum small for the common error path.
     Chunk(Box<StampedChunk>),
-    /// Retrieval failed (e.g. chunk not found), with the remote's message.
-    Error(String),
+    /// Retrieval failed. The reason is intentionally not carried.
+    Error,
 }
 
 impl Delivery {
@@ -74,17 +73,18 @@ impl Delivery {
         Self::Chunk(Box::new(chunk))
     }
 
-    /// Create an error delivery.
-    pub fn error(msg: impl Into<String>) -> Self {
-        Self::Error(msg.into())
+    /// Create a failure delivery.
+    pub fn error() -> Self {
+        Self::Error
     }
 
-    /// Check if this delivery is an error.
+    /// Check if this delivery is a failure.
     pub fn is_error(&self) -> bool {
-        matches!(self, Self::Error(_))
+        matches!(self, Self::Error)
     }
 
-    /// Encode this delivery to its protobuf wire form.
+    /// Encode this delivery to its protobuf wire form. A failure is encoded as
+    /// empty `data`/`stamp`; we emit nothing on the (omitted) error field.
     fn into_proto(self) -> vertex_swarm_net_proto::retrieval::Delivery {
         match self {
             Self::Chunk(chunk) => {
@@ -92,13 +92,11 @@ impl Delivery {
                 vertex_swarm_net_proto::retrieval::Delivery {
                     data: chunk.into_bytes().to_vec(),
                     stamp: stamp.to_bytes().to_vec(),
-                    err: String::new(),
                 }
             }
-            Self::Error(err) => vertex_swarm_net_proto::retrieval::Delivery {
+            Self::Error => vertex_swarm_net_proto::retrieval::Delivery {
                 data: Vec::new(),
                 stamp: Vec::new(),
-                err,
             },
         }
     }
@@ -106,14 +104,23 @@ impl Delivery {
     /// Decode a delivery from its protobuf wire form, reconstructing and
     /// validating the chunk against the requested address.
     ///
-    /// An error delivery carries the `err` string and no stamp; it is decodable
-    /// from `err` alone, so the chunk is not reconstructed in that case.
+    /// An honest failure is detected structurally by an empty `data` AND an
+    /// empty `stamp`: the reference reports a retrieval failure with an empty
+    /// delivery (it does not reset the stream for retrieval), and that is the
+    /// only signal we read. Any error string the remote set on the (unmodelled)
+    /// wire field is skipped without allocation.
+    ///
+    /// Once `data` is non-empty the frame claims to carry a chunk, so it must
+    /// reconstruct and validate against the requested address; otherwise it is
+    /// malformed data, which surfaces as a decode error rather than collapsing
+    /// into an honest-failure signal. The two are scored differently upstream,
+    /// so the distinction is kept strict here.
     fn from_proto(
         proto: vertex_swarm_net_proto::retrieval::Delivery,
         expected: ChunkAddress,
     ) -> Result<Self, RetrievalError> {
-        if !proto.err.is_empty() {
-            return Ok(Self::error(proto.err));
+        if proto.data.is_empty() && proto.stamp.is_empty() {
+            return Ok(Self::Error);
         }
         let stamp = Stamp::try_from_slice(&proto.stamp)?;
         let chunk = StampedChunk::reconstruct(expected, Bytes::from(proto.data), stamp)?;
@@ -215,7 +222,7 @@ mod tests {
                 assert_eq!(*chunk.address(), address);
                 assert_eq!(chunk.chunk().clone().into_bytes(), wire_data);
             }
-            Delivery::Error(e) => panic!("expected chunk, got error {e}"),
+            Delivery::Error => panic!("expected chunk, got error"),
         }
     }
 
@@ -234,13 +241,35 @@ mod tests {
         let address = ChunkAddress::new([0x42; 32]);
         let mut enc = DeliveryCodec::new(1024, address);
         let mut buf = BytesMut::new();
-        enc.encode(Delivery::error("chunk not found"), &mut buf)
-            .unwrap();
+        enc.encode(Delivery::error(), &mut buf).unwrap();
 
         let mut dec = DeliveryCodec::new(1024, address);
         let decoded = dec.decode(&mut buf).unwrap().expect("frame decoded");
         assert!(decoded.is_error());
-        assert_eq!(decoded, Delivery::error("chunk not found"));
+        assert_eq!(decoded, Delivery::error());
+    }
+
+    /// Wire-compat: the reference signals a retrieval failure with empty data
+    /// plus a (now unmodelled) `err` string on field 3. We must decode that as a
+    /// failure and skip the err bytes entirely. This hand-builds such a frame:
+    /// a length-delimited message carrying only field 3 (`tag 0x1A`, wire type 2)
+    /// with an arbitrary error string, and asserts the decoder ignores it.
+    #[test]
+    fn decodes_reference_failure_frame_ignoring_err_field() {
+        let address = ChunkAddress::new([0x42; 32]);
+        // Inner message: field 3 (err), length-delimited, value "boom". No data,
+        // no stamp (both empty, hence omitted on the wire).
+        let inner = [&[0x1Au8, 0x04][..], b"boom"].concat();
+        // quick-protobuf framing prepends the message length as a varint; for a
+        // 6-byte message that is a single byte.
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(&[inner.len() as u8]);
+        buf.extend_from_slice(&inner);
+
+        let mut dec = DeliveryCodec::new(1024, address);
+        let decoded = dec.decode(&mut buf).unwrap().expect("frame decoded");
+        assert!(decoded.is_error(), "empty data must decode as a failure");
+        assert_eq!(decoded, Delivery::error());
     }
 
     #[test]

--- a/crates/swarm/net/retrieval/src/protocol.rs
+++ b/crates/swarm/net/retrieval/src/protocol.rs
@@ -10,7 +10,11 @@
 
 use asynchronous_codec::Framed;
 use futures::{SinkExt, TryStreamExt, future::BoxFuture};
-use nectar_primitives::ChunkAddress;
+use nectar_postage::STAMP_SIZE;
+use nectar_primitives::{
+    ChunkAddress,
+    bmt::{DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE},
+};
 use tracing::debug;
 use vertex_swarm_net_headers::{
     HeaderedInbound, HeaderedOutbound, HeaderedStream, Inbound, Outbound,
@@ -22,8 +26,27 @@ use crate::{
     error::RetrievalError,
 };
 
-/// Maximum size of a retrieval message (chunk + stamp + overhead).
-const MAX_MESSAGE_SIZE: usize = 5 * 1024 * 1024; // 5 MB
+/// Maximum size of a retrieval message, derived from the chunk-size constants.
+///
+/// The largest legitimate `data` payload is a single-owner chunk: an
+/// [`SPAN_SIZE`] span, a 32-byte ([`HASH_SIZE`]) owner id, a 65-byte recoverable
+/// signature, and a [`DEFAULT_BODY_SIZE`] body. The retrieval `Delivery` frames
+/// that as `data` + `stamp` ([`STAMP_SIZE`]) with no address of its own. A small
+/// fixed allowance covers protobuf field tags, length varints, and the outer
+/// length-delimited frame prefix.
+///
+/// The arithmetic with the current constants:
+/// `8 + 32 + 65 + 4096` data `+ 113` stamp `+ 64` framing `= 4378` bytes, well
+/// under 16 KiB. The bound is exact rather than a round number so a conformant
+/// peer never trips it and an adversarial frame (and any transient field
+/// allocation it forces) is capped tightly. Rejecting larger frames is not
+/// wire-visible.
+const SOC_SIGNATURE_SIZE: usize = 65;
+const MAX_CHUNK_DATA_SIZE: usize = SPAN_SIZE + HASH_SIZE + SOC_SIGNATURE_SIZE + DEFAULT_BODY_SIZE;
+/// Protobuf framing allowance: field tags, length varints, and the outer
+/// length-delimited frame prefix across all fields, rounded up generously.
+const PROTOBUF_FRAMING: usize = 64;
+const MAX_MESSAGE_SIZE: usize = MAX_CHUNK_DATA_SIZE + STAMP_SIZE + PROTOBUF_FRAMING;
 
 /// Retrieval inbound: receives a chunk request from remote.
 #[derive(Debug, Clone)]
@@ -82,10 +105,12 @@ impl RetrievalResponder {
         self.framed.send(Delivery::success(chunk)).await
     }
 
-    /// Send an error response.
-    pub async fn send_error(mut self, error: impl Into<String>) -> Result<(), RetrievalError> {
-        debug!("Retrieval: Sending error delivery");
-        self.framed.send(Delivery::error(error)).await
+    /// Signal a failure by resetting the stream (no frame is sent).
+    pub fn send_error(self) {
+        // We never put a placeholder or remote-controlled error on the wire. The
+        // requester reads the reset (or EOF) as a failed request. Dropping the
+        // framed stream resets the substream at the muxer.
+        debug!("Retrieval: resetting stream to signal failure");
     }
 }
 

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -64,19 +64,20 @@ pub enum ChunkTransferError {
     /// Request cancelled.
     #[error("Request cancelled")]
     Cancelled,
-    /// Protocol error.
+    /// Local protocol failure (dial, stream, or an inactive handler). Failures
+    /// reported by the remote peer are carried by [`Self::Remote`] instead.
     #[error("Protocol error: {0}")]
     Protocol(String),
+    /// The remote peer reported a failure (a retrieval error delivery or a
+    /// non-success pushsync receipt). The reason is intentionally not carried:
+    /// the remote's error string is adversarial input we never read.
+    #[error("Remote peer reported a failure")]
+    Remote,
 
     // Retrieval-specific: only a get produces this.
     /// Chunk not found.
     #[error("Chunk not found: {0}")]
     NotFound(ChunkAddress),
-
-    // Push-specific: only a put produces this.
-    /// The storer rejected the chunk. Carries the storer's wire error string.
-    #[error("Push rejected by storer: {0}")]
-    PushRejected(String),
 }
 
 impl ClientHandle {

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -566,21 +566,22 @@ impl ClientHandler {
     ) {
         let overlay = self.overlay();
         match delivery {
-            vertex_swarm_net_retrieval::Delivery::Error(err) => {
-                // A storer-supplied error string (for example "not found") is a
-                // plain protocol failure, not malformed data. Malformed chunks
-                // never reach this arm: they fail reconstruction at decode and
-                // surface as a dial upgrade error.
-                debug!(?overlay, %address, error = %err, "Retrieval failed");
+            vertex_swarm_net_retrieval::Delivery::Error => {
+                // The remote reported a failure (signalled by empty data). The
+                // reason is adversarial input we never read; it is a plain
+                // protocol failure, not malformed data. Malformed chunks never
+                // reach this arm: they fail reconstruction at decode and surface
+                // as a dial upgrade error.
+                debug!(?overlay, %address, "Retrieval failed");
                 if let Some(overlay) = overlay {
                     self.push_event(HandlerEvent::RetrievalFailed {
                         overlay,
                         address,
-                        error: err.clone(),
+                        error: "remote reported a failure".to_string(),
                         kind: FailureKind::Protocol,
                     });
                 }
-                let _ = response.send(Err(ChunkTransferError::Protocol(err)));
+                let _ = response.send(Err(ChunkTransferError::Remote));
             }
             vertex_swarm_net_retrieval::Delivery::Chunk(chunk) => {
                 let Some(overlay) = overlay else {
@@ -607,44 +608,51 @@ impl ClientHandler {
     /// Handle pushsync receipt, resolving the caller's response channel.
     fn on_pushsync_receipt(
         &mut self,
-        receipt: vertex_swarm_net_pushsync::Receipt,
+        response_msg: vertex_swarm_net_pushsync::ReceiptResponse,
+        address: ChunkAddress,
         response: PushResponseTx,
         latency: Duration,
     ) {
         let overlay = self.overlay();
-        if let Some(err) = receipt.error {
-            debug!(?overlay, address = %receipt.address, error = %err, "Pushsync failed");
-            if let Some(overlay) = overlay {
-                self.push_event(HandlerEvent::PushFailed {
+        match response_msg {
+            vertex_swarm_net_pushsync::ReceiptResponse::Failed => {
+                // The remote reported a rejection (signalled by an empty
+                // signature; the reference does not sign its failures). The
+                // reason is adversarial input we never read.
+                debug!(?overlay, %address, "Pushsync failed");
+                if let Some(overlay) = overlay {
+                    self.push_event(HandlerEvent::PushFailed {
+                        overlay,
+                        address,
+                        error: "remote reported a failure".to_string(),
+                        kind: FailureKind::Protocol,
+                    });
+                }
+                let _ = response.send(Err(ChunkTransferError::Remote));
+            }
+            vertex_swarm_net_pushsync::ReceiptResponse::Stored(receipt) => {
+                let Some(overlay) = overlay else {
+                    let _ = response.send(Err(ChunkTransferError::Protocol(
+                        "handler not active".to_string(),
+                    )));
+                    return;
+                };
+                debug!(%overlay, address = %receipt.address, "Received receipt");
+                self.push_event(HandlerEvent::ReceiptReceived {
                     overlay,
                     address: receipt.address,
-                    error: err.clone(),
-                    kind: FailureKind::Protocol,
+                    signature: receipt.signature,
+                    nonce: receipt.nonce,
+                    storage_radius: receipt.storage_radius,
+                    latency,
                 });
+                let _ = response.send(Ok(PushReceipt {
+                    storer: overlay,
+                    signature: receipt.signature,
+                    nonce: receipt.nonce,
+                    storage_radius: receipt.storage_radius,
+                }));
             }
-            let _ = response.send(Err(ChunkTransferError::PushRejected(err)));
-        } else {
-            let Some(overlay) = overlay else {
-                let _ = response.send(Err(ChunkTransferError::Protocol(
-                    "handler not active".to_string(),
-                )));
-                return;
-            };
-            debug!(%overlay, address = %receipt.address, "Received receipt");
-            self.push_event(HandlerEvent::ReceiptReceived {
-                overlay,
-                address: receipt.address,
-                signature: receipt.signature,
-                nonce: receipt.nonce,
-                storage_radius: receipt.storage_radius,
-                latency,
-            });
-            let _ = response.send(Ok(PushReceipt {
-                storer: overlay,
-                signature: receipt.signature,
-                nonce: receipt.nonce,
-                storage_radius: receipt.storage_radius,
-            }));
         }
     }
 }
@@ -1098,7 +1106,7 @@ impl ClientHandler {
             ) => {
                 let latency = requested_at.elapsed();
                 debug!(%address, "Received pushsync receipt");
-                self.on_pushsync_receipt(receipt, response, latency);
+                self.on_pushsync_receipt(receipt, address, response, latency);
             }
             (
                 ClientOutboundOutput::Pseudosettle(ack),

--- a/crates/swarm/node/src/protocol/upgrade.rs
+++ b/crates/swarm/node/src/protocol/upgrade.rs
@@ -29,7 +29,7 @@ use vertex_swarm_net_pseudosettle::{
 };
 use vertex_swarm_net_pushsync::{
     Delivery as PushsyncDelivery, PROTOCOL_NAME as PUSHSYNC_PROTOCOL, PushsyncInboundProtocol,
-    PushsyncOutboundProtocol, PushsyncResponder, Receipt as PushsyncReceipt,
+    PushsyncOutboundProtocol, PushsyncResponder, ReceiptResponse as PushsyncReceiptResponse,
 };
 use vertex_swarm_net_retrieval::{
     Delivery as RetrievalDelivery, PROTOCOL_NAME as RETRIEVAL_PROTOCOL,
@@ -330,8 +330,8 @@ pub(crate) enum ClientOutboundOutput {
     Pricing,
     /// Received chunk delivery.
     Retrieval(RetrievalDelivery),
-    /// Received receipt.
-    Pushsync(PushsyncReceipt),
+    /// Received receipt response (signed receipt on success, or failure).
+    Pushsync(PushsyncReceiptResponse),
     /// Received pseudosettle ack.
     Pseudosettle(PaymentAck),
     /// Cheque sent; carries the peer's negotiated headers.

--- a/crates/swarm/node/src/swarm_client.rs
+++ b/crates/swarm/node/src/swarm_client.rs
@@ -473,9 +473,7 @@ mod tests {
         match rx.recv().await.expect("command emitted") {
             ClientCommand::PushChunk { response, .. } => {
                 response
-                    .send(Err(ChunkTransferError::PushRejected(
-                        "rejected".to_string(),
-                    )))
+                    .send(Err(ChunkTransferError::Remote))
                     .expect("receiver alive");
             }
             other => panic!("unexpected command: {other:?}"),
@@ -483,8 +481,8 @@ mod tests {
 
         let result = push.await.unwrap();
         match result {
-            Err(ChunkTransferError::PushRejected(reason)) => assert_eq!(reason, "rejected"),
-            other => panic!("expected PushRejected, got {other:?}"),
+            Err(ChunkTransferError::Remote) => {}
+            other => panic!("expected Remote, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Approach: never read the error string, and never send one

The `Err` field is adversarial input the remote fully controls, and the reference node never introspects it (it only checks presence, else falls back to `data`/signature validity). So this strips it from both directions.

### Receive: detect failure structurally, never from the string
- Retrieval failure = empty `data` (chunk reconstruction fails).
- Pushsync failure = an empty (non-65-byte) `signature`.

The `err` field is dropped from **both** protos, so an inbound value is skipped by quick-protobuf without allocation.

### Send: reset the stream, don't write a failure frame
A responder that cannot serve resets the substream instead of encoding a failure frame. The reference pusher/requester reads the reset (or EOF) as a failure at every hop:

```go
// pushsync.go:643, used by origin AND forwarder
if err = r.ReadMsgWithContext(ctx, &rec); err != nil { return nil, err } // reset = failed push
```

This also removes the need for the one-byte forwarder marker from the earlier revision of this PR: the forwarder signature-skip only bites when a receipt is actually *read*, and resetting means there is no receipt to read. It matches the reference's own idiom, which resets on failure (`pushsync.go:194`, `pushChunkToPeer`'s deferred `Reset()`).

### Other
- `Delivery::Error` and the pushsync receipt failure are payload-free; the node carries a stringless `ChunkTransferError::Remote`.
- `MAX_MESSAGE_SIZE` tightened 5 MiB → 16 KiB on both protocols (a legitimate frame is under ~4.4 KiB), bounding any transient field allocation ~320x.

## Wire compatibility

Confirmed against bee v2.7.0-rc5 (analysis in #296): bee discriminates success/failure by `Err != ""` first, else by `data`/signature validity, and never parses, length-checks, or compares the content; an empty/absent field is identical in proto3; a reset/EOF on the receipt or delivery read is a failure, not a hang or a false success. So a bee peer still detects our failures and we detect theirs. A test (`decodes_reference_failure_frame_ignoring_err_field`) hand-builds a reference-shaped failure frame carrying an `err` string and asserts we skip it and decode a failure.

## Tests

Codec failure round-trips updated to the payload-free, marker-free form; the structural (empty-signature) failure signal is asserted; the reference-frame skip test proves wire-compat. fmt + clippy `--all-features` + tests green locally across the touched crates.

Stacked on #294. Closes #296.
