### PR TITLE
feat(chain): swap price oracle indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,6 +8364,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-chain-index-swap-price"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "nectar-contracts",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "vertex-chain-index",
+ "vertex-storage",
+ "vertex-storage-redb",
+]
+
+[[package]]
 name = "vertex-ffi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
     # Chain (Ethereum RPC access)
     "crates/chain",
     "crates/chain/index",
+    "crates/chain/index-swap-price",
 
     # FFI (native embedding surface)
     "crates/ffi",
@@ -238,6 +239,7 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 # chain (Ethereum RPC access)
 vertex-chain = { path = "crates/chain" }
 vertex-chain-index = { path = "crates/chain/index" }
+vertex-chain-index-swap-price = { path = "crates/chain/index-swap-price" }
 
 # ffi (native embedding surface)
 vertex-ffi = { path = "crates/ffi" }

--- a/crates/chain/index-swap-price/Cargo.toml
+++ b/crates/chain/index-swap-price/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "vertex-chain-index-swap-price"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Swap (settlement) price oracle indexer: folds PriceUpdate and ChequeValueDeductionUpdate into a vertex-storage projection"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The generic engine drives this indexer; the `Indexer` trait and `IndexError`
+# come from here.
+vertex-chain-index = { workspace = true }
+# The projection table lives behind the `Database`/`DbTx` traits.
+vertex-storage = { workspace = true }
+
+# nectar: the canonical `ISwapPriceOracle` event bindings and the
+# `SWAP_PRICE_ORACLE` deployment constants (address + deployment block).
+nectar-contracts = { workspace = true }
+
+# alloy: `U256` for the projected values, the `Filter`/`Log` types the
+# `Indexer` trait speaks, and `SolEvent` for decoding. `default-features =
+# false` keeps reqwest and native TLS out so the crate stays wasm-clean; it
+# carries no transport of its own.
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true }
+alloy-sol-types = { workspace = true }
+
+# serialization: the projected row derives serde.
+serde = { workspace = true, features = ["derive"] }
+
+# derive macros
+thiserror = { workspace = true }
+
+[dev-dependencies]
+# In-memory backend for the synthetic-log unit tests.
+vertex-storage-redb = { workspace = true }
+# A full provider with an HTTP transport for the ignored e2e fork test, plus
+# the engine and its reader trait to drive a real sync, and the request/call
+# types for the direct `getPrice()` cross-check.
+alloy-provider = { workspace = true, features = ["reqwest"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/chain/index-swap-price/src/indexer.rs
+++ b/crates/chain/index-swap-price/src/indexer.rs
@@ -1,0 +1,133 @@
+//! The [`SwapPriceIndexer`]: folds swap price oracle events into the projection.
+//!
+//! The swap (settlement) price oracle publishes two scalars the node reads when
+//! pricing settlement cheques: the BZZ/xDAI exchange rate (`PriceUpdate`) and the
+//! cheque value deduction (`ChequeValueDeductionUpdate`). This indexer watches
+//! both, decodes each log, and folds it into the [`SwapPriceTable`] projection.
+//!
+//! The fold is pure and idempotent: `apply` writes only to the projection table,
+//! never calls into accounting or any other domain, and a replayed finalized log
+//! re-applies to the same row with the same value. Reacting to a rate change (for
+//! example re-pricing a cheque) is the consumer's job, done lazily by reading the
+//! projection at its own decision point; this crate stays domain-agnostic.
+
+use std::sync::Arc;
+
+use alloy_rpc_types_eth::{Filter, Log};
+use alloy_sol_types::SolEvent;
+use nectar_contracts::{ISwapPriceOracle, SwapPriceOracle};
+use vertex_chain_index::{IndexError, Indexer};
+use vertex_storage::{Database, Tables};
+
+use crate::projection::{LogPosition, SwapPriceField, SwapPriceTables, apply_update};
+
+/// A stable, human-readable name; also the cursor key and metric label.
+const INDEXER_NAME: &str = "swap_price_oracle";
+
+/// Indexes the swap (settlement) price oracle into a [`SwapPriceTable`].
+///
+/// Construct with [`SwapPriceIndexer::new`] from a `nectar_contracts`
+/// [`SwapPriceOracle`] deployment (its address and deployment block) and a
+/// `vertex-storage` [`Database`], then register it with the engine:
+///
+/// ```ignore
+/// use nectar_contracts::mainnet;
+/// let indexer = SwapPriceIndexer::new(mainnet::SWAP_PRICE_ORACLE, db.clone());
+/// indexer.init()?;
+/// let engine = EventEngine::new(provider, db).register(Arc::new(indexer));
+/// ```
+///
+/// [`SwapPriceTable`]: crate::SwapPriceTable
+pub struct SwapPriceIndexer<DB> {
+    deployment: SwapPriceOracle,
+    db: Arc<DB>,
+}
+
+impl<DB: Database> SwapPriceIndexer<DB> {
+    /// Build an indexer for a swap price oracle deployment over a database.
+    ///
+    /// `deployment` carries the contract address and its deployment block, so the
+    /// same constructor serves mainnet and testnet from the canonical
+    /// `nectar_contracts` constants.
+    pub fn new(deployment: SwapPriceOracle, db: Arc<DB>) -> Self {
+        Self { deployment, db }
+    }
+
+    /// Create the projection table if it does not exist.
+    ///
+    /// The engine initializes its own cursor table; the indexer owns its
+    /// projection table, so a consumer calls this once before the first run. It
+    /// is idempotent.
+    pub fn init(&self) -> Result<(), IndexError> {
+        SwapPriceTables::init(self.db.as_ref())?;
+        Ok(())
+    }
+
+    /// Decode one log and return the field and value it updates, or `None` if the
+    /// log is not one of the two indexed events.
+    ///
+    /// Split out from [`apply`](Indexer::apply) so the decode is unit-testable in
+    /// isolation and `apply` stays a thin store-the-result fold.
+    fn decode(log: &Log) -> Result<Option<(SwapPriceField, alloy_primitives::U256)>, IndexError> {
+        let Some(topic0) = log.topic0() else {
+            return Ok(None);
+        };
+
+        if *topic0 == ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH {
+            let decoded = log
+                .log_decode::<ISwapPriceOracle::PriceUpdate>()
+                .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?;
+            Ok(Some((SwapPriceField::ExchangeRate, decoded.inner.price)))
+        } else if *topic0 == ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH {
+            let decoded = log
+                .log_decode::<ISwapPriceOracle::ChequeValueDeductionUpdate>()
+                .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?;
+            Ok(Some((
+                SwapPriceField::ChequeValueDeduction,
+                decoded.inner.chequeValueDeduction,
+            )))
+        } else {
+            // The filter selects only these two topics, but the contract also
+            // emits `OwnershipTransferred`; tolerate an unrelated log by ignoring
+            // it rather than erroring the run loop.
+            Ok(None)
+        }
+    }
+}
+
+impl<DB: Database> Indexer for SwapPriceIndexer<DB> {
+    fn name(&self) -> &'static str {
+        INDEXER_NAME
+    }
+
+    fn start_block(&self) -> u64 {
+        self.deployment.block
+    }
+
+    fn filter(&self) -> Filter {
+        Filter::new()
+            .address(self.deployment.address)
+            .event_signature(vec![
+                ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH,
+                ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH,
+            ])
+    }
+
+    fn apply(&self, block: u64, log: &Log) -> Result<(), IndexError> {
+        let Some((field, value)) = Self::decode(log)? else {
+            return Ok(());
+        };
+
+        let log_index = log
+            .log_index
+            .ok_or(IndexError::apply(INDEXER_NAME, "log missing log_index"))?;
+        let pos = LogPosition { block, log_index };
+
+        // Pure projection write: store the value at its source position, guarded
+        // so a replayed or reordered log never rolls the row back. No side
+        // effects, no reactions; a consumer reads the projection lazily.
+        self.db
+            .update(|tx| apply_update(tx, field, value, pos))
+            .map_err(IndexError::from)
+    }
+}

--- a/crates/chain/index-swap-price/src/lib.rs
+++ b/crates/chain/index-swap-price/src/lib.rs
@@ -1,0 +1,55 @@
+//! Swap (settlement) price oracle indexer for Vertex.
+//!
+//! A per-contract [`Indexer`](vertex_chain_index::Indexer) for the swap price
+//! oracle, driven by the generic [`vertex-chain-index`](vertex_chain_index)
+//! engine. It folds the oracle's two events into a small `vertex-storage`
+//! projection a consumer reads lazily.
+//!
+//! # What it indexes
+//!
+//! The swap price oracle publishes the two scalars the node needs to price
+//! settlement cheques:
+//!
+//! - `PriceUpdate(uint256 price)` sets the swap exchange rate.
+//! - `ChequeValueDeductionUpdate(uint256 chequeValueDeduction)` sets the cheque
+//!   value deduction.
+//!
+//! The event bindings and the contract's deployment constants (address and
+//! deployment block, for Gnosis Chain mainnet and Sepolia testnet) come from
+//! `nectar_contracts`, so the address book is not duplicated here.
+//!
+//! # The projection
+//!
+//! State lands in the [`SwapPriceTable`], a two-row table keyed by
+//! [`SwapPriceField`]: one row for the exchange rate, one for the deduction. Each
+//! row records the value and the `(block, log_index)` that set it. Read the
+//! current values with [`read_field`].
+//!
+//! # Pure, idempotent fold (no reactions)
+//!
+//! [`SwapPriceIndexer::apply`](vertex_chain_index::Indexer::apply) is a pure fold
+//! into the projection: it writes only the projection table, never calls into
+//! accounting, the storer, or any other domain, and re-applying a finalized log
+//! produces the same row. A consumer that wants to react to a rate change (say,
+//! re-pricing a cheque) does so lazily by reading the projection at its own
+//! decision point. The chain crate stays domain-agnostic; reactions are the
+//! consumer's job. See `CHAIN_REACTIONS_DESIGN.md`.
+//!
+//! # Placement
+//!
+//! Native, RPC-and-persistence code intended to run behind a `chain` feature in
+//! its consumers and to stay out of the wasm cone. Like the engine, it depends
+//! on `alloy` with `default-features = false` and carries no transport of its
+//! own.
+
+mod indexer;
+mod projection;
+
+pub use indexer::SwapPriceIndexer;
+pub use projection::{
+    LogPosition, SwapPriceField, SwapPriceRow, SwapPriceTable, SwapPriceTables, apply_update,
+    read_field,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/chain/index-swap-price/src/projection.rs
+++ b/crates/chain/index-swap-price/src/projection.rs
@@ -1,0 +1,134 @@
+//! The swap price oracle projection: a `vertex-storage` table holding the
+//! current exchange rate and cheque value deduction.
+//!
+//! The projection is the indexed state the [`SwapPriceIndexer`] folds into. It
+//! is a tiny, single-contract table with exactly two logical rows, keyed by
+//! [`SwapPriceField`]:
+//!
+//! - [`SwapPriceField::ExchangeRate`] holds the latest `PriceUpdate` price.
+//! - [`SwapPriceField::ChequeValueDeduction`] holds the latest
+//!   `ChequeValueDeductionUpdate` deduction.
+//!
+//! Each row records the value together with the `(block, log_index)` of the log
+//! that set it. That source position makes the fold idempotent and monotonic: a
+//! replayed finalized log re-applies to the same row with the same value, and a
+//! log that is not strictly newer than the stored one is ignored, so reordering
+//! or replay can never roll the projection back to a stale value. The engine
+//! delivers logs in `(block, log_index)` order and only over the canonical
+//! finalized range, so the stored position only ever moves forward in a clean
+//! run; the guard is the belt-and-braces that keeps replay a no-op.
+//!
+//! [`SwapPriceIndexer`]: crate::SwapPriceIndexer
+
+use alloy_primitives::U256;
+use serde::{Deserialize, Serialize};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table, Tables};
+
+vertex_storage::table!(
+    pub SwapPriceTable,
+    "swap_price_oracle",
+    SwapPriceField,
+    SwapPriceRow
+);
+
+/// The set of tables this indexer persists, for one-shot initialization.
+pub struct SwapPriceTables;
+
+impl Tables for SwapPriceTables {
+    const NAMES: &'static [&'static str] = &[SwapPriceTable::NAME];
+}
+
+/// Which projected value a row holds.
+///
+/// The table has one row per variant: the swap exchange rate and the cheque
+/// value deduction are independent on-chain values, each updated by its own
+/// event, so they project to independent rows that never contend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum SwapPriceField {
+    /// The swap exchange rate, set by `PriceUpdate`.
+    ExchangeRate = 0,
+    /// The cheque value deduction, set by `ChequeValueDeductionUpdate`.
+    ChequeValueDeduction = 1,
+}
+
+impl Encode for SwapPriceField {
+    type Encoded = [u8; 1];
+
+    fn encode(self) -> Self::Encoded {
+        [self as u8]
+    }
+}
+
+impl Decode for SwapPriceField {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        match value {
+            [0] => Ok(Self::ExchangeRate),
+            [1] => Ok(Self::ChequeValueDeduction),
+            _ => Err(DatabaseError::Decode),
+        }
+    }
+}
+
+/// A single projected value with the chain position that set it.
+///
+/// `source` is the `(block, log_index)` of the log that produced `value`. It is
+/// the idempotency key: a fold only overwrites a row when the incoming log is
+/// strictly newer (see [`SwapPriceRow::superseded_by`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SwapPriceRow {
+    /// The current value (an exchange rate or a deduction, per the row's key).
+    pub value: U256,
+    /// The `(block_number, log_index)` of the log that set `value`.
+    pub source: LogPosition,
+}
+
+impl SwapPriceRow {
+    /// Whether a log at `pos` should overwrite this row.
+    ///
+    /// True only when `pos` is strictly after the stored source. Equal positions
+    /// (a replayed log) and earlier positions (a reordered log) are no-ops, which
+    /// is what makes the fold idempotent and monotonic.
+    pub fn superseded_by(&self, pos: LogPosition) -> bool {
+        pos > self.source
+    }
+}
+
+/// A log's canonical position: `(block_number, log_index)`.
+///
+/// Ordered lexicographically, matching the order the engine delivers logs in, so
+/// `>` on a [`LogPosition`] means "strictly later in the canonical stream".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LogPosition {
+    /// The block the log was emitted in.
+    pub block: u64,
+    /// The log's index within its block.
+    pub log_index: u64,
+}
+
+/// Read the current value of `field` from the projection, if it has been set.
+pub fn read_field<DB: Database>(
+    db: &DB,
+    field: SwapPriceField,
+) -> Result<Option<SwapPriceRow>, DatabaseError> {
+    db.view(|tx| tx.get::<SwapPriceTable>(field))
+}
+
+/// Fold a single update into `field`: write `value` at `pos`, unless an existing
+/// row was set by a strictly-newer log.
+///
+/// This is the pure projection step shared by both events. It is idempotent: a
+/// replayed or reordered log that is not strictly newer than the stored source
+/// leaves the row unchanged.
+pub fn apply_update<TX: DbTxMut>(
+    tx: &TX,
+    field: SwapPriceField,
+    value: U256,
+    pos: LogPosition,
+) -> Result<(), DatabaseError> {
+    if let Some(existing) = tx.get::<SwapPriceTable>(field)?
+        && !existing.superseded_by(pos)
+    {
+        return Ok(());
+    }
+    tx.put::<SwapPriceTable>(field, SwapPriceRow { value, source: pos })
+}

