### PR TITLE
feat(chain): generic reorg-safe event-indexing engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8344,6 +8344,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-chain-index"
+version = "0.1.0"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vertex-metrics",
+ "vertex-storage",
+ "vertex-storage-redb",
+]
+
+[[package]]
 name = "vertex-ffi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ members = [
 
     # Chain (Ethereum RPC access)
     "crates/chain",
+    "crates/chain/index",
 
     # FFI (native embedding surface)
     "crates/ffi",
@@ -234,6 +235,7 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 
 # chain (Ethereum RPC access)
 vertex-chain = { path = "crates/chain" }
+vertex-chain-index = { path = "crates/chain/index" }
 
 # ffi (native embedding surface)
 vertex-ffi = { path = "crates/ffi" }
@@ -245,6 +247,7 @@ alloy-network = { version = "2.0", default-features = false }
 alloy-provider = { version = "2.0", default-features = false }
 alloy-contract = { version = "2.0", default-features = false }
 alloy-rpc-types-eth = { version = "2.0", default-features = false }
+alloy-json-rpc = { version = "2.0", default-features = false }
 alloy-signer = { version = "2.0" }
 # The `keystore` feature pulls `eth-keystore`, which does not build for
 # wasm32. It is enabled per-target (native-only) by the sole keystore consumer,

--- a/crates/chain/index/Cargo.toml
+++ b/crates/chain/index/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "vertex-chain-index"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Generic, reorg-safe, contract-agnostic chain event-indexing engine for Vertex"
+
+[lints]
+workspace = true
+
+[dependencies]
+# storage: the persisted cursor lives behind the `Database`/`DbTx` traits.
+vertex-storage = { workspace = true }
+# metrics: lazy counters for pages/logs/errors.
+vertex-metrics = { workspace = true }
+
+# alloy: the engine drives an `alloy_provider::Provider` over the Ethereum
+# network. `default-features = false` keeps reqwest and native TLS out so the
+# crate stays buildable for wasm when a wasm-friendly transport is selected; the
+# concrete transport is the consumer's choice.
+alloy-network = { workspace = true }
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-provider = { workspace = true }
+alloy-rpc-types-eth = { workspace = true }
+
+# serialization: the persisted cursor derives serde.
+serde = { workspace = true, features = ["derive"] }
+
+# async: the engine selects between its driver loop and shutdown with
+# `tokio::select!` and ticks the follow loop with `tokio::time::interval`.
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
+tracing = { workspace = true }
+
+# derive macros
+strum = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+vertex-storage-redb = { workspace = true }
+alloy-sol-types = { workspace = true }
+# Constructing a synthetic provider range error for the adaptive-paging test.
+alloy-json-rpc = { workspace = true }
+# A full provider with an HTTP transport for the ignored e2e fork test.
+alloy-provider = { workspace = true, features = ["reqwest"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/chain/index/src/cursor.rs
+++ b/crates/chain/index/src/cursor.rs
@@ -1,0 +1,99 @@
+//! The persisted indexing cursor.
+//!
+//! A [`Cursor`] records how far an indexer has folded: the last fully-applied
+//! block and that block's hash. It is persisted in a `vertex-storage` table
+//! keyed by the indexer's [`name`](crate::Indexer::name), so every indexer keeps
+//! its own independent checkpoint and resumes from it on restart.
+//!
+//! The cursor is committed in its own `vertex-storage` write transaction, last,
+//! after a page's logs are applied (see [`EventEngine`](crate::EventEngine)), so
+//! it advances only on a clean page and never claims a range that failed to
+//! apply. On restart the engine resumes from `last_block + 1`; re-reading an
+//! already-applied range is the indexer's idempotency concern, kept trivial
+//! because the range is canonical and finalized.
+
+use alloy_primitives::B256;
+use serde::{Deserialize, Serialize};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table};
+
+vertex_storage::table!(
+    pub CursorTable,
+    "chain_index_cursors",
+    CursorKey,
+    Cursor
+);
+
+/// The cursor table key: an indexer's [`name`](crate::Indexer::name).
+///
+/// A thin newtype over [`String`] so the indexer name satisfies the storage
+/// [`Encode`]/[`Decode`] key contract. Names are encoded as their UTF-8 bytes
+/// and ordered lexicographically.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CursorKey(pub String);
+
+impl From<&str> for CursorKey {
+    fn from(name: &str) -> Self {
+        Self(name.to_owned())
+    }
+}
+
+impl Encode for CursorKey {
+    type Encoded = Vec<u8>;
+
+    fn encode(self) -> Self::Encoded {
+        self.0.into_bytes()
+    }
+}
+
+impl Decode for CursorKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let name = core::str::from_utf8(value).map_err(|_| DatabaseError::Decode)?;
+        Ok(Self(name.to_owned()))
+    }
+}
+
+/// The set of tables this crate persists, for one-shot initialization.
+pub struct CursorTables;
+
+impl vertex_storage::Tables for CursorTables {
+    const NAMES: &'static [&'static str] = &[CursorTable::NAME];
+}
+
+/// A persisted indexing checkpoint for a single indexer.
+///
+/// `last_block` is the highest block whose logs have been fully applied;
+/// `block_hash` is that block's hash, recorded so a future head-tracking engine
+/// can detect a reorg by comparing it against the canonical chain. The MVP
+/// indexes only finalized blocks, so the hash is informational today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cursor {
+    /// Highest block fully applied (inclusive).
+    pub last_block: u64,
+    /// Hash of `last_block`.
+    pub block_hash: B256,
+}
+
+impl Cursor {
+    /// Load the cursor for `name`, if one has been persisted.
+    pub fn load<DB: Database>(db: &DB, name: &str) -> Result<Option<Self>, DatabaseError> {
+        db.view(|tx| tx.get::<CursorTable>(CursorKey::from(name)))
+    }
+
+    /// Read the cursor for `name` from an open read transaction.
+    pub fn read<TX: DbTx>(tx: &TX, name: &str) -> Result<Option<Self>, DatabaseError> {
+        tx.get::<CursorTable>(CursorKey::from(name))
+    }
+
+    /// Write the cursor for `name` into an open write transaction.
+    ///
+    /// The caller commits the transaction, so the cursor lands atomically with
+    /// whatever indexed state the same transaction carries.
+    pub fn write<TX: DbTxMut>(&self, tx: &TX, name: &str) -> Result<(), DatabaseError> {
+        tx.put::<CursorTable>(CursorKey::from(name), *self)
+    }
+
+    /// The block backfill should resume from: one past the last applied block.
+    pub fn next_block(&self) -> u64 {
+        self.last_block.saturating_add(1)
+    }
+}

