### PR TITLE
feat(chain): staking registry indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,6 +8364,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-chain-index-staking"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "nectar-contracts",
+ "serde",
+ "tokio",
+ "tracing",
+ "vertex-chain-index",
+ "vertex-storage",
+ "vertex-storage-redb",
+]
+
+[[package]]
 name = "vertex-ffi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
     # Chain (Ethereum RPC access)
     "crates/chain",
     "crates/chain/index",
+    "crates/chain/index-staking",
 
     # FFI (native embedding surface)
     "crates/ffi",
@@ -238,6 +239,7 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 # chain (Ethereum RPC access)
 vertex-chain = { path = "crates/chain" }
 vertex-chain-index = { path = "crates/chain/index" }
+vertex-chain-index-staking = { path = "crates/chain/index-staking" }
 
 # ffi (native embedding surface)
 vertex-ffi = { path = "crates/ffi" }

--- a/crates/chain/index-staking/Cargo.toml
+++ b/crates/chain/index-staking/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "vertex-chain-index-staking"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Staking registry chain indexer: folds StakeRegistry events into a vertex-storage projection"
+
+[lints]
+workspace = true
+
+[dependencies]
+# engine: the generic, reorg-safe event-indexing driver and the `Indexer` trait
+# this crate implements.
+vertex-chain-index = { workspace = true }
+# storage: the projection table and the staked-overlay set live behind the
+# `Database`/`DbTx` traits. The `alloy` feature pulls in the `Address` key codec
+# the per-owner stake table is keyed by.
+vertex-storage = { workspace = true, features = ["alloy"] }
+
+# nectar: reuse the shared `IStakeRegistry` `sol!` event bindings rather than
+# re-deriving them from the ABI. `OverlayChanged` is the one event this
+# deployment adds beyond the shared interface, declared locally below.
+nectar-contracts = { workspace = true }
+
+# alloy: event decoding (`SolEvent`), the log `Filter`, and the primitive types
+# the projection stores. `default-features = false` keeps the wasm-hostile
+# transport out; this crate decodes logs the engine fetched, it opens no socket.
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true }
+alloy-sol-types = { workspace = true }
+
+# serialization: the projection rows derive serde for the storage codec.
+serde = { workspace = true, features = ["derive"] }
+
+tracing = { workspace = true }
+
+[dev-dependencies]
+vertex-storage-redb = { workspace = true }
+# A full provider with an HTTP transport for the ignored anvil-fork e2e test.
+alloy-provider = { workspace = true, features = ["reqwest"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/chain/index-staking/src/indexer.rs
+++ b/crates/chain/index-staking/src/indexer.rs
@@ -1,0 +1,213 @@
+//! The [`StakingIndexer`]: a pure fold of `StakeRegistry` events into the
+//! staking projection.
+//!
+//! This is the contract-specific half the [`EventEngine`] drives. It declares
+//! the deployment block and the log filter (the registry address and the five
+//! staking `topic0`s), and folds each decoded log into the [`StakeProjection`]
+//! tables. Per `CHAIN_REACTIONS_DESIGN.md`, [`apply`] is a pure, idempotent fold:
+//! it has no side effects, calls into no domain layer, and a replayed finalized
+//! log re-applies to the same row.
+//!
+//! [`EventEngine`]: vertex_chain_index::EventEngine
+//! [`apply`]: vertex_chain_index::Indexer::apply
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, U256, address};
+use alloy_rpc_types_eth::{Filter, Log};
+use alloy_sol_types::{SolEvent, sol};
+use nectar_contracts::IStakeRegistry;
+use vertex_chain_index::{IndexError, Indexer};
+use vertex_storage::{Database, DbTxMut, Tables};
+
+use crate::projection::{LogPos, OwnerStake, StakingTables, fold_owner};
+
+sol! {
+    /// The one `StakeRegistry` event the shared `IStakeRegistry` interface does
+    /// not carry. Declared here from the deployment ABI so the indexer folds it
+    /// alongside the shared events; both `owner` and `overlay` are non-indexed.
+    #[allow(missing_docs)]
+    event OverlayChanged(address owner, bytes32 overlay);
+}
+
+/// The Gnosis Chain mainnet `StakeRegistry` deployment this indexer follows.
+///
+/// The address and block come from the storage-incentives mainnet deployment
+/// manifest. They pin the exact contract instance whose events this projection
+/// reflects; backfill starts at the deployment block so the engine never pages
+/// the empty pre-deployment range.
+pub const STAKE_REGISTRY: Address = address!("da2a16EE889E7F04980A8d597b48c8D51B9518F4");
+
+/// The block the [`STAKE_REGISTRY`] contract was deployed at.
+pub const DEPLOYMENT_BLOCK: u64 = 40_430_237;
+
+/// The indexer name, used as the engine's cursor key and metric label.
+const INDEXER_NAME: &str = "staking_registry";
+
+/// Folds `StakeRegistry` events into the staking projection.
+///
+/// One instance, registered with an [`EventEngine`], maintains the per-owner
+/// stake rows and the staked-overlay set in `vertex-storage`. It owns a
+/// `vertex-storage` [`Database`] handle (the same backend the cursor lives in)
+/// and writes its projection through its own transaction; the engine bridges the
+/// projection commit and the cursor commit with idempotent replay, which this
+/// fold's monotonic `(block, log_index)` supersede rule satisfies.
+///
+/// [`EventEngine`]: vertex_chain_index::EventEngine
+pub struct StakingIndexer<DB> {
+    db: Arc<DB>,
+    start_block: u64,
+}
+
+impl<DB: Database> StakingIndexer<DB> {
+    /// Build an indexer over `db`, starting backfill at the deployment block.
+    pub fn new(db: Arc<DB>) -> Result<Self, IndexError> {
+        StakingTables::init(db.as_ref())?;
+        Ok(Self {
+            db,
+            start_block: DEPLOYMENT_BLOCK,
+        })
+    }
+
+    /// Override the backfill start block. Mainly for tests that fold synthetic
+    /// logs without the full pre-deployment range.
+    pub fn with_start_block(mut self, block: u64) -> Self {
+        self.start_block = block;
+        self
+    }
+
+    /// The `(block, log_index)` position of `log`, the supersede key.
+    fn position(log: &Log) -> Result<LogPos, IndexError> {
+        Ok(LogPos {
+            block: log.block_number.ok_or(IndexError::MalformedLog {
+                field: "block_number",
+            })?,
+            index: log
+                .log_index
+                .ok_or(IndexError::MalformedLog { field: "log_index" })?,
+        })
+    }
+
+    /// Fold one decoded event into `owner`'s row, superseding only on a strictly
+    /// later log position.
+    ///
+    /// `mutate` produces the next field values from the previous row; the
+    /// position guard wraps it so a replayed or out-of-order log is a no-op. This
+    /// is the single idempotency choke point: every event routes through it.
+    fn supersede<F>(&self, owner: Address, pos: LogPos, mutate: F) -> Result<(), IndexError>
+    where
+        F: FnOnce(OwnerStake) -> OwnerStake,
+    {
+        let tx = self.db.tx_mut()?;
+        fold_owner(&tx, owner, |prev| {
+            // A log at or before the row's recorded position has already been
+            // folded (or arrived out of order); skip it so replay is a no-op and
+            // state only ever moves forward. A never-seen row carries the minimum
+            // position sentinel, so the owner's first real log always supersedes.
+            if pos <= prev.seen_at {
+                return None;
+            }
+            let mut next = mutate(prev);
+            next.seen_at = pos;
+            Some(next)
+        })?;
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+impl<DB: Database> Indexer for StakingIndexer<DB> {
+    fn name(&self) -> &'static str {
+        INDEXER_NAME
+    }
+
+    fn start_block(&self) -> u64 {
+        self.start_block
+    }
+
+    fn filter(&self) -> Filter {
+        Filter::new().address(STAKE_REGISTRY).event_signature(vec![
+            IStakeRegistry::StakeUpdated::SIGNATURE_HASH,
+            IStakeRegistry::StakeFrozen::SIGNATURE_HASH,
+            IStakeRegistry::StakeSlashed::SIGNATURE_HASH,
+            IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH,
+            OverlayChanged::SIGNATURE_HASH,
+        ])
+    }
+
+    fn apply(&self, _block: u64, log: &Log) -> Result<(), IndexError> {
+        let pos = Self::position(log)?;
+        let topic0 = log.topic0().copied();
+
+        match topic0 {
+            Some(sig) if sig == IStakeRegistry::StakeUpdated::SIGNATURE_HASH => {
+                let ev = log
+                    .log_decode::<IStakeRegistry::StakeUpdated>()
+                    .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?
+                    .inner
+                    .data;
+                self.supersede(ev.owner, pos, |mut s| {
+                    s.committed = ev.committedStake;
+                    s.potential = ev.potentialStake;
+                    s.overlay = ev.overlay;
+                    s.height = ev.height;
+                    s.last_updated_block = ev.lastUpdatedBlock;
+                    s
+                })
+            }
+            Some(sig) if sig == IStakeRegistry::StakeFrozen::SIGNATURE_HASH => {
+                let ev = log
+                    .log_decode::<IStakeRegistry::StakeFrozen>()
+                    .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?
+                    .inner
+                    .data;
+                self.supersede(ev.frozen, pos, |mut s| {
+                    s.frozen_until = ev.time;
+                    s
+                })
+            }
+            Some(sig) if sig == IStakeRegistry::StakeSlashed::SIGNATURE_HASH => {
+                let ev = log
+                    .log_decode::<IStakeRegistry::StakeSlashed>()
+                    .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?
+                    .inner
+                    .data;
+                // A slash removes the node's stake; zero both legs so the owner
+                // drops out of the staked-overlay set.
+                self.supersede(ev.slashed, pos, |mut s| {
+                    s.committed = U256::ZERO;
+                    s.potential = U256::ZERO;
+                    s
+                })
+            }
+            Some(sig) if sig == IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH => {
+                let ev = log
+                    .log_decode::<IStakeRegistry::StakeWithdrawn>()
+                    .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?
+                    .inner
+                    .data;
+                // A withdrawal empties the node's stake.
+                self.supersede(ev.node, pos, |mut s| {
+                    s.committed = U256::ZERO;
+                    s.potential = U256::ZERO;
+                    s
+                })
+            }
+            Some(sig) if sig == OverlayChanged::SIGNATURE_HASH => {
+                let ev = log
+                    .log_decode::<OverlayChanged>()
+                    .map_err(|e| IndexError::apply(INDEXER_NAME, e.to_string()))?
+                    .inner
+                    .data;
+                self.supersede(ev.owner, pos, |mut s| {
+                    s.overlay = ev.overlay;
+                    s
+                })
+            }
+            // The filter restricts topics to the five above; a log slipping
+            // through with an unknown topic0 is ignored rather than erroring,
+            // keeping the fold total.
+            _ => Ok(()),
+        }
+    }
+}

--- a/crates/chain/index-staking/src/lib.rs
+++ b/crates/chain/index-staking/src/lib.rs
@@ -1,0 +1,50 @@
+//! Staking registry chain indexer for Vertex.
+//!
+//! A per-contract [`Indexer`](vertex_chain_index::Indexer) for the Swarm
+//! `StakeRegistry`, built on the generic [`vertex_chain_index`] engine. It folds
+//! the registry's events into a [`vertex-storage`](vertex_storage) projection:
+//! the per-owner stake state (committed and potential stake, overlay, height,
+//! last-updated block, freeze deadline) and the staked-overlay set.
+//!
+//! # Events indexed
+//!
+//! - `StakeUpdated(owner, committedStake, potentialStake, overlay, lastUpdatedBlock, height)`
+//!   sets an owner's two stake legs, overlay, height, and on-chain update block.
+//! - `StakeFrozen(frozen, overlay, time)` records an owner's freeze deadline.
+//! - `StakeSlashed(slashed, overlay, amount)` zeroes an owner's stake (removing
+//!   it from the staked-overlay set).
+//! - `StakeWithdrawn(node, amount)` zeroes an owner's stake on withdrawal.
+//! - `OverlayChanged(owner, overlay)` re-points an owner's overlay.
+//!
+//! # Design: a pure, lazy projection
+//!
+//! Per `CHAIN_REACTIONS_DESIGN.md`, [`apply`](vertex_chain_index::Indexer::apply)
+//! is a pure, idempotent fold into the storage projection: no side effects, no
+//! domain logic, no calls into a storer or accounting layer. Consumers read the
+//! projection lazily at their own decision point (for example, checking whether
+//! an owner is frozen right before committing a redistribution round) through
+//! [`StakeProjection`]; the chain crate never pushes a stake event at them.
+//!
+//! Idempotency and monotonicity come from a `(block, log_index)` supersede rule:
+//! a fold step updates an owner's row only when the log's position is strictly
+//! later than the position last recorded for that owner, so re-delivering a
+//! finalized range on restart re-applies to the same row and an out-of-order log
+//! never regresses state.
+//!
+//! # Placement
+//!
+//! Native, RPC-and-persistence code, intended to run behind a `chain` feature in
+//! its consumers and to stay out of the wasm cone, exactly like the engine it
+//! builds on. The crate decodes logs the engine already fetched and persists
+//! through the `vertex-storage` trait surface; it opens no socket of its own.
+
+mod indexer;
+mod projection;
+
+pub use indexer::{DEPLOYMENT_BLOCK, STAKE_REGISTRY, StakingIndexer};
+pub use projection::{
+    LogPos, OverlayKey, OverlayOwnerTable, OwnerStake, StakeProjection, StakeTable, StakingTables,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/chain/index-staking/src/projection.rs
+++ b/crates/chain/index-staking/src/projection.rs
@@ -1,0 +1,230 @@
+//! The staking projection: per-owner stake state and the staked-overlay set.
+//!
+//! Two `vertex-storage` tables hold the folded state:
+//!
+//! - [`StakeTable`] maps an owner [`Address`] to its [`OwnerStake`] row: the
+//!   committed and potential stake, the current overlay and height, the block the
+//!   stake was last updated on-chain, and the freeze deadline. This is the
+//!   authoritative per-owner projection.
+//! - [`OverlayOwnerTable`] maps a staked `overlay` to the owner that staked it.
+//!   It is the staked-overlay set, kept queryable by overlay so a consumer can
+//!   resolve "who staked this overlay" without scanning every owner. The fold
+//!   maintains it in lockstep with the overlay field on the owner row: when an
+//!   owner's overlay changes, the stale overlay key is removed and the new one
+//!   inserted, so the set never carries a dangling overlay.
+//!
+//! Both tables are written through the same projection write transaction, so an
+//! owner row and its overlay-set entry commit atomically. Reads go through
+//! [`StakeProjection`], a thin query surface over the two tables.
+
+use alloy_primitives::{Address, B256, U256};
+use serde::{Deserialize, Serialize};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Table, Tables};
+
+// Owner address -> folded stake state.
+vertex_storage::table!(pub StakeTable, "staking_stakes", Address, OwnerStake);
+
+// Staked overlay -> the owner that staked it (the staked-overlay set).
+vertex_storage::table!(
+    pub OverlayOwnerTable,
+    "staking_overlay_owners",
+    OverlayKey,
+    Address
+);
+
+/// The overlay-set table key: a 32-byte overlay.
+///
+/// A newtype over [`B256`] so the overlay satisfies the storage key contract
+/// (`Encode`/`Decode`/`Ord`) and orders lexicographically by its bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct OverlayKey(pub B256);
+
+impl From<B256> for OverlayKey {
+    fn from(overlay: B256) -> Self {
+        Self(overlay)
+    }
+}
+
+impl vertex_storage::Encode for OverlayKey {
+    type Encoded = [u8; 32];
+
+    fn encode(self) -> Self::Encoded {
+        self.0.into()
+    }
+}
+
+impl vertex_storage::Decode for OverlayKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let bytes: [u8; 32] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        Ok(Self(B256::from(bytes)))
+    }
+}
+
+/// The set of tables the staking projection persists, for one-shot init.
+pub struct StakingTables;
+
+impl Tables for StakingTables {
+    const NAMES: &'static [&'static str] = &[StakeTable::NAME, OverlayOwnerTable::NAME];
+}
+
+/// One owner's folded stake state.
+///
+/// Every field is the last value the chain reported for this owner. `committed`
+/// and `potential` are the two stake legs from `StakeUpdated`; `overlay` and
+/// `height` pin the owner's current neighbourhood; `last_updated_block` is the
+/// on-chain block the stake was last changed (the contract's own counter, not
+/// the log's block); `frozen_until` is the freeze deadline (`0` when not frozen).
+///
+/// `seen_at` records the `(block, log_index)` of the log that produced this row,
+/// so the fold can reject an out-of-order replay: a later supersede must come
+/// from a strictly later log position. Because the engine delivers finalized
+/// logs in order and re-delivers the same range verbatim on restart, this makes
+/// the fold idempotent and monotonic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnerStake {
+    /// The committed (locked) stake leg.
+    pub committed: U256,
+    /// The potential (effective) stake leg.
+    pub potential: U256,
+    /// The owner's current overlay.
+    pub overlay: B256,
+    /// The owner's current neighbourhood height.
+    pub height: u8,
+    /// The on-chain block the stake was last updated (the contract's counter).
+    pub last_updated_block: U256,
+    /// The freeze deadline; `0` means not frozen.
+    pub frozen_until: U256,
+    /// The `(block, log_index)` of the log that produced this row.
+    pub seen_at: LogPos,
+}
+
+/// A log's position in the canonical order: `(block_number, log_index)`.
+///
+/// The fold supersedes a row only with a strictly later position, so a replayed
+/// log (same position) is a no-op and an out-of-order log never regresses state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct LogPos {
+    /// The log's block number.
+    pub block: u64,
+    /// The log's index within the block.
+    pub index: u64,
+}
+
+impl OwnerStake {
+    /// A fresh, never-seen owner row: a sentinel earlier than any real log.
+    ///
+    /// Used as the base for the first event touching an owner. Its `seen_at` is
+    /// the minimum position, so the first real log always supersedes it.
+    fn empty() -> Self {
+        Self {
+            committed: U256::ZERO,
+            potential: U256::ZERO,
+            overlay: B256::ZERO,
+            height: 0,
+            last_updated_block: U256::ZERO,
+            frozen_until: U256::ZERO,
+            seen_at: LogPos { block: 0, index: 0 },
+        }
+    }
+
+    /// Whether this owner currently holds a non-zero stake.
+    pub fn is_staked(&self) -> bool {
+        !self.potential.is_zero() || !self.committed.is_zero()
+    }
+
+    /// Whether this owner is frozen at `block` (the freeze deadline is in the
+    /// future relative to the supplied block height).
+    pub fn is_frozen_at(&self, block: U256) -> bool {
+        self.frozen_until > block
+    }
+}
+
+/// A read-only query surface over the staking projection tables.
+///
+/// Wraps a `vertex-storage` [`Database`] and answers the questions a consumer
+/// asks of the staking projection at its decision point: an owner's stake row,
+/// whether an overlay is in the staked set, and the owner behind a staked
+/// overlay. Per `CHAIN_REACTIONS_DESIGN.md`, reactions are lazy: a consumer reads
+/// this projection when it decides, it is never pushed a stake event.
+pub struct StakeProjection<'a, DB> {
+    db: &'a DB,
+}
+
+impl<'a, DB: Database> StakeProjection<'a, DB> {
+    /// Wrap a database for staking-projection reads.
+    pub fn new(db: &'a DB) -> Self {
+        Self { db }
+    }
+
+    /// The folded stake row for `owner`, if the owner has ever been seen.
+    pub fn stake_of(&self, owner: Address) -> Result<Option<OwnerStake>, DatabaseError> {
+        self.db.view(|tx| tx.get::<StakeTable>(owner))
+    }
+
+    /// Whether `overlay` is currently in the staked-overlay set.
+    pub fn is_overlay_staked(&self, overlay: B256) -> Result<bool, DatabaseError> {
+        Ok(self.owner_of_overlay(overlay)?.is_some())
+    }
+
+    /// The owner behind a staked `overlay`, if the overlay is in the set.
+    pub fn owner_of_overlay(&self, overlay: B256) -> Result<Option<Address>, DatabaseError> {
+        self.db
+            .view(|tx| tx.get::<OverlayOwnerTable>(OverlayKey::from(overlay)))
+    }
+
+    /// Every staked overlay paired with its owner.
+    pub fn staked_overlays(&self) -> Result<Vec<(B256, Address)>, DatabaseError> {
+        self.db.view(|tx| {
+            Ok(tx
+                .entries::<OverlayOwnerTable>()?
+                .into_iter()
+                .map(|(k, owner)| (k.0, owner))
+                .collect())
+        })
+    }
+}
+
+/// Apply a fold step against an owner's row, within a write transaction.
+///
+/// Loads the current row (or the empty sentinel), runs `update` to produce the
+/// next row, then reconciles the staked-overlay set so it reflects the new row's
+/// membership: the set carries `(overlay -> owner)` exactly when the owner holds
+/// a non-zero stake under a non-zero overlay. The previous set entry is removed
+/// whenever the owner's overlay or staked status changed, and the new entry is
+/// inserted whenever the owner is staked. The row and the set entry are written
+/// through the same transaction, so they commit atomically.
+///
+/// `update` returns `None` to skip the write entirely (a stale/replayed log that
+/// must not supersede), keeping the fold idempotent.
+pub(crate) fn fold_owner<TX, F>(tx: &TX, owner: Address, update: F) -> Result<(), DatabaseError>
+where
+    TX: DbTxMut,
+    F: FnOnce(OwnerStake) -> Option<OwnerStake>,
+{
+    let current = tx
+        .get::<StakeTable>(owner)?
+        .unwrap_or_else(OwnerStake::empty);
+    let prev_in_set = current.is_staked() && current.overlay != B256::ZERO;
+    let prev_overlay = current.overlay;
+
+    let Some(next) = update(current) else {
+        return Ok(());
+    };
+
+    let next_in_set = next.is_staked() && next.overlay != B256::ZERO;
+
+    // Remove the old set entry when the owner was in the set and either its
+    // overlay moved or it is leaving the set (slash/withdraw zeroed the stake).
+    // Keying the delete on the previous overlay leaves an unrelated owner that
+    // happens to share the new overlay untouched.
+    if prev_in_set && (!next_in_set || next.overlay != prev_overlay) {
+        tx.delete::<OverlayOwnerTable>(OverlayKey::from(prev_overlay))?;
+    }
+    // Insert (or refresh) the set entry whenever the owner is staked.
+    if next_in_set {
+        tx.put::<OverlayOwnerTable>(OverlayKey::from(next.overlay), owner)?;
+    }
+
+    tx.put::<StakeTable>(owner, next)?;
+    Ok(())
+}

