### PR TITLE
feat(chain): unified configuration-driven contract indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8363,6 +8363,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-chain-index-framework"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vertex-chain-index",
+ "vertex-storage",
+ "vertex-storage-redb",
+]
+
+[[package]]
 name = "vertex-ffi"
 version = "0.1.0"
 dependencies = [
@@ -8716,6 +8731,7 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -8730,6 +8746,10 @@ dependencies = [
  "tokio",
  "tracing",
  "vertex-chain",
+ "vertex-chain-index",
+ "vertex-chain-index-framework",
+ "vertex-storage",
+ "vertex-storage-redb",
 ]
 
 [[package]]
@@ -8774,6 +8794,7 @@ dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
@@ -8784,6 +8805,10 @@ dependencies = [
  "tokio",
  "tracing",
  "vertex-chain",
+ "vertex-chain-index",
+ "vertex-chain-index-framework",
+ "vertex-storage",
+ "vertex-storage-redb",
  "vertex-swarm-accounting",
  "vertex-swarm-accounting-chequebook",
  "vertex-swarm-api",
@@ -8844,6 +8869,8 @@ dependencies = [
  "tokio",
  "tracing",
  "vertex-chain",
+ "vertex-chain-index",
+ "vertex-chain-index-framework",
  "vertex-net-peer-store",
  "vertex-node-api",
  "vertex-storage-redb",
@@ -9376,13 +9403,17 @@ name = "vertex-swarm-postage"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-sol-types",
  "nectar-postage",
  "nectar-primitives",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
+ "vertex-chain-index",
+ "vertex-chain-index-framework",
  "vertex-storage",
  "vertex-storage-redb",
 ]
@@ -9429,14 +9460,21 @@ name = "vertex-swarm-redistribution"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-eth",
  "alloy-signer-local",
+ "alloy-sol-types",
  "clap 4.6.1",
  "codspeed-criterion-compat",
+ "nectar-contracts",
  "nectar-primitives",
  "serde",
  "serde_json",
  "strum 0.28.0",
  "thiserror 2.0.18",
+ "vertex-chain-index",
+ "vertex-chain-index-framework",
+ "vertex-storage",
+ "vertex-storage-redb",
  "vertex-swarm-api",
  "vertex-swarm-postage",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ members = [
     # Chain (Ethereum RPC access)
     "crates/chain",
     "crates/chain/index",
+    "crates/chain/index-framework",
 
     # FFI (native embedding surface)
     "crates/ffi",
@@ -263,6 +264,7 @@ vertex-rpc-server = { path = "crates/rpc/server" }
 # chain (Ethereum RPC access)
 vertex-chain = { path = "crates/chain" }
 vertex-chain-index = { path = "crates/chain/index" }
+vertex-chain-index-framework = { path = "crates/chain/index-framework" }
 
 # ffi (native embedding surface)
 vertex-ffi = { path = "crates/ffi" }

--- a/crates/chain/index-framework/Cargo.toml
+++ b/crates/chain/index-framework/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "vertex-chain-index-framework"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Generic, configuration-driven contract-indexing framework over the vertex-chain-index engine (mechanism only; names no contract)"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Indexer trait and error taxonomy.
+vertex-chain-index = { workspace = true }
+# Event store and secondary index machinery.
+vertex-storage = { workspace = true }
+
+# Log types, combined filter, store key primitives. No `sol!`: names no ABI.
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true }
+
+# Stored rows and keys derive serde.
+serde = { workspace = true, features = ["derive"] }
+
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+vertex-storage-redb = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/chain/index-framework/src/indexer.rs
+++ b/crates/chain/index-framework/src/indexer.rs
@@ -1,0 +1,230 @@
+//! The single [`ContractIndexer`]: one [`Indexer`] over a combined
+//! multi-address/multi-topic filter, one cursor, one position-keyed store,
+//! composed from per-domain [`DomainRegistration`]s.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use alloy_primitives::Address;
+use alloy_rpc_types_eth::{Filter, Log};
+use tracing::warn;
+use vertex_chain_index::{CursorTables, IndexError, Indexer};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Table, Tables};
+
+use crate::reducer::Reducer;
+use crate::registration::{DomainRegistration, RegistrationError, WatchedContract};
+use crate::store::{EventKey, EventTable, events_of_tx, put_event, stored_event_from_log};
+use crate::tag::ContractTag;
+
+/// The indexer name: the engine's single cursor key and metric label.
+pub const INDEXER_NAME: &str = "chain_contracts";
+
+/// The one indexer that watches every registered Swarm contract.
+///
+/// Registered as a single [`Indexer`] with the
+/// [`EventEngine`](vertex_chain_index::EventEngine). The combined filter is one
+/// `eth_getLogs` per page covering all contracts; the engine delivers the page
+/// in global `(block, log_index)` order, and [`apply`](Indexer::apply) files
+/// each log into its own `(tag, block, log_index)` slot, so two contracts'
+/// events in the same block never contend.
+pub struct ContractIndexer<DB: Database> {
+    db: Arc<DB>,
+    contracts: Vec<WatchedContract>,
+    by_address: HashMap<Address, WatchedContract>,
+    reducers: HashMap<ContractTag, Box<dyn Reducer<DB>>>,
+}
+
+impl<DB: Database> ContractIndexer<DB> {
+    /// Build the unified indexer, validating tag/address/table-name uniqueness
+    /// and reducer-tag matching across registrations, then initialising the union
+    /// of their tables plus the shared event and cursor tables. Composition
+    /// collisions return [`RegistrationError`]; a storage fault during init
+    /// propagates.
+    pub fn from_registrations(
+        db: Arc<DB>,
+        regs: Vec<DomainRegistration<DB>>,
+    ) -> Result<Self, RegistrationError> {
+        let mut contracts: Vec<WatchedContract> = Vec::new();
+        let mut reducers: HashMap<ContractTag, Box<dyn Reducer<DB>>> = HashMap::new();
+        let mut by_address: HashMap<Address, WatchedContract> = HashMap::new();
+        let mut tags: HashSet<ContractTag> = HashSet::new();
+        let mut table_names: Vec<&'static str> = Vec::new();
+        let mut seen_tables: HashSet<&'static str> = HashSet::new();
+
+        for reg in regs {
+            for c in &reg.contracts {
+                if !tags.insert(c.tag) {
+                    return Err(RegistrationError::DuplicateTag(c.tag));
+                }
+                if by_address.insert(c.address, *c).is_some() {
+                    return Err(RegistrationError::DuplicateAddress(c.address));
+                }
+                contracts.push(*c);
+            }
+
+            // table `init` does not dedup, so a name collision would silently
+            // share storage.
+            for &name in reg.tables {
+                if !seen_tables.insert(name) {
+                    return Err(RegistrationError::DuplicateTableName(name));
+                }
+                table_names.push(name);
+            }
+
+            for reducer in reg.reducers {
+                let tag = reducer.tag();
+                if !tags.contains(&tag) {
+                    return Err(RegistrationError::TagReducerMismatch(tag));
+                }
+                reducers.insert(tag, reducer);
+            }
+        }
+
+        init_tables(db.as_ref(), &table_names).map_err(RegistrationError::TableInit)?;
+
+        Ok(Self {
+            db,
+            contracts,
+            by_address,
+            reducers,
+        })
+    }
+
+    /// Resolve a log address to its watched contract, or None (the filter is
+    /// slightly over-broad).
+    fn resolve(&self, address: Address) -> Option<WatchedContract> {
+        self.by_address.get(&address).copied()
+    }
+}
+
+/// Create every projection table plus the shared [`EventTable`] and the engine
+/// cursor table in one write transaction.
+fn init_tables<DB: Database>(db: &DB, domain_tables: &[&'static str]) -> Result<(), DatabaseError> {
+    db.update(|tx| {
+        tx.ensure_table(EventTable::NAME)?;
+        for name in CursorTables::NAMES {
+            tx.ensure_table(name)?;
+        }
+        for name in domain_tables {
+            tx.ensure_table(name)?;
+        }
+        Ok(())
+    })
+}
+
+impl<DB: Database> Indexer for ContractIndexer<DB> {
+    fn name(&self) -> &'static str {
+        INDEXER_NAME
+    }
+
+    fn start_block(&self) -> u64 {
+        // The earliest deployment across the registry. The engine pages the
+        // union range from here; a contract deployed later costs only empty
+        // pages over the gap, which the adaptive paging covers cheaply.
+        self.contracts
+            .iter()
+            .map(|c| c.start_block)
+            .min()
+            .unwrap_or(0)
+    }
+
+    fn filter(&self) -> Filter {
+        let addresses: Vec<Address> = self.contracts.iter().map(|c| c.address).collect();
+        let topics: Vec<_> = self
+            .contracts
+            .iter()
+            .flat_map(|c| c.events.iter().map(|e| e.topic0))
+            .collect();
+        Filter::new().address(addresses).event_signature(topics)
+    }
+
+    fn apply(&self, block: u64, log: &Log) -> Result<(), IndexError> {
+        // Address is the authority; an unwatched address is skipped, never misfiled.
+        let Some(contract) = self.resolve(log.address()) else {
+            return Ok(());
+        };
+
+        // Verify topic0 is declared for this contract (two contracts can share a
+        // topic0).
+        let Some(topic0) = log.topic0().copied() else {
+            // Anonymous event; no watched event is anonymous, so skip.
+            return Ok(());
+        };
+        if !contract.declares(topic0) {
+            return Ok(());
+        }
+
+        let log_index = log
+            .log_index
+            .ok_or(IndexError::MalformedLog { field: "log_index" })?;
+        let key = EventKey {
+            tag: contract.tag,
+            block,
+            log_index,
+        };
+
+        let event = stored_event_from_log(log);
+        let data_len = event.data.len();
+        let reducer = self.reducers.get(&contract.tag);
+
+        // Reducer folds in the same tx as put_event; a decode miss is a skip, only
+        // a storage fault escapes.
+        self.db.update(|tx| {
+            let stored = put_event(tx, key, &event)?;
+            if !stored {
+                warn!(
+                    tag = contract.tag.0,
+                    block, log_index, data_len, "event data exceeds MAX_EVENT_DATA cap, skipping"
+                );
+                return Ok(());
+            }
+            if let Some(reducer) = reducer {
+                reducer.reduce(tx, key, &event)?;
+            }
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    fn revert(&self, from_block: u64) -> Result<(), IndexError> {
+        for contract in &self.contracts {
+            let tag = contract.tag;
+            let reducer = self.reducers.get(&tag).map(|r| r.as_ref());
+            self.db
+                .update(|tx| revert_contract::<DB>(tx, tag, reducer, from_block))?;
+        }
+        Ok(())
+    }
+}
+
+/// Range-delete this contract's raw rows at or after `from_block`, then rebuild
+/// its projection (if any) from the survivors.
+///
+/// Views derive purely from raw rows, so this is sufficient even for a batch
+/// created earlier but mutated within the reverted range.
+fn revert_contract<DB: Database>(
+    tx: &DB::TXMut,
+    tag: ContractTag,
+    reducer: Option<&dyn Reducer<DB>>,
+    from_block: u64,
+) -> Result<(), DatabaseError> {
+    let doomed: Vec<EventKey> = tx
+        .range::<EventTable>(
+            EventKey::range_from(tag, from_block),
+            EventKey::range_end(tag),
+        )?
+        .into_iter()
+        .map(|(k, _)| k)
+        .collect();
+    for key in doomed {
+        tx.delete::<EventTable>(key)?;
+    }
+
+    if let Some(reducer) = reducer {
+        let surviving = events_of_tx(tx, tag)?;
+        reducer.rebuild(tx, &surviving)?;
+    }
+
+    Ok(())
+}

--- a/crates/chain/index-framework/src/lib.rs
+++ b/crates/chain/index-framework/src/lib.rs
@@ -1,0 +1,33 @@
+//! Configuration-driven contract-indexing mechanism. Names no contract, ABI,
+//! address, or projection of its own; each domain registers its watched
+//! contracts, `sol!` events, optional [`Reducer`], and projection tables, and the
+//! node builder composes them into one [`ContractIndexer`] (one filter, one
+//! cursor, one position-keyed store). Native, runs behind a `chain` feature,
+//! stays out of the wasm cone.
+
+mod indexer;
+mod store;
+
+pub mod projection;
+pub mod reducer;
+pub mod registration;
+pub mod tag;
+
+/// Stable re-export the `projection!` / `secondary_index!` macros expand through.
+#[doc(hidden)]
+pub use vertex_storage as __vertex_storage;
+
+pub use indexer::{ContractIndexer, INDEXER_NAME};
+pub use projection::{
+    IndexedProjection, Projection, contains, fold_events, get_via_index, last_event, list_all,
+    list_by, point_get, range_head, scalar,
+};
+pub use reducer::Reducer;
+pub use registration::{
+    DomainRegistration, EventDescriptor, Network, RegistrationError, WatchedContract,
+};
+pub use store::{EventKey, EventTable, MAX_EVENT_DATA, StoredEvent, events_of};
+pub use tag::ContractTag;
+
+#[cfg(test)]
+mod tests;

--- a/crates/chain/index-framework/src/projection.rs
+++ b/crates/chain/index-framework/src/projection.rs
@@ -1,0 +1,197 @@
+//! Typed projections plus a fixed set of read combinators over them, and the lazy
+//! fold backbone ([`fold_events`] / [`last_event`]) for reducer-less contracts. A
+//! decode failure inside any read is scoped to the offending row (skipped), never
+//! an error.
+
+use vertex_storage::{Database, DatabaseError, DbTx, IndexedRead, SecondaryIndex, Table};
+
+use crate::store::{EventKey, StoredEvent, events_of};
+use crate::tag::ContractTag;
+
+/// A typed projection: a [`Table`] a [`Reducer`](crate::reducer::Reducer)
+/// maintains alongside the verbatim event store.
+pub trait Projection: Table {}
+
+/// A typed projection carried with a self-healing secondary index, so a view can
+/// read it both by primary key ([`point_get`]) and in index order
+/// ([`range_head`], [`get_via_index`]).
+///
+/// `Index::Primary` is the projection table, so the two stay in lockstep; the
+/// [`secondary_index!`](crate::secondary_index) macro wires both.
+pub trait IndexedProjection: Projection {
+    /// The self-healing secondary index over this projection.
+    type Index: SecondaryIndex<Primary = Self>;
+}
+
+/// Declare a typed [`Projection`] (a maintained [`Table`]) in one line.
+///
+/// Wraps the storage crate's [`table!`](vertex_storage::table) and adds the
+/// [`Projection`] marker. Projections are uncompressed by default to match the
+/// small fixed-size rows a reducer maintains; pass `compressed = false`
+/// explicitly only to be emphatic (it is the default here).
+#[macro_export]
+macro_rules! projection {
+    ($vis:vis $name:ident, $table_name:literal, $key:ty, $value:ty) => {
+        $crate::__vertex_storage::table!($vis $name, $table_name, $key, $value);
+        impl $crate::projection::Projection for $name {}
+    };
+}
+
+/// Declare a self-healing secondary index over a [`Projection`] and bind it as
+/// that projection's [`IndexedProjection::Index`] in one line.
+///
+/// Wraps the storage crate's [`index!`](vertex_storage::index) and additionally
+/// records the index on the primary via [`IndexedProjection`], so [`range_head`]
+/// / [`get_via_index`] can find it from the projection type alone.
+#[macro_export]
+macro_rules! secondary_index {
+    ($vis:vis $name:ident, $table_name:literal, $index_key:ty, $primary:ty, |$val:ident| $extract:expr) => {
+        $crate::__vertex_storage::index!($vis $name, $table_name, $index_key, $primary, |$val| $extract);
+        impl $crate::projection::IndexedProjection for $primary {
+            type Index = $name;
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Eager-projection combinators.
+// ---------------------------------------------------------------------------
+
+/// Point-read a projection row by its primary key.
+pub fn point_get<P, DB>(db: &DB, key: P::Key) -> Result<Option<P::Value>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    db.view(|tx| tx.get::<P>(key))
+}
+
+/// Whether a projection holds a row at `key` (membership without the value).
+pub fn contains<P, DB>(db: &DB, key: P::Key) -> Result<bool, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    Ok(db.view(|tx| tx.get::<P>(key))?.is_some())
+}
+
+/// Every row in a projection, as `(key, value)` pairs.
+// The `(P::Key, P::Value)` pair is the storage trait's own `entries` shape (which
+// carries the same allow); it is a deliberate, readable signature here.
+#[allow(clippy::type_complexity)]
+pub fn list_all<P, DB>(db: &DB) -> Result<Vec<(P::Key, P::Value)>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    db.view(|tx| tx.entries::<P>())
+}
+
+/// Every projection row whose value satisfies `pred`.
+///
+/// The generic "list by some attribute" read (e.g. batches by owner): the
+/// projection carries the attribute, so no secondary table is needed for a
+/// linear filter.
+#[allow(clippy::type_complexity)]
+pub fn list_by<P, DB, F>(db: &DB, mut pred: F) -> Result<Vec<(P::Key, P::Value)>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+    F: FnMut(&P::Value) -> bool,
+{
+    Ok(db
+        .view(|tx| tx.entries::<P>())?
+        .into_iter()
+        .filter(|(_, v)| pred(v))
+        .collect())
+}
+
+/// Read a projection row via its secondary index key, resolving through to the
+/// primary value.
+pub fn get_via_index<P, DB>(
+    db: &DB,
+    index_key: <P::Index as Table>::Key,
+) -> Result<Option<P::Value>, DatabaseError>
+where
+    P: IndexedProjection,
+    DB: Database,
+{
+    db.view(|tx| tx.get_via::<P::Index>(index_key))
+}
+
+/// Head of the secondary index in ascending order, bounded to `limit`, returned
+/// as the primary keys it points at.
+///
+/// Scans the `[from ..= to]` range so the cost is the head window, not the whole
+/// index.
+pub fn range_head<P, DB>(
+    db: &DB,
+    from: <P::Index as Table>::Key,
+    to: <P::Index as Table>::Key,
+    limit: usize,
+) -> Result<Vec<<P::Index as Table>::Value>, DatabaseError>
+where
+    P: IndexedProjection,
+    DB: Database,
+{
+    db.view(|tx| {
+        Ok(tx
+            .range::<P::Index>(from, to)?
+            .into_iter()
+            .take(limit)
+            .map(|(_, pk)| pk)
+            .collect())
+    })
+}
+
+/// Read a single-row summary projection at a fixed key (point_get specialised to
+/// the summary read).
+pub fn scalar<P, DB>(db: &DB, key: P::Key) -> Result<Option<P::Value>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    point_get::<P, DB>(db, key)
+}
+
+// ---------------------------------------------------------------------------
+// Lazy fold backbone (reducer-less contracts).
+// ---------------------------------------------------------------------------
+
+/// Fold a contract's verbatim event stream in canonical order into an
+/// accumulator; `step` decodes and folds each row, skipping a decode miss.
+pub fn fold_events<DB, A, F>(
+    db: &DB,
+    tag: ContractTag,
+    init: A,
+    mut step: F,
+) -> Result<A, DatabaseError>
+where
+    DB: Database,
+    F: FnMut(&mut A, EventKey, &StoredEvent),
+{
+    let mut acc = init;
+    for (key, ev) in events_of(db, tag)? {
+        step(&mut acc, key, &ev);
+    }
+    Ok(acc)
+}
+
+/// Walk a contract's rows backward and return the first value `pick` yields (last
+/// write in canonical order).
+pub fn last_event<DB, T, F>(
+    db: &DB,
+    tag: ContractTag,
+    mut pick: F,
+) -> Result<Option<T>, DatabaseError>
+where
+    DB: Database,
+    F: FnMut(&StoredEvent) -> Option<T>,
+{
+    for (_key, ev) in events_of(db, tag)?.into_iter().rev() {
+        if let Some(v) = pick(&ev) {
+            return Ok(Some(v));
+        }
+    }
+    Ok(None)
+}

--- a/crates/chain/index-framework/src/reducer.rs
+++ b/crates/chain/index-framework/src/reducer.rs
@@ -1,0 +1,39 @@
+//! The [`Reducer`] trait: a domain's per-contract handler the
+//! [`ContractIndexer`](crate::indexer::ContractIndexer) dispatches by tag to
+//! maintain eager projection(s). Held as `Box<dyn Reducer<DB>>`, object-safe
+//! because it takes the concrete `&DB::TXMut`. A contract needing no eager
+//! structure registers no reducer.
+
+use vertex_storage::{Database, DatabaseError};
+
+use crate::store::{EventKey, StoredEvent};
+use crate::tag::ContractTag;
+
+/// A domain's per-contract reducer, dispatched by [`ContractTag`], maintaining
+/// its eager projection(s).
+pub trait Reducer<DB: Database>: Send + Sync {
+    /// The contract tag this reducer maintains the projection for; the indexer's
+    /// dispatch key. Must match a watched contract in the same registration.
+    fn tag(&self) -> ContractTag;
+
+    /// Decode `ev` and fold it into this reducer's typed projection(s).
+    ///
+    /// Runs in the verbatim `put_event` transaction. A decode miss is a skip
+    /// (`Ok(())`); the only error returned is a storage fault.
+    fn reduce(&self, tx: &DB::TXMut, key: EventKey, ev: &StoredEvent) -> Result<(), DatabaseError>;
+
+    /// Clear the projection(s) and replay the fold over the surviving rows so the
+    /// projection cannot drift from the raw store. `surviving` is this contract's
+    /// remaining rows in canonical order.
+    fn rebuild(
+        &self,
+        tx: &DB::TXMut,
+        surviving: &[(EventKey, StoredEvent)],
+    ) -> Result<(), DatabaseError>;
+
+    /// Forward hook for a per-block conservative prune. Not yet invoked by the
+    /// indexer (#317); do not rely on it firing. Default is a no-op.
+    fn on_block(&self, _tx: &DB::TXMut, _block: u64) -> Result<(), DatabaseError> {
+        Ok(())
+    }
+}

--- a/crates/chain/index-framework/src/registration.rs
+++ b/crates/chain/index-framework/src/registration.rs
@@ -1,0 +1,99 @@
+//! Contracts as data: the [`WatchedContract`] / [`EventDescriptor`] model and the
+//! [`DomainRegistration`] each domain hands the
+//! [`ContractIndexer`](crate::indexer::ContractIndexer). The framework validates
+//! uniqueness across registrations and inits the union of their tables.
+
+use alloy_primitives::{Address, B256};
+
+use crate::reducer::Reducer;
+use crate::tag::ContractTag;
+use vertex_storage::Database;
+
+/// One event a contract emits: its `topic0` (`E::SIGNATURE_HASH`) and a human
+/// label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventDescriptor {
+    /// The event's `topic0` (`E::SIGNATURE_HASH`).
+    pub topic0: B256,
+    /// A human label for the stored row and metrics.
+    pub name: &'static str,
+}
+
+/// A contract to watch: its tag, address, deployment block, and event set.
+///
+/// A value, not a type. The combined
+/// [`ContractIndexer`](crate::indexer::ContractIndexer) filter is the union of
+/// every watched contract's address and every descriptor's `topic0`.
+#[derive(Debug, Clone, Copy)]
+pub struct WatchedContract {
+    /// The stable, domain-allocated contract tag (the on-disk key prefix).
+    pub tag: ContractTag,
+    /// The contract address.
+    pub address: Address,
+    /// The deployment block; backfill starts here.
+    pub start_block: u64,
+    /// The events this contract emits that the indexer records.
+    pub events: &'static [EventDescriptor],
+}
+
+impl WatchedContract {
+    /// Whether `topic0` is an event this contract declares.
+    pub fn declares(&self, topic0: B256) -> bool {
+        self.events.iter().any(|e| e.topic0 == topic0)
+    }
+}
+
+/// The settlement network whose address book a domain's `registration` is built
+/// from. The framework carries it only so domains share one selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Network {
+    /// Gnosis Chain mainnet.
+    Mainnet,
+    /// Sepolia testnet.
+    Testnet,
+}
+
+/// One domain's contribution to the unified indexer: the contracts it watches,
+/// the reducers that maintain its eager projections, and the projection table
+/// names it persists.
+///
+/// A domain exposes `registration(network) -> DomainRegistration<DB>`; the node
+/// builder collects every domain's registration and hands the vector to
+/// [`ContractIndexer::from_registrations`](crate::indexer::ContractIndexer::from_registrations),
+/// which validates uniqueness and initializes the union of `tables`.
+pub struct DomainRegistration<DB: Database> {
+    /// The contracts this domain watches (address-as-authority + event topics).
+    pub contracts: Vec<WatchedContract>,
+    /// The reducers maintaining this domain's eager projections. A verbatim-only
+    /// domain leaves this empty.
+    pub reducers: Vec<Box<dyn Reducer<DB>>>,
+    /// The projection table names this domain persists, for one-shot init. The
+    /// framework adds the shared `EventTable` and the engine cursor table on top.
+    pub tables: &'static [&'static str],
+}
+
+/// A registration set that failed the
+/// [`from_registrations`](crate::indexer::ContractIndexer::from_registrations)
+/// startup checks.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistrationError {
+    /// Two watched contracts declared the same [`ContractTag`]; the on-disk key
+    /// prefix would alias their event streams.
+    #[error("duplicate contract tag {0:?} across registrations")]
+    DuplicateTag(ContractTag),
+    /// Two watched contracts declared the same [`Address`]; `apply` could not
+    /// resolve which contract a log belongs to.
+    #[error("duplicate watched address {0} across registrations")]
+    DuplicateAddress(Address),
+    /// Two registrations declared the same projection table name; table `init`
+    /// does not dedup, so the second would silently share the first's storage.
+    #[error("duplicate projection table name {0:?} across registrations")]
+    DuplicateTableName(&'static str),
+    /// A reducer's [`tag`](crate::reducer::Reducer::tag) is not among the watched
+    /// contracts' tags, so it could never be dispatched.
+    #[error("reducer tag {0:?} has no matching watched contract")]
+    TagReducerMismatch(ContractTag),
+    /// Creating the initial set of tables failed: an unrecoverable storage fault.
+    #[error("failed to initialize indexer tables: {0}")]
+    TableInit(#[from] vertex_storage::DatabaseError),
+}

--- a/crates/chain/index-framework/src/store.rs
+++ b/crates/chain/index-framework/src/store.rs
@@ -1,0 +1,162 @@
+//! Generic event store: one table keyed by `(tag, block, log_index)` holding
+//! every watched contract's events verbatim. The key is the position, so a
+//! replayed finalized log overwrites its own slot, the btree yields a contract's
+//! stream in canonical order, and revert is a per-contract range-delete. Decoding
+//! happens on read, not here.
+
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_rpc_types_eth::Log;
+use serde::{Deserialize, Serialize};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode};
+
+use crate::tag::ContractTag;
+
+/// Hard cap on a stored event's data length; a real watched event is far
+/// smaller, so this only bounds an oversized log.
+pub const MAX_EVENT_DATA: usize = 8 * 1024;
+
+vertex_storage::table!(pub EventTable, "chain_events", EventKey, StoredEvent);
+
+/// The [`EventTable`] key: `(tag, block, log_index)`.
+///
+/// Encoded as `[tag u8][block u64 BE][log_index u64 BE]` = 17 bytes, grouping a
+/// contract's rows and ordering them canonically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct EventKey {
+    /// The watched contract this event belongs to.
+    pub tag: ContractTag,
+    /// The block the event was emitted in.
+    pub block: u64,
+    /// The event's index within its block.
+    pub log_index: u64,
+}
+
+impl EventKey {
+    /// The first key of `tag`'s range (block 0, log 0).
+    pub const fn range_start(tag: ContractTag) -> Self {
+        Self {
+            tag,
+            block: 0,
+            log_index: 0,
+        }
+    }
+
+    /// The first key of `tag`'s range at or after `from_block`.
+    pub const fn range_from(tag: ContractTag, from_block: u64) -> Self {
+        Self {
+            tag,
+            block: from_block,
+            log_index: 0,
+        }
+    }
+
+    /// The last key of `tag`'s range (block/log saturated to `MAX`).
+    pub const fn range_end(tag: ContractTag) -> Self {
+        Self {
+            tag,
+            block: u64::MAX,
+            log_index: u64::MAX,
+        }
+    }
+}
+
+impl Encode for EventKey {
+    type Encoded = [u8; 17];
+
+    fn encode(self) -> Self::Encoded {
+        let mut out = [0u8; 17];
+        out[0] = self.tag.0;
+        out[1..9].copy_from_slice(&self.block.to_be_bytes());
+        out[9..17].copy_from_slice(&self.log_index.to_be_bytes());
+        out
+    }
+}
+
+impl Decode for EventKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let bytes: [u8; 17] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        let tag = ContractTag(bytes[0]);
+        let block = u64::from_be_bytes(bytes[1..9].try_into().map_err(|_| DatabaseError::Decode)?);
+        let log_index =
+            u64::from_be_bytes(bytes[9..17].try_into().map_err(|_| DatabaseError::Decode)?);
+        Ok(Self {
+            tag,
+            block,
+            log_index,
+        })
+    }
+}
+
+/// One event recorded verbatim: exactly the bytes the log carried.
+///
+/// `topics` includes `topic0` as its first element (the EVM bounds it to <= 4).
+/// `data` is the non-indexed ABI tail. A domain re-derives the typed event from
+/// `topics` + `data` with the concrete `sol!` type; this struct asserts nothing
+/// about meaning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredEvent {
+    /// The emitting contract address, a redundant cross-check a view can assert.
+    pub address: Address,
+    /// The event's `topic0` (also `topics[0]`), kept for cheap filtering.
+    pub topic0: B256,
+    /// All indexed topics, `topic0` first (EVM-bounded to <= 4).
+    pub topics: Vec<B256>,
+    /// The non-indexed ABI tail, verbatim.
+    pub data: Bytes,
+}
+
+impl StoredEvent {
+    /// Reconstruct [`alloy_primitives::LogData`] for `sol!` decoding.
+    pub fn log_data(&self) -> alloy_primitives::LogData {
+        alloy_primitives::LogData::new_unchecked(self.topics.clone(), self.data.clone())
+    }
+}
+
+/// Write one event verbatim, enforcing the [`MAX_EVENT_DATA`] cap.
+///
+/// Returns `Ok(false)` (skipped, not an error) when the `data` exceeds the cap,
+/// so an oversized log cannot wedge the cursor; the caller logs the skip. The
+/// position-keyed put is idempotent by construction.
+pub(crate) fn put_event<TX: DbTxMut>(
+    tx: &TX,
+    key: EventKey,
+    event: &StoredEvent,
+) -> Result<bool, DatabaseError> {
+    if event.data.len() > MAX_EVENT_DATA {
+        return Ok(false);
+    }
+    tx.put::<EventTable>(key, event.clone())?;
+    Ok(true)
+}
+
+/// Read a contract's stored events in canonical `(block, log_index)` order.
+///
+/// Scans only this tag's key range via the bounded [`range`](vertex_storage::DbTx::range),
+/// so a fold over multi-contract history touches just one contract's rows.
+pub fn events_of<DB: Database>(
+    db: &DB,
+    tag: ContractTag,
+) -> Result<Vec<(EventKey, StoredEvent)>, DatabaseError> {
+    db.view(|tx| tx.range::<EventTable>(EventKey::range_start(tag), EventKey::range_end(tag)))
+}
+
+/// In-tx twin of [`events_of`], used by revert to gather the surviving rows.
+pub(crate) fn events_of_tx<TX: DbTx>(
+    tx: &TX,
+    tag: ContractTag,
+) -> Result<Vec<(EventKey, StoredEvent)>, DatabaseError> {
+    tx.range::<EventTable>(EventKey::range_start(tag), EventKey::range_end(tag))
+}
+
+/// Build a [`StoredEvent`] from a provider [`Log`], enforcing the EVM topic
+/// bound implicitly (the log already carries <= 4 topics).
+pub(crate) fn stored_event_from_log(log: &Log) -> StoredEvent {
+    let topics = log.topics().to_vec();
+    let topic0 = topics.first().copied().unwrap_or_default();
+    StoredEvent {
+        address: log.address(),
+        topic0,
+        topics,
+        data: log.data().data.clone(),
+    }
+}

