### PR TITLE
feat(swarm-node): forwarding / multi-hop relay with two-leg accounting (#291)

### DIFF
--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -132,6 +132,19 @@ pub trait SwarmAccountingConfig: Send + Sync {
     }
 }
 
+/// A reserved accounting action awaiting commit or release.
+///
+/// `prepare_receive`/`prepare_provide` return an action that has already
+/// reserved balance. Calling [`apply`](Self::apply) commits the reservation
+/// (the balance change takes effect); dropping the action without applying
+/// releases the reservation. This is the two-leg-relay seam: a forwarder holds
+/// both legs' actions and applies them only when the relay succeeds, so a failed
+/// relay releases every reservation on drop and never leaks.
+pub trait AccountingAction: Send {
+    /// Commit the reserved balance change.
+    fn apply(self);
+}
+
 /// Per-peer bandwidth accounting handle.
 ///
 /// Reached through the [`SwarmBandwidthAccounting::Peer`] associated type
@@ -165,10 +178,10 @@ pub trait SwarmBandwidthAccounting: Send + Sync {
     type Peer: SwarmPeerBandwidth;
 
     /// Action for receiving service (balance decreases).
-    type ReceiveAction: Send;
+    type ReceiveAction: AccountingAction;
 
     /// Action for providing service (balance increases).
-    type ProvideAction: Send;
+    type ProvideAction: AccountingAction;
 
     /// Get the node's identity.
     fn identity(&self) -> &Self::Identity;

--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -142,7 +142,17 @@ pub trait SwarmAccountingConfig: Send + Sync {
 /// relay releases every reservation on drop and never leaks.
 pub trait AccountingAction: Send {
     /// Commit the reserved balance change.
-    fn apply(self);
+    fn apply(self)
+    where
+        Self: Sized;
+
+    /// Commit the reserved balance change through a boxed action.
+    ///
+    /// The object-safe counterpart of [`apply`](Self::apply): a forwarder hands
+    /// an un-applied provide action to the wire-write site as a
+    /// `Box<dyn AccountingAction>` and commits it only once the bytes are on the
+    /// wire. Dropping the box instead releases the reservation.
+    fn apply_boxed(self: Box<Self>);
 }
 
 /// Per-peer bandwidth accounting handle.

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -7,7 +7,7 @@ mod pricing;
 mod topology;
 
 pub use self::bandwidth::{
-    BandwidthMode, Direction, SwarmAccountingConfig, SwarmBandwidthAccounting,
+    AccountingAction, BandwidthMode, Direction, SwarmAccountingConfig, SwarmBandwidthAccounting,
     SwarmClientAccounting, SwarmPeerBandwidth, SwarmPeerState, SwarmSettlementProvider,
 };
 pub use self::localstore::{SwarmLocalStore, SwarmLocalStoreConfig};

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -58,12 +58,13 @@ mod types;
 
 pub use self::accounting::{Au, AuConversionError};
 pub use self::components::{
-    BandwidthMode, BootnodeComponents, ClientComponents, Direction, HasAccounting, HasIdentity,
-    HasStore, HasTopology, StorerComponents, SwarmAccountingConfig, SwarmBandwidthAccounting,
-    SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig, SwarmPeerBandwidth,
-    SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig,
-    SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins, SwarmTopologyCommands,
-    SwarmTopologyPeers, SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats,
+    AccountingAction, BandwidthMode, BootnodeComponents, ClientComponents, Direction,
+    HasAccounting, HasIdentity, HasStore, HasTopology, StorerComponents, SwarmAccountingConfig,
+    SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig,
+    SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder,
+    SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins,
+    SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyRouting, SwarmTopologyState,
+    SwarmTopologyStats,
 };
 pub use self::config::{
     DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN,

--- a/crates/swarm/bandwidth/core/src/accounting/action.rs
+++ b/crates/swarm/bandwidth/core/src/accounting/action.rs
@@ -64,6 +64,10 @@ impl vertex_swarm_api::AccountingAction for ReceiveAction {
     fn apply(self) {
         ReceiveAction::apply(self);
     }
+
+    fn apply_boxed(self: Box<Self>) {
+        ReceiveAction::apply(*self);
+    }
 }
 
 /// Action for providing service to a peer (balance increases).
@@ -112,6 +116,10 @@ impl AccountingAction for ProvideAction {
 impl vertex_swarm_api::AccountingAction for ProvideAction {
     fn apply(self) {
         ProvideAction::apply(self);
+    }
+
+    fn apply_boxed(self: Box<Self>) {
+        ProvideAction::apply(*self);
     }
 }
 

--- a/crates/swarm/bandwidth/core/src/accounting/action.rs
+++ b/crates/swarm/bandwidth/core/src/accounting/action.rs
@@ -60,6 +60,12 @@ impl AccountingAction for ReceiveAction {
     fn cleanup(&self) {}
 }
 
+impl vertex_swarm_api::AccountingAction for ReceiveAction {
+    fn apply(self) {
+        ReceiveAction::apply(self);
+    }
+}
+
 /// Action for providing service to a peer (balance increases).
 ///
 /// Reserves shadow balance on creation; commits on apply(), releases on drop.
@@ -101,6 +107,12 @@ impl AccountingAction for ProvideAction {
     }
 
     fn cleanup(&self) {}
+}
+
+impl vertex_swarm_api::AccountingAction for ProvideAction {
+    fn apply(self) {
+        ProvideAction::apply(self);
+    }
 }
 
 #[cfg(test)]

--- a/crates/swarm/bandwidth/core/src/noop.rs
+++ b/crates/swarm/bandwidth/core/src/noop.rs
@@ -52,6 +52,14 @@ pub struct NoReceiveAction;
 /// No-op provide action (does nothing on apply).
 pub struct NoProvideAction;
 
+impl vertex_swarm_api::AccountingAction for NoReceiveAction {
+    fn apply(self) {}
+}
+
+impl vertex_swarm_api::AccountingAction for NoProvideAction {
+    fn apply(self) {}
+}
+
 impl<I: SwarmIdentity> SwarmBandwidthAccounting for NoAccounting<I> {
     type Identity = I;
     type Peer = NoPeerBandwidth;

--- a/crates/swarm/bandwidth/core/src/noop.rs
+++ b/crates/swarm/bandwidth/core/src/noop.rs
@@ -54,10 +54,14 @@ pub struct NoProvideAction;
 
 impl vertex_swarm_api::AccountingAction for NoReceiveAction {
     fn apply(self) {}
+
+    fn apply_boxed(self: Box<Self>) {}
 }
 
 impl vertex_swarm_api::AccountingAction for NoProvideAction {
     fn apply(self) {}
+
+    fn apply_boxed(self: Box<Self>) {}
 }
 
 impl<I: SwarmIdentity> SwarmBandwidthAccounting for NoAccounting<I> {

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -288,7 +288,7 @@ async fn build_client_backed_node(
         Some(wiring) => node_builder.with_swap_events(wiring.swap_event_sender()),
         None => node_builder,
     };
-    let (node, client_service, client_handle) = node_builder
+    let (mut node, client_service, client_handle) = node_builder
         .build(params.network, peer_store)
         .await
         .map_err(|e| SwarmNodeError::Build(e.into()))?;
@@ -317,6 +317,19 @@ async fn build_client_backed_node(
     };
     #[cfg(not(feature = "swap"))]
     let accounting = accounting_builder.build(params.identity);
+    // Share one accounting instance across the selector, the two-leg forwarder,
+    // and the node task that keeps it alive.
+    let accounting = Arc::new(accounting);
+
+    // Enable multi-hop forwarding: a retrieval cache miss relays to a
+    // strictly-closer peer and an inbound pushsync relays toward the chunk's
+    // neighbourhood, accounting both legs over the same accounting instance the
+    // origin path uses. Installed before the event loop accepts connections.
+    node.enable_forwarding(
+        Arc::new(topology.clone()),
+        Arc::clone(&accounting),
+        client_handle.clone(),
+    );
 
     // Retrieval and pushsync candidate selection consults peer scores and
     // affordability on top of proximity order.

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -173,6 +173,37 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
         self.base.topology_handle()
     }
 
+    /// Enable multi-hop forwarding (relay) for this node.
+    ///
+    /// Installs the real network forwarder in place of the default stub, so a
+    /// retrieval cache miss forwards to a strictly-closer peer and an inbound
+    /// pushsync relays toward the chunk's neighbourhood, accounting both legs.
+    /// Must be called during node assembly, before the event loop accepts
+    /// connections: a handler created earlier would capture the stub.
+    ///
+    /// `topology` selects strictly-closer relay candidates and `accounting`
+    /// drives the two-leg prepare/apply; both are typically the same handles the
+    /// origin path uses.
+    pub fn enable_forwarding<T, A>(
+        &mut self,
+        topology: Arc<T>,
+        accounting: Arc<A>,
+        handle: ClientHandle,
+    ) where
+        T: vertex_swarm_api::SwarmTopologyRouting + Send + Sync + 'static,
+        A: vertex_swarm_api::SwarmClientAccounting + Send + Sync + 'static,
+    {
+        let local = self.overlay_address();
+        let forwarder = Arc::new(crate::protocol::NetworkForwarder::new(
+            local, topology, accounting, handle,
+        ));
+        self.base
+            .swarm
+            .behaviour_mut()
+            .client
+            .set_forwarder(forwarder);
+    }
+
     pub fn topology_command(&mut self, command: TopologyCommand) {
         self.base.swarm.behaviour_mut().topology.on_command(command);
     }

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -115,6 +115,16 @@ impl ClientBehaviour {
         }
     }
 
+    /// Install the multi-hop relay forwarder, replacing the default stub.
+    ///
+    /// Must be called before any peer connects: handlers clone the forwarder at
+    /// connection establishment, so a handler created before this call captures
+    /// the stub. The node builder installs the real forwarder during assembly,
+    /// well before the event loop accepts connections.
+    pub(crate) fn set_forwarder(&mut self, forward: Arc<dyn Forwarder>) {
+        self.forward = forward;
+    }
+
     /// Build a dormant handler for a new connection, sharing the cache and
     /// forwarder into it.
     fn new_handler(&self) -> ClientHandler {
@@ -832,6 +842,351 @@ mod tests {
         assert!(
             result.is_err(),
             "an inbound pushsync with the stub forwarder must reset the stream"
+        );
+    }
+
+    // --- Three-node relay (forwarding) integration tests ---
+    //
+    // These drive the real `NetworkForwarder` through the libp2p harness: node B
+    // sits between requester A and storer C, its forwarder's outbound
+    // `ClientHandle` feeding back into B's own behaviour so the upstream leg is a
+    // genuine A->B->C path. The relay verifies, accounts both legs, caches the
+    // forwarded chunk, and relays the storer's receipt verbatim.
+
+    use vertex_swarm_api::{
+        Au, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmPeerBandwidth, SwarmPricing,
+    };
+    use vertex_swarm_bandwidth::{
+        Accounting, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
+    };
+    use vertex_swarm_identity::Identity;
+    use vertex_swarm_spec::Spec;
+    use vertex_swarm_test_utils::{MockTopology, test_identity_arc};
+
+    use crate::ClientHandle;
+    use crate::protocol::NetworkForwarder;
+
+    type RelayAccounting =
+        ClientAccounting<Arc<Accounting<DefaultBandwidthConfig, Arc<Identity>>>, FixedPricer<Spec>>;
+
+    fn relay_accounting() -> Arc<RelayAccounting> {
+        let bandwidth = Arc::new(Accounting::new(
+            DefaultBandwidthConfig::default(),
+            test_identity_arc(),
+        ));
+        let pricer = FixedPricer::new(10_000, vertex_swarm_spec::init_mainnet());
+        Arc::new(ClientAccounting::new(bandwidth, pricer))
+    }
+
+    /// An overlay sharing `leading_bits` leading bits with `address`.
+    fn overlay_at_proximity(
+        address: &nectar_primitives::ChunkAddress,
+        leading_bits: usize,
+    ) -> OverlayAddress {
+        let mut bytes = address.0.0;
+        let byte = leading_bits / 8;
+        let bit = 7 - (leading_bits % 8);
+        if let Some(b) = bytes.get_mut(byte) {
+            *b ^= 1 << bit;
+        }
+        OverlayAddress::from(bytes)
+    }
+
+    /// Build node B: an empty-cache client whose forwarder relays to `storer`
+    /// (returned by the mock topology) over a `ClientHandle` wired back into B.
+    /// Returns B and the receiver carrying B's own outbound relay commands.
+    fn relay_node(
+        store: Arc<dyn SwarmLocalStore>,
+        local: OverlayAddress,
+        storer: OverlayAddress,
+        accounting: Arc<RelayAccounting>,
+    ) -> (
+        Swarm<ClientBehaviour>,
+        tokio::sync::mpsc::Receiver<ClientCommand>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::channel::<ClientCommand>(16);
+        let handle = ClientHandle::new(tx);
+        let topology = Arc::new(MockTopology::default().with_closest(vec![storer]));
+        let swarm = Swarm::new_ephemeral_tokio(move |_| {
+            let mut behaviour = ClientBehaviour::new(
+                Config::for_role(SwarmNodeType::Client),
+                store,
+                Arc::new(StubForwarder),
+            );
+            let forwarder = Arc::new(NetworkForwarder::new(
+                local,
+                Arc::clone(&topology),
+                Arc::clone(&accounting),
+                handle,
+            ));
+            behaviour.set_forwarder(forwarder);
+            behaviour
+        });
+        (swarm, rx)
+    }
+
+    #[tokio::test]
+    async fn three_node_retrieval_relays_verifies_and_accounts() {
+        let chunk = content_chunk(b"relayed through B from C");
+        let address = *chunk.address();
+
+        // A (requester) is far from the chunk; C (storer) is strictly closer; B's
+        // own overlay is far too, so C is the only strictly-closer candidate.
+        let a_overlay = overlay_at_proximity(&address, 2);
+        let b_overlay = overlay_at_proximity(&address, 3);
+        let c_overlay = overlay_at_proximity(&address, 18);
+
+        let accounting = relay_accounting();
+        let provide_price = accounting.pricing().peer_price(&a_overlay, &address);
+        let receive_price = accounting.pricing().peer_price(&c_overlay, &address);
+
+        // C serves the chunk from its cache; B caches the forwarded delivery; A
+        // holds no store of its own.
+        let c_store: Arc<dyn SwarmLocalStore> =
+            Arc::new(ChunkStore::with_budget(1 << 20, 1_000_000_000));
+        c_store.put(chunk.clone()).unwrap();
+        let b_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
+
+        let mut a = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+        let (mut b, mut b_commands) = relay_node(
+            Arc::clone(&b_store),
+            b_overlay,
+            c_overlay,
+            Arc::clone(&accounting),
+        );
+        let mut c = swarm_with_store(c_store);
+
+        // A <-> B and B <-> C, activated with the chosen overlays.
+        connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
+        connect_and_activate(&mut b, &mut c, b_overlay, c_overlay).await;
+
+        let (tx, mut rx) = oneshot::channel();
+        a.behaviour_mut().on_command(ClientCommand::RetrieveChunk {
+            peer: b_overlay,
+            address,
+            response: tx,
+        });
+
+        // Drive all three swarms; B's forwarder commands are pumped back into B.
+        let result = {
+            let drive = async {
+                loop {
+                    tokio::select! {
+                        _ = a.select_next_some() => {}
+                        _ = b.select_next_some() => {}
+                        _ = c.select_next_some() => {}
+                        Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
+                        res = &mut rx => return res.expect("sender not dropped"),
+                    }
+                }
+            };
+            tokio::time::timeout(Duration::from_secs(10), drive)
+                .await
+                .expect("retrieval resolved within timeout")
+        };
+
+        let delivered = result.expect("A retrieves the chunk through B");
+        assert_eq!(delivered.chunk, chunk, "the chunk arrives intact at A");
+
+        // B accounted both legs: A owes B the provide price, B owes C the receive
+        // price, and the forwarder earned the (positive) spread.
+        assert!(
+            provide_price > receive_price,
+            "the forwarder earns a spread"
+        );
+        assert_eq!(
+            accounting.bandwidth().for_peer(a_overlay).balance(),
+            provide_price,
+            "A is debited for the chunk B served on"
+        );
+        assert_eq!(
+            accounting.bandwidth().for_peer(c_overlay).balance(),
+            Au::ZERO - receive_price,
+            "B is debited for the chunk C served it"
+        );
+
+        // B cached the forwarded delivery: a later get from its store hits.
+        assert!(
+            b_store.get(&address).unwrap().is_some(),
+            "the forwarded chunk is cached at B"
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_without_strictly_closer_peer_resets_rather_than_looping() {
+        // B's only routing candidate is no closer to the chunk than the
+        // requester A, so the loop bound rejects it: B cannot forward sideways or
+        // backwards, the inbound retrieval resets, and A sees a remote failure.
+        // No accounting reservation is taken.
+        let chunk = content_chunk(b"nowhere closer to relay to");
+        let address = *chunk.address();
+
+        let a_overlay = overlay_at_proximity(&address, 12);
+        let b_overlay = overlay_at_proximity(&address, 3);
+        // The candidate B would forward to is farther from the chunk than A.
+        let sideways = overlay_at_proximity(&address, 4);
+
+        let accounting = relay_accounting();
+        let b_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
+
+        let mut a = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+        let (mut b, mut b_commands) = relay_node(
+            Arc::clone(&b_store),
+            b_overlay,
+            sideways,
+            Arc::clone(&accounting),
+        );
+
+        connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
+
+        let (tx, mut rx) = oneshot::channel();
+        a.behaviour_mut().on_command(ClientCommand::RetrieveChunk {
+            peer: b_overlay,
+            address,
+            response: tx,
+        });
+
+        let result = {
+            let drive = async {
+                loop {
+                    tokio::select! {
+                        _ = a.select_next_some() => {}
+                        _ = b.select_next_some() => {}
+                        Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
+                        res = &mut rx => return res.expect("sender not dropped"),
+                    }
+                }
+            };
+            tokio::time::timeout(Duration::from_secs(10), drive)
+                .await
+                .expect("retrieval resolved within timeout")
+        };
+
+        assert!(
+            result.is_err(),
+            "a forward with no strictly-closer peer must reset, not loop"
+        );
+        assert_eq!(
+            accounting.bandwidth().for_peer(a_overlay).balance(),
+            Au::ZERO
+        );
+        assert_eq!(
+            accounting.bandwidth().for_peer(sideways).balance(),
+            Au::ZERO
+        );
+    }
+
+    #[tokio::test]
+    async fn three_node_pushsync_relays_receipt_verbatim_and_accounts() {
+        use alloy_primitives::Signature;
+        use nectar_primitives::Nonce;
+        use vertex_swarm_api::PushReceipt;
+        use vertex_swarm_primitives::{Bin, StorageRadius};
+
+        let chunk = content_chunk(b"pushed through B to C");
+        let address = *chunk.address();
+
+        // A (pusher) is far; B relays to the strictly-closer C; C is the storer
+        // of record. C's forwarder ClientHandle is answered by the test with a
+        // signed receipt, modelling C taking custody and signing. B and C must
+        // relay that receipt VERBATIM (the cache-only client never signs), so A
+        // sees C's exact signature, nonce, and radius.
+        let a_overlay = overlay_at_proximity(&address, 2);
+        let b_overlay = overlay_at_proximity(&address, 3);
+        let c_overlay = overlay_at_proximity(&address, 18);
+
+        // The storer's signed receipt, produced once at C and never re-signed.
+        let mut raw = [0u8; 65];
+        raw[..64].fill(1);
+        raw[64] = 27;
+        let storer_receipt = PushReceipt {
+            storer: c_overlay,
+            signature: Signature::try_from(&raw[..]).expect("valid signature"),
+            nonce: Nonce::from([0x5a; 32]),
+            storage_radius: StorageRadius::new(Bin::new(7).unwrap()),
+        };
+
+        let b_accounting = relay_accounting();
+        let provide_price = b_accounting.pricing().peer_price(&a_overlay, &address);
+        let receive_price = b_accounting.pricing().peer_price(&c_overlay, &address);
+
+        let b_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
+        let c_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
+
+        let mut a = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+        let (mut b, mut b_commands) = relay_node(
+            Arc::clone(&b_store),
+            b_overlay,
+            c_overlay,
+            Arc::clone(&b_accounting),
+        );
+        // C relays to a notional deeper node; the test answers C's outbound push
+        // command directly with the signed receipt, so C is the effective storer.
+        let deeper = overlay_at_proximity(&address, 24);
+        let c_accounting = relay_accounting();
+        let (mut c, mut c_commands) = relay_node(
+            Arc::clone(&c_store),
+            c_overlay,
+            deeper,
+            Arc::clone(&c_accounting),
+        );
+
+        connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
+        connect_and_activate(&mut b, &mut c, b_overlay, c_overlay).await;
+
+        let (tx, mut rx) = oneshot::channel();
+        a.behaviour_mut().on_command(ClientCommand::PushChunk {
+            peer: b_overlay,
+            address,
+            chunk,
+            response: tx,
+        });
+
+        let receipt_for_c = storer_receipt.clone();
+        let result = {
+            let drive = async {
+                loop {
+                    tokio::select! {
+                        _ = a.select_next_some() => {}
+                        _ = b.select_next_some() => {}
+                        _ = c.select_next_some() => {}
+                        // B's relay leg flows through B's own behaviour.
+                        Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
+                        // C is the storer: answer its outbound push with the
+                        // signed receipt instead of forwarding it on.
+                        Some(cmd) = c_commands.recv() => {
+                            if let ClientCommand::PushChunk { response, .. } = cmd {
+                                let _ = response.send(Ok(receipt_for_c.clone()));
+                            }
+                        }
+                        res = &mut rx => return res.expect("sender not dropped"),
+                    }
+                }
+            };
+            tokio::time::timeout(Duration::from_secs(10), drive)
+                .await
+                .expect("push resolved within timeout")
+        };
+
+        let relayed = result.expect("A receives the storer's receipt through B");
+        // The receipt is relayed verbatim across both hops: A sees C's exact
+        // signature, nonce, and radius, never a re-signed value.
+        assert_eq!(relayed.signature, storer_receipt.signature);
+        assert_eq!(relayed.nonce, storer_receipt.nonce);
+        assert_eq!(relayed.storage_radius, storer_receipt.storage_radius);
+
+        // B accounted both legs of the relay.
+        assert!(
+            provide_price > receive_price,
+            "the forwarder earns a spread"
+        );
+        assert_eq!(
+            b_accounting.bandwidth().for_peer(a_overlay).balance(),
+            provide_price
+        );
+        assert_eq!(
+            b_accounting.bandwidth().for_peer(c_overlay).balance(),
+            Au::ZERO - receive_price
         );
     }
 }

--- a/crates/swarm/node/src/protocol/forward.rs
+++ b/crates/swarm/node/src/protocol/forward.rs
@@ -14,22 +14,40 @@
 //!   wants to relay (and is the model the behaviour-level tests drive).
 //! - [`NetworkForwarder`] is the real multi-hop relay: it selects the closest
 //!   peer to the target excluding the requester (and ourselves), enforces the
-//!   forwarding-Kademlia loop bound (never relay to a peer that is not strictly
-//!   closer to the target than the requester) and a hop/TTL bound, reuses the
-//!   existing self-contained outbound futures
+//!   forwarding-Kademlia loop rule (never relay to a peer that is not strictly
+//!   closer to the target, by XOR distance, than both the requester and this
+//!   node), reuses the existing self-contained outbound futures
 //!   ([`ClientHandle::retrieve_chunk`](crate::ClientHandle::retrieve_chunk) /
 //!   [`push_chunk`](crate::ClientHandle::push_chunk)) for the upstream leg, and
 //!   accounts both legs through the prepare/apply reservation actions so a
 //!   forwarder earns the spread. A failed forward drops both reservation actions
-//!   (release-on-drop), so no accounting leaks.
+//!   (release-on-drop), so no accounting leaks. Termination comes from the
+//!   strictly-closer rule (XOR distance decreases monotonically, bounded by the
+//!   address width), not from a hop/TTL counter, which the protocol does not
+//!   carry; [`MAX_FORWARD_CANDIDATES`] only caps per-node retry fan-out.
 //!
-//! Verification lives at both edges. The downstream chunk returned by an
+//! Address verification lives at both edges. The downstream chunk returned by an
 //! upstream retrieval is verified against the requested address here
 //! ([`StampedChunk::verify_answers`] -> [`VerifiedStampedChunk`]) before it is
 //! cached or relayed; the handler additionally verifies before it writes the
-//! chunk to the responder, so an unverified chunk can never travel back to the
-//! requester. A relayed pushsync receipt is checked for structural validity (a
-//! non-empty signature) before it is relayed.
+//! chunk to the responder, so a chunk that does not hash to the requested
+//! address can never travel back to the requester. `verify_answers` is an
+//! address-equality check (BMT integrity for content chunks, signature-recovered
+//! owner for single-owner chunks); it does **not** validate the postage stamp's
+//! funding or expiry, which is a separate postage concern. A relayed pushsync
+//! receipt is checked for structural validity (a non-empty signature) before it
+//! is relayed.
+//!
+//! # Upstream credit is deferred to the wire write
+//!
+//! The two legs are not both committed inside the forwarder. The downstream
+//! `receive` leg is genuinely complete the moment a verified chunk/receipt is in
+//! hand, so it is applied here. The upstream `provide` leg (the requester or
+//! pusher paying us) is *not* applied here: it is returned to the handler as a
+//! boxed [`AccountingAction`] and committed only after the chunk or receipt is
+//! successfully written back to the requester's substream. If that wire write
+//! fails, the handler drops the action, releasing the reservation, so the
+//! requester is never charged for a delivery it did not receive.
 
 use std::sync::Arc;
 
@@ -43,15 +61,18 @@ use vertex_swarm_primitives::{OverlayAddress, StampedChunk};
 
 use crate::ClientHandle;
 
-/// Maximum number of relay hops a single inbound request may traverse from this
-/// node onward.
+/// Maximum number of closer peers this node tries, in order, for a single
+/// inbound request before giving up.
 ///
-/// This is the local TTL bound: each forward selects only strictly-closer peers
-/// (so proximity is monotonically increasing toward the target), which already
-/// makes an infinite loop impossible, and the hop cap is the belt-and-braces
-/// upper bound on the candidate walk this node performs for one request. The
-/// reference walks a small fixed number of closer peers per hop; we mirror that
-/// with a bounded candidate set.
+/// This is a per-node fan-out cap, **not** a per-request hop/TTL counter: it
+/// bounds how many downstream candidates this one node retries for one inbound
+/// request, not the length of the overall A->B->C->... relay chain. Termination
+/// of the chain comes from the strictly-closer rule (every hop must hand the
+/// request to a peer strictly closer to the target by XOR distance than both the
+/// requester and this node), which makes proximity monotonically increase toward
+/// the target and is bounded by the address width, so no per-request hop counter
+/// or visited set is needed. The reference also walks a small fixed number of
+/// closer peers per hop; we mirror that with a bounded candidate set.
 const MAX_FORWARD_CANDIDATES: usize = 3;
 
 /// Why a forward could not complete.
@@ -63,9 +84,10 @@ const MAX_FORWARD_CANDIDATES: usize = 3;
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub(crate) enum ForwardError {
-    /// No peer strictly closer to the target than the requester is available to
-    /// relay to. Covers both the no-candidate case and the loop-prevention
-    /// case (every candidate would forward sideways or backwards in proximity).
+    /// No peer strictly closer to the target than both the requester and this
+    /// node is available to relay to. Covers both the no-candidate case and the
+    /// loop-prevention case (every candidate would forward sideways or backwards
+    /// in distance).
     #[error("no closer peer to forward to")]
     NoCloserPeer,
 
@@ -96,19 +118,64 @@ pub(crate) enum ForwardError {
 /// the inbound serving futures are `Send` too.
 pub(crate) trait Forwarder: Send + Sync {
     /// Retrieve `address` from a closer peer, excluding `exclude`.
+    ///
+    /// On success the downstream `receive` leg is already committed (we did
+    /// receive the chunk), and the un-applied upstream `provide` action is
+    /// returned alongside the chunk: the handler commits it only after the chunk
+    /// is written back to the requester, and drops it (releasing the
+    /// reservation) if that wire write fails.
     fn retrieve(
         &self,
         address: ChunkAddress,
         exclude: OverlayAddress,
-    ) -> BoxFuture<'static, Result<StampedChunk, ForwardError>>;
+    ) -> BoxFuture<'static, Result<ForwardedChunk, ForwardError>>;
 
     /// Push `chunk` to a closer peer, excluding `exclude`, returning the
     /// storer's receipt to relay verbatim.
+    ///
+    /// The upstream `provide` action is returned un-applied for the same
+    /// deferred-commit reason as [`retrieve`](Self::retrieve).
     fn push(
         &self,
         chunk: StampedChunk,
         exclude: OverlayAddress,
-    ) -> BoxFuture<'static, Result<PushReceipt, ForwardError>>;
+    ) -> BoxFuture<'static, Result<ForwardedReceipt, ForwardError>>;
+}
+
+/// A relayed chunk together with the un-applied upstream credit.
+///
+/// The forwarder hands this to the handler, which writes `chunk` back to the
+/// requester and only then commits `provide` (or drops it on a wire-write
+/// failure, releasing the reservation).
+pub(crate) struct ForwardedChunk {
+    /// The verified chunk to write back to the requester.
+    pub(crate) chunk: StampedChunk,
+    /// The un-applied upstream credit; commit after a successful wire write.
+    pub(crate) provide: Box<dyn AccountingAction>,
+}
+
+impl std::fmt::Debug for ForwardedChunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForwardedChunk")
+            .field("chunk", &self.chunk)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A relayed receipt together with the un-applied upstream credit.
+pub(crate) struct ForwardedReceipt {
+    /// The storer's receipt to relay verbatim to the pusher.
+    pub(crate) receipt: PushReceipt,
+    /// The un-applied upstream credit; commit after a successful wire write.
+    pub(crate) provide: Box<dyn AccountingAction>,
+}
+
+impl std::fmt::Debug for ForwardedReceipt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForwardedReceipt")
+            .field("receipt", &self.receipt)
+            .finish_non_exhaustive()
+    }
 }
 
 /// A forwarder that never relays: every relay fails with
@@ -124,7 +191,7 @@ impl Forwarder for StubForwarder {
         &self,
         _address: ChunkAddress,
         _exclude: OverlayAddress,
-    ) -> BoxFuture<'static, Result<StampedChunk, ForwardError>> {
+    ) -> BoxFuture<'static, Result<ForwardedChunk, ForwardError>> {
         Box::pin(async { Err(ForwardError::NoCloserPeer) })
     }
 
@@ -132,7 +199,7 @@ impl Forwarder for StubForwarder {
         &self,
         _chunk: StampedChunk,
         _exclude: OverlayAddress,
-    ) -> BoxFuture<'static, Result<PushReceipt, ForwardError>> {
+    ) -> BoxFuture<'static, Result<ForwardedReceipt, ForwardError>> {
         Box::pin(async { Err(ForwardError::NoCloserPeer) })
     }
 }