--- a/crates/chain/index-staking/src/tests.rs
+++ b/crates/chain/index-staking/src/tests.rs
@@ -1,0 +1,291 @@
+//! Unit tests over synthetic ABI-encoded `StakeRegistry` logs.
+//!
+//! Each test builds a real, ABI-encoded log with the contract's `sol!` event
+//! types, folds it through [`StakingIndexer::apply`], and asserts the projection.
+//! No chain or RPC is involved: the in-memory `vertex-storage` backend holds the
+//! projection, and the logs are encoded exactly as the contract would emit them,
+//! so decoding exercises the same path a live log would.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, LogData, U256};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use nectar_contracts::IStakeRegistry;
+use vertex_chain_index::Indexer;
+use vertex_storage_redb::RedbDatabase;
+
+use crate::indexer::{OverlayChanged, STAKE_REGISTRY, StakingIndexer};
+use crate::projection::StakeProjection;
+
+/// Wrap a `sol!` event's encoded log data in an `alloy_rpc_types_eth::Log` at the
+/// given `(block, log_index)`, emitted by the registry address.
+fn log_of<E: SolEvent>(event: &E, block: u64, index: u64) -> Log {
+    let data: LogData = event.encode_log_data();
+    Log {
+        inner: alloy_primitives::Log {
+            address: STAKE_REGISTRY,
+            data,
+        },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+fn updated(
+    owner: Address,
+    committed: u64,
+    potential: u64,
+    overlay: B256,
+    last_updated: u64,
+    height: u8,
+) -> IStakeRegistry::StakeUpdated {
+    IStakeRegistry::StakeUpdated {
+        owner,
+        committedStake: U256::from(committed),
+        potentialStake: U256::from(potential),
+        overlay,
+        lastUpdatedBlock: U256::from(last_updated),
+        height,
+    }
+}
+
+fn indexer() -> (Arc<RedbDatabase>, StakingIndexer<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let idx = StakingIndexer::new(db.clone()).unwrap();
+    (db, idx)
+}
+
+fn owner(byte: u8) -> Address {
+    Address::repeat_byte(byte)
+}
+
+fn overlay(byte: u8) -> B256 {
+    B256::repeat_byte(byte)
+}
+
+#[test]
+fn stake_updated_folds_all_fields() {
+    let (db, idx) = indexer();
+    let o = owner(0x11);
+    let ov = overlay(0xaa);
+
+    let log = log_of(&updated(o, 100, 250, ov, 40_500_000, 3), 40_500_001, 0);
+    idx.apply(40_500_001, &log).unwrap();
+
+    let proj = StakeProjection::new(db.as_ref());
+    let row = proj.stake_of(o).unwrap().expect("owner row");
+    assert_eq!(row.committed, U256::from(100u64));
+    assert_eq!(row.potential, U256::from(250u64));
+    assert_eq!(row.overlay, ov);
+    assert_eq!(row.height, 3);
+    assert_eq!(row.last_updated_block, U256::from(40_500_000u64));
+    assert_eq!(row.frozen_until, U256::ZERO);
+    assert!(row.is_staked());
+
+    // The overlay joined the staked set, pointing back at the owner.
+    assert!(proj.is_overlay_staked(ov).unwrap());
+    assert_eq!(proj.owner_of_overlay(ov).unwrap(), Some(o));
+    assert_eq!(proj.staked_overlays().unwrap(), vec![(ov, o)]);
+}
+
+#[test]
+fn stake_frozen_records_deadline_without_clearing_stake() {
+    let (db, idx) = indexer();
+    let o = owner(0x22);
+    let ov = overlay(0xbb);
+
+    idx.apply(1, &log_of(&updated(o, 10, 20, ov, 100, 1), 100, 0))
+        .unwrap();
+
+    let frozen = IStakeRegistry::StakeFrozen {
+        frozen: o,
+        overlay: ov,
+        time: U256::from(40_600_000u64),
+    };
+    idx.apply(1, &log_of(&frozen, 101, 0)).unwrap();
+
+    let proj = StakeProjection::new(db.as_ref());
+    let row = proj.stake_of(o).unwrap().unwrap();
+    assert_eq!(row.frozen_until, U256::from(40_600_000u64));
+    assert!(row.is_frozen_at(U256::from(40_599_999u64)));
+    assert!(!row.is_frozen_at(U256::from(40_600_000u64)));
+    // The stake and overlay survive a freeze.
+    assert!(row.is_staked());
+    assert!(proj.is_overlay_staked(ov).unwrap());
+}
+
+#[test]
+fn stake_slashed_zeroes_stake_and_drops_overlay() {
+    let (db, idx) = indexer();
+    let o = owner(0x33);
+    let ov = overlay(0xcc);
+
+    idx.apply(1, &log_of(&updated(o, 10, 20, ov, 100, 1), 100, 0))
+        .unwrap();
+    assert!(
+        StakeProjection::new(db.as_ref())
+            .is_overlay_staked(ov)
+            .unwrap()
+    );
+
+    let slashed = IStakeRegistry::StakeSlashed {
+        slashed: o,
+        overlay: ov,
+        amount: U256::from(30u64),
+    };
+    idx.apply(1, &log_of(&slashed, 101, 0)).unwrap();
+
+    let proj = StakeProjection::new(db.as_ref());
+    let row = proj.stake_of(o).unwrap().unwrap();
+    assert_eq!(row.committed, U256::ZERO);
+    assert_eq!(row.potential, U256::ZERO);
+    assert!(!row.is_staked());
+    // A zeroed stake removes the owner from the staked-overlay set; the row
+    // survives (with its overlay field intact) but the set no longer carries it.
+    assert!(!proj.is_overlay_staked(ov).unwrap());
+    assert_eq!(proj.owner_of_overlay(ov).unwrap(), None);
+    assert!(proj.staked_overlays().unwrap().is_empty());
+}
+
+#[test]
+fn stake_withdrawn_zeroes_stake() {
+    let (db, idx) = indexer();
+    let o = owner(0x44);
+    let ov = overlay(0xdd);
+
+    idx.apply(1, &log_of(&updated(o, 10, 20, ov, 100, 1), 100, 0))
+        .unwrap();
+
+    let withdrawn = IStakeRegistry::StakeWithdrawn {
+        node: o,
+        amount: U256::from(30u64),
+    };
+    idx.apply(1, &log_of(&withdrawn, 101, 0)).unwrap();
+
+    let proj = StakeProjection::new(db.as_ref());
+    let row = proj.stake_of(o).unwrap().unwrap();
+    assert_eq!(row.potential, U256::ZERO);
+    assert!(!row.is_staked());
+    // Withdrawing the stake also drops the overlay from the staked set.
+    assert!(!proj.is_overlay_staked(ov).unwrap());
+}
+
+#[test]
+fn overlay_changed_repoints_the_set() {
+    let (db, idx) = indexer();
+    let o = owner(0x55);
+    let ov1 = overlay(0x01);
+    let ov2 = overlay(0x02);
+
+    idx.apply(1, &log_of(&updated(o, 10, 20, ov1, 100, 1), 100, 0))
+        .unwrap();
+
+    let changed = OverlayChanged {
+        owner: o,
+        overlay: ov2,
+    };
+    idx.apply(1, &log_of(&changed, 101, 0)).unwrap();
+
+    let proj = StakeProjection::new(db.as_ref());
+    let row = proj.stake_of(o).unwrap().unwrap();
+    assert_eq!(row.overlay, ov2);
+    // The old overlay left the set; the new one took its place.
+    assert!(!proj.is_overlay_staked(ov1).unwrap());
+    assert!(proj.is_overlay_staked(ov2).unwrap());
+    assert_eq!(proj.owner_of_overlay(ov2).unwrap(), Some(o));
+    assert_eq!(proj.staked_overlays().unwrap(), vec![(ov2, o)]);
+}
+
+#[test]
+fn replaying_a_log_is_idempotent() {
+    let (db, idx) = indexer();
+    let o = owner(0x66);
+    let ov = overlay(0xee);
+    let log = log_of(&updated(o, 100, 250, ov, 40_500_000, 3), 40_500_001, 0);
+
+    // Apply the identical finalized log twice; the second is a no-op, leaving the
+    // row and the overlay set exactly as the first produced them.
+    idx.apply(40_500_001, &log).unwrap();
+    let first = StakeProjection::new(db.as_ref()).stake_of(o).unwrap();
+    idx.apply(40_500_001, &log).unwrap();
+    let second = StakeProjection::new(db.as_ref()).stake_of(o).unwrap();
+
+    assert_eq!(
+        first, second,
+        "replaying a finalized log re-applies the same row"
+    );
+    assert_eq!(
+        StakeProjection::new(db.as_ref())
+            .staked_overlays()
+            .unwrap()
+            .len(),
+        1,
+        "replay does not duplicate the overlay-set entry"
+    );
+}
+
+#[test]
+fn supersede_is_monotonic_by_block_then_log_index() {
+    let (db, idx) = indexer();
+    let o = owner(0x77);
+    let ov = overlay(0x07);
+
+    // A later log (block 200) sets potential to 500.
+    idx.apply(200, &log_of(&updated(o, 0, 500, ov, 200, 2), 200, 1))
+        .unwrap();
+
+    // An earlier log (block 100) must NOT regress the row, even though it is
+    // delivered second here: the supersede key is (block, log_index).
+    idx.apply(100, &log_of(&updated(o, 0, 10, ov, 100, 1), 100, 0))
+        .unwrap();
+
+    let row = StakeProjection::new(db.as_ref())
+        .stake_of(o)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.potential,
+        U256::from(500u64),
+        "an out-of-order earlier log does not overwrite a later one"
+    );
+    assert_eq!(row.height, 2);
+
+    // A same-block log with a higher log_index does supersede.
+    idx.apply(200, &log_of(&updated(o, 0, 999, ov, 200, 4), 200, 2))
+        .unwrap();
+    let row = StakeProjection::new(db.as_ref())
+        .stake_of(o)
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.potential, U256::from(999u64));
+    assert_eq!(row.height, 4);
+}
+
+#[test]
+fn filter_targets_the_registry_and_the_five_events() {
+    let (_db, idx) = indexer();
+    let filter = idx.filter();
+
+    // The address constraint is the registry.
+    assert!(filter.address.iter().any(|a| *a == STAKE_REGISTRY));
+
+    // topic0 carries exactly the five staking signatures.
+    let topics = &filter.topics[0];
+    let expected = [
+        IStakeRegistry::StakeUpdated::SIGNATURE_HASH,
+        IStakeRegistry::StakeFrozen::SIGNATURE_HASH,
+        IStakeRegistry::StakeSlashed::SIGNATURE_HASH,
+        IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH,
+        OverlayChanged::SIGNATURE_HASH,
+    ];
+    for sig in expected {
+        assert!(topics.iter().any(|t| *t == sig), "filter matches {sig}");
+    }
+    assert_eq!(topics.iter().count(), expected.len());
+}

