### PR TITLE
feat(chain): postage batch + price indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,6 +8364,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-chain-index-postage"
+version = "0.1.0"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "serde",
+ "tokio",
+ "vertex-chain-index",
+ "vertex-storage",
+ "vertex-storage-redb",
+]
+
+[[package]]
 name = "vertex-ffi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
     # Chain (Ethereum RPC access)
     "crates/chain",
     "crates/chain/index",
+    "crates/chain/index-postage",
 
     # FFI (native embedding surface)
     "crates/ffi",
@@ -238,6 +239,7 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 # chain (Ethereum RPC access)
 vertex-chain = { path = "crates/chain" }
 vertex-chain-index = { path = "crates/chain/index" }
+vertex-chain-index-postage = { path = "crates/chain/index-postage" }
 
 # ffi (native embedding surface)
 vertex-ffi = { path = "crates/ffi" }

--- a/crates/chain/index-postage/Cargo.toml
+++ b/crates/chain/index-postage/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "vertex-chain-index-postage"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Postage stamp contract event indexer: a pure, idempotent projection of the batch set, the swap price, and the contract chain-state"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The generic engine and its `Indexer` trait this crate plugs into.
+vertex-chain-index = { workspace = true }
+# The projection tables and the persisted-fold transaction surface.
+vertex-storage = { workspace = true }
+
+# alloy: `sol!` event bindings and the log filter. `default-features = false`
+# on the provider keeps reqwest and TLS out so the crate stays out of the wasm
+# cone without dragging a native transport in; the engine selects the transport.
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true }
+alloy-sol-types = { workspace = true }
+
+# serialization: the projection rows derive serde for storage.
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+vertex-storage-redb = { workspace = true }
+# Cross-checking the indexed chain-state against direct contract reads in the
+# e2e fork test needs the contract call bindings and a full HTTP provider.
+alloy-contract = { workspace = true }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/chain/index-postage/src/events.rs
+++ b/crates/chain/index-postage/src/events.rs
@@ -1,0 +1,60 @@
+//! `sol!` event bindings for the PostageStamp contract.
+//!
+//! These are the exact event signatures from the contract ABI at
+//! `deployments/mainnet/PostageStamp.json`. They are the only contract detail
+//! this crate hard-codes; the fold in [`crate::indexer`] decodes logs through
+//! them and the [`Indexer`](vertex_chain_index::Indexer) filter selects on their
+//! `topic0` hashes.
+//!
+//! The PostageStamp contract on Gnosis Chain manages the postage batches that
+//! authorise uploads to Swarm. Five events project into the indexer's state:
+//!
+//! - `BatchCreated` opens a batch with its full parameters.
+//! - `BatchTopUp` raises a batch's `normalisedBalance`.
+//! - `BatchDepthIncrease` raises a batch's depth (and re-normalises its balance).
+//! - `PriceUpdate` sets the per-chunk-per-block storage price; the running
+//!   `totalOutPayment` accumulator is reconstructed from its cadence.
+//! - `Paused` records the contract pause state.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// A new batch was created with its full parameters.
+    ///
+    /// `batchId` is indexed; the rest carry the batch's economic state at
+    /// creation. `normalisedBalance` is the value the running
+    /// `currentTotalOutPayment` line must stay below for the batch to remain
+    /// valid.
+    #[allow(missing_docs)]
+    event BatchCreated(
+        bytes32 indexed batchId,
+        uint256 totalAmount,
+        uint256 normalisedBalance,
+        address owner,
+        uint8 depth,
+        uint8 bucketDepth,
+        bool immutableFlag
+    );
+
+    /// An existing batch was topped up, raising its `normalisedBalance`.
+    #[allow(missing_docs)]
+    event BatchTopUp(bytes32 indexed batchId, uint256 topupAmount, uint256 normalisedBalance);
+
+    /// An existing batch's depth was increased, with a re-normalised balance.
+    #[allow(missing_docs)]
+    event BatchDepthIncrease(bytes32 indexed batchId, uint8 newDepth, uint256 normalisedBalance);
+
+    /// The per-chunk-per-block storage price was set.
+    ///
+    /// The contract folds the elapsed cost into `totalOutPayment` at each price
+    /// change, then sets `lastPrice = price` and `lastUpdatedBlock = block`; the
+    /// indexer reconstructs that same accumulator from the cadence of these
+    /// events (see [`crate::projection::ChainState`]).
+    #[allow(missing_docs)]
+    event PriceUpdate(uint256 price);
+
+    /// The contract was paused (or, on the same signature, unpaused) by
+    /// `account`.
+    #[allow(missing_docs)]
+    event Paused(address account);
+}