--- a/crates/chain/index-framework/src/tag.rs
+++ b/crates/chain/index-framework/src/tag.rs
@@ -1,0 +1,37 @@
+//! A one-byte, domain-allocated contract discriminant and the high-order byte of
+//! [`EventKey`](crate::store::EventKey). Each domain pins its own `const TAG`;
+//! [`from_registrations`](crate::indexer::ContractIndexer::from_registrations)
+//! enforces mutual uniqueness. Tag values are on-disk format: never reuse or
+//! reorder.
+//!
+//! | Tag    | Domain contract        |
+//! |--------|------------------------|
+//! | `0x00` | PostageStamp           |
+//! | `0x01` | StakeRegistry          |
+//! | `0x02` | Redistribution         |
+//! | `0x03` | Chequebook factory     |
+//! | `0x04` | Swap price oracle      |
+//! | `0x05` | Storage price oracle   |
+
+use serde::{Deserialize, Serialize};
+use vertex_storage::{DatabaseError, Decode, Encode};
+
+/// A stable, one-byte contract discriminant. The wrapped byte is on-disk format;
+/// see the module allocation table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ContractTag(pub u8);
+
+impl Encode for ContractTag {
+    type Encoded = [u8; 1];
+
+    fn encode(self) -> Self::Encoded {
+        [self.0]
+    }
+}
+
+impl Decode for ContractTag {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let [b]: [u8; 1] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        Ok(Self(b))
+    }
+}