--- a/crates/chain/index-staking/tests/e2e_fork.rs
+++ b/crates/chain/index-staking/tests/e2e_fork.rs
@@ -1,0 +1,151 @@
+//! End-to-end smoke test against a real Gnosis Chain fork.
+//!
+//! It runs the real [`StakingIndexer`] over a bounded recent window of finalized
+//! blocks served by an anvil fork (or a live RPC), then cross-checks one indexed
+//! owner's projection row against a direct `stakes(owner)` contract call. This
+//! validates the fold against real on-chain `StakeRegistry` logs rather than the
+//! synthetic ones the unit tests use.
+//!
+//! It is `#[ignore]`d so CI without a fork stays green. To run it:
+//!
+//! 1. Start a fork (anvil ships with foundry; install via `foundryup` if absent).
+//!    The public Gnosis RPC is shared and rate-limited, so fork at a recent block
+//!    and let the test scan only a bounded window below the finalized head:
+//!
+//!    ```sh
+//!    anvil --fork-url ${GNOSIS_RPC_URL:-https://rpc.gnosischain.com} \
+//!          --fork-block-number <recent> --port 8549 --silent &
+//!    ```
+//!
+//!    then point the test at it (this is also the default):
+//!
+//!    ```sh
+//!    STAKING_E2E_RPC=http://localhost:8549 \
+//!        cargo test -p vertex-chain-index-staking --test e2e_fork -- --ignored --nocapture
+//!    ```
+//!
+//! 2. If anvil cannot be installed or run, point the test directly at a public
+//!    Gnosis RPC over the same bounded window:
+//!
+//!    ```sh
+//!    STAKING_E2E_RPC=https://rpc.gnosischain.com \
+//!        cargo test -p vertex-chain-index-staking --test e2e_fork -- --ignored --nocapture
+//!    ```
+//!
+//! The window size is bounded by `WINDOW` below the RPC's current finalized
+//! block, so the test stays inside the public RPC's `eth_getLogs` limits and
+//! finishes quickly on a fork and on a live RPC alike.
+
+use std::sync::Arc;
+
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types_eth::TransactionRequest;
+use alloy_sol_types::SolCall;
+use nectar_contracts::IStakeRegistry;
+use vertex_chain_index::{ChainReader, Cursor, EventEngine};
+use vertex_chain_index_staking::{STAKE_REGISTRY, StakeProjection, StakingIndexer};
+use vertex_storage_redb::RedbDatabase;
+
+/// How many blocks back from the finalized head to scan. Bounded so a single
+/// `eth_getLogs` sweep stays inside the public RPC's range and result limits.
+const WINDOW: u64 = 40_000;
+
+#[tokio::test]
+#[ignore = "requires a Gnosis fork or live RPC; see module docs"]
+async fn indexes_real_stake_registry_logs() {
+    let rpc =
+        std::env::var("STAKING_E2E_RPC").unwrap_or_else(|_| "http://localhost:8549".to_string());
+
+    let url = rpc.parse().expect("STAKING_E2E_RPC is a valid URL");
+    let provider = Arc::new(ProviderBuilder::new().connect_http(url));
+
+    // Bound the window to the RPC's finalized head. Skip (do not fail) if the RPC
+    // is unreachable so a missing fork leaves the suite green.
+    let head = match ChainReader::finalized_head(provider.as_ref()).await {
+        Ok(Some(head)) => head,
+        Ok(None) => {
+            eprintln!("skipping: RPC has no finalized block");
+            return;
+        }
+        Err(err) => {
+            eprintln!("skipping: RPC unreachable at {rpc}: {err}");
+            return;
+        }
+    };
+
+    let start = head.number.saturating_sub(WINDOW);
+    eprintln!(
+        "syncing StakeRegistry logs over blocks {start}..={} via {rpc}",
+        head.number
+    );
+
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    // Start at the bounded window, not the deployment block, so the test scans a
+    // small recent range rather than the contract's full history.
+    let indexer = Arc::new(
+        StakingIndexer::new(db.clone())
+            .expect("init projection")
+            .with_start_block(start),
+    );
+
+    // A long poll interval plus an immediate shutdown stops the engine right
+    // after the startup backfill completes.
+    EventEngine::new(provider.clone(), db.clone())
+        .register(indexer)
+        .with_poll_interval(std::time::Duration::from_secs(3600))
+        .run(async {})
+        .await
+        .expect("engine run");
+
+    let cursor = Cursor::load(db.as_ref(), "staking_registry")
+        .expect("load cursor")
+        .expect("cursor persisted");
+    assert_eq!(cursor.last_block, head.number, "cursor advanced to head");
+
+    let proj = StakeProjection::new(db.as_ref());
+    let overlays = proj.staked_overlays().expect("read staked overlays");
+    eprintln!("indexed {} staked overlays in the window", overlays.len());
+
+    // The window may legitimately contain no StakeUpdated events; if it does,
+    // cross-check one indexed owner against a direct contract call. This proves
+    // the fold reflects on-chain state, not just that decoding succeeded.
+    let Some((overlay, owner)) = overlays.first().copied() else {
+        eprintln!("no staking activity in the window; skipping the contract cross-check");
+        return;
+    };
+
+    let row = proj
+        .stake_of(owner)
+        .expect("read owner row")
+        .expect("indexed owner has a row");
+    assert_eq!(row.overlay, overlay, "row overlay matches the set entry");
+
+    // Call `stakes(owner)` directly: encode the call, `eth_call` it, decode the
+    // return. The shared `IStakeRegistry` `sol!` interface generates the call and
+    // return types; no instance wrapper is needed for a single read.
+    let calldata = IStakeRegistry::stakesCall { owner }.abi_encode();
+    let request = TransactionRequest::default()
+        .to(STAKE_REGISTRY)
+        .input(calldata.into());
+    let raw = provider.call(request).await.expect("stakes() eth_call");
+    let on_chain =
+        IStakeRegistry::stakesCall::abi_decode_returns(&raw).expect("decode stakes() return");
+
+    eprintln!(
+        "owner {owner}: indexed potential={} committed={} overlay={overlay}; \
+         on-chain potential={} committed={} overlay={}",
+        row.potential,
+        row.committed,
+        on_chain.potentialStake,
+        on_chain.committedStake,
+        on_chain.overlay
+    );
+
+    // The contract's current `stakes(owner)` reflects the latest StakeUpdated for
+    // that owner. If our window captured that owner's most recent update, the
+    // projection must agree with the live view.
+    assert_eq!(
+        row.overlay, on_chain.overlay,
+        "indexed overlay matches the on-chain stakes() overlay"
+    );
+}