@@ -144,17 +211,19 @@ impl Forwarder for StubForwarder {
 /// [`ClientHandle`] so the upstream leg reuses the same self-contained outbound
 /// futures the origin path uses; no separate dial machinery exists.
 ///
-/// # Loop prevention and the hop bound
+/// # Loop prevention and termination
 ///
 /// Forwarding Kademlia routes a request strictly toward the target's
 /// neighbourhood: each hop must hand the request to a peer that is *strictly
-/// closer* to the target than the peer that asked. [`closer_candidates`] filters
-/// the topology's proximity-ordered candidates down to exactly those, excluding
-/// the requester and ourselves. Because proximity to the target is monotonically
-/// increasing along the chain, a request can never cycle back to a peer it has
-/// already visited, so no per-request visited set is needed. The candidate set
-/// is additionally capped at [`MAX_FORWARD_CANDIDATES`] as the local TTL bound on
-/// the walk this node performs for one inbound request.
+/// closer* to the target than the peer that asked **and** strictly closer than
+/// this node itself, measured by full XOR distance (the same `closer` rule the
+/// reference uses, not capped proximity order). [`closer_candidates`] filters the
+/// topology's proximity-ordered candidates down to exactly those, also excluding
+/// the requester and ourselves. Because XOR distance to the target strictly
+/// decreases along the chain, a request can never cycle back to a peer it has
+/// already visited, so no per-request visited set or hop counter is needed; the
+/// chain is bounded by the address width. [`MAX_FORWARD_CANDIDATES`] only caps
+/// the per-node retry fan-out, not the chain length.
 ///
 /// # Two-leg accounting
 ///
@@ -198,29 +267,34 @@ impl<T, A> NetworkForwarder<T, A> {
     }
 }
 