--- a/crates/chain/index-postage/src/indexer.rs
+++ b/crates/chain/index-postage/src/indexer.rs
@@ -1,0 +1,253 @@
+//! The [`PostageIndexer`]: the per-contract fold over PostageStamp logs.
+//!
+//! This is the contract-specific half the generic
+//! [`EventEngine`](vertex_chain_index::EventEngine) drives. It declares the
+//! contract address, the deployment block, and the `topic0` set of the events it
+//! folds, then folds each decoded log into the [`projection`](crate::projection)
+//! with a pure, idempotent write.
+//!
+//! Per the chain-reactions design, `apply` only RECORDS: it writes projection
+//! rows and returns. It calls into no domain crate (no storer, no accounting, no
+//! postage issuer), fires no reaction, evicts nothing, and gates no node
+//! behaviour. Batch expiry has no event to hook (a batch dies when the rising
+//! `currentTotalOutPayment` line crosses its static `normalisedBalance`, with no
+//! transaction at the crossing), so the validity decision is left to a consumer
+//! that recomputes it lazily on the block clock via
+//! [`is_batch_valid_now`](crate::projection::is_batch_valid_now).
+//!
+//! [`EventEngine`]: vertex_chain_index::EventEngine
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, address};
+use alloy_rpc_types_eth::{Filter, Log};
+use alloy_sol_types::SolEvent;
+use vertex_chain_index::{IndexError, Indexer};
+use vertex_storage::{Database, DbTxMut};
+
+use crate::events::{BatchCreated, BatchDepthIncrease, BatchTopUp, Paused, PriceUpdate};
+use crate::projection::{
+    BatchKey, BatchState, BatchTable, ChainState, ChainStateKey, ChainStateTable, LogPosition,
+    PostageTables,
+};
+
+/// The PostageStamp contract on Gnosis Chain (id 100).
+///
+/// This is the specific deployment this indexer projects, distinct from older
+/// PostageStamp deployments; the deployment block below pairs with it.
+pub const POSTAGE_STAMP_ADDRESS: Address = address!("45a1502382541Cd610CC9068e88727426b696293");
+
+/// The PostageStamp contract deployment block on Gnosis Chain.
+///
+/// Backfill starts here so the engine never pages the empty range before the
+/// contract existed.
+pub const POSTAGE_STAMP_DEPLOYMENT_BLOCK: u64 = 31_305_656;
+
+/// The indexer name, used as the engine's cursor key and metric label.
+pub const INDEXER_NAME: &str = "postage_stamp";
+
+/// Folds PostageStamp contract logs into the [`crate::projection`].
+///
+/// Construct with [`new`](PostageIndexer::new) over a `vertex-storage`
+/// [`Database`], then register it with an
+/// [`EventEngine`](vertex_chain_index::EventEngine). The engine delivers each
+/// matching log to [`apply`](Indexer::apply) in canonical `(block, log_index)`
+/// order; `apply` decodes it and folds the corresponding projection row.
+pub struct PostageIndexer<DB> {
+    db: Arc<DB>,
+    start_block: u64,
+}
+
+impl<DB: Database> PostageIndexer<DB> {
+    /// Build the indexer over the database holding the projection tables.
+    ///
+    /// Backfills from the contract's deployment block. Initializes the projection
+    /// tables so the first `apply` has somewhere to write; the engine separately
+    /// initializes its own cursor table. Takes the database by `Arc` so the same
+    /// handle the [`EventEngine`](vertex_chain_index::EventEngine) drives can be
+    /// shared.
+    pub fn new(db: Arc<DB>) -> Result<Self, IndexError> {
+        Self::with_start_block(db, POSTAGE_STAMP_DEPLOYMENT_BLOCK)
+    }
+
+    /// Build the indexer with an explicit backfill start block.
+    ///
+    /// Production uses [`new`](Self::new) (the deployment block); tests use this
+    /// to bound the backfill to a recent window. A start block below the
+    /// deployment block has no effect, since the engine never pages before the
+    /// contract existed.
+    pub fn with_start_block(db: Arc<DB>, start_block: u64) -> Result<Self, IndexError> {
+        PostageTables::init(db.as_ref())?;
+        Ok(Self { db, start_block })
+    }
+
+    /// Decode `log` against `E` or map the decode failure to an apply error.
+    fn decode<E: SolEvent>(log: &Log) -> Result<E, IndexError> {
+        log.log_decode::<E>()
+            .map(|decoded| decoded.inner.data)
+            .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))
+    }
+}
+
+impl<DB: Database> Indexer for PostageIndexer<DB> {
+    fn name(&self) -> &'static str {
+        INDEXER_NAME
+    }
+
+    fn start_block(&self) -> u64 {
+        self.start_block
+    }
+
+    fn filter(&self) -> Filter {
+        Filter::new()
+            .address(POSTAGE_STAMP_ADDRESS)
+            .event_signature(vec![
+                BatchCreated::SIGNATURE_HASH,
+                BatchTopUp::SIGNATURE_HASH,
+                BatchDepthIncrease::SIGNATURE_HASH,
+                PriceUpdate::SIGNATURE_HASH,
+                Paused::SIGNATURE_HASH,
+            ])
+    }
+
+    fn apply(&self, block: u64, log: &Log) -> Result<(), IndexError> {
+        let log_index = log
+            .log_index
+            .ok_or(IndexError::MalformedLog { field: "log_index" })?;
+        let pos = LogPosition { block, log_index };
+
+        let topic0 = log
+            .topic0()
+            .copied()
+            .ok_or(IndexError::apply(INDEXER_NAME, "log has no topic0"))?;
+
+        let tx = self.db.as_ref().tx_mut()?;
+
+        match topic0 {
+            BatchCreated::SIGNATURE_HASH => {
+                let e = Self::decode::<BatchCreated>(log)?;
+                upsert_batch(&tx, BatchKey(e.batchId), pos, |batch| match batch {
+                    // First sight: open the row from the create payload.
+                    None => Some(BatchState {
+                        owner: e.owner,
+                        depth: e.depth,
+                        bucket_depth: e.bucketDepth,
+                        normalised_balance: e.normalisedBalance,
+                        immutable: e.immutableFlag,
+                        start_block: block,
+                        source: pos,
+                    }),
+                    // A create for an already-known batch only refreshes the
+                    // mutable fields; `start_block` stays the creation block.
+                    Some(mut existing) => {
+                        existing.owner = e.owner;
+                        existing.depth = e.depth;
+                        existing.bucket_depth = e.bucketDepth;
+                        existing.normalised_balance = e.normalisedBalance;
+                        existing.immutable = e.immutableFlag;
+                        existing.source = pos;
+                        Some(existing)
+                    }
+                })?;
+            }
+            BatchTopUp::SIGNATURE_HASH => {
+                let e = Self::decode::<BatchTopUp>(log)?;
+                upsert_batch(&tx, BatchKey(e.batchId), pos, |batch| {
+                    batch.map(|mut b| {
+                        b.normalised_balance = e.normalisedBalance;
+                        b.source = pos;
+                        b
+                    })
+                })?;
+            }
+            BatchDepthIncrease::SIGNATURE_HASH => {
+                let e = Self::decode::<BatchDepthIncrease>(log)?;
+                upsert_batch(&tx, BatchKey(e.batchId), pos, |batch| {
+                    batch.map(|mut b| {
+                        b.depth = e.newDepth;
+                        b.normalised_balance = e.normalisedBalance;
+                        b.source = pos;
+                        b
+                    })
+                })?;
+            }
+            PriceUpdate::SIGNATURE_HASH => {
+                let e = Self::decode::<PriceUpdate>(log)?;
+                upsert_chain_state(&tx, pos, |state| {
+                    state.fold_price_update(e.price, block);
+                    state.source = pos;
+                })?;
+            }
+            Paused::SIGNATURE_HASH => {
+                let _ = Self::decode::<Paused>(log)?;
+                upsert_chain_state(&tx, pos, |state| {
+                    state.paused = true;
+                    state.source = pos;
+                })?;
+            }
+            other => {
+                return Err(IndexError::apply(
+                    INDEXER_NAME,
+                    format!("unexpected topic0 {other}"),
+                ));
+            }
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+/// Fold one batch event into [`BatchTable`], guarded by the source position.
+///
+/// `mutate` receives the loaded row (or `None` on first sight) and returns the
+/// row to store, or `None` to leave the table untouched. The supersede guard
+/// runs first: a log that is not strictly newer than the stored row is a no-op,
+/// so replay and reordering never roll a batch back. A topup or depth-increase
+/// for a batch that was never created (only reachable if the create log is
+/// outside the indexed window) returns `None` and is dropped rather than
+/// fabricating a partial row.
+fn upsert_batch<TX, F>(
+    tx: &TX,
+    key: BatchKey,
+    pos: LogPosition,
+    mutate: F,
+) -> Result<(), IndexError>
+where
+    TX: DbTxMut,
+    F: FnOnce(Option<BatchState>) -> Option<BatchState>,
+{
+    let existing = tx.get::<BatchTable>(key)?;
+    if let Some(current) = existing
+        && !current.superseded_by(pos)
+    {
+        return Ok(());
+    }
+    if let Some(next) = mutate(existing) {
+        tx.put::<BatchTable>(key, next)?;
+    }
+    Ok(())
+}
+
+/// Fold one pricing/pause event into the single-row [`ChainStateTable`], guarded
+/// by the source position.
+///
+/// `mutate` applies the event to the loaded-or-default chain-state. The supersede
+/// guard keeps a replayed or reordered log a no-op; a default row is created on
+/// first sight so the first `PriceUpdate` or `Paused` log has somewhere to land.
+fn upsert_chain_state<TX, F>(tx: &TX, pos: LogPosition, mutate: F) -> Result<(), IndexError>
+where
+    TX: DbTxMut,
+    F: FnOnce(&mut ChainState),
+{
+    let existing = tx.get::<ChainStateTable>(ChainStateKey)?;
+    if let Some(current) = existing
+        && !current.superseded_by(pos)
+    {
+        return Ok(());
+    }
+    let mut state = existing.unwrap_or_default();
+    mutate(&mut state);
+    tx.put::<ChainStateTable>(ChainStateKey, state)?;
+    Ok(())
+}

--- a/crates/chain/index-postage/src/lib.rs
+++ b/crates/chain/index-postage/src/lib.rs
@@ -1,0 +1,66 @@
+//! PostageStamp contract event indexer: a pure, idempotent projection of the
+//! Swarm postage batch set, the storage price, and the contract chain-state.
+//!
+//! The PostageStamp contract on Gnosis Chain manages the postage batches that
+//! authorise uploads to Swarm. This crate plugs a [`PostageIndexer`] into the
+//! generic [`EventEngine`](vertex_chain_index::EventEngine) and folds the
+//! contract's logs into a `vertex-storage` projection a consumer reads lazily.
+//!
+//! # What it indexes
+//!
+//! Five events from the contract ABI:
+//!
+//! - `BatchCreated`, `BatchTopUp`, `BatchDepthIncrease` maintain the **batch
+//!   set**: per-batch owner, depth, bucket depth, `normalisedBalance`,
+//!   immutability, and creation block.
+//! - `PriceUpdate` drives the **pricing chain-state**: the current per-chunk
+//!   per-block price and the running `totalOutPayment` accumulator, reconstructed
+//!   from the price-update cadence exactly as the contract maintains it.
+//! - `Paused` records the contract pause flag.
+//!
+//! # The projection
+//!
+//! - [`BatchTable`](projection::BatchTable): the batch set, keyed by `batchId`.
+//! - [`ChainStateTable`](projection::ChainStateTable): the single-row pricing
+//!   chain-state (`totalOutPayment`, `lastPrice`, `lastUpdatedBlock`, `paused`).
+//!
+//! # The validity query
+//!
+//! The headline read helper,
+//! [`is_batch_valid_now`](projection::is_batch_valid_now), answers "is this batch
+//! valid at this block" as `normalisedBalance > currentTotalOutPayment(block)`,
+//! where `currentTotalOutPayment(block) = totalOutPayment + lastPrice * (block -
+//! lastUpdatedBlock)`. It is a pure read against the projection plus the live
+//! block clock.
+//!
+//! # Pure, idempotent fold (no reactions)
+//!
+//! Per `CHAIN_REACTIONS_DESIGN.md`,
+//! [`PostageIndexer::apply`](vertex_chain_index::Indexer::apply) is a pure fold:
+//! it writes only the projection tables, never calls into the storer, accounting,
+//! the postage issuer, or any other domain, and re-applying a finalized log
+//! re-applies to the same row. It performs **no eviction and no reaction**: batch
+//! expiry has no event to hook (a batch dies when the rising
+//! `currentTotalOutPayment` line crosses its static `normalisedBalance`, with no
+//! transaction at the crossing), so a consumer recomputes validity lazily on the
+//! block clock at its own decision point. The chain crate stays domain-agnostic.
+//!
+//! # Placement
+//!
+//! Native, RPC-and-persistence code intended to run behind a `chain` feature in
+//! its consumers and to stay out of the wasm cone, like the engine it builds on.
+
+pub mod events;
+pub mod indexer;
+pub mod projection;
+
+#[cfg(test)]
+mod tests;
+
+pub use indexer::{
+    INDEXER_NAME, POSTAGE_STAMP_ADDRESS, POSTAGE_STAMP_DEPLOYMENT_BLOCK, PostageIndexer,
+};
+pub use projection::{
+    BatchKey, BatchState, BatchTable, ChainState, ChainStateKey, ChainStateTable, LogPosition,
+    PostageTables, is_batch_valid_now, read_batch, read_chain_state,
+};

--- a/crates/chain/index-postage/src/projection.rs
+++ b/crates/chain/index-postage/src/projection.rs
@@ -1,0 +1,286 @@
+//! The `vertex-storage` projection the indexer folds PostageStamp logs into.
+//!
+//! Two tables, both written by a pure, idempotent fold (see
+//! `CHAIN_REACTIONS_DESIGN.md`): re-applying a finalized log re-writes the same
+//! row to the same value, never accumulates twice, and never triggers a side
+//! effect.
+//!
+//! - [`BatchTable`] is the batch set, keyed by `batchId`. The batch-lifecycle
+//!   events ([`BatchCreated`], [`BatchTopUp`], [`BatchDepthIncrease`]) fold into a
+//!   [`BatchState`] row carrying owner, depth, bucket depth, immutability,
+//!   `normalisedBalance`, and the block the batch started at. Each write is
+//!   guarded by the source log position so a replayed or reordered log never
+//!   rolls a row back.
+//! - [`ChainStateTable`] is a single-row projection of the contract's pricing
+//!   chain-state, keyed by the unit [`ChainStateKey`]. It folds the
+//!   [`PriceUpdate`] cadence into the running `totalOutPayment` accumulator the
+//!   contract maintains, plus the current price and the [`Paused`] flag.
+//!
+//! # The validity query
+//!
+//! The headline read helper is [`BatchState::is_valid_now`] /
+//! [`ChainState::current_total_out_payment`]. A batch is valid at a block when
+//! its static `normalisedBalance` is still above the rising
+//! `currentTotalOutPayment(block)` line, exactly as the contract computes it:
+//!
+//! ```text
+//! currentTotalOutPayment(block) = totalOutPayment + lastPrice * (block - lastUpdatedBlock)
+//! valid_now(block)              = normalisedBalance > currentTotalOutPayment(block)
+//! ```
+//!
+//! This crate only RECORDS and exposes that query. It fires no eviction and no
+//! reaction; expiry has no event to hook (a batch dies when the rising line
+//! crosses its static balance, with no transaction at the crossing), so any
+//! consumer recomputes it lazily on the block clock at its own decision point.
+//!
+//! [`BatchCreated`]: crate::events::BatchCreated
+//! [`BatchTopUp`]: crate::events::BatchTopUp
+//! [`BatchDepthIncrease`]: crate::events::BatchDepthIncrease
+//! [`PriceUpdate`]: crate::events::PriceUpdate
+//! [`Paused`]: crate::events::Paused
+
+use alloy_primitives::{Address, B256, U256};
+use serde::{Deserialize, Serialize};
+use vertex_storage::{Database, DatabaseError, DbTx, Decode, Encode, Table, Tables};
+
+// The batch set, keyed by the on-chain `batchId`.
+vertex_storage::table!(
+    pub BatchTable,
+    "postage_batches",
+    BatchKey,
+    BatchState
+);
+
+// The single-row pricing chain-state of the contract.
+vertex_storage::table!(
+    pub ChainStateTable,
+    "postage_chain_state",
+    ChainStateKey,
+    ChainState
+);
+
+/// The set of tables this indexer persists, for one-shot initialization.
+pub struct PostageTables;
+
+impl Tables for PostageTables {
+    const NAMES: &'static [&'static str] = &[BatchTable::NAME, ChainStateTable::NAME];
+}
+
+impl PostageTables {
+    /// Create the projection tables if they do not yet exist.
+    pub fn init<DB: Database>(db: &DB) -> Result<(), DatabaseError> {
+        <Self as Tables>::init(db)
+    }
+}
+
+/// A log's canonical position: `(block_number, log_index)`.
+///
+/// Ordered lexicographically, matching the order the engine delivers logs in, so
+/// `>` on a [`LogPosition`] means "strictly later in the canonical stream". It is
+/// the idempotency key for every fold in this crate: a write only lands when the
+/// incoming log is strictly newer than the one that set the current row.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LogPosition {
+    /// The block the log was emitted in.
+    pub block: u64,
+    /// The log's index within its block.
+    pub log_index: u64,
+}
+
+/// The [`BatchTable`] key: an on-chain `batchId`.
+///
+/// A newtype over the 32-byte batch id, encoded verbatim so the table iterates
+/// in batch-id order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct BatchKey(pub B256);
+
+impl Encode for BatchKey {
+    type Encoded = [u8; 32];
+
+    fn encode(self) -> Self::Encoded {
+        self.0.0
+    }
+}
+
+impl Decode for BatchKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let bytes: [u8; 32] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        Ok(Self(B256::from(bytes)))
+    }
+}
+
+/// The folded state of a single postage batch.
+///
+/// Every field is written last-write-wins by its source event, guarded by
+/// [`source`](BatchState::source): a fold only lands when the incoming log is
+/// strictly newer, so replay and reordering are no-ops. The `start_block` is the
+/// block the batch was created in and never changes after creation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BatchState {
+    /// The batch owner.
+    pub owner: Address,
+    /// The batch depth (the number of chunks the batch can stamp is `2^depth`).
+    pub depth: u8,
+    /// The batch bucket depth.
+    pub bucket_depth: u8,
+    /// The normalised balance: the per-chunk total-out-payment level the batch
+    /// has paid up to. A batch is valid while this stays above the contract's
+    /// rising `currentTotalOutPayment(block)` line.
+    pub normalised_balance: U256,
+    /// Whether the batch is immutable (its depth can never be increased).
+    pub immutable: bool,
+    /// The block the batch was created in.
+    pub start_block: u64,
+    /// The `(block, log_index)` of the most recent log that set this row, the
+    /// idempotency and supersede key.
+    pub source: LogPosition,
+}
+
+impl BatchState {
+    /// Whether a log at `pos` should overwrite this row.
+    ///
+    /// True only when `pos` is strictly after the stored source. Equal positions
+    /// (a replayed log) and earlier positions (a reordered log) are no-ops, which
+    /// is what makes the fold idempotent and monotonic.
+    pub fn superseded_by(&self, pos: LogPosition) -> bool {
+        pos > self.source
+    }
+
+    /// Whether the batch is still valid at `block`, given the current
+    /// `chain_state`.
+    ///
+    /// A batch is valid while its static `normalisedBalance` is strictly above
+    /// the contract's rising `currentTotalOutPayment(block)` line. This is a pure
+    /// read against the projection plus the block clock; it fires nothing.
+    pub fn is_valid_now(&self, chain_state: &ChainState, block: u64) -> bool {
+        self.normalised_balance > chain_state.current_total_out_payment(block)
+    }
+}
+
+/// The [`ChainStateTable`] key: a unit key for the single chain-state row.
+///
+/// The pricing chain-state is one global record, not a per-key map, so the table
+/// holds exactly one row under this constant key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ChainStateKey;
+
+impl Encode for ChainStateKey {
+    type Encoded = [u8; 1];
+
+    fn encode(self) -> Self::Encoded {
+        [0]
+    }
+}
+
+impl Decode for ChainStateKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        match value {
+            [0] => Ok(Self),
+            _ => Err(DatabaseError::Decode),
+        }
+    }
+}
+
+/// The folded pricing chain-state of the PostageStamp contract.
+///
+/// This reconstructs, from the [`PriceUpdate`](crate::events::PriceUpdate)
+/// cadence alone, the three values the contract uses to price storage over time:
+///
+/// - `total_out_payment`: the per-chunk cost accumulated up to `last_updated_block`.
+/// - `last_price`: the per-chunk-per-block price in force since `last_updated_block`.
+/// - `last_updated_block`: the block the price last changed.
+///
+/// The contract advances these at each `setPrice`: if the previous price was
+/// non-zero it first folds the elapsed cost into `total_out_payment`
+/// (`total_out_payment += last_price * (block - last_updated_block)`), then sets
+/// `last_price = price` and `last_updated_block = block`. Folding the events in
+/// canonical order reproduces the same accumulator the contract holds, so
+/// [`current_total_out_payment`](ChainState::current_total_out_payment) matches
+/// the contract's `currentTotalOutPayment()` view at any block.
+///
+/// The `paused` flag and the [`source`](ChainState::source) position round out the
+/// row; `source` guards the fold so a replayed or reordered log is a no-op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ChainState {
+    /// The per-chunk total-out-payment accumulated up to `last_updated_block`.
+    pub total_out_payment: U256,
+    /// The per-chunk-per-block price in force since `last_updated_block`.
+    pub last_price: U256,
+    /// The block the price last changed (the accumulator's anchor block).
+    pub last_updated_block: u64,
+    /// Whether the contract is currently paused.
+    pub paused: bool,
+    /// The `(block, log_index)` of the most recent log that set this row.
+    pub source: LogPosition,
+}
+
+impl ChainState {
+    /// Whether a log at `pos` should overwrite this row.
+    pub fn superseded_by(&self, pos: LogPosition) -> bool {
+        pos > self.source
+    }
+
+    /// The contract's `currentTotalOutPayment(block)`: the per-chunk cost of
+    /// storing one chunk since the beginning of time, at `block`.
+    ///
+    /// `total_out_payment + last_price * (block - last_updated_block)`. Blocks at
+    /// or before `last_updated_block` (only reachable for a historical query)
+    /// contribute no elapsed cost, matching the contract's saturating behaviour
+    /// rather than underflowing.
+    pub fn current_total_out_payment(&self, block: u64) -> U256 {
+        let blocks = block.saturating_sub(self.last_updated_block);
+        self.total_out_payment + self.last_price * U256::from(blocks)
+    }
+
+    /// Fold a [`PriceUpdate`](crate::events::PriceUpdate) at `block` into the
+    /// accumulator, mirroring the contract's `setPrice`.
+    ///
+    /// Pure and self-contained: when the previous price is non-zero it first
+    /// settles the elapsed cost into `total_out_payment`, then adopts the new
+    /// price at `block`. The caller is responsible for the supersede guard; this
+    /// only computes the next accumulator state.
+    pub fn fold_price_update(&mut self, price: U256, block: u64) {
+        if !self.last_price.is_zero() {
+            self.total_out_payment = self.current_total_out_payment(block);
+        }
+        self.last_price = price;
+        self.last_updated_block = block;
+    }
+}
+
+/// Read a batch's state from the projection, if it has been indexed.
+pub fn read_batch<DB: Database>(
+    db: &DB,
+    batch_id: B256,
+) -> Result<Option<BatchState>, DatabaseError> {
+    db.view(|tx| tx.get::<BatchTable>(BatchKey(batch_id)))
+}
+
+/// Read the contract's pricing chain-state from the projection, if any
+/// `PriceUpdate` or `Paused` log has been folded yet.
+pub fn read_chain_state<DB: Database>(db: &DB) -> Result<Option<ChainState>, DatabaseError> {
+    db.view(|tx| tx.get::<ChainStateTable>(ChainStateKey))
+}
+
+/// Whether `batch_id` is valid at `block`, against the indexed projection.
+///
+/// Resolves to `Some(valid)` once both the batch and the chain-state have been
+/// indexed, and `None` while either is still missing (a consumer treats a
+/// not-yet-indexed batch as not-yet-known, not as expired). This is the lazy,
+/// compute-at-time query the chain-reactions design calls for: it reads the
+/// projection plus the live block clock and fires nothing.
+pub fn is_batch_valid_now<DB: Database>(
+    db: &DB,
+    batch_id: B256,
+    block: u64,
+) -> Result<Option<bool>, DatabaseError> {
+    db.view(|tx| {
+        let Some(batch) = tx.get::<BatchTable>(BatchKey(batch_id))? else {
+            return Ok(None);
+        };
+        let Some(chain_state) = tx.get::<ChainStateTable>(ChainStateKey)? else {
+            return Ok(None);
+        };
+        Ok(Some(batch.is_valid_now(&chain_state, block)))
+    })
+}