### PR DESCRIPTION
## What

Adds `vertex-chain-index-staking`, a per-contract indexer for the Swarm `StakeRegistry` (Gnosis Chain, `0xda2a16EE889E7F04980A8d597b48c8D51B9518F4`, deployed at block 40430237), built on the generic `vertex-chain-index` engine merged in #300.

## Events indexed

The indexer's filter selects five `StakeRegistry` topics at the registry address:

- `StakeUpdated(owner, committedStake, potentialStake, overlay, lastUpdatedBlock, height)`
- `StakeFrozen(frozen, overlay, time)`
- `StakeSlashed(slashed, overlay, amount)`
- `StakeWithdrawn(node, amount)`
- `OverlayChanged(owner, overlay)`

It reuses the shared `nectar_contracts::IStakeRegistry` `sol!` event bindings for the first four; `OverlayChanged` is the one event the shared interface does not carry, so it is declared locally from the deployment ABI.

## Projection

Two `vertex-storage` tables hold the folded state:

- `StakeTable` (`staking_stakes`): owner `Address` to an `OwnerStake` row carrying the committed and potential stake legs, the current overlay and height, the on-chain last-updated block, and the freeze deadline.
- `OverlayOwnerTable` (`staking_overlay_owners`): a staked `overlay` to the owner that staked it. This is the staked-overlay set, kept queryable by overlay. The fold reconciles it against the owner row's staked status: a slash or withdrawal that zeroes the stake removes the overlay from the set, and an `OverlayChanged` re-points the entry.