--- a/crates/chain/index-swap-price/src/tests.rs
+++ b/crates/chain/index-swap-price/src/tests.rs
@@ -1,0 +1,275 @@
+//! Unit tests over synthetic logs (no chain).
+//!
+//! These build canonical swap-price-oracle logs by ABI-encoding the two events,
+//! fold them through [`SwapPriceIndexer::apply`], and assert the projection holds
+//! the decoded value. They also assert the fold is idempotent (replay is a no-op)
+//! and monotonic (a stale, reordered log never rolls the row back), and that an
+//! unrelated topic is ignored.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, LogData, U256};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use nectar_contracts::{ISwapPriceOracle, SwapPriceOracle};
+use vertex_chain_index::Indexer;
+use vertex_storage_redb::RedbDatabase;
+
+use crate::indexer::SwapPriceIndexer;
+use crate::projection::{LogPosition, SwapPriceField, read_field};
+
+/// The contract address used in the synthetic logs.
+const ORACLE: Address = Address::repeat_byte(0x5a);
+
+/// A deployment fixture: the test oracle address, deployment block 0.
+fn deployment() -> SwapPriceOracle {
+    SwapPriceOracle::new(ORACLE, 0)
+}
+
+/// Build an indexer over a fresh in-memory database with its table created.
+fn fresh_indexer() -> (SwapPriceIndexer<RedbDatabase>, Arc<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = SwapPriceIndexer::new(deployment(), db.clone());
+    indexer.init().expect("init projection table");
+    (indexer, db)
+}
+
+/// A synthetic `PriceUpdate` log at `(block, index)` carrying `price`.
+fn price_update_log(block: u64, index: u64, price: U256) -> Log {
+    let event = ISwapPriceOracle::PriceUpdate { price };
+    log_for(
+        block,
+        index,
+        event.encode_topics_array::<1>()[0].into(),
+        event,
+    )
+}
+
+/// A synthetic `ChequeValueDeductionUpdate` log at `(block, index)`.
+fn deduction_log(block: u64, index: u64, deduction: U256) -> Log {
+    let event = ISwapPriceOracle::ChequeValueDeductionUpdate {
+        chequeValueDeduction: deduction,
+    };
+    log_for(
+        block,
+        index,
+        event.encode_topics_array::<1>()[0].into(),
+        event,
+    )
+}
+
+/// Wrap an encoded event into an RPC [`Log`] at a chosen position.
+fn log_for<E: SolEvent>(block: u64, index: u64, topic0: B256, event: E) -> Log {
+    let topics = vec![topic0];
+    let data = event.encode_data().into();
+    Log {
+        inner: alloy_primitives::Log {
+            address: ORACLE,
+            data: LogData::new_unchecked(topics, data),
+        },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+#[test]
+fn filter_selects_both_event_topics() {
+    let (indexer, _db) = fresh_indexer();
+    let filter = indexer.filter();
+    // The filter's topic0 set selects exactly the two indexed events.
+    assert!(
+        filter.topics[0].matches(&ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH),
+        "filter selects PriceUpdate"
+    );
+    assert!(
+        filter.topics[0].matches(&ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH),
+        "filter selects ChequeValueDeductionUpdate"
+    );
+}
+
+#[test]
+fn price_update_folds_into_exchange_rate() {
+    let (indexer, db) = fresh_indexer();
+    let rate = U256::from(123_456_789_u64);
+
+    indexer
+        .apply(40_000_000, &price_update_log(40_000_000, 2, rate))
+        .expect("apply price update");
+
+    let row = read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+        .expect("read")
+        .expect("rate row present");
+    assert_eq!(row.value, rate);
+    assert_eq!(
+        row.source,
+        LogPosition {
+            block: 40_000_000,
+            log_index: 2
+        }
+    );
+    // The deduction row is untouched.
+    assert!(
+        read_field(db.as_ref(), SwapPriceField::ChequeValueDeduction)
+            .expect("read")
+            .is_none()
+    );
+}
+
+#[test]
+fn deduction_update_folds_into_deduction_row() {
+    let (indexer, db) = fresh_indexer();
+    let deduction = U256::from(42_u64);
+
+    indexer
+        .apply(40_000_100, &deduction_log(40_000_100, 0, deduction))
+        .expect("apply deduction update");
+
+    let row = read_field(db.as_ref(), SwapPriceField::ChequeValueDeduction)
+        .expect("read")
+        .expect("deduction row present");
+    assert_eq!(row.value, deduction);
+    assert!(
+        read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+            .expect("read")
+            .is_none()
+    );
+}
+
+#[test]
+fn both_events_project_independently() {
+    let (indexer, db) = fresh_indexer();
+    let rate = U256::from(1_000_u64);
+    let deduction = U256::from(7_u64);
+
+    indexer.apply(100, &price_update_log(100, 0, rate)).unwrap();
+    indexer
+        .apply(101, &deduction_log(101, 0, deduction))
+        .unwrap();
+
+    assert_eq!(
+        read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+            .unwrap()
+            .unwrap()
+            .value,
+        rate
+    );
+    assert_eq!(
+        read_field(db.as_ref(), SwapPriceField::ChequeValueDeduction)
+            .unwrap()
+            .unwrap()
+            .value,
+        deduction
+    );
+}
+
+#[test]
+fn reapplying_the_same_log_is_idempotent() {
+    let (indexer, db) = fresh_indexer();
+    let rate = U256::from(555_u64);
+    let log = price_update_log(200, 3, rate);
+
+    // Apply the identical finalized log twice: the second is a no-op replay.
+    indexer.apply(200, &log).unwrap();
+    let after_first = read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+        .unwrap()
+        .unwrap();
+    indexer.apply(200, &log).unwrap();
+    let after_second = read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(after_first, after_second, "replay leaves the row unchanged");
+}
+
+#[test]
+fn newer_log_supersedes_and_stale_log_is_ignored() {
+    let (indexer, db) = fresh_indexer();
+    let old = U256::from(10_u64);
+    let new = U256::from(20_u64);
+
+    // A later log wins.
+    indexer.apply(300, &price_update_log(300, 0, old)).unwrap();
+    indexer.apply(305, &price_update_log(305, 0, new)).unwrap();
+    assert_eq!(
+        read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+            .unwrap()
+            .unwrap()
+            .value,
+        new
+    );
+
+    // Re-delivering the older log (a reorder/replay) must not roll the row back.
+    indexer.apply(300, &price_update_log(300, 0, old)).unwrap();
+    let row = read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.value, new,
+        "stale log does not overwrite the newer value"
+    );
+    assert_eq!(
+        row.source,
+        LogPosition {
+            block: 305,
+            log_index: 0
+        }
+    );
+}
+
+#[test]
+fn same_block_higher_log_index_supersedes() {
+    let (indexer, db) = fresh_indexer();
+
+    indexer
+        .apply(400, &price_update_log(400, 0, U256::from(1_u64)))
+        .unwrap();
+    indexer
+        .apply(400, &price_update_log(400, 5, U256::from(2_u64)))
+        .unwrap();
+
+    let row = read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.value, U256::from(2_u64));
+    assert_eq!(row.source.log_index, 5);
+}
+
+#[test]
+fn unrelated_topic_is_ignored() {
+    let (indexer, db) = fresh_indexer();
+
+    // A log whose topic0 matches neither event (here `OwnershipTransferred`'s
+    // shape is irrelevant; any other topic must be a no-op).
+    let other = Log {
+        inner: alloy_primitives::Log {
+            address: ORACLE,
+            data: LogData::new_unchecked(vec![B256::repeat_byte(0xff)], Default::default()),
+        },
+        block_hash: Some(B256::repeat_byte(1)),
+        block_number: Some(500),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(0),
+        removed: false,
+    };
+
+    indexer
+        .apply(500, &other)
+        .expect("unrelated log is ignored");
+    assert!(
+        read_field(db.as_ref(), SwapPriceField::ExchangeRate)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        read_field(db.as_ref(), SwapPriceField::ChequeValueDeduction)
+            .unwrap()
+            .is_none()
+    );
+}