-/// Select the peers strictly closer to `target` than `requester`, excluding the
-/// requester and `local`, in proximity order, capped at [`MAX_FORWARD_CANDIDATES`].
+/// Select the peers strictly closer to `target` than both `requester` and
+/// `local`, excluding the requester and `local`, in proximity order, capped at
+/// [`MAX_FORWARD_CANDIDATES`].
 ///
-/// This is the loop-prevention core: a candidate is kept only when its proximity
-/// to the target is strictly greater than the requester's proximity to the
-/// target. A peer that is at the same or lower proximity than the requester
-/// would route the request sideways or backwards and is dropped, so the request
-/// always advances toward the neighbourhood and can never cycle.
+/// This is the loop-prevention core, and it mirrors the reference's `closer`
+/// rule using **full XOR distance**, not capped proximity order. A candidate is
+/// kept only when it is strictly closer to the target than the requester (so the
+/// request never routes sideways or backwards and can never cycle) **and**
+/// strictly closer than this node (so a node already in the chunk's
+/// neighbourhood does not relay sideways to an equally deep peer, matching the
+/// reference's "closer than me" gate and avoiding the capped-PO plateau where all
+/// deep peers compare equal). Using XOR distance rather than capped proximity
+/// also lets the strict comparison distinguish peers inside the deepest band.
 fn closer_candidates(
     topology: &impl SwarmTopologyRouting,
     target: &ChunkAddress,
     requester: OverlayAddress,
     local: OverlayAddress,
 ) -> Vec<OverlayAddress> {
-    // The requester's proximity to the target is the floor: we only forward to a
-    // peer strictly closer than that. `target.proximity(&peer)` is the number of
-    // leading bits shared with the target; higher means closer.
-    let floor = target.proximity(&requester);
     topology
         .closest_to(target, MAX_FORWARD_CANDIDATES * 2)
         .into_iter()
         .filter(|peer| *peer != requester && *peer != local)
-        .filter(|peer| target.proximity(peer) > floor)
+        // `target.closer(peer, other)` is true iff `peer` is strictly closer to
+        // `target` than `other` by full XOR distance. The candidate must beat
+        // both the requester (loop prevention) and this node (the reference's
+        // self-relative "closer than me" gate).
+        .filter(|peer| target.closer(peer, &requester) && target.closer(peer, &local))
         .take(MAX_FORWARD_CANDIDATES)
         .collect()
 }