--- a/crates/chain/index/src/engine.rs
+++ b/crates/chain/index/src/engine.rs
@@ -1,0 +1,377 @@
+//! The [`EventEngine`]: the reorg/cursor/paging story, written once.
+//!
+//! One engine instance drives one [`Indexer`] against one [`ChainReader`] and
+//! one `vertex-storage` [`Database`]. It backfills the indexer's filter from the
+//! deployment block (or the persisted cursor) up to the chain's finalized head,
+//! then follows the head and indexes each newly-finalized range the same way.
+//!
+//! # Reorg strategy
+//!
+//! Safety keys off the chain's `finalized` tag, not a fixed block lag. The
+//! engine never applies a log above the finalized head, and finalized blocks do
+//! not reorg, so the backfill needs no rollback logic and the cursor never has
+//! to walk backwards. The latency cost is one finality window (minutes on
+//! Gnosis); the benefit is that the entire indexed range is canonical by
+//! construction.
+//!
+//! Optimistic head-tracking (indexing the `finalized..latest` window and
+//! reverting on the WS `log.removed` flag or a parent-hash mismatch) is a
+//! documented enhancement, not implemented here. The hooks for it already exist:
+//! [`Indexer::revert`] and the block hash stored in the [`Cursor`]. The MVP
+//! leaves `revert` a default no-op and never calls it.
+//!
+//! # Atomicity and idempotency
+//!
+//! A page's cursor is written and committed in one `vertex-storage` write
+//! transaction. The cursor advances only on a clean commit, so it never outruns
+//! a page that failed to apply: an [`Indexer::apply`] error aborts the page
+//! before the cursor moves, and the failed range is retried on the next run.
+//!
+//! The [`Indexer`] trait folds state through `apply` without taking the engine's
+//! write transaction, so an indexer that persists into its own
+//! [`Database`](vertex_storage::Database) commits separately from the cursor. The
+//! engine bridges that gap with idempotency rather than a shared transaction: a
+//! crash after an indexer commit but before the cursor commit re-delivers the
+//! same finalized range on restart, and because the range is canonical and
+//! cannot have changed, re-applying it must be a no-op for a correctly-written
+//! indexer. The MVP keeps the cursor commit last so the worst case is replay,
+//! never a skipped range. A shared-transaction variant (an `apply` that takes
+//! the engine's `DbTxMut`) is a possible future tightening, not the MVP.
+//!
+//! [`Indexer`]: crate::Indexer
+//! [`Indexer::revert`]: crate::Indexer::revert
+//! [`ChainReader`]: crate::ChainReader
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_rpc_types_eth::Log;
+use tracing::{debug, info, warn};
+use vertex_storage::{Database, DbTxMut, Tables};
+
+use crate::cursor::{Cursor, CursorTables};
+use crate::metrics;
+use crate::reader::{ChainReader, FinalizedHead};
+use crate::{IndexError, Indexer};
+
+/// The largest block span requested in a single `eth_getLogs` page.
+///
+/// Public RPC providers cap log queries by block range and by result count;
+/// this is a conservative starting span that the adaptive loop shrinks on a
+/// provider range/limit error.
+pub const DEFAULT_PAGE_SIZE: u64 = 10_000;
+
+/// The smallest the adaptive page span is allowed to shrink to.
+///
+/// A single block always fits, so the floor is one; the engine returns the
+/// provider error rather than looping forever if even one block is rejected.
+const MIN_PAGE_SIZE: u64 = 1;
+
+/// How often the follow loop re-checks the finalized head.
+///
+/// Gnosis produces a block roughly every five seconds and finalizes in minutes,
+/// so polling the finalized tag this often keeps follow latency well inside one
+/// block of the finality window without hammering the RPC.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Builder for an [`EventEngine`]: holds the reader and store before an indexer
+/// is attached.
+///
+/// [`EventEngine::new`] returns this; [`register`](EventEngineBuilder::register)
+/// attaches the indexer and produces a runnable [`EventEngine`]. Splitting the
+/// builder out makes "an engine without an indexer" unrepresentable, so
+/// [`run`](EventEngine::run) never has to handle a missing indexer.
+pub struct EventEngineBuilder<R, DB> {
+    reader: Arc<R>,
+    db: Arc<DB>,
+}
+
+impl<R, DB> EventEngineBuilder<R, DB>
+where
+    R: ChainReader + 'static,
+    DB: Database,
+{
+    /// Attach the indexer this engine drives, producing a runnable engine.
+    ///
+    /// One engine instance drives one indexer with its own cursor; a
+    /// combined-filter multi-indexer mode is an explicit future optimization,
+    /// not the MVP.
+    pub fn register(self, indexer: Arc<dyn Indexer>) -> EventEngine<R, DB> {
+        EventEngine {
+            reader: self.reader,
+            db: self.db,
+            indexer,
+            page_size: DEFAULT_PAGE_SIZE,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+        }
+    }
+}
+
+/// Drives a single [`Indexer`] over a [`ChainReader`] with a persisted cursor.
+///
+/// Build with [`EventEngine::new`] then [`register`](EventEngineBuilder::register)
+/// an indexer, then [`run`](EventEngine::run) until the supplied shutdown future
+/// resolves.
+pub struct EventEngine<R, DB> {
+    reader: Arc<R>,
+    db: Arc<DB>,
+    indexer: Arc<dyn Indexer>,
+    page_size: u64,
+    poll_interval: Duration,
+}
+
+impl<R, DB> EventEngine<R, DB>
+where
+    R: ChainReader + 'static,
+    DB: Database,
+{
+    /// Begin building an engine over a chain reader and a cursor store.
+    ///
+    /// The reader is any `alloy_provider::Provider<Ethereum>` (or a test double);
+    /// the database is any `vertex-storage` [`Database`]. Attach an indexer with
+    /// [`register`](EventEngineBuilder::register) to get a runnable engine.
+    ///
+    /// Returns the builder rather than `Self` so an engine cannot exist without
+    /// an indexer; the `EventEngine::new(...).register(...)` chain reads as one
+    /// fluent construction.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(reader: Arc<R>, db: Arc<DB>) -> EventEngineBuilder<R, DB> {
+        EventEngineBuilder { reader, db }
+    }
+
+    /// Override the initial `eth_getLogs` page span. Mainly for tests.
+    pub fn with_page_size(mut self, page_size: u64) -> Self {
+        self.page_size = page_size.max(MIN_PAGE_SIZE);
+        self
+    }
+
+    /// Override the finalized-head poll interval. Mainly for tests.
+    pub fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// Run the engine until `shutdown` resolves.
+    ///
+    /// Initializes the cursor table, backfills to the current finalized head,
+    /// then follows: each time the finalized head advances, the newly-finalized
+    /// range is indexed the same way. Returns when the shutdown future resolves
+    /// or when an indexer callback errors.
+    ///
+    /// The initial catch-up runs to completion before the follow loop, so the
+    /// engine has fully backfilled the chain as it stood at startup before it
+    /// begins waiting on the shutdown signal. Within the follow loop the shutdown
+    /// future is checked between sync passes, so a shutdown lands on a page
+    /// boundary and never tears a page (each page commits or rolls back whole).
+    pub async fn run<F>(mut self, shutdown: F) -> Result<(), IndexError>
+    where
+        F: Future<Output = ()>,
+    {
+        let indexer = Arc::clone(&self.indexer);
+        let name = indexer.name();
+
+        CursorTables::init(self.db.as_ref())?;
+
+        info!(indexer = name, "starting chain event engine");
+
+        // Backfill the chain as it stands at startup before entering the follow
+        // loop. This makes one full catch-up a guaranteed, shutdown-independent
+        // step rather than racing the shutdown future on the first poll.
+        self.sync_once(indexer.as_ref()).await?;
+
+        let follow = self.follow(indexer.as_ref());
+        tokio::pin!(follow);
+        tokio::pin!(shutdown);
+
+        tokio::select! {
+            result = &mut follow => result,
+            () = &mut shutdown => {
+                info!(indexer = name, "chain event engine shutting down");
+                Ok(())
+            }
+        }
+    }
+
+    /// The follow loop: re-check the finalized head each interval and index any
+    /// newly-finalized range.
+    async fn follow(&mut self, indexer: &dyn Indexer) -> Result<(), IndexError> {
+        let mut ticker = tokio::time::interval(self.poll_interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // The first tick fires immediately; consume it so the initial wait is a
+        // full interval (the startup catch-up already covered the current head).
+        ticker.tick().await;
+
+        loop {
+            ticker.tick().await;
+            self.sync_once(indexer).await?;
+        }
+    }
+
+    /// Fetch the finalized head and index up to it, if the chain has finalized.
+    async fn sync_once(&mut self, indexer: &dyn Indexer) -> Result<(), IndexError> {
+        match self.reader.finalized_head().await? {
+            Some(head) => self.sync_to(indexer, head).await,
+            None => {
+                debug!(indexer = indexer.name(), "chain has no finalized head yet");
+                Ok(())
+            }
+        }
+    }
+
+    /// Index every page from the cursor (or start block) up to `head`.
+    async fn sync_to(
+        &mut self,
+        indexer: &dyn Indexer,
+        head: FinalizedHead,
+    ) -> Result<(), IndexError> {
+        let name = indexer.name();
+
+        // Resume from one past the last applied block, but never before the
+        // contract's deployment block.
+        let resume = match Cursor::load(self.db.as_ref(), name)? {
+            Some(cursor) => cursor.next_block(),
+            None => indexer.start_block(),
+        }
+        .max(indexer.start_block());
+
+        let mut from = resume;
+        while from <= head.number {
+            let requested_to = self.page_end(from, head.number);
+            // `fetch_page` may shrink the page, so checkpoint and advance by the
+            // range it actually covered, not the one requested.
+            let (to, logs) = self.fetch_page(indexer, from, requested_to).await?;
+
+            // The page's checkpoint hash is the finalized head hash when the
+            // page reaches the head, otherwise unknown (zero) for an interior
+            // page; only the head boundary needs a verifiable hash for future
+            // head-tracking, and interior finalized blocks never reorg.
+            let block_hash = if to == head.number {
+                head.hash
+            } else {
+                alloy_primitives::B256::ZERO
+            };
+
+            self.commit_page(indexer, &logs, to, block_hash)?;
+
+            metrics::pages_total(name).increment(1);
+            debug!(
+                indexer = name,
+                from,
+                to,
+                logs = logs.len(),
+                "applied chain log page"
+            );
+
+            from = to.saturating_add(1);
+        }
+
+        Ok(())
+    }
+
+    /// The inclusive end block for a page starting at `from`, clamped to `head`.
+    fn page_end(&self, from: u64, head: u64) -> u64 {
+        from.saturating_add(self.page_size.saturating_sub(1))
+            .min(head)
+    }
+
+    /// Fetch one page of logs, shrinking the page span and retrying on a
+    /// provider range/limit error.
+    ///
+    /// Returns the logs together with the block the page actually ended at: a
+    /// shrunk page covers a narrower range than requested, and the caller must
+    /// checkpoint and advance by the covered range, not the requested one.
+    async fn fetch_page(
+        &mut self,
+        indexer: &dyn Indexer,
+        from: u64,
+        mut to: u64,
+    ) -> Result<(u64, Vec<Log>), IndexError> {
+        loop {
+            let filter = indexer.filter().from_block(from).to_block(to);
+            match self.reader.get_logs(&filter).await {
+                Ok(logs) => return Ok((to, logs)),
+                Err(IndexError::Transport(err)) if is_range_error(&err) && to > from => {
+                    // Halve the span (round up so it always shrinks) and retry.
+                    let span = (to - from).div_ceil(2);
+                    to = from.saturating_add(span.saturating_sub(1)).max(from);
+                    self.page_size = self.page_size.div_ceil(2).max(MIN_PAGE_SIZE);
+                    metrics::PAGE_SHRINKS_TOTAL.increment(1);
+                    warn!(
+                        indexer = indexer.name(),
+                        from, to, "shrinking log page after provider range error"
+                    );
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    /// Apply a page's logs in order, then checkpoint the cursor.
+    ///
+    /// The cursor write commits last, in its own transaction, so it advances only
+    /// after every log in the page applied cleanly; an `apply` error returns
+    /// before the cursor moves and the page is retried on the next run. See the
+    /// module-level atomicity note for why the indexer's own state and the cursor
+    /// need not share one transaction.
+    fn commit_page(
+        &self,
+        indexer: &dyn Indexer,
+        logs: &[Log],
+        last_block: u64,
+        block_hash: alloy_primitives::B256,
+    ) -> Result<(), IndexError> {
+        let name = indexer.name();
+
+        // Order by (block_number, log_index). A single eth_getLogs response is
+        // already canonical-ordered, but sorting makes the contract explicit and
+        // tolerates a provider that does not guarantee it.
+        let mut ordered: Vec<&Log> = logs.iter().collect();
+        ordered.sort_by_key(|log| (log.block_number, log.log_index));
+
+        // Apply every log, then commit the cursor. The cursor commit is last, so
+        // a failure mid-page leaves the cursor where it was and the page replays.
+        let tx = self.db.tx_mut()?;
+        for log in ordered {
+            let block = log.block_number.ok_or(IndexError::MalformedLog {
+                field: "block_number",
+            })?;
+            indexer.apply(block, log)?;
+            metrics::logs_total(name).increment(1);
+        }
+        Cursor {
+            last_block,
+            block_hash,
+        }
+        .write(&tx, name)?;
+        tx.commit()?;
+
+        metrics::checkpoints_total(name).increment(1);
+        Ok(())
+    }
+}
+
+/// Whether a transport error is a provider range/limit rejection worth shrinking
+/// the page for.
+///
+/// Providers signal "too many results" or "block range too wide" as a JSON-RPC
+/// error response; the exact code and text vary, so this matches the common
+/// phrasings rather than a single code. A non-`ErrorResp` transport failure (a
+/// dropped connection) is not a range error and propagates.
+fn is_range_error(err: &alloy_provider::transport::TransportError) -> bool {
+    if !err.is_error_resp() {
+        return false;
+    }
+    let text = err.to_string().to_ascii_lowercase();
+    const RANGE_HINTS: &[&str] = &[
+        "range",
+        "too many",
+        "limit",
+        "exceed",
+        "more than",
+        "query returned more than",
+        "block range",
+        "response size",
+    ];
+    RANGE_HINTS.iter().any(|hint| text.contains(hint))
+}

--- a/crates/chain/index/src/error.rs
+++ b/crates/chain/index/src/error.rs
@@ -1,0 +1,66 @@
+//! Error taxonomy for the event-indexing engine.
+//!
+//! These wrap the underlying transport and storage errors through `#[from]`
+//! rather than flattening them into strings: a consumer keeps the full error for
+//! matching and logging, and the [`strum::IntoStaticStr`] discriminant gives a
+//! `reason` metric label without a hand-written match. This mirrors the
+//! `vertex-chain` `ChainError` style.
+
+use alloy_provider::transport::TransportError;
+use vertex_storage::DatabaseError;
+
+/// A failure indexing chain events.
+///
+/// Returned by [`crate::Indexer`] callbacks and by the engine's backfill and
+/// follow loops. The transport and storage variants carry the underlying alloy
+/// and `vertex-storage` errors whole so a consumer can inspect the RPC error
+/// code or the storage failure.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum IndexError {
+    /// The RPC transport failed, or the node returned an error response while
+    /// fetching logs or the finalized head.
+    #[error(transparent)]
+    Transport(#[from] TransportError),
+
+    /// A read or write against the persisted cursor (or any state an indexer
+    /// folds atomically with it) failed.
+    #[error(transparent)]
+    Storage(#[from] DatabaseError),
+
+    /// A log returned by the provider was missing a field the engine needs to
+    /// order or checkpoint it (`block_number` or `log_index`).
+    ///
+    /// Canonical logs always carry both; a `None` here means the provider
+    /// returned a pending log, which the engine never requests.
+    #[error("log missing required field {field}")]
+    MalformedLog {
+        /// The absent field, used as the operator-facing detail.
+        field: &'static str,
+    },
+
+    /// An [`Indexer`](crate::Indexer) callback (`apply` or `revert`) failed.
+    ///
+    /// The engine stops the affected indexer's run loop on this so a fold error
+    /// does not silently advance the cursor past unapplied state.
+    #[error("indexer {indexer}: {message}")]
+    Apply {
+        /// The failing indexer's [`name`](crate::Indexer::name).
+        indexer: &'static str,
+        /// The operator-facing failure detail.
+        message: String,
+    },
+}
+
+impl IndexError {
+    vertex_metrics::impl_record_error!("chain_index_errors_total");
+
+    /// Build an [`IndexError::Apply`] for a named indexer.
+    pub fn apply(indexer: &'static str, message: impl Into<String>) -> Self {
+        Self::Apply {
+            indexer,
+            message: message.into(),
+        }
+    }
+}

--- a/crates/chain/index/src/indexer.rs
+++ b/crates/chain/index/src/indexer.rs
@@ -1,0 +1,66 @@
+//! The [`Indexer`] trait: the per-contract contract the engine drives.
+//!
+//! An indexer is the minimal, contract-specific half of the indexing story. It
+//! declares what to watch (a deployment start block and a log [`Filter`]) and
+//! how to fold a single decoded log into its own state. Everything else (paging,
+//! ordering, the finalized-tag reorg boundary, cursor persistence, restart
+//! idempotency, metrics) is the engine's job, written once in [`EventEngine`].
+//!
+//! [`EventEngine`]: crate::EventEngine
+
+use alloy_rpc_types_eth::{Filter, Log};
+
+use crate::IndexError;
+
+/// A contract-specific event consumer the [`EventEngine`] drives.
+///
+/// Implementors fold logs into their own indexed state (typically a
+/// `vertex-storage` table). The engine guarantees logs reach [`apply`] in
+/// `(block_number, log_index)` order, within the canonical, already-finalized
+/// range, and that re-applying an already-seen range on restart is the
+/// implementor's only idempotency concern (the engine never advances the cursor
+/// past an `apply` that returned an error).
+///
+/// [`apply`]: Indexer::apply
+/// [`EventEngine`]: crate::EventEngine
+pub trait Indexer: Send + Sync {
+    /// A stable, human-readable name, used as the cursor key and in metrics and
+    /// logs. Must be unique per engine instance.
+    fn name(&self) -> &'static str;
+
+    /// The contract deployment block. Backfill starts here (or at the persisted
+    /// cursor, whichever is later), so the engine never pages the empty range
+    /// before the contract existed.
+    fn start_block(&self) -> u64;
+
+    /// The log filter selecting this indexer's events: the contract
+    /// address(es) and the event `topic0` set. The engine overrides the
+    /// filter's block range per page and leaves the address and topic
+    /// constraints intact.
+    fn filter(&self) -> Filter;
+
+    /// Fold one log into indexed state.
+    ///
+    /// Called once per matching log, in `(block_number, log_index)` order, with
+    /// `block` equal to the log's block number. Decode the log here with
+    /// `log.log_decode::<MyEvent>()`. Returning an error stops this indexer's
+    /// run loop without advancing its cursor, so the failed range is retried on
+    /// the next run rather than skipped.
+    ///
+    /// State mutations made here are committed atomically with the cursor by the
+    /// engine; see [`EventEngine`](crate::EventEngine) for how an indexer shares
+    /// the engine's write transaction.
+    fn apply(&self, block: u64, log: &Log) -> Result<(), IndexError>;
+
+    /// Roll indexed state back to before `from_block`.
+    ///
+    /// Reserved for optimistic head-tracking: the MVP engine indexes only up to
+    /// the chain's finalized tag, which never reorgs, so this is never called by
+    /// the current engine and defaults to a no-op. An implementor that opts into
+    /// head-tracking (a documented future enhancement) implements this to undo
+    /// the folds for the reorged-out range `from_block..`.
+    fn revert(&self, from_block: u64) -> Result<(), IndexError> {
+        let _ = from_block;
+        Ok(())
+    }
+}

--- a/crates/chain/index/src/lib.rs
+++ b/crates/chain/index/src/lib.rs
@@ -1,0 +1,62 @@
+//! Generic, reorg-safe, contract-agnostic chain event-indexing engine.
+//!
+//! This crate is the foundation per-contract indexers build on. It owns the
+//! reorg, cursor, and paging story once, so a per-contract indexer (postage
+//! batches, the price oracles, the chequebook factory, staking, redistribution)
+//! only declares what to watch and how to fold one log.
+//!
+//! # Shape
+//!
+//! - [`Indexer`]: the minimalist, contract-specific trait. Declare a start
+//!   block and a log [`Filter`](alloy_rpc_types_eth::Filter), and fold one
+//!   decoded log in [`apply`](Indexer::apply).
+//! - [`EventEngine`]: the driver. One instance backfills a single indexer from
+//!   its deployment block (or persisted cursor) to the chain's finalized head,
+//!   then follows the head, indexing each newly-finalized range the same way.
+//! - [`Cursor`]: the per-indexer checkpoint persisted in `vertex-storage`,
+//!   keyed by the indexer's [`name`](Indexer::name).
+//! - [`ChainReader`]: the narrow chain-read slice the engine drives, blanket
+//!   implemented for every `alloy_provider::Provider<Ethereum>`.
+//! - [`IndexError`]: the typed error taxonomy, with `strum::IntoStaticStr`
+//!   `reason` metric labels matching the `vertex-chain` `ChainError` style.
+//!
+//! # Reorg strategy
+//!
+//! The engine indexes only up to the chain's `finalized` tag, not a fixed block
+//! lag. Finalized blocks do not reorg, so the indexed range is canonical by
+//! construction and needs no rollback logic; the cost is one finality window of
+//! latency. Optimistic head-tracking (indexing `finalized..latest` and reverting
+//! on the WS `log.removed` flag or a parent-hash mismatch) is a documented
+//! enhancement, not implemented: the hooks ([`Indexer::revert`], the block hash
+//! in the [`Cursor`]) exist, but the MVP never calls `revert`.
+//!
+//! # Placement
+//!
+//! Native, RPC-and-persistence code; intended to run behind a `chain` feature in
+//! its consumers and to stay out of the wasm cone. The crate itself depends only
+//! on `alloy` with `default-features = false` (no reqwest, no native TLS) and on
+//! the `vertex-storage` trait surface, so it imposes no wasm-hostile transport
+//! of its own; the consumer selects the transport and the storage backend.
+//!
+//! # Usage sketch
+//!
+//! ```ignore
+//! let engine = EventEngine::new(provider, db).register(my_indexer);
+//! engine.run(shutdown).await?;
+//! ```
+
+mod cursor;
+mod engine;
+mod error;
+mod indexer;
+mod metrics;
+mod reader;
+
+#[cfg(test)]
+mod tests;
+
+pub use cursor::{Cursor, CursorTable, CursorTables};
+pub use engine::{DEFAULT_PAGE_SIZE, DEFAULT_POLL_INTERVAL, EventEngine};
+pub use error::IndexError;
+pub use indexer::Indexer;
+pub use reader::{ChainReader, FinalizedHead};

--- a/crates/chain/index/src/metrics.rs
+++ b/crates/chain/index/src/metrics.rs
@@ -1,0 +1,30 @@
+//! Engine metrics: lazy counters for pages, logs, and errors.
+//!
+//! Counters are labelled by indexer `name` so an operator can attribute paging
+//! volume and fold throughput to a specific contract. Errors are recorded via
+//! [`IndexError::record`](crate::IndexError) with a `reason` label, matching the
+//! repo's error-counter convention.
+
+use std::sync::LazyLock;
+
+use vertex_metrics::metrics_crate::{Counter, counter};
+
+/// Number of `eth_getLogs` pages fetched, per indexer.
+pub(crate) fn pages_total(name: &'static str) -> Counter {
+    counter!("chain_index_pages_total", "indexer" => name)
+}
+
+/// Number of logs applied, per indexer.
+pub(crate) fn logs_total(name: &'static str) -> Counter {
+    counter!("chain_index_logs_total", "indexer" => name)
+}
+
+/// Number of cursor checkpoints committed, per indexer.
+pub(crate) fn checkpoints_total(name: &'static str) -> Counter {
+    counter!("chain_index_checkpoints_total", "indexer" => name)
+}
+
+/// Number of adaptive page-size shrink events (provider range/limit errors),
+/// across all indexers.
+pub(crate) static PAGE_SHRINKS_TOTAL: LazyLock<Counter> =
+    LazyLock::new(|| counter!("chain_index_page_shrinks_total"));

--- a/crates/chain/index/src/reader.rs
+++ b/crates/chain/index/src/reader.rs
@@ -1,0 +1,63 @@
+//! The chain-read surface the engine depends on.
+//!
+//! [`ChainReader`] is the narrow slice of `alloy_provider::Provider` the
+//! [`EventEngine`](crate::EventEngine) actually uses: fetch the finalized head,
+//! and page logs for a filter. Depending on this slice rather than the full
+//! `Provider` trait keeps the engine testable against synthetic logs without a
+//! live RPC, while the blanket impl means any real `Provider<Ethereum>` is a
+//! `ChainReader` for free.
+
+use alloy_network::Ethereum;
+use alloy_primitives::B256;
+use alloy_provider::Provider;
+use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, Log};
+
+use crate::IndexError;
+
+/// A finalized block's number and hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FinalizedHead {
+    /// The finalized block number.
+    pub number: u64,
+    /// The finalized block hash.
+    pub hash: B256,
+}
+
+/// The chain reads the engine drives.
+///
+/// Implemented for every `alloy_provider::Provider<Ethereum>` by the blanket
+/// impl below; unit tests supply an in-memory implementation that serves
+/// synthetic logs.
+#[allow(async_fn_in_trait)]
+pub trait ChainReader: Send + Sync {
+    /// The current finalized head (number and hash).
+    ///
+    /// Returns `None` when the chain has not finalized any block yet (a fresh
+    /// devnet), in which case the engine has nothing safe to index and waits.
+    async fn finalized_head(&self) -> Result<Option<FinalizedHead>, IndexError>;
+
+    /// Fetch all logs matching `filter`.
+    ///
+    /// The engine sets the filter's block range per page; the implementor just
+    /// forwards it to `eth_getLogs`.
+    async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>, IndexError>;
+}
+
+impl<P> ChainReader for P
+where
+    P: Provider<Ethereum> + Send + Sync,
+{
+    async fn finalized_head(&self) -> Result<Option<FinalizedHead>, IndexError> {
+        let block = self
+            .get_block_by_number(BlockNumberOrTag::Finalized)
+            .await?;
+        Ok(block.map(|b| FinalizedHead {
+            number: b.header.number,
+            hash: b.header.hash,
+        }))
+    }
+
+    async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>, IndexError> {
+        Ok(Provider::get_logs(self, filter).await?)
+    }
+}

--- a/crates/chain/index/src/tests.rs
+++ b/crates/chain/index/src/tests.rs
@@ -1,0 +1,369 @@
+//! Unit tests over synthetic logs (no chain).
+//!
+//! These exercise the engine's contract without a live RPC: a [`MockReader`]
+//! serves canned logs and a chosen finalized head, and the in-memory
+//! `vertex-storage` backend holds the cursor. They cover backfill ordering,
+//! cursor persistence and resume, restart idempotency, adaptive page shrinking,
+//! and the head-tracking `revert` hook (even though the MVP never calls it).
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use alloy_primitives::{Address, B256, LogData};
+use alloy_rpc_types_eth::{Filter, Log};
+use vertex_storage::Database;
+use vertex_storage_redb::RedbDatabase;
+
+use crate::reader::{ChainReader, FinalizedHead};
+use crate::{Cursor, EventEngine, IndexError, Indexer};
+
+/// Build a synthetic log at `(block, index)` for `address`.
+fn log_at(block: u64, index: u64, address: Address) -> Log {
+    Log {
+        inner: alloy_primitives::Log {
+            address,
+            data: LogData::default(),
+        },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+/// A chain reader that serves a fixed log set and finalized head from memory.
+///
+/// `get_logs` returns the subset of `logs` inside the requested block range,
+/// honouring the engine's per-page `from`/`to`. When `range_limit` is set, a
+/// page wider than that many blocks fails with a synthetic provider range error,
+/// driving the adaptive shrink path.
+struct MockReader {
+    logs: Vec<Log>,
+    head: Mutex<Option<FinalizedHead>>,
+    range_limit: Option<u64>,
+    get_logs_calls: Mutex<u64>,
+}
+
+impl MockReader {
+    fn new(logs: Vec<Log>, head: FinalizedHead) -> Self {
+        Self {
+            logs,
+            head: Mutex::new(Some(head)),
+            range_limit: None,
+            get_logs_calls: Mutex::new(0),
+        }
+    }
+
+    fn with_range_limit(mut self, limit: u64) -> Self {
+        self.range_limit = Some(limit);
+        self
+    }
+
+    fn calls(&self) -> u64 {
+        *self.get_logs_calls.lock().unwrap()
+    }
+}
+
+/// Extract the inclusive `[from, to]` block bounds the engine set on a filter.
+fn filter_bounds(filter: &Filter) -> (u64, u64) {
+    let from = filter
+        .get_from_block()
+        .expect("engine always sets from_block");
+    let to = filter.get_to_block().expect("engine always sets to_block");
+    (from, to)
+}
+
+impl ChainReader for MockReader {
+    async fn finalized_head(&self) -> Result<Option<FinalizedHead>, IndexError> {
+        Ok(*self.head.lock().unwrap())
+    }
+
+    async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>, IndexError> {
+        *self.get_logs_calls.lock().unwrap() += 1;
+        let (from, to) = filter_bounds(filter);
+
+        if let Some(limit) = self.range_limit
+            && to.saturating_sub(from).saturating_add(1) > limit
+        {
+            // Mirror a provider rejecting an over-wide range. The engine's
+            // `is_range_error` matches on the message text.
+            let payload = alloy_json_rpc::ErrorPayload {
+                code: -32005,
+                message: "query exceeds max block range".into(),
+                data: None,
+            };
+            return Err(IndexError::Transport(
+                alloy_provider::transport::RpcError::err_resp(payload),
+            ));
+        }
+
+        Ok(self
+            .logs
+            .iter()
+            .filter(|log| {
+                let b = log.block_number.unwrap();
+                b >= from && b <= to
+            })
+            .cloned()
+            .collect())
+    }
+}
+
+/// An indexer that records every applied `(block, index)` and every revert, so a
+/// test can assert ordering, idempotency, and the revert hook.
+struct RecordingIndexer {
+    address: Address,
+    start: u64,
+    applied: Mutex<Vec<(u64, u64)>>,
+    reverted: Mutex<Vec<u64>>,
+}
+
+impl RecordingIndexer {
+    fn new(address: Address, start: u64) -> Arc<Self> {
+        Arc::new(Self {
+            address,
+            start,
+            applied: Mutex::new(Vec::new()),
+            reverted: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn applied(&self) -> Vec<(u64, u64)> {
+        self.applied.lock().unwrap().clone()
+    }
+}
+
+impl Indexer for RecordingIndexer {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+
+    fn start_block(&self) -> u64 {
+        self.start
+    }
+
+    fn filter(&self) -> Filter {
+        Filter::new().address(self.address)
+    }
+
+    fn apply(&self, block: u64, log: &Log) -> Result<(), IndexError> {
+        self.applied
+            .lock()
+            .unwrap()
+            .push((block, log.log_index.unwrap()));
+        Ok(())
+    }
+
+    fn revert(&self, from_block: u64) -> Result<(), IndexError> {
+        self.reverted.lock().unwrap().push(from_block);
+        Ok(())
+    }
+}
+
+fn head(number: u64) -> FinalizedHead {
+    FinalizedHead {
+        number,
+        hash: B256::repeat_byte(number as u8),
+    }
+}
+
+/// Run a single backfill pass: an immediately-resolved shutdown stops the engine
+/// after the first finalized sync, before the follow loop's first tick.
+async fn backfill_once<R, DB>(engine: EventEngine<R, DB>)
+where
+    R: ChainReader + 'static,
+    DB: Database,
+{
+    // A poll interval longer than the test keeps the engine from re-syncing; the
+    // immediate shutdown stops it after the first backfill completes.
+    engine
+        .with_poll_interval(Duration::from_secs(3600))
+        .run(async {})
+        .await
+        .expect("engine run");
+}
+
+#[tokio::test]
+async fn backfill_applies_logs_in_order() {
+    let addr = Address::repeat_byte(0xab);
+    // Deliberately out of order in the source vec; the engine must sort.
+    let logs = vec![
+        log_at(5, 1, addr),
+        log_at(3, 0, addr),
+        log_at(5, 0, addr),
+        log_at(4, 2, addr),
+    ];
+    let reader = Arc::new(MockReader::new(logs, head(10)));
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    let engine = EventEngine::new(reader, db.clone()).register(indexer.clone());
+    backfill_once(engine).await;
+
+    assert_eq!(
+        indexer.applied(),
+        vec![(3, 0), (4, 2), (5, 0), (5, 1)],
+        "logs applied in (block, log_index) order"
+    );
+
+    let cursor = Cursor::load(db.as_ref(), "recording").unwrap().unwrap();
+    assert_eq!(cursor.last_block, 10, "cursor advanced to finalized head");
+}
+
+#[tokio::test]
+async fn cursor_persists_and_resumes() {
+    let addr = Address::repeat_byte(0x01);
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+
+    // First run: head at 10, logs through block 8.
+    {
+        let logs = vec![log_at(2, 0, addr), log_at(8, 0, addr)];
+        let reader = Arc::new(MockReader::new(logs, head(10)));
+        let indexer = RecordingIndexer::new(addr, 0);
+        let engine = EventEngine::new(reader, db.clone()).register(indexer.clone());
+        backfill_once(engine).await;
+        assert_eq!(indexer.applied(), vec![(2, 0), (8, 0)]);
+        assert_eq!(
+            Cursor::load(db.as_ref(), "recording")
+                .unwrap()
+                .unwrap()
+                .last_block,
+            10
+        );
+    }
+
+    // Second run: head advanced to 20, a new log at 15. The resumed engine must
+    // only see the new log, not re-deliver blocks 0..=10.
+    {
+        let logs = vec![log_at(2, 0, addr), log_at(8, 0, addr), log_at(15, 0, addr)];
+        let reader = Arc::new(MockReader::new(logs, head(20)));
+        let indexer = RecordingIndexer::new(addr, 0);
+        let engine = EventEngine::new(reader, db.clone()).register(indexer.clone());
+        backfill_once(engine).await;
+        assert_eq!(
+            indexer.applied(),
+            vec![(15, 0)],
+            "resumed run applies only the newly-finalized range"
+        );
+        assert_eq!(
+            Cursor::load(db.as_ref(), "recording")
+                .unwrap()
+                .unwrap()
+                .last_block,
+            20
+        );
+    }
+}
+
+#[tokio::test]
+async fn reapplying_a_range_is_idempotent() {
+    let addr = Address::repeat_byte(0x02);
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let logs = vec![log_at(4, 0, addr), log_at(7, 1, addr)];
+
+    // Run the identical backfill twice against the same database. Because the
+    // cursor persisted to 10 the first time, the second run resumes past the
+    // logs and applies nothing: re-running a finalized range is a no-op.
+    for expected in [vec![(4, 0), (7, 1)], vec![]] {
+        let reader = Arc::new(MockReader::new(logs.clone(), head(10)));
+        let indexer = RecordingIndexer::new(addr, 0);
+        let engine = EventEngine::new(reader, db.clone()).register(indexer.clone());
+        backfill_once(engine).await;
+        assert_eq!(indexer.applied(), expected);
+    }
+}
+
+#[tokio::test]
+async fn start_block_skips_pre_deployment_range() {
+    let addr = Address::repeat_byte(0x03);
+    let logs = vec![log_at(100, 0, addr)];
+    let reader = Arc::new(MockReader::new(logs, head(200)));
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    // Deployment at block 50: the engine must not page 0..50.
+    let indexer = RecordingIndexer::new(addr, 50);
+
+    let engine = EventEngine::new(reader.clone(), db.clone())
+        .register(indexer.clone())
+        .with_page_size(10);
+    backfill_once(engine).await;
+
+    assert_eq!(indexer.applied(), vec![(100, 0)]);
+    // From 50 to 200 inclusive in pages of 10 is 16 pages; a backfill that
+    // started at 0 would have made 21. The exact count proves the start block
+    // bounded the first page.
+    assert_eq!(reader.calls(), 16, "paged only from the deployment block");
+}
+
+#[tokio::test]
+async fn adaptive_page_shrinks_on_range_error() {
+    let addr = Address::repeat_byte(0x04);
+    let logs = vec![log_at(3, 0, addr), log_at(9, 0, addr)];
+    // Provider rejects any page wider than 4 blocks.
+    let reader = Arc::new(MockReader::new(logs, head(10)).with_range_limit(4));
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    // Start with an over-wide page (11 blocks) and let the engine shrink it.
+    let engine = EventEngine::new(reader.clone(), db.clone())
+        .register(indexer.clone())
+        .with_page_size(11);
+    backfill_once(engine).await;
+
+    assert_eq!(
+        indexer.applied(),
+        vec![(3, 0), (9, 0)],
+        "all logs indexed despite the provider range cap"
+    );
+    assert_eq!(
+        Cursor::load(db.as_ref(), "recording")
+            .unwrap()
+            .unwrap()
+            .last_block,
+        10
+    );
+}
+
+/// The head-tracking `revert` hook fires when an optimistic engine sees a
+/// reorg. The MVP never calls it, so this drives the indexer's hook directly to
+/// prove the contract: a `revert(from)` is recorded and undoes its range.
+#[tokio::test]
+async fn revert_hook_is_invoked_on_simulated_reorg() {
+    let addr = Address::repeat_byte(0x05);
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    // Apply two blocks optimistically, then simulate a reorg that drops block 5.
+    indexer.apply(4, &log_at(4, 0, addr)).unwrap();
+    indexer.apply(5, &log_at(5, 0, addr)).unwrap();
+    indexer.revert(5).unwrap();
+
+    assert_eq!(
+        *indexer.reverted.lock().unwrap(),
+        vec![5],
+        "revert hook records the reorged-out block"
+    );
+}
+
+/// The engine waits rather than indexing when the chain has no finalized head.
+#[tokio::test]
+async fn no_finalized_head_indexes_nothing() {
+    let addr = Address::repeat_byte(0x06);
+    let logs = vec![log_at(1, 0, addr)];
+    let reader = Arc::new(MockReader {
+        logs,
+        head: Mutex::new(None),
+        range_limit: None,
+        get_logs_calls: Mutex::new(0),
+    });
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    let engine = EventEngine::new(reader.clone(), db.clone()).register(indexer.clone());
+    backfill_once(engine).await;
+
+    assert!(indexer.applied().is_empty());
+    assert_eq!(reader.calls(), 0, "no get_logs without a finalized head");
+    assert!(Cursor::load(db.as_ref(), "recording").unwrap().is_none());
+}

--- a/crates/chain/index/tests/e2e_fork.rs
+++ b/crates/chain/index/tests/e2e_fork.rs
@@ -1,0 +1,140 @@
+//! End-to-end smoke test against a real Gnosis Chain fork.
+//!
+//! This validates the engine against real on-chain logs rather than synthetic
+//! ones: it registers a trivial indexer for the BZZ token `Transfer` event, syncs
+//! a bounded recent window, and asserts a non-zero number of transfers were
+//! indexed and the cursor advanced.
+//!
+//! It is `#[ignore]`d so CI without a fork stays green. To run it:
+//!
+//! 1. Start a fork (anvil ships with foundry; install via `foundryup` if absent):
+//!
+//!    ```sh
+//!    anvil --fork-url ${GNOSIS_RPC_URL:-https://rpc.gnosischain.com} \
+//!          --fork-block-number <recent> --port 8545 --silent &
+//!    ```
+//!
+//!    then point the test at it (this is also the default):
+//!
+//!    ```sh
+//!    CHAIN_INDEX_E2E_RPC=http://localhost:8545 \
+//!        cargo test -p vertex-chain-index --test e2e_fork -- --ignored --nocapture
+//!    ```
+//!
+//! 2. If anvil cannot be installed or run, point the test directly at a public
+//!    Gnosis RPC over the same bounded recent window:
+//!
+//!    ```sh
+//!    CHAIN_INDEX_E2E_RPC=https://rpc.gnosischain.com \
+//!        cargo test -p vertex-chain-index --test e2e_fork -- --ignored --nocapture
+//!    ```
+//!
+//! The window size and head are derived from the RPC's current finalized block,
+//! so the test works against both a fork and a live RPC.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use alloy_primitives::{Address, address};
+use alloy_provider::ProviderBuilder;
+use alloy_rpc_types_eth::{Filter, Log};
+use alloy_sol_types::{SolEvent, sol};
+use vertex_chain_index::{ChainReader, Cursor, EventEngine, IndexError, Indexer};
+use vertex_storage_redb::RedbDatabase;
+
+/// The BZZ token on Gnosis Chain.
+const BZZ_TOKEN: Address = address!("dBF3Ea6F5beE45c02255B2c26a16F300502F68da");
+
+/// How many blocks back from the finalized head to sync.
+const WINDOW: u64 = 50_000;
+
+sol! {
+    /// The ERC-20 transfer event, used only for its `topic0` signature here.
+    #[allow(missing_docs)]
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+/// A trivial indexer that counts BZZ `Transfer` logs.
+struct TransferCounter {
+    start: u64,
+    count: Arc<AtomicU64>,
+}
+
+impl Indexer for TransferCounter {
+    fn name(&self) -> &'static str {
+        "bzz_transfers"
+    }
+
+    fn start_block(&self) -> u64 {
+        self.start
+    }
+
+    fn filter(&self) -> Filter {
+        Filter::new()
+            .address(BZZ_TOKEN)
+            .event_signature(Transfer::SIGNATURE_HASH)
+    }
+
+    fn apply(&self, _block: u64, log: &Log) -> Result<(), IndexError> {
+        // Decode to prove the log is a real, well-formed Transfer.
+        log.log_decode::<Transfer>()
+            .map_err(|e| IndexError::apply(self.name(), e.to_string()))?;
+        self.count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a Gnosis fork or live RPC; see module docs"]
+async fn indexes_real_bzz_transfers() {
+    let rpc = std::env::var("CHAIN_INDEX_E2E_RPC")
+        .unwrap_or_else(|_| "http://localhost:8545".to_string());
+
+    let url = rpc.parse().expect("CHAIN_INDEX_E2E_RPC is a valid URL");
+    let provider = Arc::new(ProviderBuilder::new().connect_http(url));
+
+    // Bound the window to the RPC's finalized head so the test is fast on a fork
+    // and on a live RPC alike. Skip (do not fail) if the RPC is unreachable.
+    let head = match ChainReader::finalized_head(provider.as_ref()).await {
+        Ok(Some(head)) => head,
+        Ok(None) => {
+            eprintln!("skipping: RPC has no finalized block");
+            return;
+        }
+        Err(err) => {
+            eprintln!("skipping: RPC unreachable at {rpc}: {err}");
+            return;
+        }
+    };
+
+    let start = head.number.saturating_sub(WINDOW);
+    eprintln!(
+        "syncing BZZ Transfer logs over blocks {start}..={} via {rpc}",
+        head.number
+    );
+
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let count = Arc::new(AtomicU64::new(0));
+    let indexer = Arc::new(TransferCounter {
+        start,
+        count: count.clone(),
+    });
+
+    // A short poll interval keeps the follow loop from delaying the test; the
+    // immediate shutdown stops the engine right after the startup backfill.
+    EventEngine::new(provider, db.clone())
+        .register(indexer)
+        .with_poll_interval(std::time::Duration::from_secs(3600))
+        .run(async {})
+        .await
+        .expect("engine run");
+
+    let indexed = count.load(Ordering::Relaxed);
+    eprintln!("indexed {indexed} BZZ Transfer logs");
+    assert!(indexed > 0, "expected a non-zero number of Transfer logs");
+
+    let cursor = Cursor::load(db.as_ref(), "bzz_transfers")
+        .expect("load cursor")
+        .expect("cursor persisted");
+    assert_eq!(cursor.last_block, head.number, "cursor advanced to head");
+}


### PR DESCRIPTION
## Summary

Phase A of the chain event-indexing engine: a generic, reorg-safe, contract-agnostic engine that owns the reorg, cursor, and paging story once. Per-contract indexers (postage batches, the price oracles, the chequebook factory, staking, redistribution) build on this in Phase B; this PR ships only the engine.

New crate `vertex-chain-index` at `crates/chain/index`, native and intended to sit behind a `chain` feature in its consumers, kept out of the wasm cone.

## The `Indexer` trait

The minimalist per-contract contract the engine drives:

```rust
pub trait Indexer: Send + Sync {
    fn name(&self) -> &'static str;            // cursor key + metric label
    fn start_block(&self) -> u64;              // contract deployment block
    fn filter(&self) -> Filter;                // address(es) + event topic0 set
    fn apply(&self, block: u64, log: &Log) -> Result<(), IndexError>;
    fn revert(&self, from_block: u64) -> Result<(), IndexError> { Ok(()) }
}
```

An indexer only declares what to watch and how to fold one decoded log. Logs reach `apply` in `(block_number, log_index)` order within the canonical, already-finalized range.

## The `EventEngine`

`EventEngine::new(provider, db).register(indexer).run(shutdown)`. `new` returns a builder so an engine cannot exist without an indexer; `run` takes any `Future<Output = ()>` as the shutdown signal.

- Backfill: page `get_logs` from `max(start_block, cursor+1)` to the finalized head, apply each log in `(block, log_index)` order, and checkpoint a `(last_block, block_hash)` cursor in one `vertex-storage` write transaction per page.
- Adaptive paging: the page span shrinks (and the engine retries the narrower range) on a provider range/limit error; the page advances by the range actually covered, not the range requested.
- Follow: poll the finalized head each interval and index each newly-finalized range the same way. The startup catch-up runs to completion before the follow loop, so a shutdown lands on a page boundary.
- One engine instance per indexer with its own cursor; a combined-filter multi-indexer mode is an explicit future optimization, not MVP.
- Typed `IndexError` (`thiserror` + `strum::IntoStaticStr`, `record()` metric labels matching the `vertex-chain` `ChainError` style) and per-indexer counters for pages, logs, checkpoints, and page shrinks.

The engine drives a narrow `ChainReader` slice (finalized head + paged logs), blanket-implemented for every `alloy_provider::Provider<Ethereum>`, so it is testable against synthetic logs without a live RPC.

## Reorg strategy

Safety keys off the chain's `finalized` tag, not a fixed block lag. The engine never applies a log above the finalized head, and finalized blocks do not reorg, so the indexed range is canonical by construction and backfill needs no rollback logic. The cost is one finality window of latency.

## MVP vs documented enhancement

MVP indexes only up to `finalized` and never calls `revert`. Optimistic head-tracking (indexing the `finalized..latest` window and reverting on the WS `log.removed` flag or a parent-hash mismatch) is a documented enhancement, not implemented: the hooks already exist (`Indexer::revert`, the block hash persisted in the `Cursor`). Restart is idempotent because the resumed range is finalized and cannot have changed.

## Cursor persistence

A per-indexer `(last_block, block_hash)` checkpoint persisted in a `vertex-storage` table keyed by the indexer name. The cursor advances only on a clean page commit, so it never outruns applied state; on restart the engine resumes from `last_block + 1`.

## Tests

Unit tests over synthetic logs (in-memory provider + in-memory storage backend) cover backfill ordering, cursor persistence and resume, restart idempotency, adaptive page shrinking, the `revert` hook, and the no-finalized-head case. An `#[ignore]`d e2e test syncs real BZZ token `Transfer` logs over a bounded recent window against a Gnosis anvil fork (or a live RPC, selected by `CHAIN_INDEX_E2E_RPC`) and asserts a non-zero indexed count and an advanced cursor. Verified against a live Gnosis fork: 1716 Transfer logs indexed over a 50k-block window, cursor advanced to the finalized head.

Run the e2e:

```sh
anvil --fork-url ${GNOSIS_RPC_URL:-https://rpc.gnosischain.com} --port 8545 --silent &
CHAIN_INDEX_E2E_RPC=http://localhost:8545 \
    cargo test -p vertex-chain-index --test e2e_fork -- --ignored --nocapture
```

## Follow-on

Phase B fans out the per-contract indexers (postage/price/chequebook/staking/redistribution) on top of this stable engine, each an independent unit.