--- a/crates/chain/index-postage/src/tests.rs
+++ b/crates/chain/index-postage/src/tests.rs
@@ -1,0 +1,349 @@
+//! Unit tests over synthetic logs: each event decodes and folds into the
+//! projection correctly, re-applying a log is idempotent, the supersede guard is
+//! monotonic by `(block, log_index)`, and the validity query matches the
+//! contract's arithmetic.
+//!
+//! No chain here. We build a [`Log`] for each event by ABI-encoding it through
+//! the same `sol!` bindings the indexer decodes with, drive
+//! [`Indexer::apply`](vertex_chain_index::Indexer::apply) directly, and read the
+//! projection back from an in-memory `vertex-storage` backend.
+
+use alloy_primitives::{Address, B256, U256, address};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use vertex_chain_index::Indexer;
+
+use crate::PostageIndexer;
+use crate::events::{BatchCreated, BatchDepthIncrease, BatchTopUp, Paused, PriceUpdate};
+use crate::indexer::POSTAGE_STAMP_ADDRESS;
+use crate::projection::{ChainState, is_batch_valid_now, read_batch, read_chain_state};
+
+type Db = vertex_storage_redb::RedbDatabase;
+
+const BATCH: B256 = B256::repeat_byte(0xab);
+const OWNER: Address = address!("00000000000000000000000000000000000000bb");
+
+/// Build a `Log` from an ABI-encoded event, placed at `(block, index)` on the
+/// PostageStamp contract address.
+fn log_for<E: SolEvent>(event: &E, block: u64, index: u64) -> Log {
+    let data = event.encode_log_data();
+    Log {
+        inner: alloy_primitives::Log {
+            address: POSTAGE_STAMP_ADDRESS,
+            data,
+        },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+fn new_indexer() -> (PostageIndexer<Db>, std::sync::Arc<Db>) {
+    let db = std::sync::Arc::new(Db::in_memory().expect("in-memory db"));
+    let indexer = PostageIndexer::new(db.clone()).expect("init indexer");
+    (indexer, db)
+}
+
+fn created(normalised: u64, depth: u8) -> BatchCreated {
+    BatchCreated {
+        batchId: BATCH,
+        totalAmount: U256::from(1_000u64),
+        normalisedBalance: U256::from(normalised),
+        owner: OWNER,
+        depth,
+        bucketDepth: 16,
+        immutableFlag: false,
+    }
+}
+
+#[test]
+fn batch_created_folds_into_batch_set() {
+    let (indexer, db) = new_indexer();
+    let log = log_for(&created(500, 20), 100, 0);
+    indexer.apply(100, &log).expect("apply");
+
+    let batch = read_batch(db.as_ref(), BATCH).unwrap().expect("batch row");
+    assert_eq!(batch.owner, OWNER);
+    assert_eq!(batch.depth, 20);
+    assert_eq!(batch.bucket_depth, 16);
+    assert_eq!(batch.normalised_balance, U256::from(500u64));
+    assert!(!batch.immutable);
+    assert_eq!(batch.start_block, 100);
+}
+
+#[test]
+fn batch_topup_raises_normalised_balance_keeps_start_block() {
+    let (indexer, db) = new_indexer();
+    indexer
+        .apply(100, &log_for(&created(500, 20), 100, 0))
+        .expect("create");
+
+    let topup = BatchTopUp {
+        batchId: BATCH,
+        topupAmount: U256::from(250u64),
+        normalisedBalance: U256::from(800u64),
+    };
+    indexer.apply(150, &log_for(&topup, 150, 2)).expect("topup");
+
+    let batch = read_batch(db.as_ref(), BATCH).unwrap().unwrap();
+    assert_eq!(batch.normalised_balance, U256::from(800u64));
+    assert_eq!(
+        batch.start_block, 100,
+        "start block is immutable after create"
+    );
+    assert_eq!(batch.depth, 20, "topup leaves depth untouched");
+}
+
+#[test]
+fn batch_depth_increase_folds_depth_and_balance() {
+    let (indexer, db) = new_indexer();
+    indexer
+        .apply(100, &log_for(&created(500, 20), 100, 0))
+        .expect("create");
+
+    let bump = BatchDepthIncrease {
+        batchId: BATCH,
+        newDepth: 22,
+        normalisedBalance: U256::from(450u64),
+    };
+    indexer.apply(160, &log_for(&bump, 160, 1)).expect("bump");
+
+    let batch = read_batch(db.as_ref(), BATCH).unwrap().unwrap();
+    assert_eq!(batch.depth, 22);
+    assert_eq!(batch.normalised_balance, U256::from(450u64));
+}
+
+#[test]
+fn topup_before_create_is_dropped() {
+    let (indexer, db) = new_indexer();
+    let topup = BatchTopUp {
+        batchId: BATCH,
+        topupAmount: U256::from(250u64),
+        normalisedBalance: U256::from(800u64),
+    };
+    indexer.apply(150, &log_for(&topup, 150, 0)).expect("topup");
+    assert!(
+        read_batch(db.as_ref(), BATCH).unwrap().is_none(),
+        "a topup with no prior create fabricates no partial row"
+    );
+}
+
+#[test]
+fn price_update_folds_chain_state_accumulator() {
+    let (indexer, db) = new_indexer();
+
+    // First price update: lastPrice was zero, so totalOutPayment does not move.
+    indexer
+        .apply(
+            200,
+            &log_for(
+                &PriceUpdate {
+                    price: U256::from(10u64),
+                },
+                200,
+                0,
+            ),
+        )
+        .expect("first price");
+    let state = read_chain_state(db.as_ref()).unwrap().unwrap();
+    assert_eq!(state.last_price, U256::from(10u64));
+    assert_eq!(state.last_updated_block, 200);
+    assert_eq!(state.total_out_payment, U256::ZERO);
+
+    // Second price update at block 210: settle 10 * (210 - 200) = 100 into the
+    // accumulator, then adopt the new price.
+    indexer
+        .apply(
+            210,
+            &log_for(
+                &PriceUpdate {
+                    price: U256::from(20u64),
+                },
+                210,
+                0,
+            ),
+        )
+        .expect("second price");
+    let state = read_chain_state(db.as_ref()).unwrap().unwrap();
+    assert_eq!(state.total_out_payment, U256::from(100u64));
+    assert_eq!(state.last_price, U256::from(20u64));
+    assert_eq!(state.last_updated_block, 210);
+
+    // currentTotalOutPayment(260) = 100 + 20 * (260 - 210) = 1100.
+    assert_eq!(
+        state.current_total_out_payment(260),
+        U256::from(1_100u64),
+        "matches the contract's currentTotalOutPayment arithmetic"
+    );
+}
+
+#[test]
+fn paused_sets_the_flag() {
+    let (indexer, db) = new_indexer();
+    indexer
+        .apply(300, &log_for(&Paused { account: OWNER }, 300, 0))
+        .expect("paused");
+    let state = read_chain_state(db.as_ref()).unwrap().unwrap();
+    assert!(state.paused);
+}
+
+#[test]
+fn is_batch_valid_now_tracks_the_rising_line() {
+    let (indexer, db) = new_indexer();
+
+    // Batch with normalisedBalance 1000.
+    indexer
+        .apply(100, &log_for(&created(1_000, 20), 100, 0))
+        .expect("create");
+    // Price 10/block anchored at block 200, totalOutPayment 0.
+    indexer
+        .apply(
+            200,
+            &log_for(
+                &PriceUpdate {
+                    price: U256::from(10u64),
+                },
+                200,
+                0,
+            ),
+        )
+        .expect("price");
+
+    // At block 250: currentTotalOutPayment = 0 + 10 * 50 = 500 < 1000 -> valid.
+    assert_eq!(
+        is_batch_valid_now(db.as_ref(), BATCH, 250).unwrap(),
+        Some(true)
+    );
+    // At block 300: 10 * 100 = 1000, not strictly greater -> invalid.
+    assert_eq!(
+        is_batch_valid_now(db.as_ref(), BATCH, 300).unwrap(),
+        Some(false)
+    );
+    // At block 400: 10 * 200 = 2000 > 1000 -> invalid.
+    assert_eq!(
+        is_batch_valid_now(db.as_ref(), BATCH, 400).unwrap(),
+        Some(false)
+    );
+
+    // An unknown batch is not-yet-known, not expired.
+    assert_eq!(
+        is_batch_valid_now(db.as_ref(), B256::repeat_byte(0xff), 250).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn is_valid_now_method_matches_helper() {
+    let state = ChainState {
+        total_out_payment: U256::from(100u64),
+        last_price: U256::from(20u64),
+        last_updated_block: 210,
+        paused: false,
+        source: Default::default(),
+    };
+    // currentTotalOutPayment(260) = 100 + 20*50 = 1100.
+    assert_eq!(state.current_total_out_payment(260), U256::from(1_100u64));
+    // A query before the anchor block contributes no elapsed cost (saturating).
+    assert_eq!(state.current_total_out_payment(200), U256::from(100u64));
+}
+
+#[test]
+fn reapplying_a_create_is_idempotent() {
+    let (indexer, db) = new_indexer();
+    let log = log_for(&created(500, 20), 100, 0);
+    indexer.apply(100, &log).expect("first");
+    let first = read_batch(db.as_ref(), BATCH).unwrap();
+    indexer.apply(100, &log).expect("second");
+    let second = read_batch(db.as_ref(), BATCH).unwrap();
+    assert_eq!(first, second, "re-applying a log re-writes the same row");
+}
+
+#[test]
+fn reapplying_a_price_update_is_idempotent() {
+    let (indexer, db) = new_indexer();
+    indexer
+        .apply(
+            200,
+            &log_for(
+                &PriceUpdate {
+                    price: U256::from(10u64),
+                },
+                200,
+                0,
+            ),
+        )
+        .expect("first");
+    let log2 = log_for(
+        &PriceUpdate {
+            price: U256::from(20u64),
+        },
+        210,
+        0,
+    );
+    indexer.apply(210, &log2).expect("second");
+    let after_first = read_chain_state(db.as_ref()).unwrap();
+    // Replay the second update: the accumulator must not double-advance.
+    indexer.apply(210, &log2).expect("replay");
+    let after_replay = read_chain_state(db.as_ref()).unwrap();
+    assert_eq!(
+        after_first, after_replay,
+        "a replayed price update does not re-fold the accumulator"
+    );
+}
+
+#[test]
+fn supersede_is_monotonic_by_position() {
+    let (indexer, db) = new_indexer();
+    indexer
+        .apply(100, &log_for(&created(500, 20), 100, 0))
+        .expect("create");
+
+    // A topup at an EARLIER position than the create must be ignored.
+    let stale = BatchTopUp {
+        batchId: BATCH,
+        topupAmount: U256::from(1u64),
+        normalisedBalance: U256::from(999u64),
+    };
+    // Same block, earlier log_index than the create (create was at index 0; a
+    // strictly-earlier index is impossible, so use an earlier block instead).
+    indexer.apply(50, &log_for(&stale, 50, 5)).expect("stale");
+    let batch = read_batch(db.as_ref(), BATCH).unwrap().unwrap();
+    assert_eq!(
+        batch.normalised_balance,
+        U256::from(500u64),
+        "an earlier-positioned log never rolls the row back"
+    );
+
+    // A topup at a LATER position supersedes.
+    let fresh = BatchTopUp {
+        batchId: BATCH,
+        topupAmount: U256::from(1u64),
+        normalisedBalance: U256::from(700u64),
+    };
+    indexer.apply(120, &log_for(&fresh, 120, 0)).expect("fresh");
+    let batch = read_batch(db.as_ref(), BATCH).unwrap().unwrap();
+    assert_eq!(batch.normalised_balance, U256::from(700u64));
+}
+
+#[test]
+fn filter_selects_the_contract_and_all_events() {
+    let (indexer, _db) = new_indexer();
+    let filter = indexer.filter();
+    let addrs: Vec<_> = filter.address.iter().collect();
+    assert!(addrs.contains(&&POSTAGE_STAMP_ADDRESS));
+
+    let topic0 = filter.topics[0].iter().collect::<Vec<_>>();
+    for sig in [
+        BatchCreated::SIGNATURE_HASH,
+        BatchTopUp::SIGNATURE_HASH,
+        BatchDepthIncrease::SIGNATURE_HASH,
+        PriceUpdate::SIGNATURE_HASH,
+        Paused::SIGNATURE_HASH,
+    ] {
+        assert!(topic0.contains(&&sig), "topic0 set includes every event");
+    }
+}

--- a/crates/chain/index-postage/tests/e2e_fork.rs
+++ b/crates/chain/index-postage/tests/e2e_fork.rs
@@ -1,0 +1,228 @@
+//! End-to-end smoke test against a real Gnosis Chain fork (or live RPC).
+//!
+//! This validates the postage indexer against real on-chain logs rather than
+//! synthetic ones: it syncs the [`PostageIndexer`] over a bounded recent window,
+//! asserts the engine reaches the finalized head and the cursor advances, then
+//! cross-checks the reconstructed pricing chain-state against direct
+//! `currentTotalOutPayment()`, `lastPrice()`, and `lastUpdatedBlock()` contract
+//! reads at the finalized head.
+//!
+//! # The cross-check
+//!
+//! The indexer reconstructs the contract's `totalOutPayment` accumulator from the
+//! `PriceUpdate` cadence alone. The strong proof is that the projection's
+//! `current_total_out_payment(head)` equals the contract's
+//! `currentTotalOutPayment()` view at the same block. That only holds if the
+//! indexer saw *every* `PriceUpdate` since the accumulator's current anchor, so
+//! the cross-check is gated on the synced window reaching back past the
+//! contract's `lastUpdatedBlock()`:
+//!
+//! - If `lastUpdatedBlock()` falls inside the synced window, the projection's
+//!   `last_price` / `last_updated_block` must equal the on-chain values and the
+//!   computed `current_total_out_payment(head)` must equal
+//!   `currentTotalOutPayment()`.
+//! - If the last price change predates the window (no `PriceUpdate` in range),
+//!   the projection's chain-state stays empty while the contract still reports a
+//!   non-zero price, proving the indexer is wired to the right live contract and
+//!   the engine reached head over real data. Grow `POSTAGE_E2E_WINDOW` to capture
+//!   a price change and exercise the full accumulator cross-check.
+//!
+//! It is `#[ignore]`d so CI without a fork stays green. To run it:
+//!
+//! 1. Start a fork (anvil ships with foundry; install via `foundryup` if absent).
+//!    Use a UNIQUE port (8546) so it does not collide with sibling indexers:
+//!
+//!    ```sh
+//!    anvil --fork-url ${GNOSIS_RPC_URL:-https://rpc.gnosischain.com} \
+//!          --fork-block-number <recent> --port 8546 --silent &
+//!    POSTAGE_E2E_RPC=http://localhost:8546 \
+//!        cargo test -p vertex-chain-index-postage --test e2e_fork \
+//!        -- --ignored --nocapture
+//!    ```
+//!
+//! 2. If anvil cannot be run, point the test at a public Gnosis RPC directly
+//!    (this is also the default URL):
+//!
+//!    ```sh
+//!    POSTAGE_E2E_RPC=https://rpc.gnosischain.com \
+//!        cargo test -p vertex-chain-index-postage --test e2e_fork \
+//!        -- --ignored --nocapture
+//!    ```
+//!
+//! The window size and head are derived from the RPC's current finalized block,
+//! so the test works against both a fork and a live RPC. The public RPC is shared
+//! and rate-limited; the default window is bounded to a handful of `eth_getLogs`
+//! pages and the engine uses a generous poll interval that runs exactly one
+//! startup backfill.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_primitives::{TxKind, U256};
+use alloy_provider::network::TransactionBuilder;
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types_eth::{BlockId, TransactionRequest};
+use alloy_sol_types::{SolCall, sol};
+use vertex_chain_index::{ChainReader, Cursor, EventEngine};
+use vertex_chain_index_postage::{
+    INDEXER_NAME, POSTAGE_STAMP_ADDRESS, PostageIndexer, read_chain_state,
+};
+use vertex_storage_redb::RedbDatabase;
+
+sol! {
+    /// The PostageStamp view functions the cross-check reads.
+    #[allow(missing_docs)]
+    function currentTotalOutPayment() external view returns (uint256);
+    #[allow(missing_docs)]
+    function lastPrice() external view returns (uint64);
+    #[allow(missing_docs)]
+    function lastUpdatedBlock() external view returns (uint64);
+}
+
+/// How many blocks back from the finalized head to sync, overridable with
+/// `POSTAGE_E2E_WINDOW`.
+///
+/// The price oracle updates the PostageStamp price roughly once per
+/// redistribution round (152 blocks on Gnosis), so this default spans several
+/// rounds and reliably captures a `PriceUpdate` while keeping the `eth_getLogs`
+/// paging to a handful of pages.
+const DEFAULT_WINDOW: u64 = 6_000;
+
+fn window() -> u64 {
+    std::env::var("POSTAGE_E2E_WINDOW")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_WINDOW)
+}
+
+/// Call a unit-input view `C` at `block` via `eth_call` and decode its return.
+///
+/// Returns the error rather than panicking so the lone `#[tokio::test]` owns the
+/// assertions; the test `.expect()`s each call where the `allow-expect-in-tests`
+/// clippy config applies.
+async fn call_view<P: Provider, C: SolCall>(
+    provider: &P,
+    call: C,
+    block: u64,
+) -> Result<C::Return, Box<dyn std::error::Error>> {
+    let tx = TransactionRequest::default()
+        .with_kind(TxKind::Call(POSTAGE_STAMP_ADDRESS))
+        .with_input(call.abi_encode());
+    let returned = provider.call(tx).block(BlockId::number(block)).await?;
+    Ok(C::abi_decode_returns(&returned)?)
+}
+
+#[tokio::test]
+#[ignore = "requires a Gnosis fork or live RPC; see module docs"]
+async fn indexes_real_postage_logs() {
+    let rpc = std::env::var("POSTAGE_E2E_RPC")
+        .unwrap_or_else(|_| "https://rpc.gnosischain.com".to_string());
+
+    let url = rpc.parse().expect("POSTAGE_E2E_RPC is a valid URL");
+    let provider = Arc::new(ProviderBuilder::new().connect_http(url));
+
+    // Bound the window to the RPC's finalized head. Skip (do not fail) if the RPC
+    // is unreachable so a CI run without network stays green.
+    let head = match ChainReader::finalized_head(provider.as_ref()).await {
+        Ok(Some(head)) => head,
+        Ok(None) => {
+            eprintln!("skipping: RPC has no finalized block");
+            return;
+        }
+        Err(err) => {
+            eprintln!("skipping: RPC unreachable at {rpc}: {err}");
+            return;
+        }
+    };
+
+    let start = head.number.saturating_sub(window());
+    eprintln!(
+        "syncing PostageStamp logs over blocks {start}..={} via {rpc}",
+        head.number
+    );
+
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer =
+        Arc::new(PostageIndexer::with_start_block(db.clone(), start).expect("build indexer"));
+
+    // A long poll interval plus an immediate shutdown runs exactly one startup
+    // backfill of the bounded window, then stops.
+    EventEngine::new(provider.clone(), db.clone())
+        .register(indexer)
+        .with_poll_interval(Duration::from_secs(3600))
+        .run(async {})
+        .await
+        .expect("engine run");
+
+    // The engine fully backfilled to the finalized head: the cursor advanced.
+    let cursor = Cursor::load(db.as_ref(), INDEXER_NAME)
+        .expect("load cursor")
+        .expect("cursor persisted");
+    assert_eq!(cursor.last_block, head.number, "cursor advanced to head");
+
+    let projected = read_chain_state(db.as_ref()).expect("read chain-state");
+    eprintln!("projected chain-state: {projected:?}");
+
+    // Read the on-chain pricing state at the head.
+    let on_chain_total = call_view(
+        provider.as_ref(),
+        currentTotalOutPaymentCall {},
+        head.number,
+    )
+    .await
+    .expect("currentTotalOutPayment");
+    let on_chain_last_price = U256::from(
+        call_view(provider.as_ref(), lastPriceCall {}, head.number)
+            .await
+            .expect("lastPrice"),
+    );
+    let on_chain_last_updated = call_view(provider.as_ref(), lastUpdatedBlockCall {}, head.number)
+        .await
+        .expect("lastUpdatedBlock");
+    eprintln!(
+        "on-chain currentTotalOutPayment({})={on_chain_total}, lastPrice={on_chain_last_price}, lastUpdatedBlock={on_chain_last_updated}",
+        head.number
+    );
+    assert!(
+        on_chain_last_price > U256::ZERO,
+        "the live PostageStamp reports a non-zero price: indexer is wired to the right contract"
+    );
+
+    // The cross-check holds only when the synced window reaches back past the
+    // accumulator's current anchor (so the indexer saw the PriceUpdate that set
+    // it). Otherwise the projection is legitimately empty.
+    match projected {
+        Some(state) if on_chain_last_updated >= start => {
+            assert_eq!(
+                state.last_price, on_chain_last_price,
+                "projected last_price matches the on-chain lastPrice()",
+            );
+            assert_eq!(
+                state.last_updated_block, on_chain_last_updated,
+                "projected last_updated_block matches the on-chain lastUpdatedBlock()",
+            );
+            assert_eq!(
+                state.current_total_out_payment(head.number),
+                on_chain_total,
+                "reconstructed currentTotalOutPayment(head) matches the contract view",
+            );
+        }
+        Some(state) => {
+            eprintln!(
+                "lastUpdatedBlock {on_chain_last_updated} predates window start {start}; \
+                 skipping strict accumulator cross-check (projected={state:?})"
+            );
+        }
+        None => {
+            assert!(
+                on_chain_last_updated < start,
+                "no PriceUpdate indexed, yet the last price change is inside the window: \
+                 the indexer should have folded it",
+            );
+            eprintln!(
+                "no PriceUpdate in window; projection empty while contract reports a price \
+                 (grow POSTAGE_E2E_WINDOW to exercise the accumulator cross-check)"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `vertex-chain-index-postage`, a per-contract indexer for the PostageStamp
contract on Gnosis Chain (`0x45a1502382541Cd610CC9068e88727426b696293`,
deployment block `31305656`). It plugs into the generic `vertex-chain-index`
engine merged in #300 and follows the layout of the sibling indexers
(`index-swap-price` #302, `index-redistribution` #303): `sol!` event bindings, a
`vertex-storage` projection, and an `impl Indexer`.

## Events indexed

Five events from the contract ABI:

- `BatchCreated(batchId, totalAmount, normalisedBalance, owner, depth, bucketDepth, immutableFlag)`
- `BatchTopUp(batchId, topupAmount, normalisedBalance)`
- `BatchDepthIncrease(batchId, newDepth, normalisedBalance)`
- `PriceUpdate(price)`
- `Paused(account)`

The PostageStamp event lifecycle is not present in the upstream
`nectar_contracts::IPostageStamp` interface (which carries the call/view bindings
only), so the event bindings are derived from the ABI JSON in a local `sol!`
block, matching how `index-redistribution` derives its events.

## Projection tables

Two `vertex-storage` tables, both written by a pure, idempotent fold:

- `postage_batches` (`BatchTable`): the **batch set**, keyed by `batchId`. Each
  row holds owner, depth, bucketDepth, normalisedBalance, immutable, the
  creation `start_block`, and the source `(block, log_index)` that last set it.
- `postage_chain_state` (`ChainStateTable`): a **single-row** projection of the
  contract's pricing chain-state, holding `totalOutPayment`, `lastPrice`
  (`currentPrice`), `lastUpdatedBlock`, and `paused`. The running
  `totalOutPayment` accumulator is reconstructed from the `PriceUpdate` cadence
  exactly as the contract maintains it in `setPrice`: on each price change, if
  the prior price was non-zero, the elapsed cost is settled
  (`totalOutPayment += lastPrice * (block - lastUpdatedBlock)`) before adopting
  the new price at the new block.

Both folds are guarded by the source log position, so a replayed or reordered
finalized log re-applies to the same row (idempotent) and never rolls a row back
(monotonic by `(block, log_index)`).

## Read helper: "is batch valid now"

`is_batch_valid_now(db, batch_id, block)` answers
`normalisedBalance > currentTotalOutPayment(block)`, where
`currentTotalOutPayment(block) = totalOutPayment + lastPrice * (block - lastUpdatedBlock)`.
It is a pure read against the projection plus the live block clock, returning
`None` while either the batch or the chain-state is not yet indexed.

## `apply` is a pure, no-reaction fold (per CHAIN_REACTIONS_DESIGN.md)

`PostageIndexer::apply` writes only the two projection tables and returns. It
calls into no storer, accounting, or postage-issuer code, fires no reaction, and
**implements no eviction**. Batch expiry has no event to hook (a batch dies when
the rising `currentTotalOutPayment` line crosses its static `normalisedBalance`,
with no transaction at the crossing), so validity is left to a consumer that
recomputes it lazily on the block clock at its own decision point via the read
helper above. The chain crate stays domain-agnostic.

The crate is native-only behind the `chain` feature in its consumers (alloy with
`default-features = false`, no reqwest/TLS of its own), staying out of the wasm
cone like the engine it builds on.

## Tests

- **Unit tests** (`cargo test -p vertex-chain-index-postage`, 12 passing) over
  synthetic ABI-encoded logs against the in-memory `vertex-storage` backend:
  each event decodes and folds correctly; the price-update accumulator matches
  the contract arithmetic; the validity query tracks the rising line across the
  expiry crossing; re-applying a log (create and price-update) is idempotent;
  supersede is monotonic by `(block, log_index)`; an out-of-order topup never
  rolls the row back; a topup before a create fabricates no partial row.
- **Env-guarded `#[ignore]`d anvil-fork e2e** (`tests/e2e_fork.rs`): syncs a
  bounded recent window of the live contract, asserts the cursor advances to the
  finalized head, and cross-checks the reconstructed chain-state against direct
  `currentTotalOutPayment()`, `lastPrice()`, and `lastUpdatedBlock()` contract
  reads at the head. The cross-check is gated on the window reaching back past
  the on-chain `lastUpdatedBlock()` so it only asserts the strict accumulator
  match when the indexer actually saw the `PriceUpdate` that set the anchor.

  E2E RESULT: the test compiles and links, and against a local Gnosis fork
  (anvil `--fork-block-number 46545000 --port 8546`) the engine connected,
  resolved the fork's finalized head, and began syncing the live PostageStamp
  contract's `eth_getLogs` over the bounded window. It did not finish within the
  run window because the public Gnosis RPC the fork proxies is shared and
  heavily rate-limited (a single `eth_getLogs` page over this busy contract was
  throttled past several minutes), which is the documented shared-RPC failure
  mode. The test is therefore left `#[ignore]`d with full run instructions in the
  module docs; run it against a private or less-throttled Gnosis RPC (or a fork
  of one) to exercise the on-chain `currentTotalOutPayment()` /  `lastPrice()` /
  `lastUpdatedBlock()` cross-check end to end.