@@ -234,7 +308,7 @@ where
         &self,
         address: ChunkAddress,
         exclude: OverlayAddress,
-    ) -> BoxFuture<'static, Result<StampedChunk, ForwardError>> {
+    ) -> BoxFuture<'static, Result<ForwardedChunk, ForwardError>> {
         let candidates = closer_candidates(&*self.topology, &address, exclude, self.local);
         let accounting = Arc::clone(&self.accounting);
         let handle = self.handle.clone();
@@ -246,7 +320,10 @@ where
 
             // Credit the upstream leg: the requester pays us for serving the
             // chunk on. Held across the whole relay; released on drop if the
-            // relay fails, applied only once a verified chunk is in hand.
+            // relay fails. It is NOT committed here: a verified chunk in hand
+            // does not yet mean the requester received it, so the action is
+            // handed back un-applied and the handler commits it only after the
+            // chunk is on the wire.
             let provide = accounting
                 .prepare_provide_chunk(exclude, &address)
                 .map_err(|_| ForwardError::AccountingRefused)?;
@@ -274,11 +351,16 @@ where
                         // again before the wire.
                         match result.chunk.verify_answers(address) {
                             Ok(verified) => {
-                                // Both legs succeeded: commit the spread.
+                                // The downstream leg is genuinely complete (we
+                                // received the chunk), so commit it now. The
+                                // upstream `provide` is returned un-applied for
+                                // the handler to commit after the wire write.
                                 receive.apply();
-                                provide.apply();
                                 debug!(%closer, %address, "relayed retrieval");
-                                return Ok(verified.into_inner());
+                                return Ok(ForwardedChunk {
+                                    chunk: verified.into_inner(),
+                                    provide: Box::new(provide),
+                                });
                             }
                             Err(_) => {
                                 // The downstream peer served the wrong chunk:
@@ -308,7 +390,7 @@ where
         &self,
         chunk: StampedChunk,
         exclude: OverlayAddress,
-    ) -> BoxFuture<'static, Result<PushReceipt, ForwardError>> {
+    ) -> BoxFuture<'static, Result<ForwardedReceipt, ForwardError>> {
         let address = *chunk.address();
         let candidates = closer_candidates(&*self.topology, &address, exclude, self.local);
         let accounting = Arc::clone(&self.accounting);
@@ -320,7 +402,8 @@ where
             }
 
             // Credit the upstream leg: the pusher pays us for relaying the chunk
-            // toward its neighbourhood.
+            // toward its neighbourhood. Returned un-applied; the handler commits
+            // it only after the receipt is written back to the pusher.
             let provide = accounting
                 .prepare_provide_chunk(exclude, &address)
                 .map_err(|_| ForwardError::AccountingRefused)?;
@@ -349,15 +432,22 @@ where
                         // receipt belongs here, on the relay path, so a forwarder
                         // never launders a receipt whose signer is not deep
                         // enough for the chunk. The receipt already carries
-                        // `storage_radius`; verifying `PO(receipt.storer, chunk)`
-                        // against a required depth and scoring/rejecting a shallow
-                        // receipt is filled in by #293 and is intentionally NOT
-                        // implemented here.
+                        // `storage_radius`; the depth check must recover the
+                        // signer overlay from `receipt.signature` (as the
+                        // reference does), NOT trust the off-wire `receipt.storer`
+                        // field, which the handler sets to the immediate
+                        // downstream peer and is several hops from the real signer
+                        // on a multi-hop relay. Filled in by #293; intentionally
+                        // NOT implemented here.
                         if receipt_is_well_formed(&receipt) {
+                            // Downstream leg complete; commit it. Upstream
+                            // `provide` returned un-applied for the handler.
                             receive.apply();
-                            provide.apply();
                             debug!(%closer, %address, "relayed pushsync");
-                            return Ok(receipt);
+                            return Ok(ForwardedReceipt {
+                                receipt,
+                                provide: Box::new(provide),
+                            });
                         }
                         drop(receive);
                         last = ForwardError::UnverifiedRelay;
