### PR TITLE
feat(chain): chequebook factory indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,6 +8364,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-chain-index-chequebook-factory"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "nectar-contracts",
+ "serde",
+ "tokio",
+ "vertex-chain-index",
+ "vertex-storage",
+ "vertex-storage-redb",
+]
+
+[[package]]
 name = "vertex-ffi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
     # Chain (Ethereum RPC access)
     "crates/chain",
     "crates/chain/index",
+    "crates/chain/index-chequebook-factory",
 
     # FFI (native embedding surface)
     "crates/ffi",
@@ -238,6 +239,7 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 # chain (Ethereum RPC access)
 vertex-chain = { path = "crates/chain" }
 vertex-chain-index = { path = "crates/chain/index" }
+vertex-chain-index-chequebook-factory = { path = "crates/chain/index-chequebook-factory" }
 
 # ffi (native embedding surface)
 vertex-ffi = { path = "crates/ffi" }

--- a/crates/chain/index-chequebook-factory/Cargo.toml
+++ b/crates/chain/index-chequebook-factory/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "vertex-chain-index-chequebook-factory"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Chequebook factory indexer: folds SimpleSwapDeployed into a vertex-storage set of factory-deployed chequebook addresses"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The generic engine drives this indexer; the `Indexer` trait and `IndexError`
+# come from here.
+vertex-chain-index = { workspace = true }
+# The projection table lives behind the `Database`/`DbTx` traits.
+vertex-storage = { workspace = true }
+
+# nectar: the canonical `IChequebookFactory::SimpleSwapDeployed` event binding
+# and the `CHEQUEBOOK_FACTORY` deployment constants (address + deployment block)
+# for Gnosis Chain mainnet and Sepolia testnet.
+nectar-contracts = { workspace = true }
+
+# alloy: `Address` for the projected keys, the `Filter`/`Log` types the
+# `Indexer` trait speaks, and `SolEvent` for decoding. The crate carries no
+# transport of its own so it stays wasm-clean.
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true }
+alloy-sol-types = { workspace = true }
+
+# serialization: the projected row derives serde.
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+# In-memory backend for the synthetic-log unit tests.
+vertex-storage-redb = { workspace = true }
+# A full provider with an HTTP transport for the ignored e2e fork test, plus
+# the call types for the direct `deployedContracts()` cross-check.
+alloy-provider = { workspace = true, features = ["reqwest"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/chain/index-chequebook-factory/src/indexer.rs
+++ b/crates/chain/index-chequebook-factory/src/indexer.rs
@@ -1,0 +1,125 @@
+//! The [`ChequebookFactoryIndexer`]: folds factory deployments into the set.
+//!
+//! The SimpleSwapFactory (the chequebook factory) deploys an ERC20SimpleSwap
+//! chequebook per node and emits `SimpleSwapDeployed(address contractAddress)`
+//! for each. This indexer watches that one event, decodes the deployed address,
+//! and folds it into the [`ChequebookFactoryTable`] projection: the set of
+//! chequebooks the factory has deployed.
+//!
+//! The fold is pure and idempotent: `apply` writes only to the projection table,
+//! never calls into accounting, the storer, or any other domain, and a replayed
+//! finalized log re-applies to the same row. Validating a cheque's chequebook as
+//! factory-deployed is the consumer's job, done lazily by reading the projection
+//! at its own decision point (see `CHAIN_REACTIONS_DESIGN.md`); this crate stays
+//! domain-agnostic.
+
+use std::sync::Arc;
+
+use alloy_primitives::Address;
+use alloy_rpc_types_eth::{Filter, Log};
+use alloy_sol_types::SolEvent;
+use nectar_contracts::{ChequebookFactory, IChequebookFactory};
+use vertex_chain_index::{IndexError, Indexer};
+use vertex_storage::{Database, Tables};
+
+use crate::projection::{ChequebookFactoryTables, LogPosition, apply_deployment};
+
+/// A stable, human-readable name; also the cursor key and metric label.
+const INDEXER_NAME: &str = "chequebook_factory";
+
+/// Indexes the chequebook factory into a [`ChequebookFactoryTable`].
+///
+/// Construct with [`ChequebookFactoryIndexer::new`] from a `nectar_contracts`
+/// [`ChequebookFactory`] deployment (its address and deployment block) and a
+/// `vertex-storage` [`Database`], then register it with the engine:
+///
+/// ```ignore
+/// use nectar_contracts::mainnet;
+/// let indexer = ChequebookFactoryIndexer::new(mainnet::CHEQUEBOOK_FACTORY, db.clone());
+/// indexer.init()?;
+/// let engine = EventEngine::new(provider, db).register(Arc::new(indexer));
+/// ```
+///
+/// [`ChequebookFactoryTable`]: crate::ChequebookFactoryTable
+pub struct ChequebookFactoryIndexer<DB> {
+    deployment: ChequebookFactory,
+    db: Arc<DB>,
+}
+
+impl<DB: Database> ChequebookFactoryIndexer<DB> {
+    /// Build an indexer for a chequebook factory deployment over a database.
+    ///
+    /// `deployment` carries the contract address and its deployment block, so the
+    /// same constructor serves mainnet and testnet from the canonical
+    /// `nectar_contracts` constants.
+    pub fn new(deployment: ChequebookFactory, db: Arc<DB>) -> Self {
+        Self { deployment, db }
+    }
+
+    /// Create the projection table if it does not exist.
+    ///
+    /// The engine initializes its own cursor table; the indexer owns its
+    /// projection table, so a consumer calls this once before the first run. It
+    /// is idempotent.
+    pub fn init(&self) -> Result<(), IndexError> {
+        ChequebookFactoryTables::init(self.db.as_ref())?;
+        Ok(())
+    }
+
+    /// Decode one log and return the deployed chequebook address, or `None` if
+    /// the log is not a `SimpleSwapDeployed`.
+    ///
+    /// Split out from [`apply`](Indexer::apply) so the decode is unit-testable in
+    /// isolation and `apply` stays a thin store-the-result fold.
+    fn decode(log: &Log) -> Result<Option<Address>, IndexError> {
+        let Some(topic0) = log.topic0() else {
+            return Ok(None);
+        };
+
+        if *topic0 == IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH {
+            let decoded = log
+                .log_decode::<IChequebookFactory::SimpleSwapDeployed>()
+                .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?;
+            Ok(Some(decoded.inner.contractAddress))
+        } else {
+            // The filter selects only this topic; tolerate any other log the
+            // contract might emit by ignoring it rather than erroring the run.
+            Ok(None)
+        }
+    }
+}
+
+impl<DB: Database> Indexer for ChequebookFactoryIndexer<DB> {
+    fn name(&self) -> &'static str {
+        INDEXER_NAME
+    }
+
+    fn start_block(&self) -> u64 {
+        self.deployment.block
+    }
+
+    fn filter(&self) -> Filter {
+        Filter::new()
+            .address(self.deployment.address)
+            .event_signature(vec![IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH])
+    }
+
+    fn apply(&self, block: u64, log: &Log) -> Result<(), IndexError> {
+        let Some(chequebook) = Self::decode(log)? else {
+            return Ok(());
+        };
+
+        let log_index = log
+            .log_index
+            .ok_or(IndexError::apply(INDEXER_NAME, "log missing log_index"))?;
+        let pos = LogPosition { block, log_index };
+
+        // Pure projection write: record the deployed chequebook at its source
+        // position, guarded so a replayed or reordered log never regresses the
+        // set. No side effects, no reactions; a consumer validates a cheque's
+        // chequebook lazily by reading the projection.
+        self.db
+            .update(|tx| apply_deployment(tx, chequebook, pos))
+            .map_err(IndexError::from)
+    }
+}

--- a/crates/chain/index-chequebook-factory/src/lib.rs
+++ b/crates/chain/index-chequebook-factory/src/lib.rs
@@ -1,0 +1,62 @@
+//! Chequebook factory indexer for Vertex.
+//!
+//! A per-contract [`Indexer`](vertex_chain_index::Indexer) for the SimpleSwap
+//! chequebook factory, driven by the generic
+//! [`vertex-chain-index`](vertex_chain_index) engine. It folds the factory's
+//! deployment event into a `vertex-storage` set a consumer reads lazily.
+//!
+//! # What it indexes
+//!
+//! The SimpleSwapFactory deploys one ERC20SimpleSwap chequebook per node and
+//! emits, for each, the single event:
+//!
+//! - `SimpleSwapDeployed(address contractAddress)` names a newly deployed
+//!   chequebook.
+//!
+//! The event binding and the contract's deployment constants (address and
+//! deployment block, for Gnosis Chain mainnet and Sepolia testnet) come from
+//! `nectar_contracts`, so the address book is not duplicated here.
+//!
+//! # The projection
+//!
+//! State lands in the [`ChequebookFactoryTable`], a set keyed by the deployed
+//! chequebook [`Address`](alloy_primitives::Address). Each row records the
+//! `(block, log_index)` of the `SimpleSwapDeployed` log that created it.
+//! Membership is the fact a consumer needs: ask [`is_factory_deployed`] whether a
+//! chequebook came from the factory.
+//!
+//! # Why this set exists
+//!
+//! When a cheque arrives, its drawer chequebook must be validated as a genuine,
+//! factory-deployed ERC20SimpleSwap before the node trusts it. That validation is
+//! a membership query against this set: the indexer records every deployment, and
+//! the accounting consumer checks the drawer against the set at the point a cheque
+//! is received.
+//!
+//! # Pure, idempotent fold (no reactions)
+//!
+//! [`ChequebookFactoryIndexer::apply`](vertex_chain_index::Indexer::apply) is a
+//! pure fold into the projection: it writes only the projection table, never
+//! calls into accounting, the storer, or any other domain, and re-applying a
+//! finalized log produces the same row. A consumer that wants to validate a
+//! chequebook does so lazily by reading the set at its own decision point. The
+//! chain crate stays domain-agnostic; reactions are the consumer's job. See
+//! `CHAIN_REACTIONS_DESIGN.md`.
+//!
+//! # Placement
+//!
+//! Native, RPC-and-persistence code intended to run behind a `chain` feature in
+//! its consumers and to stay out of the wasm cone. Like the engine, it depends on
+//! `alloy` with `default-features = false` and carries no transport of its own.
+
+mod indexer;
+mod projection;
+
+pub use indexer::ChequebookFactoryIndexer;
+pub use projection::{
+    ChequebookFactoryTable, ChequebookFactoryTables, ChequebookKey, DeployedRow, LogPosition,
+    apply_deployment, deployment_of, is_factory_deployed,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/chain/index-chequebook-factory/src/projection.rs
+++ b/crates/chain/index-chequebook-factory/src/projection.rs
@@ -1,0 +1,142 @@
+//! The chequebook-factory projection: a `vertex-storage` table recording the
+//! set of chequebook contracts the factory has deployed.
+//!
+//! The projection is the indexed state the [`ChequebookFactoryIndexer`] folds
+//! `SimpleSwapDeployed` logs into. Each deployed chequebook is one row, keyed by
+//! its [`Address`], so membership is a single point read: a cheque arriving from
+//! a chequebook is factory-deployed iff [`is_factory_deployed`] finds its row.
+//!
+//! Each row records the `(block, log_index)` of the `SimpleSwapDeployed` log
+//! that created it. That source position makes the fold idempotent and
+//! monotonic: a replayed finalized log re-applies to the same row with the same
+//! value, and a log that is not strictly newer than the stored one leaves the
+//! row unchanged, so reordering or replay can never regress the projection. The
+//! engine delivers logs in `(block, log_index)` order over the canonical
+//! finalized range, so the stored position only ever moves forward in a clean
+//! run; the guard is the belt-and-braces that keeps replay a no-op.
+//!
+//! A chequebook is deployed exactly once, so in practice no two distinct logs
+//! ever target the same address; the monotonic guard is what makes a replay of
+//! that one log a no-op rather than a way of resolving genuine contention.
+//!
+//! [`ChequebookFactoryIndexer`]: crate::ChequebookFactoryIndexer
+
+use alloy_primitives::Address;
+use serde::{Deserialize, Serialize};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table, Tables};
+
+vertex_storage::table!(
+    pub ChequebookFactoryTable,
+    "chequebook_factory_deployed",
+    ChequebookKey,
+    DeployedRow
+);
+
+/// The set of tables this indexer persists, for one-shot initialization.
+pub struct ChequebookFactoryTables;
+
+impl Tables for ChequebookFactoryTables {
+    const NAMES: &'static [&'static str] = &[ChequebookFactoryTable::NAME];
+}
+
+/// The [`ChequebookFactoryTable`] key: a factory-deployed chequebook address.
+///
+/// A newtype over [`Address`] encoded as its 20 raw bytes, so the table iterates
+/// in ascending address order and membership is a single point read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ChequebookKey(pub Address);
+
+impl Encode for ChequebookKey {
+    type Encoded = [u8; 20];
+
+    fn encode(self) -> Self::Encoded {
+        self.0.into_array()
+    }
+}
+
+impl Decode for ChequebookKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let bytes: [u8; 20] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        Ok(Self(Address::from(bytes)))
+    }
+}
+
+/// A deployed-chequebook row: the chain position of the `SimpleSwapDeployed` log
+/// that recorded it.
+///
+/// The row carries no further payload; presence in the table is the fact. The
+/// `source` position is the idempotency key: a fold only overwrites a row when
+/// the incoming log is strictly newer (see [`DeployedRow::superseded_by`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeployedRow {
+    /// The `(block_number, log_index)` of the `SimpleSwapDeployed` log.
+    pub source: LogPosition,
+}
+
+impl DeployedRow {
+    /// Whether a log at `pos` should overwrite this row.
+    ///
+    /// True only when `pos` is strictly after the stored source. Equal positions
+    /// (a replayed log) and earlier positions (a reordered log) are no-ops, which
+    /// is what makes the fold idempotent and monotonic.
+    pub fn superseded_by(&self, pos: LogPosition) -> bool {
+        pos > self.source
+    }
+}
+
+/// A log's canonical position: `(block_number, log_index)`.
+///
+/// Ordered lexicographically, matching the order the engine delivers logs in, so
+/// `>` on a [`LogPosition`] means "strictly later in the canonical stream".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LogPosition {
+    /// The block the log was emitted in.
+    pub block: u64,
+    /// The log's index within its block.
+    pub log_index: u64,
+}
+
+/// Whether `chequebook` is in the factory-deployed set.
+///
+/// This is the lazy read a consumer performs at its own decision point: when a
+/// cheque arrives, it validates the cheque's chequebook by checking membership
+/// here, rather than the indexer pushing any reaction. See
+/// `CHAIN_REACTIONS_DESIGN.md`.
+pub fn is_factory_deployed<DB: Database>(
+    db: &DB,
+    chequebook: Address,
+) -> Result<bool, DatabaseError> {
+    db.view(|tx| {
+        Ok(tx
+            .get::<ChequebookFactoryTable>(ChequebookKey(chequebook))?
+            .is_some())
+    })
+}
+
+/// Read the deployment record of `chequebook`, if it is factory-deployed.
+pub fn deployment_of<DB: Database>(
+    db: &DB,
+    chequebook: Address,
+) -> Result<Option<DeployedRow>, DatabaseError> {
+    db.view(|tx| tx.get::<ChequebookFactoryTable>(ChequebookKey(chequebook)))
+}
+
+/// Fold a single deployment into the set: record `chequebook` at `pos`, unless an
+/// existing row was set by a strictly-newer log.
+///
+/// This is the pure projection step. It is idempotent: a replayed or reordered
+/// log that is not strictly newer than the stored source leaves the row
+/// unchanged.
+pub fn apply_deployment<TX: DbTxMut>(
+    tx: &TX,
+    chequebook: Address,
+    pos: LogPosition,
+) -> Result<(), DatabaseError> {
+    let key = ChequebookKey(chequebook);
+    if let Some(existing) = tx.get::<ChequebookFactoryTable>(key)?
+        && !existing.superseded_by(pos)
+    {
+        return Ok(());
+    }
+    tx.put::<ChequebookFactoryTable>(key, DeployedRow { source: pos })
+}