--- a/crates/chain/index-swap-price/tests/e2e_fork.rs
+++ b/crates/chain/index-swap-price/tests/e2e_fork.rs
@@ -1,0 +1,164 @@
+//! End-to-end smoke test against a real Gnosis Chain fork (or live RPC).
+//!
+//! This validates the swap-price-oracle indexer against real on-chain state: it
+//! syncs the [`SwapPriceIndexer`] over a bounded recent window, asserts the
+//! engine reaches the finalized head and the cursor advances, and cross-checks
+//! the projection against a direct `getPrice()` contract call at the head.
+//!
+//! # A note on this contract's events
+//!
+//! The Gnosis mainnet swap (settlement) price oracle
+//! (`0xA57A50a831B31c904A770edBCb706E03afCdbd94`) sets its price and deduction in
+//! its constructor and, as of this writing, has never emitted a `PriceUpdate` or
+//! `ChequeValueDeductionUpdate`: `getPrice()` returns the constructor values
+//! (price `100000`, deduction `100`) and a full-lifetime `eth_getLogs` over the
+//! two event topics returns nothing. So the cross-check is two-sided:
+//!
+//! - If the synced window contains updates, the projected exchange rate must
+//!   equal the on-chain `getPrice().price` (the projection tracks the chain).
+//! - If it contains none (the live mainnet case), the projection stays empty and
+//!   the on-chain `getPrice()` still returns a value, proving the indexer is
+//!   wired to the right contract and the engine reached head over real data.
+//!
+//! Set `SWAP_PRICE_E2E_FROM_DEPLOYMENT=1` to sync the whole contract lifetime
+//! instead of a recent window; on a fork that proxies `eth_getLogs` upstream this
+//! is slow but exercises the full backfill.
+//!
+//! It is `#[ignore]`d so CI without a fork stays green. To run it:
+//!
+//! 1. Start a fork (anvil ships with foundry; install via `foundryup` if absent).
+//!    Use a UNIQUE port (8547) so it does not collide with sibling indexers:
+//!
+//!    ```sh
+//!    anvil --fork-url ${GNOSIS_RPC_URL:-https://rpc.gnosischain.com} \
+//!          --fork-block-number <recent> --port 8547 --silent &
+//!    SWAP_PRICE_E2E_RPC=http://localhost:8547 \
+//!        cargo test -p vertex-chain-index-swap-price --test e2e_fork \
+//!        -- --ignored --nocapture
+//!    ```
+//!
+//! 2. If anvil cannot be run, point the test at a public Gnosis RPC directly:
+//!
+//!    ```sh
+//!    SWAP_PRICE_E2E_RPC=https://rpc.gnosischain.com \
+//!        cargo test -p vertex-chain-index-swap-price --test e2e_fork \
+//!        -- --ignored --nocapture
+//!    ```
+
+use std::sync::Arc;
+
+use alloy_primitives::{TxKind, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types_eth::{BlockId, TransactionInput, TransactionRequest};
+use alloy_sol_types::{SolCall, SolValue};
+use nectar_contracts::{ISwapPriceOracle, SwapPriceOracle, mainnet};
+use vertex_chain_index::{ChainReader, Cursor, EventEngine};
+use vertex_chain_index_swap_price::{SwapPriceField, SwapPriceIndexer, read_field};
+use vertex_storage_redb::RedbDatabase;
+
+/// How many blocks back from the finalized head to sync by default. A modest
+/// window keeps a fork-proxied backfill fast; set
+/// `SWAP_PRICE_E2E_FROM_DEPLOYMENT=1` to sync the whole contract lifetime.
+const WINDOW: u64 = 100_000;
+
+#[tokio::test]
+#[ignore = "requires a Gnosis fork or live RPC; see module docs"]
+async fn indexes_real_swap_price_oracle() {
+    let rpc =
+        std::env::var("SWAP_PRICE_E2E_RPC").unwrap_or_else(|_| "http://localhost:8547".to_string());
+
+    let url = rpc.parse().expect("SWAP_PRICE_E2E_RPC is a valid URL");
+    let provider = Arc::new(ProviderBuilder::new().connect_http(url));
+
+    // Bound the window to the RPC's finalized head. Skip (do not fail) if the RPC
+    // is unreachable so the test is a smoke check, not a hard dependency.
+    let head = match ChainReader::finalized_head(provider.as_ref()).await {
+        Ok(Some(head)) => head,
+        Ok(None) => {
+            eprintln!("skipping: RPC has no finalized block");
+            return;
+        }
+        Err(err) => {
+            eprintln!("skipping: RPC unreachable at {rpc}: {err}");
+            return;
+        }
+    };
+
+    let deployment = mainnet::SWAP_PRICE_ORACLE;
+    let from_deployment = std::env::var("SWAP_PRICE_E2E_FROM_DEPLOYMENT").is_ok();
+    let start = if from_deployment {
+        deployment.block
+    } else {
+        head.number.saturating_sub(WINDOW).max(deployment.block)
+    };
+    let oracle = SwapPriceOracle::new(deployment.address, start);
+    eprintln!(
+        "syncing swap price oracle {} over blocks {start}..={} via {rpc}",
+        deployment.address, head.number
+    );
+
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = Arc::new(SwapPriceIndexer::new(oracle, db.clone()));
+    indexer.init().expect("init projection table");
+
+    // A long poll interval keeps the follow loop from delaying the test; the
+    // immediate shutdown stops the engine right after the startup backfill.
+    EventEngine::new(provider.clone(), db.clone())
+        .register(indexer)
+        .with_poll_interval(std::time::Duration::from_secs(3600))
+        .run(async {})
+        .await
+        .expect("engine run");
+
+    // The engine fully backfilled to the finalized head: the cursor advanced.
+    let cursor = Cursor::load(db.as_ref(), "swap_price_oracle")
+        .expect("load cursor")
+        .expect("cursor persisted");
+    assert_eq!(cursor.last_block, head.number, "cursor advanced to head");
+
+    let rate = read_field(db.as_ref(), SwapPriceField::ExchangeRate).expect("read rate");
+    let deduction =
+        read_field(db.as_ref(), SwapPriceField::ChequeValueDeduction).expect("read deduction");
+    eprintln!("projected exchange rate: {rate:?}");
+    eprintln!("projected cheque value deduction: {deduction:?}");
+
+    // Read the on-chain values at the head via a direct `getPrice()` call and
+    // decode the returned `(price, chequeValueDeduction)` tuple.
+    let call = ISwapPriceOracle::getPriceCall {};
+    let tx = TransactionRequest {
+        to: Some(TxKind::Call(deployment.address)),
+        input: TransactionInput::new(call.abi_encode().into()),
+        ..Default::default()
+    };
+    let returned = provider
+        .call(tx)
+        .block(BlockId::number(head.number))
+        .await
+        .expect("getPrice eth_call");
+    let (on_chain_price, on_chain_deduction) =
+        <(U256, U256)>::abi_decode(&returned).expect("decode getPrice return");
+    eprintln!("on-chain getPrice() = (price {on_chain_price}, deduction {on_chain_deduction})");
+
+    // Two-sided cross-check (see the module docs): when the window held an
+    // update, the projection must equal the chain; when it held none, the
+    // projection is empty while the chain still reports a value.
+    match rate {
+        Some(row) => assert_eq!(
+            row.value, on_chain_price,
+            "projected exchange rate matches the on-chain getPrice().price",
+        ),
+        None => {
+            assert!(
+                on_chain_price > U256::ZERO,
+                "no PriceUpdate in window, yet the contract reports a price: \
+                 indexer is wired to the right live contract",
+            );
+        }
+    }
+    if let Some(row) = deduction {
+        assert_eq!(
+            row.value, on_chain_deduction,
+            "projected deduction matches the on-chain getPrice().chequeValueDeduction",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `vertex-chain-index-swap-price`, the first per-contract indexer built on the generic, reorg-safe `vertex-chain-index` engine (#300). It indexes the swap (settlement) price oracle on Gnosis Chain (`0xA57A50a831B31c904A770edBCb706E03afCdbd94`, chain id 100) and folds its events into a `vertex-storage` projection a consumer reads lazily.

Part of the chain-indexing initiative: the engine owns reorg/cursor/paging once, and each contract ships a thin `Indexer` that declares what to watch and how to fold one log.

## Events indexed

- `PriceUpdate(uint256 price)` sets the swap exchange rate.
- `ChequeValueDeductionUpdate(uint256 chequeValueDeduction)` sets the cheque value deduction.

The event bindings (`ISwapPriceOracle`) and the deployment constants (address and deployment block, for both Gnosis mainnet and testnet) come from `nectar_contracts`, so the address book is not duplicated here. `OwnershipTransferred` and any other topic are ignored.

## Projection table

`SwapPriceTable` (`"swap_price_oracle"`), a two-row table keyed by `SwapPriceField`:

| Key | Value |
|---|---|
| `ExchangeRate` | `SwapPriceRow { value: U256, source: LogPosition }` |
| `ChequeValueDeduction` | `SwapPriceRow { value: U256, source: LogPosition }` |

Each row records the value and the `(block, log_index)` (`LogPosition`) of the log that set it. Read the current values with `read_field(db, field)`.

## Pure, no-reaction fold

`SwapPriceIndexer::apply` is a pure, idempotent projection step per `CHAIN_REACTIONS_DESIGN.md`:

- It writes **only** the projection table. No side effects, no reactions, no calls into accounting, the storer, or any other domain. The chain crate stays domain-agnostic.
- A replayed finalized log re-applies to the same row with the same value. The stored `source` position guards the write (`apply_update` overwrites only when the incoming log is strictly newer), so a reordered or replayed log never rolls a row back: the fold is idempotent and monotonic.
- Reacting to a rate change (for example re-pricing a cheque) is the consumer's job, done lazily by reading the projection at its own decision point. No `on_event` hook is added.

Placement matches the engine: native, RPC-and-persistence code, `alloy` with `default-features = false`, no transport of its own, kept out of the wasm cone (not a dependency of any wasm-bound crate).

## Tests

- **Unit tests over synthetic logs** (in-memory `vertex-storage` backend): ABI-encode each event into a real `Log`, fold it, and assert the projected value and source. Covers both events projecting independently, idempotent replay (re-applying the same log is a no-op), monotonic supersede (a stale reordered log does not overwrite a newer value; same-block higher `log_index` wins), unrelated-topic ignoring, and topic-filter selection.
- **Env-guarded `#[ignore]`d anvil-fork e2e** on a unique port (8547): syncs a bounded recent window against a real Gnosis fork, asserts the cursor advanced to the finalized head, and cross-checks the projection against a direct `getPrice()` `eth_call` at the head.

### e2e result

Ran against an anvil fork of Gnosis at a recent block (`anvil --fork-url https://rpc.gnosischain.com --port 8547`). The engine backfilled cleanly and the cursor advanced to the finalized head.

This particular swap oracle is a real edge case: it sets its price and deduction in its constructor and, across its entire on-chain lifetime, has emitted **zero** `PriceUpdate` / `ChequeValueDeductionUpdate` logs (a full-lifetime `eth_getLogs` over the two topics returns nothing; its only log ever is the deployment `OwnershipTransferred`). So the e2e cross-check is two-sided: when the window holds an update the projection must equal `getPrice()`, and when it holds none (the live case) the projection stays empty while the on-chain `getPrice()` still reports a value (`price 100000, deduction 100`), proving the indexer is wired to the right live contract and the engine reached head over real data. The synthetic-log unit tests exercise the actual event-capture and fold path that the live contract has not yet triggered.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo test --all-features` on the crate: 8 unit tests pass; the e2e is `#[ignore]`d.