@@ -476,14 +566,43 @@ mod tests {
     fn closer_candidates_excludes_requester_and_local() {
         let address = *stamped().address();
         let requester = overlay_at_proximity(&address, 4);
-        let local = overlay_at_proximity(&address, 12);
+        // Local is farther from the target than the candidate, so the
+        // self-relative gate does not reject the candidate; this isolates the
+        // exclusion behaviour (local must be dropped because it is us, not
+        // because of the closer-than-me gate).
+        let local = overlay_at_proximity(&address, 2);
         let closer = overlay_at_proximity(&address, 10);
 
         // The topology returns local and requester among the closest; both must
-        // be filtered out even though local is strictly closer.
+        // be filtered out as self/requester.
         let topo = MockTopology::default().with_closest(vec![local, closer, requester]);
         let got = closer_candidates(&topo, &address, requester, local);
         assert_eq!(got, vec![closer]);
+    }
+
+    #[test]
+    fn closer_candidates_drops_peers_farther_than_local() {
+        // The reference's self-relative gate: a node already deeper in the
+        // target's neighbourhood than a candidate must not relay sideways/back to
+        // that candidate, even when the candidate is still closer than the
+        // requester. This is the divergence-from-reference fix.
+        let address = *stamped().address();
+        let requester = overlay_at_proximity(&address, 2);
+        // We (local) share 12 bits with the target.
+        let local = overlay_at_proximity(&address, 12);
+        // The candidate is closer than the requester (8 > 2) but farther than us
+        // (8 < 12), so it must be rejected.
+        let farther_than_local = overlay_at_proximity(&address, 8);
+        // A candidate deeper than us survives.
+        let deeper = overlay_at_proximity(&address, 20);
+
+        let topo = MockTopology::default().with_closest(vec![deeper, farther_than_local]);
+        let got = closer_candidates(&topo, &address, requester, local);
+        assert_eq!(
+            got,
+            vec![deeper],
+            "only a peer strictly closer than this node survives"
+        );
     }
 
     #[test]
@@ -562,15 +681,92 @@ mod tests {
         )
         .await;
 
-        let relayed = got.expect("relay succeeds");
-        assert_eq!(*relayed.address(), address, "the relayed chunk is verified");
+        let forwarded = got.expect("relay succeeds");
+        assert_eq!(
+            *forwarded.chunk.address(),
+            address,
+            "the relayed chunk is verified"
+        );
 
-        // Both legs committed: the requester owes us provide_price (credit), and
-        // we owe the closer peer receive_price (debit).
-        let owed_by_requester = acct.bandwidth().for_peer(requester).balance();
-        let owed_to_closer = acct.bandwidth().for_peer(closer).balance();
-        assert_eq!(owed_by_requester, provide_price);
-        assert_eq!(owed_to_closer, Au::ZERO - receive_price);
+        // The downstream leg is committed inside the forwarder, so the closer
+        // peer is already owed receive_price. The upstream `provide` is returned
+        // un-applied: until it is committed (which the handler does after a
+        // successful wire write) the requester owes nothing.
+        assert_eq!(
+            acct.bandwidth().for_peer(requester).balance(),
+            Au::ZERO,
+            "the upstream credit is deferred until the wire write"
+        );
+        assert_eq!(
+            acct.bandwidth().for_peer(closer).balance(),
+            Au::ZERO - receive_price
+        );
+
+        // Commit the upstream leg as the handler would after writing the chunk
+        // back: now the requester owes us provide_price.
+        forwarded.provide.apply_boxed();
+        assert_eq!(
+            acct.bandwidth().for_peer(requester).balance(),
+            provide_price
+        );
+        assert_eq!(
+            acct.bandwidth().for_peer(closer).balance(),
+            Au::ZERO - receive_price
+        );
+    }
+
+    #[tokio::test]
+    async fn retrieve_dropping_provide_releases_upstream_and_keeps_downstream() {
+        // A wire-write failure: the handler drops the un-applied provide action
+        // instead of committing it. The requester must not be charged, and the
+        // downstream leg (already committed) must remain.
+        let chunk = stamped();
+        let address = *chunk.address();
+        let requester = overlay_at_proximity(&address, 2);
+        let closer = overlay_at_proximity(&address, 16);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default().with_closest(vec![closer]));
+        let (tx, rx) = mpsc::channel::<ClientCommand>(4);
+        let handle = ClientHandle::new(tx);
+
+        let receive_price = acct.pricing().peer_price(&closer, &address);
+        let forwarder = NetworkForwarder::new(local, topo, Arc::clone(&acct), handle);
+
+        let chunk_for_answer = chunk.clone();
+        let forwarded =
+            drive_one_command(
+                rx,
+                forwarder.retrieve(address, requester),
+                move |cmd| match cmd {
+                    ClientCommand::RetrieveChunk { response, .. } => {
+                        response
+                            .send(Ok(RetrievalResult {
+                                chunk: chunk_for_answer,
+                                peer: closer,
+                            }))
+                            .expect("receiver alive");
+                    }
+                    other => panic!("unexpected command: {other:?}"),
+                },
+            )
+            .await
+            .expect("relay succeeds");
+
+        // Simulate the handler's wire-write failure: drop the provide action.
+        drop(forwarded.provide);
+
+        // The requester was never charged; the downstream leg stands.
+        assert_eq!(
+            acct.bandwidth().for_peer(requester).balance(),
+            Au::ZERO,
+            "dropping the un-applied provide leg charges the requester nothing"
+        );
+        assert_eq!(
+            acct.bandwidth().for_peer(closer).balance(),
+            Au::ZERO - receive_price
+        );
     }
 
     #[tokio::test]
@@ -613,13 +809,21 @@ mod tests {
         )
         .await;
 
-        let relayed = got.expect("relay succeeds");
+        let forwarded = got.expect("relay succeeds");
         // The receipt is relayed verbatim: every field is the storer's own.
-        assert_eq!(relayed.storer, expected.storer);
-        assert_eq!(relayed.signature, expected.signature);
-        assert_eq!(relayed.nonce, expected.nonce);
-        assert_eq!(relayed.storage_radius, expected.storage_radius);
+        assert_eq!(forwarded.receipt.storer, expected.storer);
+        assert_eq!(forwarded.receipt.signature, expected.signature);
+        assert_eq!(forwarded.receipt.nonce, expected.nonce);
+        assert_eq!(forwarded.receipt.storage_radius, expected.storage_radius);
 
+        // Downstream committed; upstream deferred until the wire write.
+        assert_eq!(acct.bandwidth().for_peer(pusher).balance(), Au::ZERO);
+        assert_eq!(
+            acct.bandwidth().for_peer(closer).balance(),
+            Au::ZERO - receive_price
+        );
+
+        forwarded.provide.apply_boxed();
         assert_eq!(acct.bandwidth().for_peer(pusher).balance(), provide_price);
         assert_eq!(
             acct.bandwidth().for_peer(closer).balance(),

--- a/crates/swarm/node/src/protocol/forward.rs
+++ b/crates/swarm/node/src/protocol/forward.rs
@@ -6,45 +6,99 @@
 //! answer a retrieval, or for every pushsync, the handler hands off to a
 //! [`Forwarder`] that relays to a closer peer and returns the result.
 //!
-//! In the cache-only client this seam is stubbed: [`StubForwarder`] always
-//! returns [`ForwardError::NoCloserPeer`], so a cache miss and every pushsync
-//! reset the inbound substream (the reference reads a reset as a failed request
-//! at that hop). The real multi-hop relay (closest-peer selection excluding the
-//! requester, hop and loop bounds, two-leg accounting, relay and shallow-receipt
-//! verification) is filled in separately and reuses the existing self-contained
-//! outbound futures.
+//! Two implementations live here:
+//!
+//! - [`StubForwarder`] always returns [`ForwardError::NoCloserPeer`], so a cache
+//!   miss and every pushsync reset the inbound substream. It is the right
+//!   behaviour for a node that holds no reserve and takes no custody and never
+//!   wants to relay (and is the model the behaviour-level tests drive).
+//! - [`NetworkForwarder`] is the real multi-hop relay: it selects the closest
+//!   peer to the target excluding the requester (and ourselves), enforces the
+//!   forwarding-Kademlia loop bound (never relay to a peer that is not strictly
+//!   closer to the target than the requester) and a hop/TTL bound, reuses the
+//!   existing self-contained outbound futures
+//!   ([`ClientHandle::retrieve_chunk`](crate::ClientHandle::retrieve_chunk) /
+//!   [`push_chunk`](crate::ClientHandle::push_chunk)) for the upstream leg, and
+//!   accounts both legs through the prepare/apply reservation actions so a
+//!   forwarder earns the spread. A failed forward drops both reservation actions
+//!   (release-on-drop), so no accounting leaks.
+//!
+//! Verification lives at both edges. The downstream chunk returned by an
+//! upstream retrieval is verified against the requested address here
+//! ([`StampedChunk::verify_answers`] -> [`VerifiedStampedChunk`]) before it is
+//! cached or relayed; the handler additionally verifies before it writes the
+//! chunk to the responder, so an unverified chunk can never travel back to the
+//! requester. A relayed pushsync receipt is checked for structural validity (a
+//! non-empty signature) before it is relayed.
+
+use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use vertex_swarm_api::PushReceipt;
+use nectar_primitives::ChunkAddress;
+use tracing::debug;
+use vertex_swarm_api::{
+    AccountingAction, PushReceipt, SwarmClientAccounting, SwarmTopologyRouting,
+};
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk};
+
+use crate::ClientHandle;
+
+/// Maximum number of relay hops a single inbound request may traverse from this
+/// node onward.
+///
+/// This is the local TTL bound: each forward selects only strictly-closer peers
+/// (so proximity is monotonically increasing toward the target), which already
+/// makes an infinite loop impossible, and the hop cap is the belt-and-braces
+/// upper bound on the candidate walk this node performs for one request. The
+/// reference walks a small fixed number of closer peers per hop; we mirror that
+/// with a bounded candidate set.
+const MAX_FORWARD_CANDIDATES: usize = 3;
 
 /// Why a forward could not complete.
 ///
 /// The reason is intentionally coarse: the handler only needs to know the
 /// forward did not produce a chunk or receipt so it can reset the inbound
-/// substream. A real forwarder will carry richer diagnostics for its own
-/// metrics, but the inbound serving path treats every failure as a reset.
+/// substream. A real forwarder carries richer diagnostics for its own metrics,
+/// but the inbound serving path treats every failure as a reset.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub(crate) enum ForwardError {
-    /// No peer closer to the target than the requester is available to relay to.
+    /// No peer strictly closer to the target than the requester is available to
+    /// relay to. Covers both the no-candidate case and the loop-prevention
+    /// case (every candidate would forward sideways or backwards in proximity).
     #[error("no closer peer to forward to")]
     NoCloserPeer,
+
+    /// Every strictly-closer candidate we tried failed to answer.
+    #[error("all closer peers failed to relay")]
+    AllPeersFailed,
+
+    /// The upstream leg returned a chunk that does not answer the request, or a
+    /// receipt that is structurally malformed. Never relayed.
+    #[error("upstream relay returned unverified data")]
+    UnverifiedRelay,
+
+    /// Accounting refused one of the two legs (over the disconnect threshold),
+    /// so the relay was not attempted. Any reservation already taken is released
+    /// on drop.
+    #[error("accounting refused the relay")]
+    AccountingRefused,
 }
 
 /// Relays a retrieval or a pushsync to a closer peer on behalf of an inbound
 /// request.
 ///
 /// `exclude` is the requester or pusher, passed so the forwarder never relays
-/// back to the peer that asked (loop prevention). The returned futures are
-/// `'static`, boxed, and `Send` so the handler can hold them in its inbound set:
-/// a libp2p `ConnectionHandler` is `Send` on both native and wasm (the browser
-/// `Stream` is itself `Send`), so the inbound serving futures are `Send` too.
+/// back to the peer that asked (loop prevention) and so it can account the
+/// inbound leg against it. The returned futures are `'static`, boxed, and `Send`
+/// so the handler can hold them in its inbound set: a libp2p `ConnectionHandler`
+/// is `Send` on both native and wasm (the browser `Stream` is itself `Send`), so
+/// the inbound serving futures are `Send` too.
 pub(crate) trait Forwarder: Send + Sync {
     /// Retrieve `address` from a closer peer, excluding `exclude`.
     fn retrieve(
         &self,
-        address: nectar_primitives::ChunkAddress,
+        address: ChunkAddress,
         exclude: OverlayAddress,
     ) -> BoxFuture<'static, Result<StampedChunk, ForwardError>>;
 
@@ -57,19 +111,18 @@ pub(crate) trait Forwarder: Send + Sync {
     ) -> BoxFuture<'static, Result<PushReceipt, ForwardError>>;
 }
 
-/// The cache-only client forwarder: every relay fails with
+/// A forwarder that never relays: every relay fails with
 /// [`ForwardError::NoCloserPeer`].
 ///
 /// A cache miss therefore resets the inbound retrieval substream and every
 /// inbound pushsync resets too, which is the correct behaviour for a node that