--- a/crates/chain/index-framework/src/tests.rs
+++ b/crates/chain/index-framework/src/tests.rs
@@ -1,0 +1,449 @@
+//! Mechanism tests over a synthetic registration (a dummy reducer over two
+//! synthetic contracts), exercising store/apply/revert/idempotency/topic-confusion/
+//! decode-miss without naming a real contract.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, Bytes, LogData, address};
+use alloy_rpc_types_eth::Log;
+use vertex_chain_index::Indexer;
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Table};
+use vertex_storage_redb::RedbDatabase;
+
+use crate::reducer::Reducer;
+use crate::registration::{
+    DomainRegistration, EventDescriptor, RegistrationError, WatchedContract,
+};
+use crate::store::{EventKey, EventTable, MAX_EVENT_DATA, StoredEvent};
+use crate::tag::ContractTag;
+use crate::{ContractIndexer, point_get};
+
+// Two synthetic contracts: one with a reducer (FOO), one verbatim-only (BAR).
+const TAG_FOO: ContractTag = ContractTag(0xF0);
+const TAG_BAR: ContractTag = ContractTag(0xBA);
+const FOO_ADDR: Address = address!("0000000000000000000000000000000000000f00");
+const BAR_ADDR: Address = address!("0000000000000000000000000000000000000ba0");
+
+// A synthetic topic0 each contract declares. FOO_TOPIC drives the dummy reducer;
+// BAR_TOPIC is verbatim-only. Arbitrary 32-byte constants, not real event
+// signatures (the framework names no ABI).
+const FOO_TOPIC: B256 = B256::repeat_byte(0x11);
+const BAR_TOPIC: B256 = B256::repeat_byte(0x22);
+
+const FOO_EVENTS: &[EventDescriptor] = &[EventDescriptor {
+    topic0: FOO_TOPIC,
+    name: "Foo",
+}];
+const BAR_EVENTS: &[EventDescriptor] = &[EventDescriptor {
+    topic0: BAR_TOPIC,
+    name: "Bar",
+}];
+
+// A one-row projection the dummy reducer maintains, keyed by the contract tag so
+// there is exactly one row per FOO contract.
+crate::projection!(DummyTable, "test__dummy", DummyKey, u64);
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+struct DummyKey(u8);
+vertex_storage::impl_fixed_codec!(DummyKey, 1);
+impl From<DummyKey> for [u8; 1] {
+    fn from(k: DummyKey) -> Self {
+        [k.0]
+    }
+}
+impl From<[u8; 1]> for DummyKey {
+    fn from(b: [u8; 1]) -> Self {
+        Self(b[0])
+    }
+}
+
+/// The dummy reducer: on a FOO event whose data is exactly 8 bytes, store that
+/// `u64`; any other body (too short / too long) is a decode-miss skip, never an
+/// error. This stands in for a domain's typed `sol!` decode without an ABI.
+struct DummyReducer;
+
+impl DummyReducer {
+    fn decode(ev: &StoredEvent) -> Option<u64> {
+        let bytes: [u8; 8] = ev.data.as_ref().try_into().ok()?;
+        Some(u64::from_be_bytes(bytes))
+    }
+}
+
+impl<DB: Database> Reducer<DB> for DummyReducer {
+    fn tag(&self) -> ContractTag {
+        TAG_FOO
+    }
+
+    fn reduce(&self, tx: &DB::TXMut, key: EventKey, ev: &StoredEvent) -> Result<(), DatabaseError> {
+        let Some(v) = Self::decode(ev) else {
+            return Ok(()); // decode miss is a skip, never an error
+        };
+        tx.put::<DummyTable>(DummyKey(key.tag.0), v)
+    }
+
+    fn rebuild(
+        &self,
+        tx: &DB::TXMut,
+        surviving: &[(EventKey, StoredEvent)],
+    ) -> Result<(), DatabaseError> {
+        tx.clear::<DummyTable>()?;
+        for (key, ev) in surviving {
+            if let Some(v) = Self::decode(ev) {
+                tx.put::<DummyTable>(DummyKey(key.tag.0), v)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn dummy_registration<DB: Database>() -> DomainRegistration<DB> {
+    DomainRegistration {
+        contracts: vec![
+            WatchedContract {
+                tag: TAG_FOO,
+                address: FOO_ADDR,
+                start_block: 0,
+                events: FOO_EVENTS,
+            },
+            WatchedContract {
+                tag: TAG_BAR,
+                address: BAR_ADDR,
+                start_block: 0,
+                events: BAR_EVENTS,
+            },
+        ],
+        reducers: vec![Box::new(DummyReducer)],
+        tables: &[DummyTable::NAME],
+    }
+}
+
+/// Build a synthetic log at `(block, index)` from `address` with `topic0` and a
+/// raw `data` body.
+fn log_with(block: u64, index: u64, address: Address, topic0: B256, data: Bytes) -> Log {
+    Log {
+        inner: alloy_primitives::Log {
+            address,
+            data: LogData::new_unchecked(vec![topic0], data),
+        },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+fn harness() -> (Arc<RedbDatabase>, ContractIndexer<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = ContractIndexer::from_registrations(db.clone(), vec![dummy_registration()])
+        .expect("indexer");
+    (db, indexer)
+}
+
+fn u64_body(v: u64) -> Bytes {
+    Bytes::from(v.to_be_bytes().to_vec())
+}
+
+/// Extract the [`RegistrationError`] from a failed composition. `ContractIndexer`
+/// is intentionally not `Debug` (it holds `Box<dyn Reducer>`), so the tests can't
+/// use `unwrap_err`; this asserts the `Err` and returns it.
+fn expect_err(
+    result: Result<ContractIndexer<RedbDatabase>, RegistrationError>,
+) -> RegistrationError {
+    match result {
+        Err(e) => e,
+        Ok(_) => panic!("expected a RegistrationError"),
+    }
+}
+
+#[test]
+fn filter_unions_addresses_and_topics() {
+    let (_db, indexer) = harness();
+    let filter = indexer.filter();
+    assert_eq!(filter.address.len(), 2);
+    let topics = filter.topics[0].to_value_or_array();
+    assert!(topics.is_some());
+}
+
+#[test]
+fn unwatched_address_is_skipped() {
+    let (db, indexer) = harness();
+    let stray = address!("00000000000000000000000000000000deadbeef");
+    let log = log_with(10, 0, stray, FOO_TOPIC, u64_body(7));
+    indexer.apply(10, &log).expect("apply");
+    let count = db.view(|tx| tx.count::<EventTable>()).unwrap();
+    assert_eq!(
+        count, 0,
+        "a log from an unwatched address must not be stored"
+    );
+}
+
+#[test]
+fn topic_not_declared_for_resolved_contract_is_skipped() {
+    // Emit BAR's topic0 at FOO's address. The address resolves to FOO, which does
+    // NOT declare BAR_TOPIC, so the row must be skipped (never misfiled).
+    let (db, indexer) = harness();
+    let log = log_with(5, 0, FOO_ADDR, BAR_TOPIC, u64_body(1));
+    indexer.apply(5, &log).expect("apply");
+    let stored = db
+        .view(|tx| {
+            tx.get::<EventTable>(EventKey {
+                tag: TAG_FOO,
+                block: 5,
+                log_index: 0,
+            })
+        })
+        .unwrap();
+    assert!(
+        stored.is_none(),
+        "a topic0 not declared for the resolved contract must be skipped"
+    );
+}
+
+#[test]
+fn oversized_data_is_capped() {
+    let (db, indexer) = harness();
+    let huge = Bytes::from(vec![0u8; MAX_EVENT_DATA + 1]);
+    let log = log_with(9, 0, FOO_ADDR, FOO_TOPIC, huge);
+    indexer
+        .apply(9, &log)
+        .expect("apply must not error on oversized data");
+    let stored = db
+        .view(|tx| {
+            tx.get::<EventTable>(EventKey {
+                tag: TAG_FOO,
+                block: 9,
+                log_index: 0,
+            })
+        })
+        .unwrap();
+    assert!(
+        stored.is_none(),
+        "data over MAX_EVENT_DATA must be skipped, not stored"
+    );
+}
+
+#[test]
+fn missing_log_index_errors() {
+    let (_db, indexer) = harness();
+    let mut log = log_with(3, 0, FOO_ADDR, FOO_TOPIC, u64_body(1));
+    log.log_index = None;
+    let err = indexer.apply(3, &log).unwrap_err();
+    assert!(matches!(
+        err,
+        vertex_chain_index::IndexError::MalformedLog { field: "log_index" }
+    ));
+}
+
+#[test]
+fn replayed_log_is_idempotent() {
+    let (db, indexer) = harness();
+    let log = log_with(100, 0, FOO_ADDR, FOO_TOPIC, u64_body(42));
+    indexer.apply(100, &log).expect("apply");
+    indexer.apply(100, &log).expect("replay");
+    let count = db.view(|tx| tx.count::<EventTable>()).unwrap();
+    assert_eq!(
+        count, 1,
+        "a replayed (block, log_index) overwrites in place"
+    );
+}
+
+#[test]
+fn reducer_folds_into_projection() {
+    let (db, indexer) = harness();
+    let log = log_with(1, 0, FOO_ADDR, FOO_TOPIC, u64_body(99));
+    indexer.apply(1, &log).expect("apply");
+    let row = point_get::<DummyTable, _>(&*db, DummyKey(TAG_FOO.0)).unwrap();
+    assert_eq!(row, Some(99));
+}
+
+#[test]
+fn verbatim_only_contract_stores_without_projection() {
+    let (db, indexer) = harness();
+    // BAR has no reducer: its event is stored verbatim, no projection touched.
+    indexer
+        .apply(7, &log_with(7, 0, BAR_ADDR, BAR_TOPIC, u64_body(3)))
+        .expect("apply");
+    let stored = db
+        .view(|tx| {
+            tx.get::<EventTable>(EventKey {
+                tag: TAG_BAR,
+                block: 7,
+                log_index: 0,
+            })
+        })
+        .unwrap();
+    assert!(
+        stored.is_some(),
+        "a verbatim-only contract still stores the row"
+    );
+    assert_eq!(
+        point_get::<DummyTable, _>(&*db, DummyKey(TAG_BAR.0)).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn malformed_reducer_body_skips_not_wedges() {
+    // A declared FOO topic0 with a body the dummy reducer cannot decode must:
+    //  (1) NOT error apply (the cursor advances),
+    //  (2) still land the verbatim row,
+    //  (3) but produce NO projection row (the reducer decode miss is a skip).
+    let (db, indexer) = harness();
+    let garbage = Bytes::from(vec![0xFFu8; 3]); // not 8 bytes => decode miss
+    let log = log_with(12, 0, FOO_ADDR, FOO_TOPIC, garbage);
+    indexer
+        .apply(12, &log)
+        .expect("a malformed reducer body must not error apply");
+
+    let stored = db
+        .view(|tx| {
+            tx.get::<EventTable>(EventKey {
+                tag: TAG_FOO,
+                block: 12,
+                log_index: 0,
+            })
+        })
+        .unwrap();
+    assert!(stored.is_some(), "the verbatim row must still be stored");
+
+    let row = point_get::<DummyTable, _>(&*db, DummyKey(TAG_FOO.0)).unwrap();
+    assert!(
+        row.is_none(),
+        "a decode miss must produce no projection row"
+    );
+}
+
+#[test]
+fn revert_range_deletes_per_contract_and_rebuilds() {
+    let (db, indexer) = harness();
+    // Two FOO events; the later one wins the projection.
+    indexer
+        .apply(100, &log_with(100, 0, FOO_ADDR, FOO_TOPIC, u64_body(1)))
+        .expect("apply");
+    indexer
+        .apply(200, &log_with(200, 0, FOO_ADDR, FOO_TOPIC, u64_body(2)))
+        .expect("apply");
+    assert_eq!(
+        point_get::<DummyTable, _>(&*db, DummyKey(TAG_FOO.0)).unwrap(),
+        Some(2)
+    );
+
+    // Revert from 150: the block-200 event is dropped, the projection rebuilds to
+    // the surviving block-100 value.
+    indexer.revert(150).expect("revert");
+    let count = db.view(|tx| tx.count::<EventTable>()).unwrap();
+    assert_eq!(count, 1, "the block-200 row must be range-deleted");
+    assert_eq!(
+        point_get::<DummyTable, _>(&*db, DummyKey(TAG_FOO.0)).unwrap(),
+        Some(1),
+        "the projection must rebuild from the surviving row"
+    );
+}
+
+#[test]
+fn from_registrations_rejects_duplicate_tag() {
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let dup = DomainRegistration::<RedbDatabase> {
+        contracts: vec![
+            WatchedContract {
+                tag: TAG_FOO,
+                address: FOO_ADDR,
+                start_block: 0,
+                events: FOO_EVENTS,
+            },
+            WatchedContract {
+                tag: TAG_FOO, // duplicate tag
+                address: BAR_ADDR,
+                start_block: 0,
+                events: BAR_EVENTS,
+            },
+        ],
+        reducers: vec![],
+        tables: &[],
+    };
+    let err = expect_err(ContractIndexer::from_registrations(db, vec![dup]));
+    assert!(matches!(
+        err,
+        RegistrationError::DuplicateTag(ContractTag(0xF0))
+    ));
+}
+
+#[test]
+fn from_registrations_rejects_duplicate_address() {
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let dup = DomainRegistration::<RedbDatabase> {
+        contracts: vec![
+            WatchedContract {
+                tag: TAG_FOO,
+                address: FOO_ADDR,
+                start_block: 0,
+                events: FOO_EVENTS,
+            },
+            WatchedContract {
+                tag: TAG_BAR,
+                address: FOO_ADDR, // duplicate address
+                start_block: 0,
+                events: BAR_EVENTS,
+            },
+        ],
+        reducers: vec![],
+        tables: &[],
+    };
+    let err = expect_err(ContractIndexer::from_registrations(db, vec![dup]));
+    assert!(matches!(err, RegistrationError::DuplicateAddress(_)));
+}
+
+#[test]
+fn from_registrations_rejects_duplicate_table_name() {
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let a = DomainRegistration::<RedbDatabase> {
+        contracts: vec![WatchedContract {
+            tag: TAG_FOO,
+            address: FOO_ADDR,
+            start_block: 0,
+            events: FOO_EVENTS,
+        }],
+        reducers: vec![],
+        tables: &["shared__name"],
+    };
+    let b = DomainRegistration::<RedbDatabase> {
+        contracts: vec![WatchedContract {
+            tag: TAG_BAR,
+            address: BAR_ADDR,
+            start_block: 0,
+            events: BAR_EVENTS,
+        }],
+        reducers: vec![],
+        tables: &["shared__name"], // collides with `a`
+    };
+    let err = expect_err(ContractIndexer::from_registrations(db, vec![a, b]));
+    assert!(matches!(
+        err,
+        RegistrationError::DuplicateTableName("shared__name")
+    ));
+}
+
+#[test]
+fn from_registrations_rejects_orphan_reducer() {
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let reg = DomainRegistration::<RedbDatabase> {
+        contracts: vec![WatchedContract {
+            tag: TAG_BAR, // only BAR is watched
+            address: BAR_ADDR,
+            start_block: 0,
+            events: BAR_EVENTS,
+        }],
+        reducers: vec![Box::new(DummyReducer)], // DummyReducer.tag() == TAG_FOO
+        tables: &[DummyTable::NAME],
+    };
+    let err = expect_err(ContractIndexer::from_registrations(db, vec![reg]));
+    assert!(matches!(
+        err,
+        RegistrationError::TagReducerMismatch(ContractTag(0xF0))
+    ));
+}

--- a/crates/storage/redb/src/tx.rs
+++ b/crates/storage/redb/src/tx.rs
@@ -203,6 +203,56 @@ macro_rules! impl_db_tx_reads {
             Ok(result)
         }
 
+        fn range<T: Table>(
+            &self,
+            from: T::Key,
+            to: T::Key,
+        ) -> Result<Vec<(T::Key, T::Value)>, DatabaseError> {
+            let start = Instant::now();
+            let _span = tracing::trace_span!("db_range", table = T::NAME).entered();
+
+            let def = table_def(T::NAME);
+            let table = self.inner.open_table(def).map_err(|e| {
+                DatabaseError::Read(DatabaseErrorInfo::with_source(
+                    format!("open table {}", T::NAME),
+                    e,
+                ))
+            })?;
+            let lo = from.encode();
+            let hi = to.encode();
+            // redb scans only the bounded key range over the btree. No length
+            // hint like `entries`/`keys`: the range size is unknown without a
+            // second pass, so do not size this `Vec`.
+            let mut result = Vec::new();
+            for entry in table
+                .range::<&[u8]>(lo.as_ref()..=hi.as_ref())
+                .map_err(|e| {
+                    DatabaseError::Read(DatabaseErrorInfo::with_source(
+                        format!("range {}", T::NAME),
+                        e,
+                    ))
+                })?
+            {
+                let (k, v) = entry.map_err(|e| {
+                    DatabaseError::Read(DatabaseErrorInfo::with_source(
+                        format!("read entry from {}", T::NAME),
+                        e,
+                    ))
+                })?;
+                let key = T::Key::decode(k.value())?;
+                let value = decode_value::<T>(v.value())?;
+                result.push((key, value));
+            }
+
+            record_op(
+                T::NAME,
+                operation::ENTRIES,
+                "success",
+                start.elapsed().as_secs_f64(),
+            );
+            Ok(result)
+        }
+
         fn keys<T: Table>(&self) -> Result<Vec<T::Key>, DatabaseError> {
             let start = Instant::now();
             let _span = tracing::trace_span!("db_keys", table = T::NAME).entered();

--- a/crates/storage/src/traits.rs
+++ b/crates/storage/src/traits.rs
@@ -112,6 +112,36 @@ pub trait DbTx: Send + Sync {
     /// Get all entries from a table as key/value pairs.
     fn entries<T: Table>(&self) -> Result<Vec<(T::Key, T::Value)>, DatabaseError>;
 
+    /// Get the entries whose encoded key lies in `[from, to]` (inclusive), in
+    /// ascending key order.
+    ///
+    /// Backends with native ordered range support (redb) scan only the bounded
+    /// key range; the default falls back to a full [`entries`](Self::entries)
+    /// scan filtered by the encoded-key bounds, so a backend without range
+    /// support is still correct (just not bounded). Use this for a key-prefix
+    /// scan (e.g. one contract's `(tag, ..)` range) instead of materializing the
+    /// whole table.
+    fn range<T: Table>(
+        &self,
+        from: T::Key,
+        to: T::Key,
+    ) -> Result<Vec<(T::Key, T::Value)>, DatabaseError> {
+        let lo = from.encode();
+        let hi = to.encode();
+        let (lo, hi) = (lo.as_ref().to_vec(), hi.as_ref().to_vec());
+        let mut rows: Vec<(T::Key, T::Value)> = self
+            .entries::<T>()?
+            .into_iter()
+            .filter(|(k, _)| {
+                let enc = k.clone().encode();
+                let enc = enc.as_ref();
+                enc >= lo.as_slice() && enc <= hi.as_slice()
+            })
+            .collect();
+        rows.sort_by(|(a, _), (b, _)| a.clone().encode().as_ref().cmp(b.clone().encode().as_ref()));
+        Ok(rows)
+    }
+
     /// Get all keys from a table without deserializing values.
     fn keys<T: Table>(&self) -> Result<Vec<T::Key>, DatabaseError> {
         Ok(self.entries::<T>()?.into_iter().map(|(k, _)| k).collect())

--- a/crates/swarm/accounting/chequebook/Cargo.toml
+++ b/crates/swarm/accounting/chequebook/Cargo.toml
@@ -27,6 +27,13 @@ swap-chequebook = [
     "dep:alloy-network",
     "dep:tracing",
 ]
+# `chain` adds the on-chain chequebook-factory indexing (watched contract plus
+# lazy deployed-set views). Off by default to keep the wasm/light cone clean.
+chain = [
+    "dep:vertex-chain-index-framework",
+    "dep:vertex-storage",
+    "dep:alloy-rpc-types-eth",
+]
 
 [dependencies]
 # nectar
@@ -45,6 +52,16 @@ alloy-sol-types = { workspace = true }
 # `sol!` interfaces.
 vertex-chain = { workspace = true, optional = true }
 alloy-contract = { workspace = true, optional = true }
+
+# chain feature: the indexing framework plus the storage and alloy RPC types the
+# lazy views read. The `SimpleSwapDeployed` event comes from `nectar-contracts`.
+vertex-chain-index-framework = { workspace = true, optional = true }
+vertex-storage = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
+alloy-provider = { workspace = true, optional = true, features = [
+    "reqwest",
+    "reqwest-native-tls",
+] }
 alloy-network = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
@@ -77,3 +94,6 @@ alloy-provider = { workspace = true, optional = true, features = ["reqwest"] }
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
+# chain-feature tests: drive the framework indexer over an in-memory db.
+vertex-storage-redb = { workspace = true }
+vertex-chain-index = { workspace = true }

--- a/crates/swarm/accounting/chequebook/src/index.rs
+++ b/crates/swarm/accounting/chequebook/src/index.rs
@@ -1,0 +1,13 @@
+//! On-chain chequebook-factory indexing (behind the `chain` feature).
+//!
+//! A lazy domain: records `SimpleSwapDeployed` verbatim and answers
+//! deployed-set queries by folding on read; no reducer, no projection tables.
+
+mod canonical;
+mod register;
+pub mod views;
+
+pub use register::{TAG_CHEQUEBOOK, registration};
+
+#[cfg(test)]
+mod tests;

--- a/crates/swarm/accounting/chequebook/src/index/canonical.rs
+++ b/crates/swarm/accounting/chequebook/src/index/canonical.rs
@@ -1,0 +1,37 @@
+//! Canonical chequebook-factory deployment, pinned locally so the domain sources
+//! its address from one place; the address agrees with nectar (see FIXME(#315)).
+
+use alloy_primitives::{Address, address};
+
+/// `(address, start_block)` for a canonical deployment.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Deployment {
+    /// The contract address.
+    pub(crate) address: Address,
+    /// The deployment block; backfill starts here.
+    pub(crate) block: u64,
+}
+
+/// Gnosis Chain mainnet deployment.
+pub(crate) mod mainnet {
+    use super::{Deployment, address};
+
+    /// Chequebook factory / SimpleSwapFactory (`MainnetChequebookFactory`).
+    // FIXME(#315): override until nectar fixed; then source from nectar.
+    pub(crate) const CHEQUEBOOK_FACTORY: Deployment = Deployment {
+        address: address!("c2d5a532cf69aa9a1378737d8ccdef884b6e7420"),
+        block: 39_939_970,
+    };
+}
+
+/// Sepolia testnet deployment.
+pub(crate) mod testnet {
+    use super::{Deployment, address};
+
+    /// Chequebook factory / SimpleSwapFactory (`TestnetChequebookFactory`).
+    // FIXME(#315): override until nectar fixed; then source from nectar.
+    pub(crate) const CHEQUEBOOK_FACTORY: Deployment = Deployment {
+        address: address!("0fF044F6bB4F684a5A149B46D7eC03ea659F98A1"),
+        block: 4_752_810,
+    };
+}

--- a/crates/swarm/accounting/chequebook/src/index/register.rs
+++ b/crates/swarm/accounting/chequebook/src/index/register.rs
@@ -1,0 +1,38 @@
+//! The chequebook domain's registration: its tag and single watched factory contract.
+
+use alloy_sol_types::SolEvent;
+use nectar_contracts::IChequebookFactory;
+use vertex_chain_index_framework::{
+    ContractTag, DomainRegistration, EventDescriptor, Network, WatchedContract,
+};
+use vertex_storage::Database;
+
+use crate::index::canonical;
+
+/// The chequebook-factory contract tag. Stable across releases (part of the
+/// on-disk [`EventKey`](vertex_chain_index_framework::EventKey) byte format).
+pub const TAG_CHEQUEBOOK: ContractTag = ContractTag(0x03);
+
+const CHEQUEBOOK_EVENTS: &[EventDescriptor] = &[EventDescriptor {
+    topic0: IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH,
+    name: "SimpleSwapDeployed",
+}];
+
+/// Build the chequebook domain's registration for `network`.
+pub fn registration<DB: Database>(network: Network) -> DomainRegistration<DB> {
+    let factory = match network {
+        Network::Mainnet => canonical::mainnet::CHEQUEBOOK_FACTORY,
+        Network::Testnet => canonical::testnet::CHEQUEBOOK_FACTORY,
+    };
+
+    DomainRegistration {
+        contracts: vec![WatchedContract {
+            tag: TAG_CHEQUEBOOK,
+            address: factory.address,
+            start_block: factory.block,
+            events: CHEQUEBOOK_EVENTS,
+        }],
+        reducers: vec![],
+        tables: &[],
+    }
+}

--- a/crates/swarm/accounting/chequebook/src/index/tests.rs
+++ b/crates/swarm/accounting/chequebook/src/index/tests.rs
@@ -1,0 +1,167 @@
+//! Chequebook-domain tests: the lazy factory-deployed-set fold and revert over a
+//! synthetic registration.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, LogData, address};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use nectar_contracts::IChequebookFactory;
+use vertex_chain_index::Indexer;
+use vertex_chain_index_framework::{
+    ContractIndexer, DomainRegistration, EventDescriptor, Network, WatchedContract,
+};
+use vertex_storage_redb::RedbDatabase;
+
+use crate::index::{TAG_CHEQUEBOOK, views};
+
+// A synthetic chequebook-factory address, distinct from mainnet so a test never
+// accidentally matches a real deployment.
+const CHEQUEBOOK_ADDR: Address = address!("0000000000000000000000000000000000000a04");
+
+// The event descriptor set, mirroring the production registration, so a synthetic
+// registration can reuse it at a synthetic address.
+const CHEQUEBOOK_EVENTS: &[EventDescriptor] = &[EventDescriptor {
+    topic0: IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH,
+    name: "SimpleSwapDeployed",
+}];
+
+fn test_registration<DB: vertex_storage::Database>() -> DomainRegistration<DB> {
+    DomainRegistration {
+        contracts: vec![WatchedContract {
+            tag: TAG_CHEQUEBOOK,
+            address: CHEQUEBOOK_ADDR,
+            start_block: 0,
+            events: CHEQUEBOOK_EVENTS,
+        }],
+        reducers: vec![],
+        tables: &[],
+    }
+}
+
+fn harness() -> (Arc<RedbDatabase>, ContractIndexer<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = ContractIndexer::from_registrations(db.clone(), vec![test_registration()])
+        .expect("indexer");
+    (db, indexer)
+}
+
+fn log_from(block: u64, index: u64, address: Address, data: LogData) -> Log {
+    Log {
+        inner: alloy_primitives::Log { address, data },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+fn apply<E: SolEvent>(
+    indexer: &ContractIndexer<RedbDatabase>,
+    block: u64,
+    index: u64,
+    address: Address,
+    event: &E,
+) {
+    let log = log_from(block, index, address, event.encode_log_data());
+    indexer.apply(block, &log).expect("apply");
+}
+
+#[test]
+fn registration_builds_indexer() {
+    // The production registration with the real canonical address composes
+    // cleanly into the unified indexer.
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let indexer =
+        ContractIndexer::from_registrations(db, vec![crate::index::registration(Network::Mainnet)])
+            .expect("chequebook registration must compose into the unified indexer");
+    let filter = indexer.filter();
+    assert_eq!(
+        filter.address.len(),
+        1,
+        "the single chequebook-factory address"
+    );
+}
+
+#[test]
+fn chequebook_membership() {
+    let (db, indexer) = harness();
+    let cb = address!("00000000000000000000000000000000000000c1");
+    assert!(!views::is_factory_deployed(&*db, cb).unwrap());
+    apply(
+        &indexer,
+        7,
+        0,
+        CHEQUEBOOK_ADDR,
+        &IChequebookFactory::SimpleSwapDeployed {
+            contractAddress: cb,
+        },
+    );
+    assert!(views::is_factory_deployed(&*db, cb).unwrap());
+    assert_eq!(views::deployed_chequebooks(&*db).unwrap(), vec![cb]);
+}
+
+#[test]
+fn deployed_set_collects_every_chequebook() {
+    let (db, indexer) = harness();
+    let a = address!("00000000000000000000000000000000000000a1");
+    let b = address!("00000000000000000000000000000000000000b2");
+    apply(
+        &indexer,
+        1,
+        0,
+        CHEQUEBOOK_ADDR,
+        &IChequebookFactory::SimpleSwapDeployed { contractAddress: a },
+    );
+    apply(
+        &indexer,
+        1,
+        1,
+        CHEQUEBOOK_ADDR,
+        &IChequebookFactory::SimpleSwapDeployed { contractAddress: b },
+    );
+    let mut got = views::deployed_chequebooks(&*db).unwrap();
+    got.sort();
+    let mut expected = vec![a, b];
+    expected.sort();
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn revert_drops_out_of_range_deployments() {
+    let (db, indexer) = harness();
+    let early = address!("00000000000000000000000000000000000000e1");
+    let late = address!("00000000000000000000000000000000000000f2");
+    apply(
+        &indexer,
+        50,
+        0,
+        CHEQUEBOOK_ADDR,
+        &IChequebookFactory::SimpleSwapDeployed {
+            contractAddress: early,
+        },
+    );
+    apply(
+        &indexer,
+        150,
+        0,
+        CHEQUEBOOK_ADDR,
+        &IChequebookFactory::SimpleSwapDeployed {
+            contractAddress: late,
+        },
+    );
+    assert!(views::is_factory_deployed(&*db, late).unwrap());
+
+    indexer.revert(100).expect("revert");
+    assert!(
+        !views::is_factory_deployed(&*db, late).unwrap(),
+        "the in-range deployment must be reverted from the verbatim store"
+    );
+    assert!(
+        views::is_factory_deployed(&*db, early).unwrap(),
+        "the out-of-range deployment must survive the revert"
+    );
+}

--- a/crates/swarm/accounting/chequebook/src/index/views.rs
+++ b/crates/swarm/accounting/chequebook/src/index/views.rs
@@ -1,0 +1,44 @@
+//! Chequebook views: the factory-deployed set by lazy existence fold.
+//!
+//! A chequebook is deployed once, so [`is_factory_deployed`] and
+//! [`deployed_chequebooks`] are a pure existence fold, no supersede logic.
+
+use std::collections::HashSet;
+
+use alloy_primitives::Address;
+use alloy_sol_types::SolEvent;
+use nectar_contracts::IChequebookFactory;
+use vertex_chain_index_framework::fold_events;
+use vertex_storage::{Database, DatabaseError};
+
+use crate::index::TAG_CHEQUEBOOK;
+
+/// Fold the factory-deployed chequebook set from the verbatim rows.
+fn deployed_set<DB: Database>(db: &DB) -> Result<HashSet<Address>, DatabaseError> {
+    fold_events(
+        db,
+        TAG_CHEQUEBOOK,
+        HashSet::new(),
+        |set: &mut HashSet<Address>, _key, ev| {
+            if ev.topic0 != IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH {
+                return;
+            }
+            if let Ok(e) = IChequebookFactory::SimpleSwapDeployed::decode_log_data(&ev.log_data()) {
+                set.insert(e.contractAddress);
+            }
+        },
+    )
+}
+
+/// Whether `chequebook` is in the factory-deployed set.
+pub fn is_factory_deployed<DB: Database>(
+    db: &DB,
+    chequebook: Address,
+) -> Result<bool, DatabaseError> {
+    Ok(deployed_set(db)?.contains(&chequebook))
+}
+
+/// Every chequebook the factory has deployed, in unspecified order.
+pub fn deployed_chequebooks<DB: Database>(db: &DB) -> Result<Vec<Address>, DatabaseError> {
+    Ok(deployed_set(db)?.into_iter().collect())
+}

--- a/crates/swarm/accounting/chequebook/src/lib.rs
+++ b/crates/swarm/accounting/chequebook/src/lib.rs
@@ -53,10 +53,14 @@
 #[cfg(feature = "swap-chequebook")]
 pub mod chain;
 pub mod cheque;
+#[cfg(feature = "chain")]
+pub mod index;
 
 #[cfg(feature = "swap-chequebook")]
 pub use chain::ChequebookContract;
 pub use cheque::{Cheque, ChequeExt, SignedCheque};
+#[cfg(feature = "chain")]
+pub use index::{TAG_CHEQUEBOOK, registration};
 
 // Re-export commonly used types
 pub use alloy_primitives::{Address, U256};

--- a/crates/swarm/accounting/swap/Cargo.toml
+++ b/crates/swarm/accounting/swap/Cargo.toml
@@ -31,6 +31,13 @@ tracing = { workspace = true }
 vertex-chain = { workspace = true, optional = true }
 alloy-provider = { workspace = true, optional = true }
 
+# `chain`: indexing framework plus the ABIs, storage, and alloy types it decodes with.
+vertex-chain-index-framework = { workspace = true, optional = true }
+nectar-contracts = { workspace = true, features = ["std"], optional = true }
+vertex-storage = { workspace = true, optional = true }
+alloy-sol-types = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }
 vertex-swarm-test-utils = { workspace = true }
@@ -39,6 +46,8 @@ alloy-signer-local = { workspace = true }
 nectar-contracts = { workspace = true }
 alloy-contract = { workspace = true }
 alloy-sol-types = { workspace = true }
+vertex-storage-redb = { workspace = true }
+vertex-chain-index = { workspace = true }
 
 [features]
 default = ["std"]
@@ -49,4 +58,14 @@ swap-chequebook = [
     "dep:vertex-chain",
     "dep:alloy-provider",
     "vertex-swarm-accounting-chequebook/swap-chequebook",
+]
+# On-chain swap-price-oracle indexing (lazy settlement-scalar views). Off by
+# default so the wasm/light cone stays clean.
+chain = [
+    "std",
+    "dep:vertex-chain-index-framework",
+    "dep:nectar-contracts",
+    "dep:vertex-storage",
+    "dep:alloy-sol-types",
+    "dep:alloy-rpc-types-eth",
 ]

--- a/crates/swarm/accounting/swap/src/index/mod.rs
+++ b/crates/swarm/accounting/swap/src/index/mod.rs
@@ -1,0 +1,13 @@
+//! The swap-price-oracle domain's chain indexing (behind `chain`).
+//!
+//! A lazy domain: stores the two `*Update` events verbatim and computes the
+//! exchange rate and cheque value deduction by a last-write-wins walk on read
+//! (see [`views`]); no reducer, no projection tables.
+
+mod register;
+pub mod views;
+
+pub use register::{TAG_SWAP_ORACLE, registration};
+
+#[cfg(test)]
+mod tests;

--- a/crates/swarm/accounting/swap/src/index/register.rs
+++ b/crates/swarm/accounting/swap/src/index/register.rs
@@ -1,0 +1,43 @@
+//! The swap-price-oracle domain's registration: tag, watched contract, and the
+//! [`DomainRegistration`] the node builder collects into the unified indexer.
+
+use alloy_sol_types::SolEvent;
+use nectar_contracts::ISwapPriceOracle;
+use vertex_chain_index_framework::{
+    ContractTag, DomainRegistration, EventDescriptor, Network, WatchedContract,
+};
+use vertex_storage::Database;
+
+/// The swap price-oracle contract tag. Stable across releases (part of the
+/// on-disk [`EventKey`](vertex_chain_index_framework::EventKey) format).
+pub const TAG_SWAP_ORACLE: ContractTag = ContractTag(0x04);
+
+const SWAP_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        topic0: ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH,
+        name: "PriceUpdate",
+    },
+    EventDescriptor {
+        topic0: ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH,
+        name: "ChequeValueDeductionUpdate",
+    },
+];
+
+/// Build the swap domain's registration for `network`.
+pub fn registration<DB: Database>(network: Network) -> DomainRegistration<DB> {
+    let swap = match network {
+        Network::Mainnet => nectar_contracts::mainnet::SWAP_PRICE_ORACLE,
+        Network::Testnet => nectar_contracts::testnet::SWAP_PRICE_ORACLE,
+    };
+
+    DomainRegistration {
+        contracts: vec![WatchedContract {
+            tag: TAG_SWAP_ORACLE,
+            address: swap.address,
+            start_block: swap.block,
+            events: SWAP_EVENTS,
+        }],
+        reducers: vec![],
+        tables: &[],
+    }
+}

--- a/crates/swarm/accounting/swap/src/index/tests.rs
+++ b/crates/swarm/accounting/swap/src/index/tests.rs
@@ -1,0 +1,166 @@
+//! Swap-domain tests: the lazy two-scalar settlement views and revert over a
+//! synthetic registration.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, LogData, U256, address};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use nectar_contracts::ISwapPriceOracle;
+use vertex_chain_index::Indexer;
+use vertex_chain_index_framework::{
+    ContractIndexer, DomainRegistration, EventDescriptor, Network, WatchedContract,
+};
+use vertex_storage_redb::RedbDatabase;
+
+use crate::index::register::TAG_SWAP_ORACLE;
+use crate::index::views;
+
+// Synthetic address, distinct from any real deployment.
+const SWAP_ADDR: Address = address!("0000000000000000000000000000000000000a04");
+
+const SWAP_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        topic0: ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH,
+        name: "PriceUpdate",
+    },
+    EventDescriptor {
+        topic0: ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH,
+        name: "ChequeValueDeductionUpdate",
+    },
+];
+
+fn test_registration<DB: vertex_storage::Database>() -> DomainRegistration<DB> {
+    DomainRegistration {
+        contracts: vec![WatchedContract {
+            tag: TAG_SWAP_ORACLE,
+            address: SWAP_ADDR,
+            start_block: 0,
+            events: SWAP_EVENTS,
+        }],
+        reducers: vec![],
+        tables: &[],
+    }
+}
+
+fn harness() -> (Arc<RedbDatabase>, ContractIndexer<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = ContractIndexer::from_registrations(db.clone(), vec![test_registration()])
+        .expect("indexer");
+    (db, indexer)
+}
+
+fn log_from(block: u64, index: u64, address: Address, data: LogData) -> Log {
+    Log {
+        inner: alloy_primitives::Log { address, data },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+fn apply<E: SolEvent>(
+    indexer: &ContractIndexer<RedbDatabase>,
+    block: u64,
+    index: u64,
+    address: Address,
+    event: &E,
+) {
+    let log = log_from(block, index, address, event.encode_log_data());
+    indexer.apply(block, &log).expect("apply");
+}
+
+#[test]
+fn registration_builds_indexer() {
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let indexer =
+        ContractIndexer::from_registrations(db, vec![crate::index::registration(Network::Mainnet)])
+            .expect("swap registration must compose into the unified indexer");
+    let filter = indexer.filter();
+    assert_eq!(filter.address.len(), 1, "single swap-oracle address");
+}
+
+#[test]
+fn swap_two_scalars_last_write_wins() {
+    let (db, indexer) = harness();
+    assert_eq!(views::exchange_rate(&*db).unwrap(), None);
+    assert_eq!(views::cheque_value_deduction(&*db).unwrap(), None);
+
+    apply(
+        &indexer,
+        1,
+        0,
+        SWAP_ADDR,
+        &ISwapPriceOracle::PriceUpdate {
+            price: U256::from(10u64),
+        },
+    );
+    apply(
+        &indexer,
+        2,
+        0,
+        SWAP_ADDR,
+        &ISwapPriceOracle::PriceUpdate {
+            price: U256::from(20u64),
+        },
+    );
+    apply(
+        &indexer,
+        3,
+        0,
+        SWAP_ADDR,
+        &ISwapPriceOracle::ChequeValueDeductionUpdate {
+            chequeValueDeduction: U256::from(5u64),
+        },
+    );
+    assert_eq!(views::exchange_rate(&*db).unwrap(), Some(U256::from(20u64)));
+    assert_eq!(
+        views::cheque_value_deduction(&*db).unwrap(),
+        Some(U256::from(5u64))
+    );
+}
+
+#[test]
+fn revert_range_deletes_per_contract() {
+    let (db, indexer) = harness();
+    apply(
+        &indexer,
+        100,
+        0,
+        SWAP_ADDR,
+        &ISwapPriceOracle::PriceUpdate {
+            price: U256::from(1u64),
+        },
+    );
+    apply(
+        &indexer,
+        200,
+        0,
+        SWAP_ADDR,
+        &ISwapPriceOracle::PriceUpdate {
+            price: U256::from(2u64),
+        },
+    );
+    assert_eq!(views::exchange_rate(&*db).unwrap(), Some(U256::from(2u64)));
+
+    // Revert from 150 drops the block-200 update, keeps block-100.
+    indexer.revert(150).expect("revert");
+    assert_eq!(views::exchange_rate(&*db).unwrap(), Some(U256::from(1u64)));
+}
+
+#[test]
+fn descriptor_topic0s_are_the_signature_hashes() {
+    // Each descriptor's topic0 is the event's SIGNATURE_HASH (the match authority).
+    let [price, deduction] = SWAP_EVENTS else {
+        panic!("expected exactly the two swap-oracle descriptors");
+    };
+    assert_eq!(price.topic0, ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH);
+    assert_eq!(
+        deduction.topic0,
+        ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH
+    );
+}

--- a/crates/swarm/accounting/swap/src/index/views.rs
+++ b/crates/swarm/accounting/swap/src/index/views.rs
@@ -1,0 +1,34 @@
+//! Swap views: the two settlement scalars by last-write-wins walk over the
+//! oracle's stored rows via [`last_event`].
+
+use alloy_primitives::U256;
+use alloy_sol_types::SolEvent;
+use nectar_contracts::ISwapPriceOracle;
+use vertex_chain_index_framework::last_event;
+use vertex_storage::{Database, DatabaseError};
+
+use crate::index::register::TAG_SWAP_ORACLE;
+
+/// The latest swap exchange rate (`PriceUpdate`), if ever set.
+pub fn exchange_rate<DB: Database>(db: &DB) -> Result<Option<U256>, DatabaseError> {
+    last_event(db, TAG_SWAP_ORACLE, |ev| {
+        if ev.topic0 != ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH {
+            return None;
+        }
+        ISwapPriceOracle::PriceUpdate::decode_log_data(&ev.log_data())
+            .ok()
+            .map(|e| e.price)
+    })
+}
+
+/// The latest cheque value deduction (`ChequeValueDeductionUpdate`), if ever set.
+pub fn cheque_value_deduction<DB: Database>(db: &DB) -> Result<Option<U256>, DatabaseError> {
+    last_event(db, TAG_SWAP_ORACLE, |ev| {
+        if ev.topic0 != ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH {
+            return None;
+        }
+        ISwapPriceOracle::ChequeValueDeductionUpdate::decode_log_data(&ev.log_data())
+            .ok()
+            .map(|e| e.chequeValueDeduction)
+    })
+}

--- a/crates/swarm/accounting/swap/src/lib.rs
+++ b/crates/swarm/accounting/swap/src/lib.rs
@@ -27,6 +27,8 @@ pub mod cashout;
 pub mod constants;
 pub mod error;
 pub mod handle;
+#[cfg(feature = "chain")]
+pub mod index;
 pub mod service;
 
 use std::sync::Arc;

--- a/crates/swarm/builder/Cargo.toml
+++ b/crates/swarm/builder/Cargo.toml
@@ -20,20 +20,25 @@ default = []
 # so the chain code itself can build for wasm when its features are selected.
 chain = [
     "dep:vertex-chain",
+    "dep:vertex-chain-index",
+    "dep:vertex-chain-index-framework",
     "vertex-swarm-accounting-chequebook/swap-chequebook",
+    # Per-domain indexing registrations composed into the one ContractIndexer.
+    "vertex-swarm-postage/chain",
+    "vertex-swarm-accounting-chequebook/chain",
+    "vertex-swarm-redistribution/chain",
     "dep:alloy-provider",
     "dep:alloy-network",
     "dep:alloy-signer-local",
     "dep:alloy-chains",
-    # When the swap service is also present, the chain unlocks on-chain cashout
-    # of received cheques. Without `swap` this is a no-op.
+    # With `swap` present, also unlocks on-chain cheque cashout and the swap-oracle
+    # registration; a no-op without `swap`.
     "vertex-swarm-accounting-swap?/swap-chequebook",
+    "vertex-swarm-accounting-swap?/chain",
 ]
-# SWAP cheque-based settlement. Wires the chequebook settlement service into
-# bandwidth accounting and routes the swap wire events. Chain-free on its own:
-# cheque exchange (sign, send, validate, credit) needs no chain. Combine with
-# `chain` to enable on-chain cashout of received cheques. Off by default so the
-# chain-free client node stays the default cone.
+# SWAP cheque settlement: wires the chequebook service into accounting and routes
+# swap wire events. Chain-free on its own; add `chain` for on-chain cashout. Off
+# by default so the client stays the default cone.
 swap = [
     "dep:vertex-swarm-accounting-swap",
     "vertex-swarm-node/swap",
@@ -41,9 +46,8 @@ swap = [
     "dep:alloy-signer",
     "dep:alloy-signer-local",
 ]
-# Node role: the storer settles bandwidth over SWAP, so it pulls in the chain
-# stack, the on-chain chequebook client, and the swap settlement service.
-# Client nodes leave this off.
+# Storer role: settles bandwidth over SWAP, so it pulls the chain stack and the
+# swap settlement service. Clients leave this off.
 storer = ["chain", "swap"]
 
 [dependencies]
@@ -81,12 +85,14 @@ vertex-swarm-spec.workspace = true
 
 # vertex - chain (optional, behind the `chain` feature)
 vertex-chain = { workspace = true, optional = true }
-# The on-chain chequebook client. Pure cheque codec by default; the builder's
-# `chain` feature enables `swap-chequebook` on it to construct the SWAP
-# settlement client.
+# Reorg-safe event engine and the contract-indexing framework the registrations
+# compose into.
+vertex-chain-index = { workspace = true, optional = true }
+vertex-chain-index-framework = { workspace = true, optional = true }
+# On-chain chequebook client; `chain` enables its `swap-chequebook` to build the
+# SWAP settlement client.
 vertex-swarm-accounting-chequebook = { workspace = true, optional = true }
-# The chequebook settlement service (optional, behind the `swap` feature). Cheque
-# exchange is chain-free; `swap` + `chain` turns on the service's `swap-chequebook`
+# Chequebook settlement service (behind `swap`); `swap` + `chain` enables its
 # cashout path.
 vertex-swarm-accounting-swap = { workspace = true, optional = true }
 
@@ -95,10 +101,9 @@ nectar-primitives.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
-# chain feature: native HTTP transport (reqwest + native-tls) and the wallet
-# signer built from the node Ethereum identity. native-tls (system OpenSSL) is
-# used because the rustls path drags in a root-certs crate outside the workspace
-# license allow-list.
+# Native HTTP transport (reqwest + native-tls). native-tls (system OpenSSL) over
+# rustls because the rustls path drags in a root-certs crate outside the license
+# allow-list.
 alloy-provider = { workspace = true, optional = true, features = [
     "reqwest",
     "reqwest-native-tls",
@@ -126,10 +131,11 @@ nectar-postage.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 vertex-swarm-test-utils.workspace = true
+# The `CachedChunk` the store-factory test exercises.
+vertex-swarm-primitives.workspace = true
 
-# Client upload/download examples. They build a client through the public builder
-# and drive the chunk sender/provider directly, the way an FFI or gRPC embedder
-# would.
+# Client upload/download examples driving the public builder the way an FFI or
+# gRPC embedder would.
 [[example]]
 name = "upload_chunk"
 path = "examples/upload_chunk.rs"

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -45,6 +45,10 @@ use vertex_swarm_node::args::SwapConfig;
 
 #[cfg(feature = "chain")]
 use crate::chain::SharedChainProvider;
+#[cfg(feature = "chain")]
+use vertex_chain_index::EventEngine;
+#[cfg(feature = "chain")]
+use vertex_chain_index_framework::{ContractIndexer, Network};
 
 type PeerStore = Arc<dyn PeerSnapshotStore<PeerSnapshot>>;
 
@@ -157,6 +161,83 @@ async fn build_node_chain_provider(
     let provider = crate::chain::build_chain_provider(rpc_url, signer, address_book).await?;
 
     Ok(Some(provider))
+}
+
+/// Map an alloy chain to the [`Network`] selector each domain's registration is
+/// built from. Returns `None` for a chain with no canonical Swarm deployment.
+#[cfg(feature = "chain")]
+fn network_of(chain: alloy_chains::Chain) -> Option<Network> {
+    use alloy_chains::NamedChain;
+    if chain == alloy_chains::Chain::from(NamedChain::Gnosis) {
+        Some(Network::Mainnet)
+    } else if chain == alloy_chains::Chain::from(NamedChain::Sepolia) {
+        Some(Network::Testnet)
+    } else {
+        None
+    }
+}
+
+/// Compose every domain's registration into the single [`ContractIndexer`] and
+/// spawn one [`EventEngine`] driving it over the shared chain provider. No-op
+/// without persistence or a chain provider.
+#[cfg(feature = "chain")]
+fn spawn_chain_indexer(
+    ctx: &dyn InfrastructureContext,
+    db: &Option<Arc<RedbDatabase>>,
+    chain_provider: Option<&SharedChainProvider>,
+) {
+    let Some(provider) = chain_provider else {
+        return;
+    };
+    let Some(db) = db.as_ref() else {
+        info!(
+            "Chain indexer skipped: no shared database (run with persistence to index contracts)"
+        );
+        return;
+    };
+    let Some(network) = network_of(provider.addresses().chain) else {
+        warn!("Chain indexer skipped: chain has no canonical Swarm deployment");
+        return;
+    };
+
+    // Collect every domain's registration into the one unified indexer. Swap is
+    // only present when the node also carries the `swap` settlement feature (its
+    // crate is a dependency only under `swap`).
+    #[allow(unused_mut)]
+    let mut registrations = vec![
+        vertex_swarm_postage::index::registration(network),
+        vertex_swarm_accounting_chequebook::registration(network),
+        vertex_swarm_redistribution::index::registration(network),
+    ];
+    #[cfg(feature = "swap")]
+    registrations.push(vertex_swarm_accounting_swap::index::registration(network));
+
+    let indexer = match ContractIndexer::from_registrations(Arc::clone(db), registrations) {
+        Ok(indexer) => Arc::new(indexer),
+        Err(e) => {
+            warn!(error = %e, "Chain indexer registration failed; contract indexing not enabled");
+            return;
+        }
+    };
+
+    // The shared provider's `DynProvider` is a `ChainReader` by the engine's
+    // blanket impl. Clone it for the engine; the node keeps its own handle for
+    // SWAP and cashout.
+    let reader = Arc::new(provider.provider().clone());
+    let engine = EventEngine::new(reader, Arc::clone(db)).register(indexer);
+
+    ctx.executor().spawn_with_graceful_shutdown_signal(
+        "chain.event_engine",
+        move |shutdown| async move {
+            let shutdown = async move {
+                let _ = shutdown.await;
+            };
+            if let Err(e) = engine.run(shutdown).await {
+                tracing::error!(error = %e, "chain event engine exited with error");
+            }
+        },
+    );
+    info!("Chain indexer enabled");
 }
 
 fn create_peer_store(db: &Option<Arc<RedbDatabase>>) -> Option<PeerStore> {
@@ -510,6 +591,11 @@ async fn build_client_backed_node(
             chain_provider.as_ref(),
         );
     }
+
+    // Index every configured contract domain into the shared database before the
+    // node starts; a no-op without a provider or a persistent database.
+    #[cfg(feature = "chain")]
+    spawn_chain_indexer(ctx, &db, chain_provider.as_ref());
 
     // The chain provider is kept alive for the node's lifetime by the run task.
     #[cfg(feature = "chain")]
@@ -1076,17 +1162,12 @@ fn storer_store_factory(
 /// stamped under it, so a reorg cannot retroactively invalidate admitted chunks.
 const RESERVE_CONFIRMATION_THRESHOLD: u64 = 10;
 
-/// Build the storer reserve over the shared database, erased to the local-store
-/// trait.
+/// Build the storer reserve over the shared database (in-memory fallback without
+/// persistence), erased to the local-store trait.
 ///
-/// Reuses the opened database when present so the reserve, its batch store and
-/// the peer store share one handle; falls back to in-memory redb without
-/// persistence. Open and table-creation failures surface as a build error.
-///
-/// Admits only stamped chunks, gated by a `DbBatchStore` (the batch set) and an
-/// `AdmissionValidator` enforcing [`RESERVE_CONFIRMATION_THRESHOLD`] confirmations
-/// plus structural and signature checks. The batch store starts empty, so the
-/// reserve admits nothing until the postage indexer populates it.
+/// Admits only stamped chunks gated by a `DbBatchStore` and an
+/// `AdmissionValidator`; the batch store starts empty, so nothing is admitted
+/// until the postage indexer populates it.
 fn build_storer_reserve(
     db: Option<Arc<RedbDatabase>>,
     identity: &Arc<Identity>,

--- a/crates/swarm/postage/Cargo.toml
+++ b/crates/swarm/postage/Cargo.toml
@@ -12,25 +12,22 @@ description = "Postage batch store and event ingest seam for the vertex Swarm no
 workspace = true
 
 [dependencies]
-## nectar (re-exported public surface; do not redefine these types)
-# The `serde` feature is required so `Batch` satisfies the vertex-storage
-# `Value` bound (Serialize + DeserializeOwned) for the `Batches` table, and so
-# `ChunkAddress` (a `nectar_primitives::SwarmAddress`) is serialisable when it
-# is stored in the stamp-index entry value.
+# nectar re-exports (do not redefine). `serde` so `Batch` and `ChunkAddress`
+# meet the vertex-storage `Value` bound for the stored tables.
 nectar-postage = { workspace = true, features = ["serde"] }
 nectar-primitives = { workspace = true, features = ["serde"] }
 
-## vertex
-# The `alloy` feature provides the fixed-size codec for `Address`; `BatchId`
-# (a `B256`) is encoded by a local newtype codec in this crate.
+# `alloy` feature: fixed-size codec for `Address`.
 vertex-storage = { workspace = true, features = ["alloy"] }
 
-## misc
-# `alloy-primitives` provides `B256`, the stamp-hash type carried through the
-# arbiter (with `serde` so the stamp-index entry value serialises).
+# `serde` so the `B256` stamp hash in the stamp-index entry value serialises.
 alloy-primitives = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
+
+# chain feature: the indexing framework plus the `sol!` decode for PostageStamp.
+vertex-chain-index-framework = { workspace = true, optional = true }
+alloy-sol-types = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives.workspace = true
@@ -38,7 +35,14 @@ alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 tempfile = "3"
 vertex-storage-redb.workspace = true
+# chain-feature tests: drive the indexer over an in-memory db with synthetic logs.
+alloy-rpc-types-eth.workspace = true
+alloy-sol-types.workspace = true
+vertex-chain-index.workspace = true
 
 [features]
 default = ["std"]
 std = []
+# `chain` adds on-chain PostageStamp indexing. Off by default so the wasm/light
+# cone stays clean; the storer role turns it on.
+chain = ["std", "dep:vertex-chain-index-framework", "dep:alloy-sol-types"]

--- a/crates/swarm/postage/src/index.rs
+++ b/crates/swarm/postage/src/index.rs
@@ -1,0 +1,67 @@
+//! The postage domain's contribution to the unified contract indexer, behind
+//! the `chain` feature: the PostageStamp tag, address, event ABIs, and the
+//! [`PostageReducer`] that folds the batch lifecycle into the
+//! [`Batches`](crate::store) projection shared with
+//! [`DbBatchStore`](crate::DbBatchStore).
+
+mod abi;
+mod canonical;
+mod reducer;
+mod views;
+
+#[cfg(test)]
+mod tests;
+
+pub use reducer::PostageReducer;
+pub use views::total_out_payment_at;
+
+use alloy_sol_types::SolEvent;
+use vertex_chain_index_framework::{
+    ContractTag, DomainRegistration, EventDescriptor, Network, WatchedContract,
+};
+use vertex_storage::{Database, Table};
+
+use crate::store::Batches;
+
+/// The PostageStamp contract tag, stable across releases (the on-disk
+/// [`EventKey`](vertex_chain_index_framework::EventKey) prefix).
+pub const TAG_POSTAGE: ContractTag = ContractTag(0x00);
+
+const POSTAGE_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        topic0: abi::events::BatchCreated::SIGNATURE_HASH,
+        name: "BatchCreated",
+    },
+    EventDescriptor {
+        topic0: abi::events::BatchTopUp::SIGNATURE_HASH,
+        name: "BatchTopUp",
+    },
+    EventDescriptor {
+        topic0: abi::events::BatchDepthIncrease::SIGNATURE_HASH,
+        name: "BatchDepthIncrease",
+    },
+    EventDescriptor {
+        topic0: abi::events::PriceUpdate::SIGNATURE_HASH,
+        name: "PriceUpdate",
+    },
+];
+
+/// The postage registration for `network`: the watched PostageStamp contract,
+/// the [`PostageReducer`], and the shared [`Batches`] table.
+pub fn registration<DB: Database>(network: Network) -> DomainRegistration<DB> {
+    let deployment = match network {
+        Network::Mainnet => canonical::MAINNET,
+        Network::Testnet => canonical::TESTNET,
+    };
+
+    DomainRegistration {
+        contracts: vec![WatchedContract {
+            tag: TAG_POSTAGE,
+            address: deployment.address,
+            start_block: deployment.block,
+            events: POSTAGE_EVENTS,
+        }],
+        reducers: vec![Box::new(PostageReducer)],
+        tables: &[Batches::NAME],
+    }
+}

--- a/crates/swarm/postage/src/index/abi.rs
+++ b/crates/swarm/postage/src/index/abi.rs
@@ -1,0 +1,34 @@
+//! The PostageStamp event ABIs, declared locally (not yet shipped by
+//! `nectar-contracts`) so the reducer and the price fold share one declaration.
+
+pub(crate) mod events {
+    use alloy_sol_types::sol;
+
+    sol! {
+        /// A new batch. `normalisedBalance` is the outpayment level
+        /// `currentTotalOutPayment` must stay below for the batch to stay valid.
+        #[allow(missing_docs)]
+        event BatchCreated(
+            bytes32 indexed batchId,
+            uint256 totalAmount,
+            uint256 normalisedBalance,
+            address owner,
+            uint8 depth,
+            uint8 bucketDepth,
+            bool immutableFlag
+        );
+
+        /// A batch top-up, raising `normalisedBalance`.
+        #[allow(missing_docs)]
+        event BatchTopUp(bytes32 indexed batchId, uint256 topupAmount, uint256 normalisedBalance);
+
+        /// A depth increase with re-normalised balance.
+        #[allow(missing_docs)]
+        event BatchDepthIncrease(bytes32 indexed batchId, uint8 newDepth, uint256 normalisedBalance);
+
+        /// The per-chunk-per-block storage price; the `currentTotalOutPayment`
+        /// accumulator is folded from this cadence.
+        #[allow(missing_docs)]
+        event PriceUpdate(uint256 price);
+    }
+}

--- a/crates/swarm/postage/src/index/canonical.rs
+++ b/crates/swarm/postage/src/index/canonical.rs
@@ -1,0 +1,27 @@
+//! Canonical PostageStamp deployment, pinned locally because the nectar address
+//! diverges from the live deployment (see FIXME(#315)). Flat consts (not the
+//! nested `mainnet`/`testnet` modules the multi-contract domains use) since
+//! postage watches one contract.
+
+use alloy_primitives::{Address, address};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Deployment {
+    pub(crate) address: Address,
+    /// Deployment block; backfill starts here.
+    pub(crate) block: u64,
+}
+
+/// Gnosis Chain mainnet deployment.
+// FIXME(#315): override until nectar fixed; then source from nectar.
+pub(crate) const MAINNET: Deployment = Deployment {
+    address: address!("45a1502382541Cd610CC9068e88727426b696293"),
+    block: 31_305_656,
+};
+
+/// Sepolia testnet deployment.
+// FIXME(#315): override until nectar fixed; then source from nectar.
+pub(crate) const TESTNET: Deployment = Deployment {
+    address: address!("cdfdC3752caaA826fE62531E0000C40546eC56A6"),
+    block: 6_596_277,
+};

--- a/crates/swarm/postage/src/index/reducer.rs
+++ b/crates/swarm/postage/src/index/reducer.rs
@@ -1,0 +1,105 @@
+//! Folds the PostageStamp batch-lifecycle events into the eager
+//! [`Batches`](crate::store) projection (the table
+//! [`DbBatchStore`](crate::DbBatchStore) persists). `PriceUpdate` is left
+//! verbatim for the lazy
+//! [`total_out_payment_at`](crate::index::total_out_payment_at) fold.
+
+use alloy_sol_types::SolEvent;
+use nectar_postage::Batch;
+use vertex_chain_index_framework::{ContractTag, EventKey, Reducer, StoredEvent};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut};
+
+use crate::index::TAG_POSTAGE;
+use crate::index::abi::events;
+use crate::store::{BatchIdKey, Batches};
+
+/// The postage reducer, dispatched by the framework for [`TAG_POSTAGE`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PostageReducer;
+
+impl<DB: Database> Reducer<DB> for PostageReducer {
+    fn tag(&self) -> ContractTag {
+        TAG_POSTAGE
+    }
+
+    fn reduce(&self, tx: &DB::TXMut, key: EventKey, ev: &StoredEvent) -> Result<(), DatabaseError> {
+        apply_event::<DB>(tx, key.block, ev)
+    }
+
+    fn rebuild(
+        &self,
+        tx: &DB::TXMut,
+        surviving: &[(EventKey, StoredEvent)],
+    ) -> Result<(), DatabaseError> {
+        // Re-fold the survivors from scratch: a batch created before the boundary
+        // but mutated within the reverted range rolls back to its surviving state,
+        // which a create-block filter could not catch.
+        tx.clear::<Batches>()?;
+        for (key, ev) in surviving {
+            apply_event::<DB>(tx, key.block, ev)?;
+        }
+        Ok(())
+    }
+}
+
+/// Fold one stored PostageStamp event into [`Batches`]. A non-batch event or a
+/// decode miss is a skip, never an error, so a malformed body cannot wedge the
+/// shared cursor. Shared by the live and rebuild paths.
+fn apply_event<DB: Database>(
+    tx: &DB::TXMut,
+    block: u64,
+    ev: &StoredEvent,
+) -> Result<(), DatabaseError> {
+    let data = ev.log_data();
+
+    if ev.topic0 == events::BatchCreated::SIGNATURE_HASH {
+        let Ok(e) = events::BatchCreated::decode_log_data(&data) else {
+            return Ok(());
+        };
+        let Ok(value) = u128::try_from(e.normalisedBalance) else {
+            return Ok(());
+        };
+        // Preserve the original creation block if the batch is already known: a
+        // replayed create only refreshes the mutable fields.
+        let start = tx
+            .get::<Batches>(BatchIdKey(e.batchId))?
+            .map_or(block, |b| b.start());
+        let batch = Batch::new(
+            e.batchId,
+            value,
+            start,
+            e.owner,
+            e.depth,
+            e.bucketDepth,
+            e.immutableFlag,
+        );
+        tx.put::<Batches>(BatchIdKey(e.batchId), batch)?;
+    } else if ev.topic0 == events::BatchTopUp::SIGNATURE_HASH {
+        let Ok(e) = events::BatchTopUp::decode_log_data(&data) else {
+            return Ok(());
+        };
+        let Ok(value) = u128::try_from(e.normalisedBalance) else {
+            return Ok(());
+        };
+        if let Some(mut batch) = tx.get::<Batches>(BatchIdKey(e.batchId))? {
+            batch.set_value(value);
+            tx.put::<Batches>(BatchIdKey(e.batchId), batch)?;
+        }
+    } else if ev.topic0 == events::BatchDepthIncrease::SIGNATURE_HASH {
+        let Ok(e) = events::BatchDepthIncrease::decode_log_data(&data) else {
+            return Ok(());
+        };
+        // A dilution re-normalises the balance as it raises the depth, so apply
+        // both from the one event.
+        let Ok(value) = u128::try_from(e.normalisedBalance) else {
+            return Ok(());
+        };
+        if let Some(mut batch) = tx.get::<Batches>(BatchIdKey(e.batchId))? {
+            batch.set_depth(e.newDepth);
+            batch.set_value(value);
+            tx.put::<Batches>(BatchIdKey(e.batchId), batch)?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/swarm/postage/src/index/tests.rs
+++ b/crates/swarm/postage/src/index/tests.rs
@@ -1,0 +1,212 @@
+//! Postage index tests: the batch fold into [`Batches`] (read back via
+//! [`DbBatchStore`]), the `total_out_payment_at` price fold, and revert.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, LogData, U256};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use nectar_postage::{BatchStore, PostageContext};
+use vertex_chain_index::Indexer;
+use vertex_chain_index_framework::{ContractIndexer, Network};
+use vertex_storage_redb::RedbDatabase;
+
+use crate::DbBatchStore;
+use crate::index::abi::events;
+use crate::index::{registration, total_out_payment_at};
+
+// Synthetic address, distinct from mainnet so a test never matches a real deployment.
+const POSTAGE_ADDR: Address = Address::repeat_byte(0xa0);
+
+fn harness() -> (Arc<RedbDatabase>, ContractIndexer<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let reg = registration::<RedbDatabase>(Network::Mainnet);
+    let reg = override_address(reg, POSTAGE_ADDR);
+    let indexer = ContractIndexer::from_registrations(db.clone(), vec![reg]).expect("indexer");
+    (db, indexer)
+}
+
+// Re-home the watched contract onto the synthetic address, keeping tag, events,
+// and reducer.
+fn override_address(
+    mut reg: vertex_chain_index_framework::DomainRegistration<RedbDatabase>,
+    address: Address,
+) -> vertex_chain_index_framework::DomainRegistration<RedbDatabase> {
+    for c in &mut reg.contracts {
+        c.address = address;
+        c.start_block = 0;
+    }
+    reg
+}
+
+fn log_from(block: u64, index: u64, data: LogData) -> Log {
+    Log {
+        inner: alloy_primitives::Log {
+            address: POSTAGE_ADDR,
+            data,
+        },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+fn apply<E: SolEvent>(indexer: &ContractIndexer<RedbDatabase>, block: u64, index: u64, event: &E) {
+    let log = log_from(block, index, event.encode_log_data());
+    indexer.apply(block, &log).expect("apply");
+}
+
+fn store(db: &Arc<RedbDatabase>) -> DbBatchStore<RedbDatabase> {
+    DbBatchStore::new(db.clone()).expect("batch store")
+}
+
+#[test]
+fn registration_builds_indexer() {
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let indexer = ContractIndexer::from_registrations(db, vec![registration(Network::Mainnet)])
+        .expect("postage registration must compose into the unified indexer");
+    assert_eq!(
+        indexer.filter().address.len(),
+        1,
+        "one watched PostageStamp"
+    );
+}
+
+#[test]
+fn batch_created_topup_and_dilute_track_the_store() {
+    let (db, indexer) = harness();
+    let id = B256::repeat_byte(0x11);
+    let owner = Address::repeat_byte(0x22);
+
+    apply(
+        &indexer,
+        10,
+        0,
+        &events::BatchCreated {
+            batchId: id,
+            totalAmount: U256::from(1_000),
+            normalisedBalance: U256::from(500),
+            owner,
+            depth: 20,
+            bucketDepth: 16,
+            immutableFlag: false,
+        },
+    );
+
+    let batch = store(&db).get(&id).unwrap().expect("batch created");
+    assert_eq!(batch.value(), 500);
+    assert_eq!(batch.depth(), 20);
+    assert_eq!(batch.owner(), owner);
+    assert_eq!(batch.start(), 10, "start is the creation block");
+
+    apply(
+        &indexer,
+        20,
+        0,
+        &events::BatchTopUp {
+            batchId: id,
+            topupAmount: U256::from(250),
+            normalisedBalance: U256::from(750),
+        },
+    );
+    assert_eq!(store(&db).get(&id).unwrap().unwrap().value(), 750);
+
+    apply(
+        &indexer,
+        30,
+        0,
+        &events::BatchDepthIncrease {
+            batchId: id,
+            newDepth: 24,
+            normalisedBalance: U256::from(375),
+        },
+    );
+    let batch = store(&db).get(&id).unwrap().unwrap();
+    assert_eq!(batch.depth(), 24, "dilution raised the depth");
+    assert_eq!(batch.value(), 375, "dilution re-normalised the balance");
+}
+
+#[test]
+fn mutation_for_unknown_batch_is_dropped() {
+    let (db, indexer) = harness();
+    let id = B256::repeat_byte(0x33);
+    apply(
+        &indexer,
+        5,
+        0,
+        &events::BatchTopUp {
+            batchId: id,
+            topupAmount: U256::from(1),
+            normalisedBalance: U256::from(9),
+        },
+    );
+    assert!(
+        store(&db).get(&id).unwrap().is_none(),
+        "a top-up without a prior create fabricates no row"
+    );
+}
+
+#[test]
+fn total_out_payment_folds_the_price_cadence() {
+    let (db, indexer) = harness();
+    apply(
+        &indexer,
+        100,
+        0,
+        &events::PriceUpdate {
+            price: U256::from(10),
+        },
+    );
+    apply(
+        &indexer,
+        200,
+        0,
+        &events::PriceUpdate {
+            price: U256::from(20),
+        },
+    );
+
+    // Before the first update nothing has accrued.
+    assert_eq!(total_out_payment_at(&*db, 50).unwrap(), 0);
+    // Within the first interval: 10 * (150 - 100).
+    assert_eq!(total_out_payment_at(&*db, 150).unwrap(), 500);
+    // Past the second update: 10 * 100 + 20 * (300 - 200).
+    assert_eq!(total_out_payment_at(&*db, 300).unwrap(), 3_000);
+    // A batch whose context is unset reads the default (zero), so expiry needs a
+    // block-clock consumer to publish this figure into the PostageContext.
+    assert_eq!(store(&db).context().unwrap(), PostageContext::default());
+}
+
+#[test]
+fn revert_rebuilds_the_batch_projection_from_survivors() {
+    let (db, indexer) = harness();
+    let early = B256::repeat_byte(0x01);
+    let late = B256::repeat_byte(0x02);
+
+    let create = |id| events::BatchCreated {
+        batchId: id,
+        totalAmount: U256::from(1_000),
+        normalisedBalance: U256::from(500),
+        owner: Address::repeat_byte(0x44),
+        depth: 20,
+        bucketDepth: 16,
+        immutableFlag: false,
+    };
+    apply(&indexer, 50, 0, &create(early));
+    apply(&indexer, 150, 0, &create(late));
+    assert!(store(&db).get(&late).unwrap().is_some());
+
+    indexer.revert(100).expect("revert");
+    assert!(
+        store(&db).get(&late).unwrap().is_none(),
+        "the in-range create is reverted from the projection"
+    );
+    assert!(
+        store(&db).get(&early).unwrap().is_some(),
+        "the out-of-range create survives"
+    );
+}

--- a/crates/swarm/postage/src/index/views.rs
+++ b/crates/swarm/postage/src/index/views.rs
@@ -1,0 +1,56 @@
+//! Lazy reads over the verbatim PostageStamp event stream: the price cadence is
+//! folded on demand so a block-clock consumer can compute the head
+//! `currentTotalOutPayment` without the indexer keeping a time-derived
+//! projection.
+
+use alloy_sol_types::SolEvent;
+use vertex_chain_index_framework::events_of;
+use vertex_storage::{Database, DatabaseError};
+
+use crate::index::TAG_POSTAGE;
+use crate::index::abi::events;
+
+/// The PostageStamp `currentTotalOutPayment` at `at_block`, folded from the
+/// recorded `PriceUpdate` cadence: the running sum of each interval's price times
+/// its block span, up to `at_block`.
+pub fn total_out_payment_at<DB: Database>(db: &DB, at_block: u64) -> Result<u128, DatabaseError> {
+    let mut accumulated: u128 = 0;
+    let mut last_price: u128 = 0;
+    let mut last_block: u64 = 0;
+
+    for (key, ev) in events_of(db, TAG_POSTAGE)? {
+        if key.block > at_block {
+            break;
+        }
+        if ev.topic0 != events::PriceUpdate::SIGNATURE_HASH {
+            continue;
+        }
+        let Ok(e) = events::PriceUpdate::decode_log_data(&ev.log_data()) else {
+            continue;
+        };
+        let Ok(price) = u128::try_from(e.price) else {
+            continue;
+        };
+        // An interval that overflows the accumulator is decode-implausible; skip
+        // it rather than saturate, since saturation would expire every batch.
+        let Some(next) =
+            accrued(last_price, last_block, key.block).and_then(|d| accumulated.checked_add(d))
+        else {
+            continue;
+        };
+        accumulated = next;
+        last_price = price;
+        last_block = key.block;
+    }
+
+    let tail = accrued(last_price, last_block, at_block)
+        .and_then(|d| accumulated.checked_add(d))
+        .unwrap_or(accumulated);
+    Ok(tail)
+}
+
+/// `price * (to - from)`, zero when `to < from`, `None` on overflow.
+fn accrued(price: u128, from: u64, to: u64) -> Option<u128> {
+    let span = to.saturating_sub(from) as u128;
+    price.checked_mul(span)
+}

--- a/crates/swarm/postage/src/lib.rs
+++ b/crates/swarm/postage/src/lib.rs
@@ -1,41 +1,18 @@
-//! Node-side postage state: batch persistence and the on-chain event ingest
-//! seam.
+//! Node-side postage state for the vertex Swarm node.
 //!
-//! Postage primitives (batch and stamp models, validation, the event
-//! vocabulary) live in [`nectar_postage`] and are re-exported verbatim so the
-//! workspace shares one canonical copy of each type. This crate adds:
-//!
-//! - [`DbBatchStore`]: a [`nectar_postage::BatchStore`] backed by the
-//!   `vertex-storage` `Database`, persisting batches and the [`PostageContext`]
-//!   so a node recovers its batch set without replaying the chain.
-//! - [`DbBatchStore`]'s [`nectar_postage::BatchEventHandler`] impl: the ingest
-//!   seam mapping each [`BatchEvent`] onto an atomic store mutation (see
-//!   [`DbBatchStore::handle_event`]).
-//!
-//! Stamp validation is stateless: a stamp is valid iff `ecrecover(sig, digest)`
-//! resolves to the batch owner and the index/bucket bounds hold. The owner is
-//! already in the batch store, so [`nectar_postage::StoreValidator`] needs no
-//! side state and this crate ships no per-batch public-key cache.
-//!
-//! Ingest pipeline:
-//!
-//! ```text
-//!   chain logs --> [ PostageIndexer ] --> BatchEvent --> [ BatchEventHandler ]
-//!   (raw ABI)      (external crate)       (nectar)        (DbBatchStore here)
-//! ```
-//!
-//! Only the right-hand half lives here. The event ABI, log decoder, and the
-//! indexer that reduces logs into [`BatchEvent`]s are out of scope, owned by an
-//! external `PostageIndexer` wired up by the node builder.
-//!
-//! The store keys batches by [`BatchId`] alone (a batch is one on-chain object).
-//! Keying stamped entries by the full `(batchID, 8-byte stampIndex)` and
-//! carrying the winning stamp through an inclusion proof is the reserve's and
-//! sampler's job, not this crate's.
+//! Postage primitives (batch and stamp models, validation, events) live in
+//! [`nectar_postage`] and are re-exported. This crate adds [`DbBatchStore`], a
+//! [`nectar_postage::BatchStore`] over the `vertex-storage` `Database`, and its
+//! [`nectar_postage::BatchEventHandler`] impl. With the `chain` feature it also
+//! ships [`index`](crate::index): the on-chain PostageStamp tag, ABIs, reducer,
+//! and views that fold contract logs into the same `Batches` table the store
+//! persists.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod admission;
+#[cfg(feature = "chain")]
+pub mod index;
 mod stampindex;
 mod store;
 

--- a/crates/swarm/redistribution/Cargo.toml
+++ b/crates/swarm/redistribution/Cargo.toml
@@ -11,13 +11,24 @@ description = "Swarm redistribution (storage incentives) configuration"
 [lints]
 workspace = true
 
+[features]
+# Default is minimal so the wasm/light cone stays clean.
+default = []
+# On-chain indexing (watched contracts + lazy views) for Redistribution and
+# StakeRegistry, over the generic index framework.
+chain = [
+    "dep:vertex-chain-index-framework",
+    "dep:nectar-contracts",
+    "dep:vertex-storage",
+    "dep:alloy-sol-types",
+    "dep:alloy-rpc-types-eth",
+]
+
 [dependencies]
 # vertex
 vertex-swarm-api.workspace = true
-# Canonical postage surface: the sampler filters and the inclusion-proof stamp
-# witness consume `Stamp`, `BatchId` and `PostageContext` from here, which
-# re-exports the nectar definitions verbatim, so there is one canonical copy of
-# each postage type across the workspace (never redefined).
+# Canonical postage surface: `Stamp`, `BatchId`, `PostageContext` (nectar
+# re-exports) for the sampler filters and inclusion-proof stamp witness.
 vertex-swarm-postage.workspace = true
 
 # swarm
@@ -32,10 +43,20 @@ strum.workspace = true
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 
+# chain feature: indexing framework plus the storage and alloy types the
+# domains decode with (`alloy-primitives` is already a hard dep above).
+vertex-chain-index-framework = { workspace = true, optional = true }
+nectar-contracts = { workspace = true, features = ["std"], optional = true }
+vertex-storage = { workspace = true, optional = true }
+alloy-sol-types = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
+
 [dev-dependencies]
 serde_json.workspace = true
 alloy-signer-local.workspace = true
 criterion.workspace = true
+vertex-storage-redb = { workspace = true }
+vertex-chain-index = { workspace = true }
 
 [[bench]]
 name = "redistribution"

--- a/crates/swarm/redistribution/src/index/canonical.rs
+++ b/crates/swarm/redistribution/src/index/canonical.rs
@@ -1,0 +1,51 @@
+//! Canonical Redistribution + StakeRegistry deployments, pinned locally because
+//! the nectar addresses diverge from the live deployment (see FIXME(#315)).
+
+use alloy_primitives::{Address, address};
+
+/// `(address, start_block)` for a canonical deployment.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Deployment {
+    /// The contract address.
+    pub(crate) address: Address,
+    /// The deployment block; backfill starts here.
+    pub(crate) block: u64,
+}
+
+/// Gnosis Chain mainnet deployments.
+pub(crate) mod mainnet {
+    use super::{Deployment, address};
+
+    /// StakeRegistry (`MainnetStakingAddress`).
+    // FIXME(#315): override until nectar fixed; then source from nectar.
+    pub(crate) const STAKING: Deployment = Deployment {
+        address: address!("da2a16EE889E7F04980A8d597b48c8D51B9518F4"),
+        block: 40_430_237,
+    };
+
+    /// Redistribution (`MainnetRedistributionAddress`).
+    // FIXME(#315): override until nectar fixed; then source from nectar.
+    pub(crate) const REDISTRIBUTION: Deployment = Deployment {
+        address: address!("5069cdfB3D9E56d23B1cAeE83CE6109A7E4fd62d"),
+        block: 41_105_199,
+    };
+}
+
+/// Sepolia testnet deployments.
+pub(crate) mod testnet {
+    use super::{Deployment, address};
+
+    /// StakeRegistry (`TestnetStakingAddress`).
+    // FIXME(#315): override until nectar fixed; then source from nectar.
+    pub(crate) const STAKING: Deployment = Deployment {
+        address: address!("EEF13Ef9eD9cDD169701eeF3cd832df298dD1bB4"),
+        block: 8_262_529,
+    };
+
+    /// Redistribution (`TestnetRedistributionAddress`).
+    // FIXME(#315): override until nectar fixed; then source from nectar.
+    pub(crate) const REDISTRIBUTION: Deployment = Deployment {
+        address: address!("5b718E36F5Ce2F2F7e25A397040436Ce6af3e89e"),
+        block: 8_646_721,
+    };
+}

--- a/crates/swarm/redistribution/src/index/mod.rs
+++ b/crates/swarm/redistribution/src/index/mod.rs
@@ -1,0 +1,185 @@
+//! On-chain indexing for the two storage-incentives contracts, Redistribution
+//! and StakeRegistry, in one crate.
+//!
+//! Both are lazy domains: events land verbatim in the framework's
+//! [`EventTable`](vertex_chain_index_framework::EventTable) and the
+//! [`redistribution`]/[`staking`] views fold on read. No reducers, no projection
+//! tables.
+
+use alloy_sol_types::SolEvent;
+use nectar_contracts::IStakeRegistry;
+use vertex_chain_index_framework::{
+    ContractTag, DomainRegistration, EventDescriptor, Network, WatchedContract,
+};
+use vertex_storage::Database;
+
+pub mod redistribution;
+pub mod staking;
+
+mod canonical;
+
+/// Redistribution contract tag. Stable: part of the on-disk
+/// [`EventKey`](vertex_chain_index_framework::EventKey) prefix.
+pub const TAG_REDISTRIBUTION: ContractTag = ContractTag(0x02);
+
+/// StakeRegistry contract tag. Stable: part of the on-disk
+/// [`EventKey`](vertex_chain_index_framework::EventKey) prefix.
+pub const TAG_STAKING: ContractTag = ContractTag(0x01);
+
+/// Event ABIs nectar does not yet ship: the Redistribution set and
+/// StakeRegistry's `OverlayChanged`. Each domain owns the `sol!` events it
+/// decodes.
+pub mod events {
+    use alloy_sol_types::sol;
+
+    sol! {
+        /// A node's overlay moved. Both `owner` and `overlay` are non-indexed.
+        #[allow(missing_docs)]
+        event OverlayChanged(address owner, bytes32 overlay);
+
+        /// A node committed its obfuscated reveal hash for `roundNumber`.
+        #[allow(missing_docs)]
+        event Committed(uint256 roundNumber, bytes32 overlay, uint8 height);
+
+        /// A node revealed its reserve commitment for `roundNumber`.
+        #[allow(missing_docs)]
+        event Revealed(
+            uint256 roundNumber,
+            bytes32 overlay,
+            uint256 stake,
+            uint256 stakeDensity,
+            bytes32 reserveCommitment,
+            uint8 depth
+        );
+
+        /// The reveal anchor (the seed truth selection draws against) for
+        /// `roundNumber`.
+        #[allow(missing_docs)]
+        event CurrentRevealAnchor(uint256 roundNumber, bytes32 anchor);
+
+        /// The truth (the agreed reserve hash and depth) the round settled on.
+        #[allow(missing_docs)]
+        event TruthSelected(bytes32 hash, uint8 depth);
+
+        /// A reveal record, as carried by [`WinnerSelected`].
+        #[allow(missing_docs)]
+        struct Reveal {
+            bytes32 overlay;
+            address owner;
+            uint8 depth;
+            uint256 stake;
+            uint256 stakeDensity;
+            bytes32 hash;
+        }
+
+        /// The winning reveal a round paid out to.
+        #[allow(missing_docs)]
+        event WinnerSelected(Reveal winner);
+
+        /// The number of commits counted in the current round.
+        #[allow(missing_docs)]
+        event CountCommits(uint256 _count);
+
+        /// The number of reveals counted in the current round.
+        #[allow(missing_docs)]
+        event CountReveals(uint256 _count);
+
+        /// The valid chunk count the round priced against.
+        #[allow(missing_docs)]
+        event ChunkCount(uint256 validChunkCount);
+    }
+}
+
+const REDISTRIBUTION_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        topic0: events::Committed::SIGNATURE_HASH,
+        name: "Committed",
+    },
+    EventDescriptor {
+        topic0: events::Revealed::SIGNATURE_HASH,
+        name: "Revealed",
+    },
+    EventDescriptor {
+        topic0: events::CurrentRevealAnchor::SIGNATURE_HASH,
+        name: "CurrentRevealAnchor",
+    },
+    EventDescriptor {
+        topic0: events::TruthSelected::SIGNATURE_HASH,
+        name: "TruthSelected",
+    },
+    EventDescriptor {
+        topic0: events::WinnerSelected::SIGNATURE_HASH,
+        name: "WinnerSelected",
+    },
+    EventDescriptor {
+        topic0: events::CountCommits::SIGNATURE_HASH,
+        name: "CountCommits",
+    },
+    EventDescriptor {
+        topic0: events::CountReveals::SIGNATURE_HASH,
+        name: "CountReveals",
+    },
+    EventDescriptor {
+        topic0: events::ChunkCount::SIGNATURE_HASH,
+        name: "ChunkCount",
+    },
+];
+
+const STAKING_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        topic0: IStakeRegistry::StakeUpdated::SIGNATURE_HASH,
+        name: "StakeUpdated",
+    },
+    EventDescriptor {
+        topic0: IStakeRegistry::StakeFrozen::SIGNATURE_HASH,
+        name: "StakeFrozen",
+    },
+    EventDescriptor {
+        topic0: IStakeRegistry::StakeSlashed::SIGNATURE_HASH,
+        name: "StakeSlashed",
+    },
+    EventDescriptor {
+        topic0: IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH,
+        name: "StakeWithdrawn",
+    },
+    EventDescriptor {
+        topic0: events::OverlayChanged::SIGNATURE_HASH,
+        name: "OverlayChanged",
+    },
+];
+
+/// The two watched contracts for `network`, with no reducers and no tables.
+pub fn registration<DB: Database>(network: Network) -> DomainRegistration<DB> {
+    let (redistribution, staking) = match network {
+        Network::Mainnet => (
+            canonical::mainnet::REDISTRIBUTION,
+            canonical::mainnet::STAKING,
+        ),
+        Network::Testnet => (
+            canonical::testnet::REDISTRIBUTION,
+            canonical::testnet::STAKING,
+        ),
+    };
+
+    DomainRegistration {
+        contracts: vec![
+            WatchedContract {
+                tag: TAG_REDISTRIBUTION,
+                address: redistribution.address,
+                start_block: redistribution.block,
+                events: REDISTRIBUTION_EVENTS,
+            },
+            WatchedContract {
+                tag: TAG_STAKING,
+                address: staking.address,
+                start_block: staking.block,
+                events: STAKING_EVENTS,
+            },
+        ],
+        reducers: vec![],
+        tables: &[],
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/swarm/redistribution/src/index/redistribution.rs
+++ b/crates/swarm/redistribution/src/index/redistribution.rs
@@ -1,0 +1,172 @@
+//! Redistribution view: `RoundState` is a read-time fold over the Redistribution
+//! rows under [`TAG_REDISTRIBUTION`], decoding commit/reveal/anchor events.
+//!
+//! Grouping folds on the raw `U256` `roundNumber` so two real rounds never
+//! collide.
+
+use alloy_primitives::{B256, U256};
+use alloy_sol_types::SolEvent;
+use vertex_chain_index_framework::{EventKey, StoredEvent, events_of, fold_events};
+use vertex_storage::{Database, DatabaseError};
+
+use crate::index::TAG_REDISTRIBUTION;
+use crate::index::events;
+
+/// A commit in a round (`Committed`), tagged with its source log position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Commit {
+    /// The committing log's `(block, log_index)`, the idempotency key.
+    pub pos: (u64, u64),
+    /// The committing node's overlay address.
+    pub overlay: B256,
+    /// The committed neighbourhood height.
+    pub height: u8,
+}
+
+/// A reveal in a round (`Revealed`), tagged with its source log position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Reveal {
+    /// The revealing log's `(block, log_index)`, the idempotency key.
+    pub pos: (u64, u64),
+    /// The revealing node's overlay address.
+    pub overlay: B256,
+    /// The revealing node's stake.
+    pub stake: U256,
+    /// The revealing node's stake density.
+    pub stake_density: U256,
+    /// The revealed reserve commitment hash.
+    pub reserve_commitment: B256,
+    /// The revealed storage depth.
+    pub depth: u8,
+}
+
+/// The folded state of a single redistribution round.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RoundState {
+    /// The raw on-chain `roundNumber`, kept full-width.
+    pub round: U256,
+    /// The reveal anchor, once `CurrentRevealAnchor` is seen.
+    pub anchor: Option<B256>,
+    /// The commits seen in the round, in position order, deduped by position.
+    pub commits: Vec<Commit>,
+    /// The reveals seen in the round, in position order, deduped by position.
+    pub reveals: Vec<Reveal>,
+}
+
+/// Fold the redistribution rows into per-round state.
+///
+/// [`fold_events`] walks rows in canonical position order, so appends preserve
+/// order and a replayed log at a seen position overwrites in place. Decode
+/// misses are skipped. Cost is O(events x rounds) per call with no caching or
+/// pruning; not for a per-request path.
+fn fold_rounds<DB: Database>(db: &DB) -> Result<Vec<RoundState>, DatabaseError> {
+    let rounds: Vec<RoundState> = Vec::new();
+
+    // Linear search keeps the full-width `U256` round key (no u64-narrowing map
+    // key); the bucket is created on first sight. `get_mut` keeps the fold total
+    // (no indexing panic).
+    fn round_mut(rounds: &mut Vec<RoundState>, round: U256) -> Option<&mut RoundState> {
+        let pos = match rounds.iter().position(|r| r.round == round) {
+            Some(pos) => pos,
+            None => {
+                rounds.push(RoundState {
+                    round,
+                    ..Default::default()
+                });
+                rounds.len() - 1
+            }
+        };
+        rounds.get_mut(pos)
+    }
+
+    fold_events(db, TAG_REDISTRIBUTION, rounds, |rounds, key, ev| {
+        let data = ev.log_data();
+        let pos = (key.block, key.log_index);
+        if ev.topic0 == events::Committed::SIGNATURE_HASH
+            && let Ok(e) = events::Committed::decode_log_data(&data)
+            && let Some(round) = round_mut(rounds, e.roundNumber)
+        {
+            upsert_by_pos(
+                &mut round.commits,
+                Commit {
+                    pos,
+                    overlay: e.overlay,
+                    height: e.height,
+                },
+            );
+        } else if ev.topic0 == events::Revealed::SIGNATURE_HASH
+            && let Ok(e) = events::Revealed::decode_log_data(&data)
+            && let Some(round) = round_mut(rounds, e.roundNumber)
+        {
+            upsert_by_pos(
+                &mut round.reveals,
+                Reveal {
+                    pos,
+                    overlay: e.overlay,
+                    stake: e.stake,
+                    stake_density: e.stakeDensity,
+                    reserve_commitment: e.reserveCommitment,
+                    depth: e.depth,
+                },
+            );
+        } else if ev.topic0 == events::CurrentRevealAnchor::SIGNATURE_HASH
+            && let Ok(e) = events::CurrentRevealAnchor::decode_log_data(&data)
+            && let Some(round) = round_mut(rounds, e.roundNumber)
+        {
+            round.anchor = Some(e.anchor);
+        }
+    })
+}
+
+/// The folded state of round `round_number`, if any of its events were indexed.
+///
+/// `round_number` widens to `U256` before matching, so no round is narrowed; a
+/// caller needing a round beyond `u64::MAX` reads [`rounds`] directly.
+pub fn round<DB: Database>(
+    db: &DB,
+    round_number: u64,
+) -> Result<Option<RoundState>, DatabaseError> {
+    let target = U256::from(round_number);
+    Ok(fold_rounds(db)?.into_iter().find(|r| r.round == target))
+}
+
+/// Every round whose events have been indexed, in first-seen order.
+pub fn rounds<DB: Database>(db: &DB) -> Result<Vec<RoundState>, DatabaseError> {
+    fold_rounds(db)
+}
+
+/// The raw position-ordered redistribution event stream (every event, including
+/// the round-terminal ones that carry no round number), for a consumer that
+/// wants the verbatim log rather than the per-round projection.
+pub fn raw_events<DB: Database>(db: &DB) -> Result<Vec<(EventKey, StoredEvent)>, DatabaseError> {
+    events_of(db, TAG_REDISTRIBUTION)
+}
+
+/// Carries a `(block, log_index)` position used as the idempotency key.
+trait HasPos {
+    fn pos(&self) -> (u64, u64);
+}
+
+impl HasPos for Commit {
+    fn pos(&self) -> (u64, u64) {
+        self.pos
+    }
+}
+
+impl HasPos for Reveal {
+    fn pos(&self) -> (u64, u64) {
+        self.pos
+    }
+}
+
+/// Replace the item at this log position, or insert it keeping position order.
+fn upsert_by_pos<T: HasPos>(items: &mut Vec<T>, incoming: T) {
+    match items.binary_search_by(|x| x.pos().cmp(&incoming.pos())) {
+        Ok(idx) => {
+            if let Some(slot) = items.get_mut(idx) {
+                *slot = incoming;
+            }
+        }
+        Err(idx) => items.insert(idx, incoming),
+    }
+}

--- a/crates/swarm/redistribution/src/index/staking.rs
+++ b/crates/swarm/redistribution/src/index/staking.rs
@@ -1,0 +1,123 @@
+//! Staking view: per-owner stake and the staked-overlay set by lazy fold over
+//! the StakeRegistry rows under [`TAG_STAKING`], last-write-wins in canonical
+//! order. Overlay -> owner is a read-time inversion. No reducer, no projection
+//! table.
+
+use std::collections::HashMap;
+
+use alloy_primitives::{Address, B256, U256};
+use alloy_sol_types::SolEvent;
+use nectar_contracts::IStakeRegistry;
+use vertex_chain_index_framework::fold_events;
+use vertex_storage::{Database, DatabaseError};
+
+use crate::index::TAG_STAKING;
+use crate::index::events;
+
+/// One owner's folded stake state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct OwnerStake {
+    /// The committed (locked) stake leg.
+    pub committed: U256,
+    /// The potential (effective) stake leg.
+    pub potential: U256,
+    /// The owner's current overlay.
+    pub overlay: B256,
+    /// The owner's current neighbourhood height.
+    pub height: u8,
+    /// The on-chain block the stake was last updated (the contract's counter).
+    pub last_updated_block: U256,
+    /// The freeze deadline; `0` means not frozen.
+    pub frozen_until: U256,
+}
+
+impl OwnerStake {
+    /// Whether this owner currently holds a non-zero stake.
+    pub fn is_staked(&self) -> bool {
+        !self.potential.is_zero() || !self.committed.is_zero()
+    }
+
+    /// Whether this owner is frozen at `block`.
+    pub fn is_frozen_at(&self, block: U256) -> bool {
+        self.frozen_until > block
+    }
+}
+
+/// Fold the staking rows into a per-owner map; every staking read narrows this.
+///
+/// Canonical position order makes last-write-wins implicit. Cost is O(total
+/// staking history) per call, with no caching; not for a per-request path.
+fn fold_owners<DB: Database>(db: &DB) -> Result<HashMap<Address, OwnerStake>, DatabaseError> {
+    fold_events(
+        db,
+        TAG_STAKING,
+        HashMap::<Address, OwnerStake>::new(),
+        |owners, _key, ev| {
+            let data = ev.log_data();
+            if ev.topic0 == IStakeRegistry::StakeUpdated::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeUpdated::decode_log_data(&data)
+            {
+                let s = owners.entry(e.owner).or_default();
+                s.committed = e.committedStake;
+                s.potential = e.potentialStake;
+                s.overlay = e.overlay;
+                s.height = e.height;
+                s.last_updated_block = e.lastUpdatedBlock;
+            } else if ev.topic0 == IStakeRegistry::StakeFrozen::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeFrozen::decode_log_data(&data)
+            {
+                owners.entry(e.frozen).or_default().frozen_until = e.time;
+            } else if ev.topic0 == IStakeRegistry::StakeSlashed::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeSlashed::decode_log_data(&data)
+            {
+                let s = owners.entry(e.slashed).or_default();
+                s.committed = U256::ZERO;
+                s.potential = U256::ZERO;
+            } else if ev.topic0 == IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeWithdrawn::decode_log_data(&data)
+            {
+                let s = owners.entry(e.node).or_default();
+                s.committed = U256::ZERO;
+                s.potential = U256::ZERO;
+            } else if ev.topic0 == events::OverlayChanged::SIGNATURE_HASH
+                && let Ok(e) = events::OverlayChanged::decode_log_data(&data)
+            {
+                owners.entry(e.owner).or_default().overlay = e.overlay;
+            }
+        },
+    )
+}
+
+/// The folded stake row for `owner`, if the owner has ever been seen.
+pub fn stake_of<DB: Database>(
+    db: &DB,
+    owner: Address,
+) -> Result<Option<OwnerStake>, DatabaseError> {
+    Ok(fold_owners(db)?.get(&owner).copied())
+}
+
+/// Whether `overlay` is currently in the staked-overlay set.
+pub fn is_overlay_staked<DB: Database>(db: &DB, overlay: B256) -> Result<bool, DatabaseError> {
+    Ok(owner_of_overlay(db, overlay)?.is_some())
+}
+
+/// The owner behind a staked `overlay`, if any owner currently stakes it.
+pub fn owner_of_overlay<DB: Database>(
+    db: &DB,
+    overlay: B256,
+) -> Result<Option<Address>, DatabaseError> {
+    let owners = fold_owners(db)?;
+    Ok(owners.into_iter().find_map(|(owner, s)| {
+        (s.is_staked() && s.overlay != B256::ZERO && s.overlay == overlay).then_some(owner)
+    }))
+}
+
+/// Every staked overlay paired with its owner.
+pub fn staked_overlays<DB: Database>(db: &DB) -> Result<Vec<(B256, Address)>, DatabaseError> {
+    let owners = fold_owners(db)?;
+    Ok(owners
+        .into_iter()
+        .filter(|(_, s)| s.is_staked() && s.overlay != B256::ZERO)
+        .map(|(owner, s)| (s.overlay, owner))
+        .collect())
+}

--- a/crates/swarm/redistribution/src/index/tests.rs
+++ b/crates/swarm/redistribution/src/index/tests.rs
@@ -1,0 +1,304 @@
+//! Redistribution + staking domain tests: the lazy per-round fold, the per-owner
+//! stake fold with overlay inversion, ABI-signature pins, and the production
+//! registration composing cleanly.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, LogData, U256, address, keccak256};
+use alloy_rpc_types_eth::Log;
+use alloy_sol_types::SolEvent;
+use vertex_chain_index::Indexer;
+use vertex_chain_index_framework::{
+    ContractIndexer, DomainRegistration, EventDescriptor, Network, WatchedContract,
+};
+use vertex_storage_redb::RedbDatabase;
+
+use crate::index::events;
+use crate::index::{TAG_REDISTRIBUTION, TAG_STAKING, redistribution, staking};
+
+// Synthetic addresses, distinct from any real deployment.
+const REDIST_ADDR: Address = address!("0000000000000000000000000000000000000a03");
+const STAKING_ADDR: Address = address!("0000000000000000000000000000000000000a02");
+
+const REDISTRIBUTION_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        topic0: events::Committed::SIGNATURE_HASH,
+        name: "Committed",
+    },
+    EventDescriptor {
+        topic0: events::Revealed::SIGNATURE_HASH,
+        name: "Revealed",
+    },
+    EventDescriptor {
+        topic0: events::CurrentRevealAnchor::SIGNATURE_HASH,
+        name: "CurrentRevealAnchor",
+    },
+];
+
+const STAKING_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        topic0: nectar_contracts::IStakeRegistry::StakeUpdated::SIGNATURE_HASH,
+        name: "StakeUpdated",
+    },
+    EventDescriptor {
+        topic0: nectar_contracts::IStakeRegistry::StakeFrozen::SIGNATURE_HASH,
+        name: "StakeFrozen",
+    },
+    EventDescriptor {
+        topic0: nectar_contracts::IStakeRegistry::StakeSlashed::SIGNATURE_HASH,
+        name: "StakeSlashed",
+    },
+    EventDescriptor {
+        topic0: nectar_contracts::IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH,
+        name: "StakeWithdrawn",
+    },
+    EventDescriptor {
+        topic0: events::OverlayChanged::SIGNATURE_HASH,
+        name: "OverlayChanged",
+    },
+];
+
+fn test_registration<DB: vertex_storage::Database>() -> DomainRegistration<DB> {
+    DomainRegistration {
+        contracts: vec![
+            WatchedContract {
+                tag: TAG_REDISTRIBUTION,
+                address: REDIST_ADDR,
+                start_block: 0,
+                events: REDISTRIBUTION_EVENTS,
+            },
+            WatchedContract {
+                tag: TAG_STAKING,
+                address: STAKING_ADDR,
+                start_block: 0,
+                events: STAKING_EVENTS,
+            },
+        ],
+        reducers: vec![],
+        tables: &[],
+    }
+}
+
+fn harness() -> (Arc<RedbDatabase>, ContractIndexer<RedbDatabase>) {
+    let db = Arc::new(RedbDatabase::in_memory().expect("in-memory db"));
+    let indexer = ContractIndexer::from_registrations(db.clone(), vec![test_registration()])
+        .expect("indexer");
+    (db, indexer)
+}
+
+fn log_from(block: u64, index: u64, address: Address, data: LogData) -> Log {
+    Log {
+        inner: alloy_primitives::Log { address, data },
+        block_hash: Some(B256::repeat_byte(block as u8)),
+        block_number: Some(block),
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: Some(index),
+        removed: false,
+    }
+}
+
+fn apply<E: SolEvent>(
+    indexer: &ContractIndexer<RedbDatabase>,
+    block: u64,
+    index: u64,
+    address: Address,
+    event: &E,
+) {
+    let log = log_from(block, index, address, event.encode_log_data());
+    indexer.apply(block, &log).expect("apply");
+}
+
+#[test]
+fn registration_builds_indexer() {
+    // The production registration with real canonical addresses composes cleanly.
+    let db = Arc::new(RedbDatabase::in_memory().expect("db"));
+    let indexer =
+        ContractIndexer::from_registrations(db, vec![crate::index::registration(Network::Mainnet)])
+            .expect("redistribution + staking registration must compose into the unified indexer");
+    let filter = indexer.filter();
+    assert_eq!(
+        filter.address.len(),
+        2,
+        "redistribution + staking addresses"
+    );
+}
+
+#[test]
+fn staking_last_write_wins_and_overlay_inversion() {
+    let (db, indexer) = harness();
+    let owner = address!("00000000000000000000000000000000000000b1");
+    let overlay1 = B256::repeat_byte(0x11);
+    let overlay2 = B256::repeat_byte(0x22);
+
+    apply(
+        &indexer,
+        10,
+        0,
+        STAKING_ADDR,
+        &nectar_contracts::IStakeRegistry::StakeUpdated {
+            owner,
+            committedStake: U256::from(100u64),
+            potentialStake: U256::from(200u64),
+            overlay: overlay1,
+            lastUpdatedBlock: U256::from(10u64),
+            height: 4,
+        },
+    );
+    assert!(staking::is_overlay_staked(&*db, overlay1).unwrap());
+    assert_eq!(
+        staking::owner_of_overlay(&*db, overlay1).unwrap(),
+        Some(owner)
+    );
+
+    // Overlay changes: the new overlay is staked, the old is not.
+    apply(
+        &indexer,
+        20,
+        0,
+        STAKING_ADDR,
+        &events::OverlayChanged {
+            owner,
+            overlay: overlay2,
+        },
+    );
+    assert!(staking::is_overlay_staked(&*db, overlay2).unwrap());
+    assert!(!staking::is_overlay_staked(&*db, overlay1).unwrap());
+
+    // A slash zeroes both legs: the owner drops out of the set.
+    apply(
+        &indexer,
+        30,
+        0,
+        STAKING_ADDR,
+        &nectar_contracts::IStakeRegistry::StakeSlashed {
+            slashed: owner,
+            overlay: overlay2,
+            amount: U256::from(300u64),
+        },
+    );
+    assert!(!staking::is_overlay_staked(&*db, overlay2).unwrap());
+    assert!(!staking::stake_of(&*db, owner).unwrap().unwrap().is_staked());
+}
+
+#[test]
+fn redistribution_groups_by_raw_round() {
+    let (db, indexer) = harness();
+    let overlay = B256::repeat_byte(0x33);
+
+    apply(
+        &indexer,
+        1,
+        0,
+        REDIST_ADDR,
+        &events::Committed {
+            roundNumber: U256::from(7u64),
+            overlay,
+            height: 4,
+        },
+    );
+    apply(
+        &indexer,
+        1,
+        1,
+        REDIST_ADDR,
+        &events::Revealed {
+            roundNumber: U256::from(7u64),
+            overlay,
+            stake: U256::from(1u64),
+            stakeDensity: U256::from(2u64),
+            reserveCommitment: B256::repeat_byte(0x44),
+            depth: 4,
+        },
+    );
+    apply(
+        &indexer,
+        2,
+        0,
+        REDIST_ADDR,
+        &events::CurrentRevealAnchor {
+            roundNumber: U256::from(7u64),
+            anchor: B256::repeat_byte(0x55),
+        },
+    );
+
+    let round = redistribution::round(&*db, 7).unwrap().expect("round 7");
+    assert_eq!(round.round, U256::from(7u64));
+    assert_eq!(round.commits.len(), 1);
+    assert_eq!(round.reveals.len(), 1);
+    assert_eq!(round.anchor, Some(B256::repeat_byte(0x55)));
+
+    // A different round does not collide.
+    assert!(redistribution::round(&*db, 8).unwrap().is_none());
+}
+
+/// The local event ABIs must match the canonical on-chain signatures
+/// byte-for-byte; drift in field types or order changes the hash and breaks
+/// decode-on-read.
+#[test]
+fn abi_signatures_match_canonical() {
+    fn sig(s: &str) -> B256 {
+        keccak256(s.as_bytes())
+    }
+
+    // StakeRegistry: the one event nectar lacks.
+    assert_eq!(
+        events::OverlayChanged::SIGNATURE_HASH,
+        sig("OverlayChanged(address,bytes32)")
+    );
+
+    // Redistribution.
+    assert_eq!(
+        events::Committed::SIGNATURE_HASH,
+        sig("Committed(uint256,bytes32,uint8)")
+    );
+    assert_eq!(
+        events::Revealed::SIGNATURE_HASH,
+        sig("Revealed(uint256,bytes32,uint256,uint256,bytes32,uint8)")
+    );
+    assert_eq!(
+        events::CurrentRevealAnchor::SIGNATURE_HASH,
+        sig("CurrentRevealAnchor(uint256,bytes32)")
+    );
+}
+
+/// The production registration must watch the locally-pinned addresses, not the
+/// diverging nectar ones (see FIXME(#315)).
+#[test]
+fn canonical_addresses() {
+    fn watched(
+        network: Network,
+        tag: vertex_chain_index_framework::ContractTag,
+    ) -> WatchedContract {
+        crate::index::registration::<RedbDatabase>(network)
+            .contracts
+            .into_iter()
+            .find(|c| c.tag == tag)
+            .expect("contract in registration")
+    }
+
+    // Mainnet.
+    let m_stake = watched(Network::Mainnet, TAG_STAKING);
+    assert_eq!(
+        m_stake.address,
+        address!("da2a16EE889E7F04980A8d597b48c8D51B9518F4")
+    );
+    assert_eq!(m_stake.start_block, 40_430_237);
+    let m_redist = watched(Network::Mainnet, TAG_REDISTRIBUTION);
+    assert_eq!(
+        m_redist.address,
+        address!("5069cdfB3D9E56d23B1cAeE83CE6109A7E4fd62d")
+    );
+    assert_eq!(m_redist.start_block, 41_105_199);
+
+    // Testnet.
+    assert_eq!(
+        watched(Network::Testnet, TAG_STAKING).address,
+        address!("EEF13Ef9eD9cDD169701eeF3cd832df298dD1bB4")
+    );
+    assert_eq!(
+        watched(Network::Testnet, TAG_REDISTRIBUTION).address,
+        address!("5b718E36F5Ce2F2F7e25A397040436Ce6af3e89e")
+    );
+}

--- a/crates/swarm/redistribution/src/lib.rs
+++ b/crates/swarm/redistribution/src/lib.rs
@@ -40,6 +40,13 @@ mod proof;
 mod sample;
 mod witness;
 
+/// On-chain indexing for the Redistribution and StakeRegistry contracts, behind
+/// the non-default `chain` feature. Both are lazy domains (no reducer, no
+/// projection tables) over the generic [`vertex_chain_index_framework`]; the
+/// node builder collects [`index::registration`] into the unified indexer.
+#[cfg(feature = "chain")]
+pub mod index;
+
 /// Number of chunks retained in a reserve sample (the protocol's `SampleSize`).
 pub const SAMPLE_SIZE: usize = 16;
 


### PR DESCRIPTION
## What

Invert the chain contract indexer into a generic, configuration-driven framework plus per-domain registrations, and wire the whole thing into the node builder so a chain-needing node (the storer) actually indexes the Swarm contracts.

- New `vertex-chain-index-framework`: the mechanism only. One `ContractIndexer` plugs into the existing `vertex-chain-index` engine as a single `Indexer` over one combined multi-address/multi-topic filter, one cursor, and one position-keyed verbatim event store. `apply` is total and never decodes an event body (it resolves the emitting address to a `ContractTag`, verifies the `topic0` is declared, enforces a `MAX_EVENT_DATA` cap, and writes the row verbatim keyed by `(tag, block, log_index)`). A per-domain `Reducer<DB>` maintains an eager projection in the same transaction; `revert` is a per-contract range-delete plus a `rebuild` from the surviving rows. The framework names no contract, ABI, address, or projection.
- Per-domain registrations, each behind a non-default `chain` feature so the wasm/light cone stays clean:
  - postage: the `PostageReducer` folds `BatchCreated`/`BatchTopUp`/`BatchDepthIncrease` into the same `Batches` table `DbBatchStore` persists and the storer reserve reads through `BatchStore`, so the indexer and the batch store share one projection. `PriceUpdate` is recorded verbatim and folded lazily by `total_out_payment_at`.
  - chequebook (lazy): `SimpleSwapDeployed` membership.
  - swap oracle (lazy): the two settlement scalars by last-write-wins.
  - redistribution and staking (lazy): per-round and per-owner views over the `Redistribution` and `StakeRegistry` contracts.
- Builder composition root: behind `chain`, collect every domain registration into one `ContractIndexer` via `from_registrations` and spawn a single `EventEngine` over the shared chain provider and node database. A node without persistence or a chain provider indexes nothing.
- Storage: add `DbTx::range` for bounded per-prefix key scans (native redb btree range, with a full-scan default fallback) so a contract's `(tag, ..)` range is read without materialising the whole multi-contract table.

## Why

Closes #338. This is the generic-framework + per-domain-registration inversion: it supersedes the five per-contract indexer crates (#302, #303, #305, #308, #309) by lifting their contract-specific decode and view logic into per-domain `chain`-gated modules over one shared mechanism.

The postage domain is reconciled with the postage stack that merged on `main` after this work began (`DbBatchStore` and the `BatchEvent` ingest seam in #400, the reserve in #403): rather than maintain a second batch projection, the reducer maintains the `Batches` table the reserve already reads. Publishing the head `currentTotalOutPayment` into `PostageContext` for the expiry check is a block-clock consumer's job (the reactions layer, which builds on the block-tip stream in #332), not the indexer's; `total_out_payment_at` gives that consumer the read it needs.

## Deferrals

- #315: pin the three diverging contract addresses upstream in nectar so the `(address, block)` pairing is internally consistent, then drop the local canonical overrides and source all addresses from nectar.
- The block-clock consumer that publishes `PostageContext` (head block and `currentTotalOutPayment`) so the reserve's expiry and admission checks run live. Tracked with the chain-reactions work on top of #332.

## Testing

- `cargo test` per touched crate: framework (14), postage chain (incl. the batch-set fold read back through `DbBatchStore`, the `total_out_payment_at` price fold, and revert), chequebook chain (4), swap chain (4), redistribution chain (5), plus `vertex-storage`/`vertex-storage-redb` and the builder under `--features storer`.
- `cargo clippy --all-targets --all-features -- -D warnings` clean across the workspace, `cargo fmt --all --check` clean, and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` builds (the chain features stay out of the default cone).

## AI Assistance

Claude Code (Opus 4.8) used for the rebase onto `main`, the `bandwidth` to `accounting` relocation, the postage reducer reconciliation onto `DbBatchStore`, and the builder wiring.