--- a/crates/chain/index-chequebook-factory/src/tests.rs
+++ b/crates/chain/index-chequebook-factory/src/tests.rs
@@ -1,0 +1,210 @@
+//! Unit tests over synthetic logs (no chain).
+//!
+//! These build canonical `SimpleSwapDeployed` logs by ABI-encoding the event,
+//! fold them through [`ChequebookFactoryIndexer::apply`], and assert the
+//! projection records membership. They also assert the fold is idempotent (replay
+//! is a no-op) and monotonic (a stale, reordered log never regresses the row),
+//! that distinct deployments accumulate, and that an unrelated topic is ignored.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, LogData};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use nectar_contracts::{ChequebookFactory, IChequebookFactory};
+use vertex_chain_index::Indexer;
+use vertex_storage_redb::RedbDatabase;
+
+use crate::indexer::ChequebookFactoryIndexer;
+use crate::projection::{LogPosition, deployment_of, is_factory_deployed};
+
+/// The factory contract address used in the synthetic logs.
+const FACTORY: Address = Address::repeat_byte(0xfa);
+
+/// Two distinct deployed-chequebook addresses.
+const CHEQUEBOOK_A: Address = Address::repeat_byte(0xa1);
+const CHEQUEBOOK_B: Address = Address::repeat_byte(0xb2);
+
+/// A deployment fixture: the test factory address, deployment block 0.
+fn deployment() -> ChequebookFactory {
+    ChequebookFactory::new(FACTORY, 0)
+}
+
+/// Build an indexer over a fresh in-memory database with its table created.
+fn fresh_indexer() -> (ChequebookFactoryIndexer<RedbDatabase>, Arc<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = ChequebookFactoryIndexer::new(deployment(), db.clone());
+    indexer.init().expect("init projection table");
+    (indexer, db)
+}
+
+/// A synthetic `SimpleSwapDeployed` log at `(block, index)` for `contract`.
+fn deployed_log(block: u64, index: u64, contract: Address) -> Log {
+    let event = IChequebookFactory::SimpleSwapDeployed {
+        contractAddress: contract,
+    };
+    let topic0 = event.encode_topics_array::<1>()[0].into();
+    log_for(block, index, topic0, event)
+}
+
+/// Wrap an encoded event into an RPC [`Log`] at a chosen position.
+fn log_for<E: SolEvent>(block: u64, index: u64, topic0: B256, event: E) -> Log {
+    let topics = vec![topic0];
+    let data = event.encode_data().into();
+    Log {
+        inner: alloy_primitives::Log {
+            address: FACTORY,
+            data: LogData::new_unchecked(topics, data),
+        },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+#[test]
+fn filter_selects_the_deployment_event() {
+    let (indexer, _db) = fresh_indexer();
+    let filter = indexer.filter();
+    assert!(
+        filter.topics[0].matches(&IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH),
+        "filter selects SimpleSwapDeployed"
+    );
+    let addrs: Vec<_> = filter.address.iter().collect();
+    assert!(
+        addrs.contains(&&FACTORY),
+        "filter constrains to the factory"
+    );
+}
+
+#[test]
+fn deployment_folds_into_the_set() {
+    let (indexer, db) = fresh_indexer();
+
+    indexer
+        .apply(40_000_000, &deployed_log(40_000_000, 2, CHEQUEBOOK_A))
+        .expect("apply deployment");
+
+    assert!(
+        is_factory_deployed(db.as_ref(), CHEQUEBOOK_A).expect("read membership"),
+        "the deployed chequebook is in the set"
+    );
+    let row = deployment_of(db.as_ref(), CHEQUEBOOK_A)
+        .expect("read row")
+        .expect("row present");
+    assert_eq!(
+        row.source,
+        LogPosition {
+            block: 40_000_000,
+            log_index: 2
+        }
+    );
+
+    // An address the factory never deployed is not in the set.
+    assert!(
+        !is_factory_deployed(db.as_ref(), CHEQUEBOOK_B).expect("read membership"),
+        "an unseen chequebook is not in the set"
+    );
+}
+
+#[test]
+fn distinct_deployments_accumulate() {
+    let (indexer, db) = fresh_indexer();
+
+    indexer
+        .apply(100, &deployed_log(100, 0, CHEQUEBOOK_A))
+        .unwrap();
+    indexer
+        .apply(101, &deployed_log(101, 0, CHEQUEBOOK_B))
+        .unwrap();
+
+    assert!(is_factory_deployed(db.as_ref(), CHEQUEBOOK_A).unwrap());
+    assert!(is_factory_deployed(db.as_ref(), CHEQUEBOOK_B).unwrap());
+}
+
+#[test]
+fn reapplying_the_same_log_is_idempotent() {
+    let (indexer, db) = fresh_indexer();
+    let log = deployed_log(200, 3, CHEQUEBOOK_A);
+
+    // Apply the identical finalized log twice: the second is a no-op replay.
+    indexer.apply(200, &log).unwrap();
+    let after_first = deployment_of(db.as_ref(), CHEQUEBOOK_A).unwrap().unwrap();
+    indexer.apply(200, &log).unwrap();
+    let after_second = deployment_of(db.as_ref(), CHEQUEBOOK_A).unwrap().unwrap();
+
+    assert_eq!(after_first, after_second, "replay leaves the row unchanged");
+}
+
+#[test]
+fn stale_log_does_not_regress_the_source() {
+    let (indexer, db) = fresh_indexer();
+
+    // A later log for the same address records the newer source position.
+    indexer
+        .apply(305, &deployed_log(305, 1, CHEQUEBOOK_A))
+        .unwrap();
+    // Re-delivering an earlier log (a reorder/replay) must not roll the source
+    // back, even though the address stays in the set either way.
+    indexer
+        .apply(300, &deployed_log(300, 0, CHEQUEBOOK_A))
+        .unwrap();
+
+    let row = deployment_of(db.as_ref(), CHEQUEBOOK_A).unwrap().unwrap();
+    assert_eq!(
+        row.source,
+        LogPosition {
+            block: 305,
+            log_index: 1
+        },
+        "stale log does not overwrite the newer source"
+    );
+    assert!(is_factory_deployed(db.as_ref(), CHEQUEBOOK_A).unwrap());
+}
+
+#[test]
+fn same_block_higher_log_index_supersedes() {
+    let (indexer, db) = fresh_indexer();
+
+    indexer
+        .apply(400, &deployed_log(400, 0, CHEQUEBOOK_A))
+        .unwrap();
+    indexer
+        .apply(400, &deployed_log(400, 5, CHEQUEBOOK_A))
+        .unwrap();
+
+    let row = deployment_of(db.as_ref(), CHEQUEBOOK_A).unwrap().unwrap();
+    assert_eq!(row.source.log_index, 5);
+}
+
+#[test]
+fn unrelated_topic_is_ignored() {
+    let (indexer, db) = fresh_indexer();
+
+    // A log whose topic0 matches no indexed event must be a no-op.
+    let other = Log {
+        inner: alloy_primitives::Log {
+            address: FACTORY,
+            data: LogData::new_unchecked(vec![B256::repeat_byte(0xff)], Default::default()),
+        },
+        block_hash: Some(B256::repeat_byte(1)),
+        block_number: Some(500),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(0),
+        removed: false,
+    };
+
+    indexer
+        .apply(500, &other)
+        .expect("unrelated log is ignored");
+    assert!(
+        !is_factory_deployed(db.as_ref(), CHEQUEBOOK_A).unwrap(),
+        "no deployment was recorded"
+    );
+}

--- a/crates/chain/index-chequebook-factory/tests/e2e_fork.rs
+++ b/crates/chain/index-chequebook-factory/tests/e2e_fork.rs
@@ -1,0 +1,164 @@
+//! End-to-end smoke test against a real Gnosis Chain fork (or live RPC).
+//!
+//! This validates the chequebook-factory indexer against real on-chain state: it
+//! syncs the [`ChequebookFactoryIndexer`] over a bounded recent window, asserts
+//! the engine reaches the finalized head and the cursor advances, and
+//! cross-checks one recorded chequebook against a direct
+//! `deployedContracts(address)` call on the factory (which the factory returns
+//! `true` for exactly the addresses it deployed).
+//!
+//! # On the window
+//!
+//! The Gnosis mainnet SimpleSwapFactory
+//! (`0xc2d5a532cf69aa9a1378737d8ccdef884b6e7420`) deploys a chequebook whenever a
+//! new node funds one, so a recent window normally contains some
+//! `SimpleSwapDeployed` logs. It can, however, be quiet: if the window held no
+//! deployment the test still asserts the engine reached head over real data and
+//! skips the membership cross-check. Set
+//! `CHEQUEBOOK_FACTORY_E2E_FROM_DEPLOYMENT=1` to sync the whole contract lifetime
+//! instead of a recent window; on a fork that proxies `eth_getLogs` upstream this
+//! is slower but guarantees deployments to cross-check.
+//!
+//! It is `#[ignore]`d so CI without a fork stays green. To run it:
+//!
+//! 1. Start a fork (anvil ships with foundry; install via `foundryup` if absent).
+//!    Use the UNIQUE port 8548 so it does not collide with sibling indexers:
+//!
+//!    ```sh
+//!    anvil --fork-url ${GNOSIS_RPC_URL:-https://rpc.gnosischain.com} \
+//!          --fork-block-number <recent> --port 8548 --silent &
+//!    CHEQUEBOOK_FACTORY_E2E_RPC=http://localhost:8548 \
+//!        cargo test -p vertex-chain-index-chequebook-factory --test e2e_fork \
+//!        -- --ignored --nocapture
+//!    ```
+//!
+//! 2. If anvil cannot be run, point the test at a public Gnosis RPC directly
+//!    (shared and rate-limited, so keep the window bounded):
+//!
+//!    ```sh
+//!    CHEQUEBOOK_FACTORY_E2E_RPC=https://rpc.gnosischain.com \
+//!        cargo test -p vertex-chain-index-chequebook-factory --test e2e_fork \
+//!        -- --ignored --nocapture
+//!    ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_primitives::TxKind;
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types_eth::{BlockId, TransactionInput, TransactionRequest};
+use alloy_sol_types::{SolCall, SolValue};
+use nectar_contracts::{ChequebookFactory, IChequebookFactory, mainnet};
+use vertex_chain_index::{ChainReader, Cursor, EventEngine};
+use vertex_chain_index_chequebook_factory::{
+    ChequebookFactoryIndexer, ChequebookFactoryTable, ChequebookKey,
+};
+use vertex_storage::{Database, DbTx};
+use vertex_storage_redb::RedbDatabase;
+
+/// How many blocks back from the finalized head to sync by default. A modest
+/// window keeps a fork-proxied backfill fast; set
+/// `CHEQUEBOOK_FACTORY_E2E_FROM_DEPLOYMENT=1` to sync the whole contract
+/// lifetime.
+const WINDOW: u64 = 500_000;
+
+#[tokio::test]
+#[ignore = "requires a Gnosis fork or live RPC; see module docs"]
+async fn indexes_real_chequebook_factory() {
+    let rpc = std::env::var("CHEQUEBOOK_FACTORY_E2E_RPC")
+        .unwrap_or_else(|_| "http://localhost:8548".to_string());
+
+    let url = rpc
+        .parse()
+        .expect("CHEQUEBOOK_FACTORY_E2E_RPC is a valid URL");
+    let provider = Arc::new(ProviderBuilder::new().connect_http(url));
+
+    // Bound the window to the RPC's finalized head. Skip (do not fail) if the RPC
+    // is unreachable so the test is a smoke check, not a hard dependency.
+    let head = match ChainReader::finalized_head(provider.as_ref()).await {
+        Ok(Some(head)) => head,
+        Ok(None) => {
+            eprintln!("skipping: RPC has no finalized block");
+            return;
+        }
+        Err(err) => {
+            eprintln!("skipping: RPC unreachable at {rpc}: {err}");
+            return;
+        }
+    };
+
+    let deployment = mainnet::CHEQUEBOOK_FACTORY;
+    let from_deployment = std::env::var("CHEQUEBOOK_FACTORY_E2E_FROM_DEPLOYMENT").is_ok();
+    let start = if from_deployment {
+        deployment.block
+    } else {
+        head.number.saturating_sub(WINDOW).max(deployment.block)
+    };
+    let factory = ChequebookFactory::new(deployment.address, start);
+    eprintln!(
+        "syncing chequebook factory {} over blocks {start}..={} via {rpc}",
+        deployment.address, head.number
+    );
+
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = Arc::new(ChequebookFactoryIndexer::new(factory, db.clone()));
+    indexer.init().expect("init projection table");
+
+    // A long poll interval keeps the follow loop from delaying the test; the
+    // immediate shutdown stops the engine right after the startup backfill.
+    EventEngine::new(provider.clone(), db.clone())
+        .register(indexer)
+        .with_poll_interval(Duration::from_secs(3600))
+        .run(async {})
+        .await
+        .expect("engine run");
+
+    // The engine fully backfilled to the finalized head: the cursor advanced.
+    let cursor = Cursor::load(db.as_ref(), "chequebook_factory")
+        .expect("load cursor")
+        .expect("cursor persisted");
+    assert_eq!(cursor.last_block, head.number, "cursor advanced to head");
+
+    let deployed: Vec<ChequebookKey> = db
+        .view(|tx| {
+            Ok(tx
+                .entries::<ChequebookFactoryTable>()?
+                .into_iter()
+                .map(|(k, _)| k)
+                .collect())
+        })
+        .expect("read deployed set");
+    eprintln!("indexed {} factory-deployed chequebooks", deployed.len());
+
+    // Cross-check against real chain data: the factory's `deployedContracts`
+    // mapping returns `true` for exactly the addresses it deployed. Take one
+    // chequebook we recorded and assert the factory agrees it deployed it; this
+    // proves the indexer folded a real `SimpleSwapDeployed` payload off the chain.
+    match deployed.first() {
+        Some(ChequebookKey(chequebook)) => {
+            let call = IChequebookFactory::deployedContractsCall { addr: *chequebook };
+            let tx = TransactionRequest {
+                to: Some(TxKind::Call(deployment.address)),
+                input: TransactionInput::new(call.abi_encode().into()),
+                ..Default::default()
+            };
+            let returned = provider
+                .call(tx)
+                .block(BlockId::number(head.number))
+                .await
+                .expect("deployedContracts eth_call");
+            let on_chain = bool::abi_decode(&returned).expect("decode deployedContracts return");
+            eprintln!("factory.deployedContracts({chequebook}) = {on_chain}");
+            assert!(
+                on_chain,
+                "the factory confirms it deployed a chequebook the indexer recorded",
+            );
+        }
+        None => {
+            eprintln!(
+                "no SimpleSwapDeployed in window; engine reached head over real data \
+                 (set CHEQUEBOOK_FACTORY_E2E_FROM_DEPLOYMENT=1 to force deployments)"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

A new sibling indexer crate `crates/chain/index-chequebook-factory`
(`vertex-chain-index-chequebook-factory`) that plugs into the generic reorg-safe
`vertex-chain-index` engine (#300) and folds the SimpleSwap chequebook factory's
deployment event into a `vertex-storage` projection. It mirrors the
`index-swap-price` (#302) and `index-redistribution` (#303) layout.

## Events indexed

The SimpleSwapFactory (Gnosis mainnet `0xc2d5a532cf69aa9a1378737d8ccdef884b6e7420`,
deployment block 39939970; Sepolia testnet `0x0fF044F6bB4F684a5A149B46D7eC03ea659F98A1`)
emits one event this indexer watches:

- `SimpleSwapDeployed(address contractAddress)` names a newly factory-deployed
  ERC20SimpleSwap chequebook.

The event binding and the deployment constants come from
`nectar_contracts::IChequebookFactory` and `nectar_contracts::{mainnet,testnet}::CHEQUEBOOK_FACTORY`,
so the address book is not duplicated.

## Projection

A single `vertex-storage` table, `ChequebookFactoryTable`
(`"chequebook_factory_deployed"`): the **set of factory-deployed chequebook
addresses**, keyed by the deployed chequebook `Address`. Each row records the
`(block, log_index)` of the `SimpleSwapDeployed` log that created it.

The purpose is cheque validation: when a cheque arrives, its drawer chequebook
must be a genuine factory-deployed ERC20SimpleSwap. A consumer validates it
lazily with a single membership read, `is_factory_deployed(db, chequebook)`, at
its own decision point. The indexer never pushes a reaction.

## `apply` is a pure, idempotent, no-reaction fold

Per `CHAIN_REACTIONS_DESIGN.md`, `ChequebookFactoryIndexer::apply` only writes to
the projection table. It calls into no storer, accounting, or other domain crate;
it fires no reaction; it gates no node behaviour. The row records the source
`(block, log_index)` and a fold only overwrites when the incoming log is strictly
newer, so a replayed finalized log re-applies to the same row (idempotent) and a
reordered/stale log never regresses the set (monotonic supersede by
`(block, log_index)`). The chain crate stays domain-agnostic; reactions are the
consumer's job.

## Tests

- **Unit** (synthetic ABI-encoded logs, in-memory `vertex-storage` backend):
  the event decodes and folds into the set; distinct deployments accumulate;
  re-applying a log is idempotent; a stale/reordered log does not regress the
  source; same-block higher `log_index` supersedes; an unrelated topic is ignored;
  the filter selects the contract and the `SimpleSwapDeployed` topic.
- **e2e** (`tests/e2e_fork.rs`, env-guarded and `#[ignore]`d): syncs the live
  Gnosis mainnet factory over a bounded recent window via an anvil fork (port
  **8548**) or a public RPC, asserts the engine reaches the finalized head and the
  cursor advances, then cross-checks one recorded chequebook against a direct
  `deployedContracts(address)` call on the factory (which returns `true` for
  exactly the addresses it deployed). Run instructions are in the test's module
  docs.

## Placement

Native, RPC-and-persistence code intended to run behind a `chain` feature in its
consumers and to stay out of the wasm cone, like the engine it builds on.