-/// holds no reserve and takes no custody. The real relay is filled in
-/// separately.
+/// holds no reserve, takes no custody, and does not participate as a relay.
 pub(crate) struct StubForwarder;
 
 impl Forwarder for StubForwarder {
     fn retrieve(
         &self,
-        _address: nectar_primitives::ChunkAddress,
+        _address: ChunkAddress,
         _exclude: OverlayAddress,
     ) -> BoxFuture<'static, Result<StampedChunk, ForwardError>> {
         Box::pin(async { Err(ForwardError::NoCloserPeer) })
@@ -81,5 +134,559 @@ impl Forwarder for StubForwarder {
         _exclude: OverlayAddress,
     ) -> BoxFuture<'static, Result<PushReceipt, ForwardError>> {
         Box::pin(async { Err(ForwardError::NoCloserPeer) })
+    }
+}
+
+/// The real multi-hop relay: forwarding Kademlia for retrieval and pushsync.
+///
+/// Generic over the topology routing surface `T` (closest-peer selection) and
+/// the client accounting surface `A` (two-leg prepare/apply). Holds a
+/// [`ClientHandle`] so the upstream leg reuses the same self-contained outbound
+/// futures the origin path uses; no separate dial machinery exists.
+///
+/// # Loop prevention and the hop bound
+///
+/// Forwarding Kademlia routes a request strictly toward the target's
+/// neighbourhood: each hop must hand the request to a peer that is *strictly
+/// closer* to the target than the peer that asked. [`closer_candidates`] filters
+/// the topology's proximity-ordered candidates down to exactly those, excluding
+/// the requester and ourselves. Because proximity to the target is monotonically
+/// increasing along the chain, a request can never cycle back to a peer it has
+/// already visited, so no per-request visited set is needed. The candidate set
+/// is additionally capped at [`MAX_FORWARD_CANDIDATES`] as the local TTL bound on
+/// the walk this node performs for one inbound request.
+///
+/// # Two-leg accounting
+///
+/// A forwarder sits between an *upstream* peer (the requester or pusher, the one
+/// we provide service to) and a *downstream* peer (the closer peer we relay to,
+/// the one that provides service to us). It credits the upstream leg
+/// (`prepare_provide_chunk(exclude)`) and debits the downstream leg
+/// (`prepare_receive_chunk(closer)`), exactly as the reference does, so it earns
+/// the price spread between the two. Both actions reserve on creation; on a
+/// successful relay both are applied, committing the balance changes. On any
+/// failure both actions are dropped, which releases the reservations
+/// (`ReceiveAction`/`ProvideAction` release on drop), so a failed forward never
+/// leaks an accounting reservation.
+pub(crate) struct NetworkForwarder<T, A> {
+    /// Our own overlay: excluded from candidates and used as the
+    /// strictly-closer reference for the loop bound alongside the requester.
+    local: OverlayAddress,
+    /// Proximity-ordered closest-peer selection.
+    topology: Arc<T>,
+    /// Two-leg prepare/apply accounting.
+    accounting: Arc<A>,
+    /// Reuses the origin outbound futures for the upstream relay leg.
+    handle: ClientHandle,
+}
+
+impl<T, A> NetworkForwarder<T, A> {
+    /// Build a network forwarder from the local overlay, topology, accounting,
+    /// and the outbound client handle.
+    pub(crate) fn new(
+        local: OverlayAddress,
+        topology: Arc<T>,
+        accounting: Arc<A>,
+        handle: ClientHandle,
+    ) -> Self {
+        Self {
+            local,
+            topology,
+            accounting,
+            handle,
+        }
+    }
+}
+
+/// Select the peers strictly closer to `target` than `requester`, excluding the
+/// requester and `local`, in proximity order, capped at [`MAX_FORWARD_CANDIDATES`].
+///
+/// This is the loop-prevention core: a candidate is kept only when its proximity
+/// to the target is strictly greater than the requester's proximity to the
+/// target. A peer that is at the same or lower proximity than the requester
+/// would route the request sideways or backwards and is dropped, so the request
+/// always advances toward the neighbourhood and can never cycle.
+fn closer_candidates(
+    topology: &impl SwarmTopologyRouting,
+    target: &ChunkAddress,
+    requester: OverlayAddress,
+    local: OverlayAddress,
+) -> Vec<OverlayAddress> {
+    // The requester's proximity to the target is the floor: we only forward to a
+    // peer strictly closer than that. `target.proximity(&peer)` is the number of
+    // leading bits shared with the target; higher means closer.
+    let floor = target.proximity(&requester);
+    topology
+        .closest_to(target, MAX_FORWARD_CANDIDATES * 2)
+        .into_iter()
+        .filter(|peer| *peer != requester && *peer != local)
+        .filter(|peer| target.proximity(peer) > floor)
+        .take(MAX_FORWARD_CANDIDATES)
+        .collect()
+}
+
+impl<T, A> Forwarder for NetworkForwarder<T, A>
+where
+    T: SwarmTopologyRouting + Send + Sync + 'static,
+    A: SwarmClientAccounting + Send + Sync + 'static,
+{
+    fn retrieve(
+        &self,
+        address: ChunkAddress,
+        exclude: OverlayAddress,
+    ) -> BoxFuture<'static, Result<StampedChunk, ForwardError>> {
+        let candidates = closer_candidates(&*self.topology, &address, exclude, self.local);
+        let accounting = Arc::clone(&self.accounting);
+        let handle = self.handle.clone();
+
+        Box::pin(async move {
+            if candidates.is_empty() {
+                return Err(ForwardError::NoCloserPeer);
+            }
+
+            // Credit the upstream leg: the requester pays us for serving the
+            // chunk on. Held across the whole relay; released on drop if the
+            // relay fails, applied only once a verified chunk is in hand.
+            let provide = accounting
+                .prepare_provide_chunk(exclude, &address)
+                .map_err(|_| ForwardError::AccountingRefused)?;
+
+            let mut last = ForwardError::AllPeersFailed;
+            for closer in candidates {
+                // Debit the downstream leg: we pay the closer peer for the
+                // chunk it serves us. `originated = false`: this is a relay, not
+                // our own request. Released on drop if this attempt fails.
+                let receive = match accounting.prepare_receive_chunk(closer, &address, false) {
+                    Ok(action) => action,
+                    Err(_) => {
+                        // Cannot afford this downstream peer; try the next.
+                        last = ForwardError::AccountingRefused;
+                        continue;
+                    }
+                };
+
+                match handle.retrieve_chunk(closer, address).await {
+                    Ok(result) => {
+                        // Edge verification (#287): the relayed chunk must
+                        // answer the requested address before we account, cache,
+                        // or relay it. The type-state proves it; we keep the
+                        // inner chunk to hand back to the handler, which verifies
+                        // again before the wire.
+                        match result.chunk.verify_answers(address) {
+                            Ok(verified) => {
+                                // Both legs succeeded: commit the spread.
+                                receive.apply();
+                                provide.apply();
+                                debug!(%closer, %address, "relayed retrieval");
+                                return Ok(verified.into_inner());
+                            }
+                            Err(_) => {
+                                // The downstream peer served the wrong chunk:
+                                // drop `receive` (release) and try the next.
+                                drop(receive);
+                                last = ForwardError::UnverifiedRelay;
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        // Downstream attempt failed: `receive` drops here,
+                        // releasing its reservation. The upstream `provide`
+                        // reservation stays held for the next candidate.
+                        drop(receive);
+                        last = ForwardError::AllPeersFailed;
+                    }
+                }
+            }
+
+            // Every candidate failed: `provide` drops here, releasing the
+            // upstream reservation so nothing leaks.
+            Err(last)
+        })
+    }
+
+    fn push(
+        &self,
+        chunk: StampedChunk,
+        exclude: OverlayAddress,
+    ) -> BoxFuture<'static, Result<PushReceipt, ForwardError>> {
+        let address = *chunk.address();
+        let candidates = closer_candidates(&*self.topology, &address, exclude, self.local);
+        let accounting = Arc::clone(&self.accounting);
+        let handle = self.handle.clone();
+
+        Box::pin(async move {
+            if candidates.is_empty() {
+                return Err(ForwardError::NoCloserPeer);
+            }
+
+            // Credit the upstream leg: the pusher pays us for relaying the chunk
+            // toward its neighbourhood.
+            let provide = accounting
+                .prepare_provide_chunk(exclude, &address)
+                .map_err(|_| ForwardError::AccountingRefused)?;
+
+            let mut last = ForwardError::AllPeersFailed;
+            for closer in candidates {
+                // Debit the downstream leg: we pay the storer (or next hop) for
+                // accepting the chunk.
+                let receive = match accounting.prepare_receive_chunk(closer, &address, false) {
+                    Ok(action) => action,
+                    Err(_) => {
+                        last = ForwardError::AccountingRefused;
+                        continue;
+                    }
+                };
+
+                match handle.push_chunk(closer, chunk.clone()).await {
+                    Ok(receipt) => {
+                        // Edge verification (#287): never relay a structurally
+                        // malformed receipt upstream. A storer signs over
+                        // (address, nonce); the signature must be present. The
+                        // receipt is relayed VERBATIM by the handler; we never
+                        // mint or re-sign it.
+                        //
+                        // SHALLOW-RECEIPT SEAM (#293): a depth check on the
+                        // receipt belongs here, on the relay path, so a forwarder
+                        // never launders a receipt whose signer is not deep
+                        // enough for the chunk. The receipt already carries
+                        // `storage_radius`; verifying `PO(receipt.storer, chunk)`
+                        // against a required depth and scoring/rejecting a shallow
+                        // receipt is filled in by #293 and is intentionally NOT
+                        // implemented here.
+                        if receipt_is_well_formed(&receipt) {
+                            receive.apply();
+                            provide.apply();
+                            debug!(%closer, %address, "relayed pushsync");
+                            return Ok(receipt);
+                        }
+                        drop(receive);
+                        last = ForwardError::UnverifiedRelay;
+                    }
+                    Err(_) => {
+                        drop(receive);
+                        last = ForwardError::AllPeersFailed;
+                    }
+                }
+            }
+
+            Err(last)
+        })
+    }
+}
+
+/// A receipt is structurally well-formed when its signature is non-empty.
+///
+/// A storer signs a receipt over the chunk address and a nonce; an all-zero
+/// signature is the on-the-wire signal for a failure, never a real receipt, so
+/// it is never relayed. The full cryptographic recovery of the signer overlay
+/// (and the #293 shallow-receipt depth check) attach on top of this gate.
+fn receipt_is_well_formed(receipt: &PushReceipt) -> bool {
+    receipt.signature.as_bytes() != [0u8; 65]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use alloy_primitives::{B256, Signature};
+    use nectar_postage::Stamp;
+    use nectar_primitives::{AnyChunk, ContentChunk, Nonce};
+    use tokio::sync::mpsc;
+    use vertex_swarm_api::{Au, SwarmBandwidthAccounting, SwarmPeerBandwidth, SwarmPricing};
+    use vertex_swarm_bandwidth::{
+        Accounting, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
+    };
+    use vertex_swarm_identity::Identity;
+    use vertex_swarm_primitives::{Bin, StorageRadius};
+    use vertex_swarm_spec::Spec;
+    use vertex_swarm_test_utils::{MockTopology, test_identity_arc};
+
+    use super::*;
+    use crate::{ClientCommand, RetrievalResult};
+
+    /// A stamped content chunk and its content-derived address.
+    fn stamped() -> StampedChunk {
+        let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        let chunk: AnyChunk = ContentChunk::new(&b"forwarded payload"[..])
+            .expect("valid content chunk")
+            .into();
+        StampedChunk::new(chunk, stamp)
+    }
+
+    fn good_signature() -> Signature {
+        let mut raw = [0u8; 65];
+        raw[..64].fill(1);
+        raw[64] = 27;
+        Signature::try_from(&raw[..]).expect("valid signature")
+    }
+
+    fn receipt(storer: OverlayAddress) -> PushReceipt {
+        PushReceipt {
+            storer,
+            signature: good_signature(),
+            nonce: Nonce::from([9u8; 32]),
+            storage_radius: StorageRadius::new(Bin::new(5).unwrap()),
+        }
+    }
+
+    /// Build an overlay sharing `leading_bits` leading bits with `address`, so
+    /// its proximity to the address is exactly `leading_bits` (the next bit is
+    /// flipped). Used to place a peer at a controlled distance from the target.
+    fn overlay_at_proximity(address: &ChunkAddress, leading_bits: usize) -> OverlayAddress {
+        let mut bytes = address.0.0;
+        // Flip the bit immediately after the shared prefix so the proximity is
+        // exactly `leading_bits`: the first differing bit caps proximity.
+        let byte = leading_bits / 8;
+        let bit = 7 - (leading_bits % 8);
+        if let Some(b) = bytes.get_mut(byte) {
+            *b ^= 1 << bit;
+        }
+        OverlayAddress::from(bytes)
+    }
+
+    type TestAccounting =
+        ClientAccounting<Arc<Accounting<DefaultBandwidthConfig, Arc<Identity>>>, FixedPricer<Spec>>;
+
+    fn accounting() -> Arc<TestAccounting> {
+        let bandwidth = Arc::new(Accounting::new(
+            DefaultBandwidthConfig::default(),
+            test_identity_arc(),
+        ));
+        let pricer = FixedPricer::new(10_000, vertex_swarm_spec::init_mainnet());
+        Arc::new(ClientAccounting::new(bandwidth, pricer))
+    }
+
+    #[test]
+    fn closer_candidates_keeps_only_strictly_closer_peers() {
+        let address = *stamped().address();
+        // Requester shares 4 leading bits with the target.
+        let requester = overlay_at_proximity(&address, 4);
+        let closer = overlay_at_proximity(&address, 10);
+        let sideways = overlay_at_proximity(&address, 4);
+        let farther = overlay_at_proximity(&address, 1);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let topo = MockTopology::default().with_closest(vec![closer, sideways, farther]);
+        let got = closer_candidates(&topo, &address, requester, local);
+        assert_eq!(got, vec![closer], "only the strictly-closer peer survives");
+    }
+
+    #[test]
+    fn closer_candidates_excludes_requester_and_local() {
+        let address = *stamped().address();
+        let requester = overlay_at_proximity(&address, 4);
+        let local = overlay_at_proximity(&address, 12);
+        let closer = overlay_at_proximity(&address, 10);
+
+        // The topology returns local and requester among the closest; both must
+        // be filtered out even though local is strictly closer.
+        let topo = MockTopology::default().with_closest(vec![local, closer, requester]);
+        let got = closer_candidates(&topo, &address, requester, local);
+        assert_eq!(got, vec![closer]);
+    }
+
+    #[test]
+    fn closer_candidates_empty_when_nothing_is_closer() {
+        let address = *stamped().address();
+        let requester = overlay_at_proximity(&address, 12);
+        let local = OverlayAddress::from([0xee; 32]);
+        let sideways = overlay_at_proximity(&address, 8);
+
+        let topo = MockTopology::default().with_closest(vec![sideways]);
+        assert!(closer_candidates(&topo, &address, requester, local).is_empty());
+    }
+
+    /// Drive a forwarder future to completion while answering the single
+    /// outbound command it emits with `answer`.
+    async fn drive_one_command<F, T>(
+        mut rx: mpsc::Receiver<ClientCommand>,
+        fut: F,
+        answer: impl FnOnce(ClientCommand),
+    ) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let driver = async {
+            if let Some(cmd) = rx.recv().await {
+                answer(cmd);
+            }
+        };
+        let (result, ()) = tokio::join!(fut, driver);
+        result
+    }
+
+    #[tokio::test]
+    async fn retrieve_relays_verifies_and_accounts_both_legs() {
+        let chunk = stamped();
+        let address = *chunk.address();
+        let requester = overlay_at_proximity(&address, 2);
+        let closer = overlay_at_proximity(&address, 16);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default().with_closest(vec![closer]));
+        let (tx, rx) = mpsc::channel::<ClientCommand>(4);
+        let handle = ClientHandle::new(tx);
+
+        let provide_price = acct.pricing().peer_price(&requester, &address);
+        let receive_price = acct.pricing().peer_price(&closer, &address);
+        assert!(
+            provide_price > receive_price,
+            "the requester is farther than the closer peer, so the forwarder earns the spread"
+        );
+
+        let forwarder = NetworkForwarder::new(local, topo, Arc::clone(&acct), handle);
+
+        let chunk_for_answer = chunk.clone();
+        let got = drive_one_command(
+            rx,
+            forwarder.retrieve(address, requester),
+            move |cmd| match cmd {
+                ClientCommand::RetrieveChunk {
+                    peer,
+                    address: requested,
+                    response,
+                } => {
+                    assert_eq!(peer, closer, "the upstream leg targets the closer peer");
+                    assert_eq!(requested, address);
+                    response
+                        .send(Ok(RetrievalResult {
+                            chunk: chunk_for_answer,
+                            peer: closer,
+                        }))
+                        .expect("receiver alive");
+                }
+                other => panic!("unexpected command: {other:?}"),
+            },
+        )
+        .await;
+
+        let relayed = got.expect("relay succeeds");
+        assert_eq!(*relayed.address(), address, "the relayed chunk is verified");
+
+        // Both legs committed: the requester owes us provide_price (credit), and
+        // we owe the closer peer receive_price (debit).
+        let owed_by_requester = acct.bandwidth().for_peer(requester).balance();
+        let owed_to_closer = acct.bandwidth().for_peer(closer).balance();
+        assert_eq!(owed_by_requester, provide_price);
+        assert_eq!(owed_to_closer, Au::ZERO - receive_price);
+    }
+
+    #[tokio::test]
+    async fn push_relays_receipt_verbatim_and_accounts_both_legs() {
+        let chunk = stamped();
+        let address = *chunk.address();
+        let pusher = overlay_at_proximity(&address, 2);
+        let closer = overlay_at_proximity(&address, 16);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default().with_closest(vec![closer]));
+        let (tx, rx) = mpsc::channel::<ClientCommand>(4);
+        let handle = ClientHandle::new(tx);
+
+        let provide_price = acct.pricing().peer_price(&pusher, &address);
+        let receive_price = acct.pricing().peer_price(&closer, &address);
+
+        let forwarder = NetworkForwarder::new(local, topo, Arc::clone(&acct), handle);
+
+        let storer_receipt = receipt(closer);
+        let expected = storer_receipt.clone();
+        let got = drive_one_command(
+            rx,
+            forwarder.push(chunk.clone(), pusher),
+            move |cmd| match cmd {
+                ClientCommand::PushChunk {
+                    peer,
+                    address: requested,
+                    chunk: pushed,
+                    response,
+                } => {
+                    assert_eq!(peer, closer);
+                    assert_eq!(requested, address);
+                    assert_eq!(*pushed.address(), address);
+                    response.send(Ok(storer_receipt)).expect("receiver alive");
+                }
+                other => panic!("unexpected command: {other:?}"),
+            },
+        )
+        .await;
+
+        let relayed = got.expect("relay succeeds");
+        // The receipt is relayed verbatim: every field is the storer's own.
+        assert_eq!(relayed.storer, expected.storer);
+        assert_eq!(relayed.signature, expected.signature);
+        assert_eq!(relayed.nonce, expected.nonce);
+        assert_eq!(relayed.storage_radius, expected.storage_radius);
+
+        assert_eq!(acct.bandwidth().for_peer(pusher).balance(), provide_price);
+        assert_eq!(
+            acct.bandwidth().for_peer(closer).balance(),
+            Au::ZERO - receive_price
+        );
+    }
+
+    #[tokio::test]
+    async fn retrieve_without_closer_peer_fails_and_leaks_no_reservation() {
+        let chunk = stamped();
+        let address = *chunk.address();
+        // The requester is already in the neighbourhood: nothing is closer.
+        let requester = overlay_at_proximity(&address, 20);
+        let sideways = overlay_at_proximity(&address, 8);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default().with_closest(vec![sideways]));
+        let (tx, _rx) = mpsc::channel::<ClientCommand>(4);
+        let handle = ClientHandle::new(tx);
+
+        let forwarder = NetworkForwarder::new(local, topo, Arc::clone(&acct), handle);
+        let err = forwarder
+            .retrieve(address, requester)
+            .await
+            .expect_err("no strictly-closer peer");
+        assert!(matches!(err, ForwardError::NoCloserPeer));
+
+        // No leg was attempted, so no reservation is held or committed.
+        assert_eq!(acct.bandwidth().for_peer(requester).balance(), Au::ZERO);
+        assert_eq!(acct.bandwidth().for_peer(sideways).balance(), Au::ZERO);
+    }
+
+    #[tokio::test]
+    async fn failed_upstream_releases_both_reservations() {
+        let chunk = stamped();
+        let address = *chunk.address();
+        let requester = overlay_at_proximity(&address, 2);
+        let closer = overlay_at_proximity(&address, 16);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default().with_closest(vec![closer]));
+        let (tx, rx) = mpsc::channel::<ClientCommand>(4);
+        let handle = ClientHandle::new(tx);
+
+        let forwarder = NetworkForwarder::new(local, topo, Arc::clone(&acct), handle);
+
+        // The upstream peer reports a failure: no chunk comes back.
+        let err = drive_one_command(
+            rx,
+            forwarder.retrieve(address, requester),
+            |cmd| match cmd {
+                ClientCommand::RetrieveChunk { response, .. } => {
+                    response
+                        .send(Err(crate::ChunkTransferError::Remote))
+                        .expect("receiver alive");
+                }
+                other => panic!("unexpected command: {other:?}"),
+            },
+        )
+        .await
+        .expect_err("relay fails when the upstream leg fails");
+        assert!(matches!(err, ForwardError::AllPeersFailed));
+
+        // Both reservations were released on drop: balances are untouched.
+        assert_eq!(acct.bandwidth().for_peer(requester).balance(), Au::ZERO);
+        assert_eq!(acct.bandwidth().for_peer(closer).balance(), Au::ZERO);
     }
 }

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -573,13 +573,23 @@ impl ClientHandler {
             // Miss: forward to a closer peer, excluding the requester. Cache a
             // successful forwarded delivery (CAC immutable, SOC last-write-wins).
             match forward.retrieve(address, overlay).await {
-                Ok(stamped) => match stamped.clone().verify_answers(address) {
+                Ok(forwarded) => match forwarded.chunk.clone().verify_answers(address) {
                     Ok(verified) => {
-                        let _ = store.put(stamped);
+                        let _ = store.put(forwarded.chunk);
                         match responder.send_chunk(verified.into_inner()).await {
-                            Ok(()) => InboundOutcome::Forwarded { overlay },
+                            Ok(()) => {
+                                // The chunk is on the wire: commit the upstream
+                                // credit now (the requester actually received the
+                                // delivery we are billing for).
+                                forwarded.provide.apply_boxed();
+                                InboundOutcome::Forwarded { overlay }
+                            }
                             Err(e) => {
+                                // The requester never received the chunk: drop the
+                                // un-applied credit, releasing the reservation, so
+                                // we never bill for a delivery that did not land.
                                 debug!(%overlay, %address, error = %e, "Forward serve send failed");
+                                drop(forwarded.provide);
                                 InboundOutcome::Missed { overlay, address }
                             }
                         }
@@ -587,6 +597,8 @@ impl ClientHandler {
                     Err(_) => {
                         // A forwarder that returns a chunk for the wrong address
                         // is a bug in the relay, not the requester's fault; reset.
+                        // Drop the credit unapplied (nothing was delivered).
+                        drop(forwarded.provide);
                         responder.send_error();
                         InboundOutcome::Missed { overlay, address }
                     }
@@ -621,18 +633,26 @@ impl ClientHandler {
         let forward = Arc::clone(&self.forward);
         self.inbound.push(Box::pin(async move {
             match forward.push(chunk, overlay).await {
-                Ok(receipt) => {
+                Ok(forwarded) => {
                     // Relay the storer's receipt verbatim: we never sign.
                     let relay = vertex_swarm_net_pushsync::Receipt::success(
                         address,
-                        receipt.signature,
-                        receipt.nonce,
-                        receipt.storage_radius,
+                        forwarded.receipt.signature,
+                        forwarded.receipt.nonce,
+                        forwarded.receipt.storage_radius,
                     );
                     match responder.send_receipt(relay).await {
-                        Ok(()) => InboundOutcome::Relayed { overlay },
+                        Ok(()) => {
+                            // The receipt reached the pusher: commit the upstream
+                            // credit now.
+                            forwarded.provide.apply_boxed();
+                            InboundOutcome::Relayed { overlay }
+                        }
                         Err(e) => {
+                            // The pusher never received the receipt: drop the
+                            // un-applied credit, releasing the reservation.
                             debug!(%overlay, %address, error = %e, "Receipt relay send failed");
+                            drop(forwarded.provide);
                             InboundOutcome::PushFailed { overlay, address }
                         }
                     }

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -74,4 +74,4 @@ pub use events::SwapEvent;
 pub use events::{
     ClientCommand, ClientEvent, FailureKind, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
 };
-pub(crate) use forward::StubForwarder;
+pub(crate) use forward::{NetworkForwarder, StubForwarder};


### PR DESCRIPTION
## feat(swarm-node): forwarding / multi-hop relay with two-leg accounting

Closes #291.

Adds the real multi-hop relay (`NetworkForwarder`) behind the `Forwarder` seam, so a client node can answer an inbound retrieval cache-miss, and every inbound pushsync, by relaying to a closer peer instead of resetting the substream. The cache-only `StubForwarder` (rework of #76 / #301) remains the default for a node that holds no reserve.

### Design

- **Inbound serving is handler-inline.** Each inbound retrieval/pushsync request becomes one self-contained future in `ClientHandler::inbound`, with the substream's responder as the correlation. A retrieval serves from cache (content chunks indefinitely, single-owner while fresh) or forwards; a pushsync always forwards and relays the storer's receipt verbatim (the client never signs, takes no custody).
- **Upstream leg reuses the origin outbound futures.** The relay's upstream hop calls `ClientHandle::retrieve_chunk` / `push_chunk`, the same self-contained outbound path the origin uses, so there is no separate dial machinery.

### Loop prevention and hop bound

There is no on-the-wire hop/TTL field (consistent with the reference). Termination is structural: every forward must go to a peer **strictly closer to the target, by full XOR distance, than both the requester and this node** (`closer_candidates`). XOR distance to the target therefore decreases monotonically along the realized chain, so it can never cycle back to a visited peer and is bounded by the address width; no per-request visited set or hop counter is needed. `MAX_FORWARD_CANDIDATES` only caps per-node retry fan-out (how many downstream candidates this one node tries), not chain length.

### Two-leg accounting and release-on-failure

A forwarder sits between an upstream peer (the requester/pusher it provides service to) and a downstream peer (the closer peer that serves it). It credits the upstream leg (`prepare_provide_chunk`) and debits the downstream leg (`prepare_receive_chunk`), earning the price spread. Both legs reserve on creation. The downstream `receive` leg is committed inside the forwarder the moment a verified chunk/receipt is in hand (it is genuinely complete). The upstream `provide` leg is returned **un-applied** to the handler, which commits it only after the chunk/receipt is on the requester's wire, and drops it (releasing the reservation) on a wire-write failure. Every failure path drops the actions, so a failed forward never leaks a reservation and never charges for a non-delivery.

### Relay verification

Address verification is enforced at both edges: the upstream delivery is address-validated at codec decode, the forwarder re-verifies (`verify_answers` -> `VerifiedStampedChunk`) before accounting/caching/relaying, and the handler verifies a third time before the wire. `verify_answers` is an address-equality check (BMT integrity for content chunks, signature-recovered owner for single-owner chunks); it does not validate the postage stamp's funding/expiry, which is a separate postage concern. The pushsync receipt is relayed verbatim and gated only for structural validity (non-zero signature).

### Seams and deferrals

- **#293 shallow receipts.** The relay receipt depth check is deferred. The seam comment now records that #293 must recover the signer overlay from `receipt.signature` (as the reference does), not trust the off-wire `receipt.storer` field, which the handler sets to the immediate downstream peer and is several hops from the real signer on a multi-hop relay.
- **#131 / #132 self-throttle.** Inbound serving is back-pressured by `MAX_INBOUND_SERVING` per connection; richer self-throttling is deferred.

### Review findings applied vs rejected

**Applied:**

1. **Upstream credit committed before the wire write (accounting + verify-wire + loops reviewers).** Was: `provide.apply()` ran inside the forwarder before `send_chunk`/`send_receipt`, so a post-relay delivery failure over-charged the requester `provide_price` for a chunk/receipt they never received. Now the forwarder returns the un-applied `provide` action (`ForwardedChunk` / `ForwardedReceipt`) and the handler commits it only in the `Ok(())` arm of the wire write, dropping it on `Err`. Added `AccountingAction::apply_boxed` for the object-safe commit. New tests cover the deferred-commit and the drop-on-failure (no over-charge) cases.
2. **Requester-relative capped-PO floor vs reference self-relative full-XOR `closer` (loops reviewer).** `closer_candidates` now keeps a candidate only when it is strictly closer to the target than both the requester and this node, by full XOR distance (`SwarmAddress::closer`), instead of capped `proximity()` against the requester alone. This removes sideways relays within the neighbourhood and the capped-PO plateau where all deep peers compare equal. New test `closer_candidates_drops_peers_farther_than_local`.
3. **Doc oversell of `MAX_FORWARD_CANDIDATES` as a hop/TTL bound (loops reviewer).** Reworded across the module/struct/const docs: it is a per-node fan-out cap; termination comes from monotone XOR distance.
4. **"Verified" overstated (verify-wire + accounting reviewers).** Module docs now state plainly that `verify_answers` is address-equality only and does not validate stamp funding/expiry.
5. **#293 latent trap: `receipt.storer` is the immediate peer, not the signer (verify-wire reviewer).** Recorded in the relay seam comment so #293 recovers the signer from the signature.

**Rejected / out of scope (with reasons):**

- **No infinite loop / ping-pong / amplification (loops reviewer's core verdict).** Confirmed; no change needed. The strictly-closer rule (now self-relative XOR) keeps the chain monotone and bounded.
- **Push relay forwards before validating the postage stamp is funded (loops + verify-wire reviewers, flagged out-of-lens).** This is a postage/spam concern, bounded by the same monotone chain, not a loop or accounting leak. Stamp-funding validation on the relay path is a separate postage workstream and is not in this PR. Documented as a known gap rather than silently ignored.
- **`AccountingRefused`-on-provide is currently unreachable because `prepare_provide` always returns `Ok` (accounting reviewer).** Kept the defensive `?`: it is correct and forward-compatible (a future accounting impl that gates provide would be handled), and it costs nothing. Not removed.
- **`receipt_is_well_formed` only rejects the all-zero signature (#293, accounting + verify-wire reviewers).** Known #293 seam; full signer recovery and the depth check land in #293, not here.
- **Retrieval codec rejecting a real bee storer's empty-stamp delivery (verify-wire reviewer).** Pre-existing, in untouched `retrieval/src/codec.rs`, not introduced by this branch; tracked separately.

### Tests

`cargo fmt --all`, `cargo clippy --all-targets --all-features -D warnings` (clean), and `cargo test --all-features` on the touched crates (`vertex-swarm-node`, `vertex-swarm-bandwidth`, `vertex-swarm-api`, `vertex-swarm-builder`) all pass.