Reads go through `StakeProjection` (`stake_of`, `is_overlay_staked`, `owner_of_overlay`, `staked_overlays`).

## `apply` is a pure, no-reaction fold

Per `CHAIN_REACTIONS_DESIGN.md`, `apply` is a pure, idempotent fold into the storage projection: no side effects, no domain logic, no calls into a storer or accounting layer. Consumers read the projection lazily at their own decision point (for example, checking `is_frozen_at` right before committing a redistribution round); the chain crate never pushes a stake event at them.

Idempotency and monotonicity come from a `(block, log_index)` supersede rule: a fold step updates an owner's row only when the log's position is strictly later than the position last recorded for that owner. Re-delivering a finalized range on restart re-applies to the same row, and an out-of-order log never regresses state.

## Tests

- Unit tests over synthetic ABI-encoded logs: each of the five events decodes and folds correctly; replaying a finalized log is idempotent; the supersede is monotonic by `(block, log_index)`; slash and withdrawal drop the overlay from the staked set; the filter targets the registry and exactly the five signatures. They run against the in-memory `vertex-storage` backend.
- An env-guarded, `#[ignore]`d anvil-fork e2e (`STAKING_E2E_RPC`, default port 8549) syncs a bounded recent window of finalized blocks and cross-checks one indexed owner's overlay against a direct `stakes(owner)` contract call. Run instructions are in the test's module docs.

## Placement

Native, RPC-and-persistence code behind the engine it builds on; it decodes logs the engine already fetched and persists through the `vertex-storage` trait surface, opening no socket of its own, so it stays out of the wasm cone.

## E2E result

The anvil-fork e2e was run against a Gnosis fork (`anvil --fork-url https://rpc.gnosischain.com --fork-block-number 46670000 --port 8549 --silent`), scanning the bounded window `46629936..=46669936` below the fork's finalized head. The public RPC is shared and rate-limited, so the sweep is slow but bounded; result confirmation is appended below once the run completes. To reproduce, follow the run instructions in `crates/chain/index-staking/tests/e2e_fork.rs`.
