### PR TITLE
refactor(chain): per-contract reducer framework + uniform query surface

### DIFF
--- a/crates/chain/index-contracts/src/indexer.rs
+++ b/crates/chain/index-contracts/src/indexer.rs
@@ -1,19 +1,24 @@
 //! The single [`ContractIndexer`]: ONE `impl Indexer` over a combined
 //! multi-address / multi-topic filter, ONE cursor, ONE position-keyed store.
 //!
-//! `apply` is a TOTAL function over the filter's result set. It never decodes an
-//! event body. It resolves `log.address()` to a [`ContractId`] (the address is
-//! the authority), verifies the `topic0` is declared for that contract (skip
-//! otherwise), enforces the [`MAX_EVENT_DATA`](crate::store::MAX_EVENT_DATA)
-//! cap, and writes the row verbatim into [`EventTable`](crate::store::EventTable).
-//! For `Postage` rows it additionally feeds the typed
-//! [`BatchTable`](crate::store::BatchTable) projection that backs the one
-//! value-sorted index.
+//! `apply` keeps the #313 safety envelope: it resolves `log.address()` to a
+//! [`ContractId`] (the address is the authority), verifies the `topic0` is
+//! declared for that contract (skip otherwise), enforces the
+//! [`MAX_EVENT_DATA`](crate::store::MAX_EVENT_DATA) cap, and writes the row
+//! verbatim into [`EventTable`](crate::store::EventTable). It then dispatches the
+//! row to the contract's [`Reducer`] (if any), which decodes and folds into its
+//! typed projection(s) **in the same transaction**, so the raw row, the
+//! projection, and the cursor commit atomically.
 //!
-//! Because the body is never parsed, a malformed or unexpected log cannot panic
-//! or error the hot path; the only `apply`-time error is a missing `log_index`,
-//! which a canonical finalized log never hits. Decoding is a
-//! [`views`](crate::views) concern, scoped to one read.
+//! A reducer's decode miss is a skip (`Ok(())`), never an error, so a malformed
+//! body cannot wedge the shared cursor; the only `apply`-time errors are a
+//! missing `log_index` (which a canonical finalized log never hits) and a genuine
+//! storage fault. A contract with no reducer stays pure-lazy and pays nothing.
+//!
+//! `revert` is generic: per contract it range-deletes the raw tail at or after
+//! `from_block`, then asks the contract's reducer to [`rebuild`](Reducer::rebuild)
+//! its projection from the surviving raw rows. The verbatim store is the source
+//! of truth underneath.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -22,13 +27,11 @@ use alloy_primitives::Address;
 use alloy_rpc_types_eth::{Filter, Log};
 use tracing::warn;
 use vertex_chain_index::{IndexError, Indexer};
-use vertex_storage::Database;
+use vertex_storage::{Database, DbTxMut};
 
+use crate::reducer::{PostageReducer, Reducer};
 use crate::registry::{ContractId, Network, WatchedContract, registry};
-use crate::store::{
-    ContractIndexTables, EventKey, apply_batch_update, batch_update_from_event, put_event,
-    revert_contract, stored_event_from_log,
-};
+use crate::store::{EventKey, EventTable, events_of_tx, put_event, stored_event_from_log};
 
 /// The indexer name: the engine's single cursor key and metric label.
 pub const INDEXER_NAME: &str = "chain_contracts";
@@ -45,6 +48,7 @@ pub struct ContractIndexer<DB> {
     db: Arc<DB>,
     contracts: Vec<WatchedContract>,
     by_address: HashMap<Address, WatchedContract>,
+    reducers: HashMap<ContractId, Reducer>,
 }
 
 impl<DB: Database> ContractIndexer<DB> {
@@ -62,13 +66,23 @@ impl<DB: Database> ContractIndexer<DB> {
         db: Arc<DB>,
         contracts: Vec<WatchedContract>,
     ) -> Result<Self, IndexError> {
-        ContractIndexTables::init(db.as_ref())?;
+        crate::store::ContractIndexTables::init(db.as_ref())?;
         let by_address = contracts.iter().map(|c| (c.address, *c)).collect();
         Ok(Self {
             db,
             contracts,
             by_address,
+            reducers: Self::reducers(),
         })
+    }
+
+    /// The per-contract reducer set: one entry per contract that maintains an
+    /// eager projection. Adding an eager contract is one entry here plus its
+    /// [`Reducer`] arm. Contracts absent from this map stay verbatim-only.
+    fn reducers() -> HashMap<ContractId, Reducer> {
+        let mut m = HashMap::new();
+        m.insert(ContractId::Postage, Reducer::Postage(PostageReducer));
+        m
     }
 
     /// Resolve a log's address to its watched contract, if any.
@@ -141,20 +155,15 @@ impl<DB: Database> Indexer for ContractIndexer<DB> {
         let event = stored_event_from_log(log);
         let data_len = event.data.len();
 
-        // For Postage create/topup/depth-increase, decode the batch fields to
-        // feed the typed projection that backs the value-sorted index. This is
-        // the ONE place apply decodes, and only to maintain the eviction HINT;
-        // the verbatim row is still the source of truth, and a decode failure
-        // here is non-fatal (the verbatim row still lands). The decode runs on
-        // the already-built `StoredEvent`, the same path the revert rebuild uses.
-        let batch_update = if contract.id == ContractId::Postage {
-            batch_update_from_event(&event, block)
-        } else {
-            None
-        };
+        // The contract's reducer (if any) decodes and folds into its typed
+        // projection in the SAME tx as the verbatim put_event, so raw row +
+        // projection + cursor commit atomically. A reducer decode miss is a skip
+        // (Ok), so a malformed body never wedges the cursor; only a storage fault
+        // escapes.
+        let reducer = self.reducers.get(&contract.id);
 
         self.db.update(|tx| {
-            let stored = put_event(tx, key, event)?;
+            let stored = put_event(tx, key, event.clone())?;
             if !stored {
                 warn!(
                     contract = <&'static str>::from(contract.id),
@@ -162,8 +171,8 @@ impl<DB: Database> Indexer for ContractIndexer<DB> {
                 );
                 return Ok(());
             }
-            if let Some(update) = batch_update {
-                apply_batch_update(tx, update)?;
+            if let Some(reducer) = reducer {
+                reducer.reduce(tx, key, &event)?;
             }
             Ok(())
         })?;
@@ -173,8 +182,52 @@ impl<DB: Database> Indexer for ContractIndexer<DB> {
 
     fn revert(&self, from_block: u64) -> Result<(), IndexError> {
         for contract in &self.contracts {
-            revert_contract(self.db.as_ref(), contract.id, from_block)?;
+            let id = contract.id;
+            let reducer = self.reducers.get(&id);
+            self.db
+                .update(|tx| revert_contract(tx, id, reducer, from_block))?;
         }
         Ok(())
     }
+}
+
+/// Revert one contract: range-delete its raw tail at or after `from_block`, then
+/// rebuild its projection (if it has a reducer) from the surviving raw rows.
+///
+/// Because every view derives purely from the raw rows, deleting the reorged-out
+/// range plus rebuilding the projection from survivors is necessary and
+/// sufficient: no view holds independent state revert could miss. A batch created
+/// BEFORE `from_block` but mutated within the reverted range is handled by the
+/// reducer's full rebuild from survivors (it cannot be caught by a create-block
+/// filter). The MVP engine indexes finalized-only and never calls this; it is
+/// correct-by-construction today and correct-by-design when head-tracking arrives.
+fn revert_contract<TX: DbTxMut>(
+    tx: &TX,
+    contract: ContractId,
+    reducer: Option<&Reducer>,
+    from_block: u64,
+) -> Result<(), vertex_storage::DatabaseError> {
+    // Drop this contract's events at or after from_block, found by a bounded
+    // range scan over just this contract's tail range.
+    let doomed: Vec<EventKey> = tx
+        .range::<EventTable>(
+            EventKey::range_from(contract, from_block),
+            EventKey::range_end(contract),
+        )?
+        .into_iter()
+        .map(|(k, _)| k)
+        .collect();
+    for key in doomed {
+        tx.delete::<EventTable>(key)?;
+    }
+
+    // Rebuild the projection (if any) from exactly the surviving rows (already
+    // truncated to `< from_block`), so it can never drift from the source of
+    // truth. A reducer-less contract has no projection and nothing to rebuild.
+    if let Some(reducer) = reducer {
+        let surviving = events_of_tx(tx, contract)?;
+        reducer.rebuild(tx, &surviving)?;
+    }
+
+    Ok(())
 }

--- a/crates/chain/index-contracts/src/lib.rs
+++ b/crates/chain/index-contracts/src/lib.rs
@@ -71,13 +71,27 @@ mod indexer;
 mod registry;
 mod store;
 
+pub mod projection;
+pub mod reducer;
 pub mod views;
 
+/// Re-export of the storage crate under a stable name the
+/// [`projection!`](crate::projection) / [`secondary_index!`](crate::secondary_index)
+/// macros expand through, so they resolve `table!` / `index!` regardless of how a
+/// caller imports `vertex_storage`.
+#[doc(hidden)]
+pub use vertex_storage as __vertex_storage;
+
 pub use indexer::{ContractIndexer, INDEXER_NAME};
+pub use projection::{
+    IndexedProjection, Projection, contains, fold_events, get_via_index, last_event, list_all,
+    list_by, point_get, range_head, scalar,
+};
+pub use reducer::{BatchUpdate, PostageReducer, Reducer};
 pub use registry::{ContractId, EventDescriptor, Network, WatchedContract, abi, registry};
 pub use store::{
-    BatchByBalance, BatchKey, BatchState, BatchTable, BatchUpdate, ContractIndexTables, EventKey,
-    EventTable, MAX_EVENT_DATA, StoredEvent,
+    BatchByBalance, BatchKey, BatchState, BatchTable, ContractIndexTables, EventKey, EventTable,
+    MAX_EVENT_DATA, StoredEvent,
 };
 
 #[cfg(test)]

--- a/crates/chain/index-contracts/src/projection.rs
+++ b/crates/chain/index-contracts/src/projection.rs
@@ -1,0 +1,237 @@
+//! The generalized query surface: typed projections and a fixed vocabulary of
+//! query combinators over them, plus the lazy fold backbone for reducer-less
+//! contracts.
+//!
+//! # Two halves
+//!
+//! - **Eager projections.** A [`Projection`] is a typed [`Table`] a
+//!   [`Reducer`](crate::reducer::Reducer) maintains; an [`IndexedProjection`]
+//!   additionally carries a self-healing [`SecondaryIndex`]. The
+//!   [`projection!`](crate::projection) / [`secondary_index!`](crate::secondary_index)
+//!   macros declare one in a line, wrapping the storage crate's `table!` /
+//!   `index!` / `impl_fixed_codec!`. The [`point_get`], [`list_all`], [`list_by`],
+//!   [`get_via_index`], [`range_head`], [`scalar`] and [`contains`] combinators
+//!   are the only read shapes a view composes, so the key-codec / iterate /
+//!   filter boilerplate the duplication catalogue lists lives here once.
+//!
+//! - **Lazy fold backbone.** A reducer-less contract has no projection; its views
+//!   fold the verbatim [`EventTable`](crate::store::EventTable) rows on read.
+//!   [`fold_events`] (forward fold) and [`last_event`] (backward last-write-wins)
+//!   are the two shapes every such view narrows, so even a no-reducer contract
+//!   shares one fold.
+//!
+//! A decode failure inside any of these is scoped to the offending row (skipped),
+//! never an error: the store holds the bytes verbatim and the read decides
+//! meaning.
+
+use vertex_storage::{Database, DatabaseError, DbTx, IndexedRead, SecondaryIndex, Table};
+
+use crate::registry::ContractId;
+use crate::store::{EventKey, StoredEvent, events_of};
+
+/// A typed projection: a [`Table`] a [`Reducer`](crate::reducer::Reducer)
+/// maintains alongside the verbatim event store.
+///
+/// This is a marker over [`Table`] giving projections a name distinct from raw
+/// storage tables; the [`projection!`](crate::projection) macro implements both
+/// in one declaration. The combinators below are generic over `P: Projection`.
+pub trait Projection: Table {}
+
+/// A typed projection carried with a self-healing secondary index, so a view can
+/// read it both by primary key ([`point_get`]) and in index order
+/// ([`range_head`], [`get_via_index`]).
+///
+/// `Index::Primary` is the projection table, so the two stay in lockstep; the
+/// [`secondary_index!`](crate::secondary_index) macro wires both.
+pub trait IndexedProjection: Projection {
+    /// The self-healing secondary index over this projection.
+    type Index: SecondaryIndex<Primary = Self>;
+}
+
+/// Declare a typed [`Projection`] (a maintained [`Table`]) in one line.
+///
+/// Wraps the storage crate's [`table!`](vertex_storage::table) and adds the
+/// [`Projection`] marker. Projections are uncompressed by default to match the
+/// small fixed-size rows a reducer maintains; pass `compressed = false`
+/// explicitly only to be emphatic (it is the default here).
+#[macro_export]
+macro_rules! projection {
+    ($vis:vis $name:ident, $table_name:literal, $key:ty, $value:ty) => {
+        $crate::__vertex_storage::table!($vis $name, $table_name, $key, $value);
+        impl $crate::projection::Projection for $name {}
+    };
+}
+
+/// Declare a self-healing secondary index over a [`Projection`] and bind it as
+/// that projection's [`IndexedProjection::Index`] in one line.
+///
+/// Wraps the storage crate's [`index!`](vertex_storage::index) and additionally
+/// records the index on the primary via [`IndexedProjection`], so [`range_head`]
+/// / [`get_via_index`] can find it from the projection type alone.
+#[macro_export]
+macro_rules! secondary_index {
+    ($vis:vis $name:ident, $table_name:literal, $index_key:ty, $primary:ty, |$val:ident| $extract:expr) => {
+        $crate::__vertex_storage::index!($vis $name, $table_name, $index_key, $primary, |$val| $extract);
+        impl $crate::projection::IndexedProjection for $primary {
+            type Index = $name;
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Eager-projection combinators.
+// ---------------------------------------------------------------------------
+
+/// Point-read a projection row by its primary key.
+pub fn point_get<P, DB>(db: &DB, key: P::Key) -> Result<Option<P::Value>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    db.view(|tx| tx.get::<P>(key))
+}
+
+/// Whether a projection holds a row at `key` (membership without the value).
+pub fn contains<P, DB>(db: &DB, key: P::Key) -> Result<bool, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    Ok(db.view(|tx| tx.get::<P>(key))?.is_some())
+}
+
+/// Every row in a projection, as `(key, value)` pairs.
+// The `(P::Key, P::Value)` pair is the storage trait's own `entries` shape (which
+// carries the same allow); it is a deliberate, readable signature here.
+#[allow(clippy::type_complexity)]
+pub fn list_all<P, DB>(db: &DB) -> Result<Vec<(P::Key, P::Value)>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    db.view(|tx| tx.entries::<P>())
+}
+
+/// Every projection row whose value satisfies `pred`.
+///
+/// The generic "list by some attribute" read (e.g. batches by owner): the
+/// projection carries the attribute, so no secondary table is needed for a
+/// linear filter.
+#[allow(clippy::type_complexity)]
+pub fn list_by<P, DB, F>(db: &DB, mut pred: F) -> Result<Vec<(P::Key, P::Value)>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+    F: FnMut(&P::Value) -> bool,
+{
+    Ok(db
+        .view(|tx| tx.entries::<P>())?
+        .into_iter()
+        .filter(|(_, v)| pred(v))
+        .collect())
+}
+
+/// Read a projection row via its secondary index key, resolving through to the
+/// primary value.
+pub fn get_via_index<P, DB>(
+    db: &DB,
+    index_key: <P::Index as Table>::Key,
+) -> Result<Option<P::Value>, DatabaseError>
+where
+    P: IndexedProjection,
+    DB: Database,
+{
+    db.view(|tx| tx.get_via::<P::Index>(index_key))
+}
+
+/// The head of a projection's secondary index in ascending key order, bounded to
+/// `limit`, returned as the primary keys the index points at.
+///
+/// The bounded sorted read: it scans the index's `[from ..= to]` range via the
+/// storage trait's [`range`](DbTx::range) and `take(limit)`s, so the cost is the
+/// head window, not the whole index. This is the #317 load-bearing replacement
+/// for a full `entries()` + in-memory sort.
+pub fn range_head<P, DB>(
+    db: &DB,
+    from: <P::Index as Table>::Key,
+    to: <P::Index as Table>::Key,
+    limit: usize,
+) -> Result<Vec<<P::Index as Table>::Value>, DatabaseError>
+where
+    P: IndexedProjection,
+    DB: Database,
+{
+    db.view(|tx| {
+        Ok(tx
+            .range::<P::Index>(from, to)?
+            .into_iter()
+            .take(limit)
+            .map(|(_, pk)| pk)
+            .collect())
+    })
+}
+
+/// Read a single-row summary projection at a fixed key.
+///
+/// A summary projection (e.g. a running cumulative-payment row) lives at one
+/// well-known key; `scalar` is the `point_get` specialised to that read so a view
+/// reads "the summary" without naming the key shape twice.
+pub fn scalar<P, DB>(db: &DB, key: P::Key) -> Result<Option<P::Value>, DatabaseError>
+where
+    P: Projection,
+    DB: Database,
+{
+    point_get::<P, DB>(db, key)
+}
+
+// ---------------------------------------------------------------------------
+// Lazy fold backbone (reducer-less contracts).
+// ---------------------------------------------------------------------------
+
+/// Fold a contract's verbatim event stream in canonical `(block, log_index)`
+/// order into an accumulator.
+///
+/// The forward-fold backbone every lazy view narrows (the generalization of the
+/// per-view `fold_owners` / `fold_rounds` / `deployed_set` shapes). `step` sees
+/// each `(EventKey, &StoredEvent)` and the mutable accumulator; it decodes with
+/// the concrete `sol!` type and folds, skipping a decode miss. Reads ONLY this
+/// contract's key range via the bounded [`events_of`].
+pub fn fold_events<DB, A, F>(
+    db: &DB,
+    contract: ContractId,
+    init: A,
+    mut step: F,
+) -> Result<A, DatabaseError>
+where
+    DB: Database,
+    F: FnMut(&mut A, EventKey, &StoredEvent),
+{
+    let mut acc = init;
+    for (key, ev) in events_of(db, contract)? {
+        step(&mut acc, key, &ev);
+    }
+    Ok(acc)
+}
+
+/// Walk a contract's verbatim rows backward and return the first value `pick`
+/// yields, i.e. the last write in canonical order.
+///
+/// The last-write-wins backbone the scalar views narrow (the generalization of
+/// the swap view's `last_scalar`). `pick` decodes the row and returns `Some` for
+/// a match; a decode miss or non-match returns `None` and the walk continues.
+pub fn last_event<DB, T, F>(
+    db: &DB,
+    contract: ContractId,
+    mut pick: F,
+) -> Result<Option<T>, DatabaseError>
+where
+    DB: Database,
+    F: FnMut(&StoredEvent) -> Option<T>,
+{
+    for (_key, ev) in events_of(db, contract)?.into_iter().rev() {
+        if let Some(v) = pick(&ev) {
+            return Ok(Some(v));
+        }
+    }
+    Ok(None)
+}

--- a/crates/chain/index-contracts/src/reducer.rs
+++ b/crates/chain/index-contracts/src/reducer.rs
@@ -1,0 +1,278 @@
+//! Delegated per-contract reducers: the [`Reducer`] enum the one
+//! [`ContractIndexer`](crate::indexer::ContractIndexer) dispatches, and the
+//! concrete [`PostageReducer`].
+//!
+//! # The model
+//!
+//! A reducer is a value, one per [`ContractId`] that earns an eager projection.
+//! It is an **enum**, not a trait object, so each arm receives the concrete
+//! `&TX: DbTxMut` without object-safety contortions (a `dyn` method generic over
+//! `TX` is not object-safe). A contract that needs no eager structure has **no
+//! reducer arm**, stays pure-lazy, and pays nothing.
+//!
+//! Two invariants are non-negotiable:
+//!
+//! - **A malformed body can never wedge the cursor.** [`Reducer::reduce`] decodes
+//!   with a concrete `sol!` type; a decode miss is a **skip** (`Ok(())`), never an
+//!   `Err`. The only error that escapes is a genuine storage fault, which
+//!   fail-stops. `reduce` runs in the SAME transaction as the verbatim
+//!   `put_event`, so the raw row, the projection, and the cursor commit
+//!   atomically.
+//! - **Revert is structural.** [`Reducer::rebuild`] clears the projection(s) and
+//!   replays [`reduce`](Reducer::reduce) over the surviving raw rows. No reducer
+//!   writes a bespoke undo. The default for a reducer-less contract is a no-op.
+
+use alloy_primitives::{Address, B256, U256};
+use alloy_sol_types::SolEvent;
+use vertex_storage::{DatabaseError, DbTxMut, IndexedWrite};
+
+use crate::registry::{ContractId, abi};
+use crate::store::{BatchByBalance, BatchKey, BatchState, BatchTable, EventKey, StoredEvent};
+
+/// A delegated per-contract reducer, dispatched by [`ContractId`].
+///
+/// One arm per contract that maintains an eager projection. Adding an eager
+/// contract is one arm plus its concrete reducer type; contracts without an arm
+/// stay verbatim-only.
+#[non_exhaustive]
+pub enum Reducer {
+    /// The postage batch-set reducer (the one eager projection today).
+    Postage(PostageReducer),
+}
+
+impl Reducer {
+    /// The contract this reducer maintains the projection for.
+    pub fn contract(&self) -> ContractId {
+        match self {
+            Self::Postage(_) => ContractId::Postage,
+        }
+    }
+
+    /// Decode `ev` and fold it into this reducer's typed projection(s).
+    ///
+    /// Runs in the verbatim `put_event` transaction. A decode miss is a skip
+    /// (`Ok(())`); the only error returned is a storage fault.
+    pub fn reduce<TX: DbTxMut>(
+        &self,
+        tx: &TX,
+        key: EventKey,
+        ev: &StoredEvent,
+    ) -> Result<(), DatabaseError> {
+        match self {
+            Self::Postage(r) => r.reduce(tx, key, ev),
+        }
+    }
+
+    /// Clear this reducer's projection(s) and replay [`reduce`](Self::reduce)
+    /// over the surviving raw rows.
+    ///
+    /// The structural-revert half: after the raw tail is range-deleted, the
+    /// projection is rebuilt from exactly the rows that survived, so it can never
+    /// drift from the source of truth. `surviving` is this contract's remaining
+    /// `EventTable` rows in canonical order.
+    pub fn rebuild<TX: DbTxMut>(
+        &self,
+        tx: &TX,
+        surviving: &[(EventKey, StoredEvent)],
+    ) -> Result<(), DatabaseError> {
+        match self {
+            Self::Postage(r) => r.rebuild(tx, surviving),
+        }
+    }
+}
+
+/// The postage reducer: maintains the live [`BatchTable`] projection and its
+/// self-healing value-sorted [`BatchByBalance`] index.
+///
+/// Faithful to the prior hardcoded carve-out: `BatchCreated` opens (or refreshes)
+/// the row; `BatchTopUp` / `BatchDepthIncrease` read-modify-write the existing row
+/// so the index follows the live balance; a mutation for a batch whose create is
+/// outside the indexed window is dropped rather than fabricating a partial row.
+///
+/// The `BatchTable` + index are a pure ordering HINT (the reserve recomputes truth
+/// at dequeue); they are not the source of truth, which stays the verbatim
+/// `EventTable`.
+//
+// TODO(#326): the incremental `PostageSummary` running-summary projection
+// (O(1) `current_total_out_payment`) slots in here as a second projection this
+// reducer maintains on each `PriceUpdate`. Until then `current_total_out_payment`
+// / `chain_state` stay a read-time re-fold (see `views::postage`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PostageReducer;
+
+impl PostageReducer {
+    fn reduce<TX: DbTxMut>(
+        &self,
+        tx: &TX,
+        key: EventKey,
+        ev: &StoredEvent,
+    ) -> Result<(), DatabaseError> {
+        // Decode into a typed update; a non-batch event or a decode miss yields
+        // None and is a skip (never an error), so a malformed body cannot wedge
+        // the cursor.
+        let Some(update) = batch_update_from_event(ev, key.block) else {
+            return Ok(());
+        };
+        apply_batch_update(tx, update)
+    }
+
+    fn rebuild<TX: DbTxMut>(
+        &self,
+        tx: &TX,
+        surviving: &[(EventKey, StoredEvent)],
+    ) -> Result<(), DatabaseError> {
+        // Drop the whole projection + index, then re-fold the surviving postage
+        // rows. A batch created BEFORE the revert boundary but mutated within the
+        // reverted range carries a now-stale balance/index slot; keying the drop
+        // on the create block would miss those, so the full rebuild from
+        // surviving rows is the unambiguously-consistent choice.
+        tx.clear_indexed::<BatchByBalance>()?;
+        for (key, ev) in surviving {
+            if let Some(update) = batch_update_from_event(ev, key.block) {
+                apply_batch_update(tx, update)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A typed update to the postage batch projection, derived from a decoded batch
+/// lifecycle event. Applied by [`apply_batch_update`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchUpdate {
+    /// `BatchCreated`: open (or refresh) the full row.
+    Created {
+        /// The on-chain batch id.
+        batch_id: B256,
+        /// The batch owner.
+        owner: Address,
+        /// The batch depth.
+        depth: u8,
+        /// The batch bucket depth.
+        bucket_depth: u8,
+        /// The created `normalisedBalance`.
+        normalised_balance: U256,
+        /// Whether the batch is immutable.
+        immutable: bool,
+        /// The creation block.
+        start_block: u64,
+    },
+    /// `BatchTopUp`: raise the balance on the existing row.
+    Balance {
+        /// The on-chain batch id.
+        batch_id: B256,
+        /// The new `normalisedBalance`.
+        normalised_balance: U256,
+    },
+    /// `BatchDepthIncrease`: raise depth and re-normalise the balance.
+    Depth {
+        /// The on-chain batch id.
+        batch_id: B256,
+        /// The new depth.
+        new_depth: u8,
+        /// The re-normalised `normalisedBalance`.
+        normalised_balance: U256,
+    },
+}
+
+/// Apply a [`BatchUpdate`] to the typed projection, maintaining the value-sorted
+/// index self-healingly (a topup that raises the balance moves the index key).
+///
+/// `Created` writes the full row; `Balance` / `Depth` read-modify-write the
+/// existing row so the index follows the live balance. A topup or depth-increase
+/// for a batch whose create is outside the indexed window is dropped rather than
+/// fabricating a partial row.
+pub(crate) fn apply_batch_update<TX: DbTxMut>(
+    tx: &TX,
+    update: BatchUpdate,
+) -> Result<(), DatabaseError> {
+    match update {
+        BatchUpdate::Created {
+            batch_id,
+            owner,
+            depth,
+            bucket_depth,
+            normalised_balance,
+            immutable,
+            start_block,
+        } => {
+            // Preserve the original creation block if the batch is already known
+            // (a duplicate create only refreshes the mutable fields).
+            let start_block = tx
+                .get::<BatchTable>(BatchKey(batch_id))?
+                .map_or(start_block, |b| b.start_block);
+            tx.put_indexed::<BatchByBalance>(
+                BatchKey(batch_id),
+                BatchState {
+                    batch_id,
+                    owner,
+                    depth,
+                    bucket_depth,
+                    normalised_balance,
+                    immutable,
+                    start_block,
+                },
+            )
+        }
+        BatchUpdate::Balance {
+            batch_id,
+            normalised_balance,
+        } => {
+            let Some(mut state) = tx.get::<BatchTable>(BatchKey(batch_id))? else {
+                return Ok(());
+            };
+            state.normalised_balance = normalised_balance;
+            tx.put_indexed::<BatchByBalance>(BatchKey(batch_id), state)
+        }
+        BatchUpdate::Depth {
+            batch_id,
+            new_depth,
+            normalised_balance,
+        } => {
+            let Some(mut state) = tx.get::<BatchTable>(BatchKey(batch_id))? else {
+                return Ok(());
+            };
+            state.depth = new_depth;
+            state.normalised_balance = normalised_balance;
+            tx.put_indexed::<BatchByBalance>(BatchKey(batch_id), state)
+        }
+    }
+}
+
+/// Decode a stored postage event into the typed [`BatchUpdate`] that maintains
+/// the value-sorted index, or `None` for a non-batch event or a decode miss.
+///
+/// `block` is the row's creation block, used for a `Created` update's
+/// `start_block`. The shared decode the live `reduce` path and the revert rebuild
+/// both use, so the projection is derived identically whether built forward or
+/// rebuilt from surviving rows.
+pub(crate) fn batch_update_from_event(ev: &StoredEvent, block: u64) -> Option<BatchUpdate> {
+    let data = ev.log_data();
+    if ev.topic0 == abi::BatchCreated::SIGNATURE_HASH {
+        let e = abi::BatchCreated::decode_log_data(&data).ok()?;
+        Some(BatchUpdate::Created {
+            batch_id: e.batchId,
+            owner: e.owner,
+            depth: e.depth,
+            bucket_depth: e.bucketDepth,
+            normalised_balance: e.normalisedBalance,
+            immutable: e.immutableFlag,
+            start_block: block,
+        })
+    } else if ev.topic0 == abi::BatchTopUp::SIGNATURE_HASH {
+        let e = abi::BatchTopUp::decode_log_data(&data).ok()?;
+        Some(BatchUpdate::Balance {
+            batch_id: e.batchId,
+            normalised_balance: e.normalisedBalance,
+        })
+    } else if ev.topic0 == abi::BatchDepthIncrease::SIGNATURE_HASH {
+        let e = abi::BatchDepthIncrease::decode_log_data(&data).ok()?;
+        Some(BatchUpdate::Depth {
+            batch_id: e.batchId,
+            new_depth: e.newDepth,
+            normalised_balance: e.normalisedBalance,
+        })
+    } else {
+        None
+    }
+}

--- a/crates/chain/index-contracts/src/store.rs
+++ b/crates/chain/index-contracts/src/store.rs
@@ -25,16 +25,13 @@
 //! needs. It is a pure ordering HINT carrying no decision: the index orders
 //! batches by `normalisedBalance`, and the reserve recomputes true value at
 //! dequeue against the live block clock (see `CHAIN_REACTIONS_DESIGN.md`). It is
-//! self-healing via [`vertex_storage::IndexedWrite`] and range-reverted
-//! alongside [`EventTable`].
+//! maintained by the [`PostageReducer`](crate::reducer::PostageReducer) via
+//! [`vertex_storage::IndexedWrite`] and rebuilt from surviving rows on revert.
 
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_rpc_types_eth::Log;
 use serde::{Deserialize, Serialize};
-use vertex_chain_index::IndexError;
-use vertex_storage::{
-    Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, IndexedWrite, Table, Tables,
-};
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table, Tables};
 
 use crate::registry::ContractId;
 
@@ -48,11 +45,12 @@ pub const MAX_EVENT_DATA: usize = 8 * 1024;
 
 vertex_storage::table!(pub EventTable, "chain_events", EventKey, StoredEvent);
 
-// The typed postage batch projection and its value-sorted index. Uncompressed
-// (the index macro forces this for the index) and small.
-vertex_storage::table!(pub BatchTable, "postage_batches", BatchKey, BatchState);
+// The typed postage batch projection and its value-sorted index, declared via
+// the projection framework (see `crate::projection`). Both are uncompressed and
+// small.
+crate::projection!(pub BatchTable, "postage_batches", BatchKey, BatchState);
 
-vertex_storage::index!(
+crate::secondary_index!(
     pub BatchByBalance,
     "postage_batch_by_balance",
     BalanceKey,
@@ -110,6 +108,15 @@ impl EventKey {
             contract,
             block: from_block,
             log_index: 0,
+        }
+    }
+
+    /// The last key of `contract`'s range (block/log saturated to `MAX`).
+    pub const fn range_end(contract: ContractId) -> Self {
+        Self {
+            contract,
+            block: u64::MAX,
+            log_index: u64::MAX,
         }
     }
 }
@@ -219,6 +226,26 @@ pub struct BalanceKey {
     pub batch_id: B256,
 }
 
+impl BalanceKey {
+    /// The smallest possible index key (balance 0, zero batch id): the inclusive
+    /// lower bound of an ascending [`range_head`](crate::projection::range_head).
+    pub const fn min() -> Self {
+        Self {
+            balance: U256::ZERO,
+            batch_id: B256::ZERO,
+        }
+    }
+
+    /// The largest possible index key (max balance, all-ones batch id): the
+    /// inclusive upper bound of an ascending range scan.
+    pub const fn max() -> Self {
+        Self {
+            balance: U256::MAX,
+            batch_id: B256::repeat_byte(0xff),
+        }
+    }
+}
+
 impl Encode for BalanceKey {
     type Encoded = [u8; 64];
 
@@ -242,13 +269,14 @@ impl Decode for BalanceKey {
     }
 }
 
-/// The typed postage batch projection row, fed alongside the verbatim
+/// The typed postage batch projection row, maintained by the
+/// [`PostageReducer`](crate::reducer::PostageReducer) alongside the verbatim
 /// [`EventTable`] write for `Postage` rows only.
 ///
-/// This carries the small set of fields the value-sorted eviction index needs;
-/// the authoritative event history stays in [`EventTable`], and the lazy
-/// [`views::postage`](crate::views::postage) validity fold reads that. This row
-/// exists only so [`BatchByBalance`] has a typed value to extract from.
+/// This carries the small set of fields the value-sorted eviction index needs
+/// plus the `owner` (so `batches_by_owner` needs no second table); the
+/// authoritative event history stays in [`EventTable`], and the lazy
+/// [`views::postage`](crate::views::postage) validity fold reads that.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BatchState {
     /// The on-chain batch id, carried so the value-sorted index key
@@ -286,113 +314,10 @@ pub(crate) fn put_event<TX: DbTxMut>(
     Ok(true)
 }
 
-/// A typed update to the postage batch projection, derived from a decoded batch
-/// lifecycle event. Applied by [`apply_batch_update`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BatchUpdate {
-    /// `BatchCreated`: open (or refresh) the full row.
-    Created {
-        /// The on-chain batch id.
-        batch_id: B256,
-        /// The batch owner.
-        owner: Address,
-        /// The batch depth.
-        depth: u8,
-        /// The batch bucket depth.
-        bucket_depth: u8,
-        /// The created `normalisedBalance`.
-        normalised_balance: U256,
-        /// Whether the batch is immutable.
-        immutable: bool,
-        /// The creation block.
-        start_block: u64,
-    },
-    /// `BatchTopUp`: raise the balance on the existing row.
-    Balance {
-        /// The on-chain batch id.
-        batch_id: B256,
-        /// The new `normalisedBalance`.
-        normalised_balance: U256,
-    },
-    /// `BatchDepthIncrease`: raise depth and re-normalise the balance.
-    Depth {
-        /// The on-chain batch id.
-        batch_id: B256,
-        /// The new depth.
-        new_depth: u8,
-        /// The re-normalised `normalisedBalance`.
-        normalised_balance: U256,
-    },
-}
-
-/// Apply a [`BatchUpdate`] to the typed projection, maintaining the value-sorted
-/// index self-healingly (a topup that raises the balance moves the index key).
-///
-/// `Created` writes the full row; `Balance` / `Depth` read-modify-write the
-/// existing row so the index follows the live balance. A topup or depth-increase
-/// for a batch whose create is outside the indexed window is dropped rather than
-/// fabricating a partial row, matching the per-branch behaviour.
-pub(crate) fn apply_batch_update<TX: DbTxMut>(
-    tx: &TX,
-    update: BatchUpdate,
-) -> Result<(), DatabaseError> {
-    match update {
-        BatchUpdate::Created {
-            batch_id,
-            owner,
-            depth,
-            bucket_depth,
-            normalised_balance,
-            immutable,
-            start_block,
-        } => {
-            // Preserve the original creation block if the batch is already known
-            // (a duplicate create only refreshes the mutable fields).
-            let start_block = tx
-                .get::<BatchTable>(BatchKey(batch_id))?
-                .map_or(start_block, |b| b.start_block);
-            tx.put_indexed::<BatchByBalance>(
-                BatchKey(batch_id),
-                BatchState {
-                    batch_id,
-                    owner,
-                    depth,
-                    bucket_depth,
-                    normalised_balance,
-                    immutable,
-                    start_block,
-                },
-            )
-        }
-        BatchUpdate::Balance {
-            batch_id,
-            normalised_balance,
-        } => {
-            let Some(mut state) = tx.get::<BatchTable>(BatchKey(batch_id))? else {
-                return Ok(());
-            };
-            state.normalised_balance = normalised_balance;
-            tx.put_indexed::<BatchByBalance>(BatchKey(batch_id), state)
-        }
-        BatchUpdate::Depth {
-            batch_id,
-            new_depth,
-            normalised_balance,
-        } => {
-            let Some(mut state) = tx.get::<BatchTable>(BatchKey(batch_id))? else {
-                return Ok(());
-            };
-            state.depth = new_depth;
-            state.normalised_balance = normalised_balance;
-            tx.put_indexed::<BatchByBalance>(BatchKey(batch_id), state)
-        }
-    }
-}
-
 /// Read a contract's stored events in canonical `(block, log_index)` order.
 ///
-/// The fold backbone of every view. It scans ONLY this contract's key range
-/// `[range_start(contract) ..= (contract, MAX, MAX)]` via the storage trait's
+/// The fold backbone of every lazy view. It scans ONLY this contract's key range
+/// `[range_start(contract) ..= range_end(contract)]` via the storage trait's
 /// bounded [`range`](vertex_storage::DbTx::range), so a view fold over months of
 /// multi-contract history touches just the one contract's rows instead of
 /// materializing the whole table. Because [`EventKey`] is namespaced by the
@@ -403,115 +328,25 @@ pub(crate) fn events_of<DB: Database>(
     db: &DB,
     contract: ContractId,
 ) -> Result<Vec<(EventKey, StoredEvent)>, DatabaseError> {
-    let lo = EventKey::range_start(contract);
-    let hi = EventKey {
-        contract,
-        block: u64::MAX,
-        log_index: u64::MAX,
-    };
-    db.view(|tx| tx.range::<EventTable>(lo, hi))
+    db.view(|tx| {
+        tx.range::<EventTable>(
+            EventKey::range_start(contract),
+            EventKey::range_end(contract),
+        )
+    })
 }
 
-/// Range-delete a contract's events (and, for postage, the batch projection +
-/// index) from `from_block` onward.
-///
-/// The generic `revert(from_block)` body. Because every view derives purely from
-/// the raw rows, deleting the reorged-out range is necessary and sufficient: no
-/// view holds independent state revert could miss. The MVP engine indexes
-/// finalized-only and never calls this; it is correct-by-construction today and
-/// correct-by-design when head-tracking arrives.
-pub(crate) fn revert_contract<DB: Database>(
-    db: &DB,
+/// Read a contract's stored events within an open transaction (the in-tx twin of
+/// [`events_of`]), used by the generic revert to gather the surviving rows it
+/// hands to [`Reducer::rebuild`](crate::reducer::Reducer::rebuild).
+pub(crate) fn events_of_tx<TX: DbTx>(
+    tx: &TX,
     contract: ContractId,
-    from_block: u64,
-) -> Result<(), IndexError> {
-    db.update(|tx| {
-        // The keys to drop: this contract's events at or after from_block, found
-        // by a bounded range scan over just this contract's tail range.
-        let doomed_lo = EventKey::range_from(contract, from_block);
-        let doomed_hi = EventKey {
-            contract,
-            block: u64::MAX,
-            log_index: u64::MAX,
-        };
-        let doomed: Vec<EventKey> = tx
-            .range::<EventTable>(doomed_lo, doomed_hi)?
-            .into_iter()
-            .map(|(k, _)| k)
-            .collect();
-        for key in doomed {
-            tx.delete::<EventTable>(key)?;
-        }
-
-        // The postage batch projection mirrors EventTable, but a batch created
-        // BEFORE from_block and mutated (topped up / depth-increased) within the
-        // reverted range carries a now-stale balance and a stale index slot.
-        // Keying the drop on `start_block >= from_block` would miss those. So
-        // rebuild the whole projection from the surviving verbatim rows: drop
-        // every batch row + index entry, then re-fold the remaining
-        // `EventTable` Postage rows (which are already truncated to
-        // `< from_block`). This is unambiguously consistent with the source of
-        // truth and the MVP never calls revert, so the full rebuild is cheap.
-        if contract == ContractId::Postage {
-            tx.clear_indexed::<BatchByBalance>()?;
-            let lo = EventKey::range_start(ContractId::Postage);
-            let hi = EventKey {
-                contract: ContractId::Postage,
-                block: u64::MAX,
-                log_index: u64::MAX,
-            };
-            for (key, ev) in tx.range::<EventTable>(lo, hi)? {
-                if let Some(update) = batch_update_from_event(&ev, key.block) {
-                    apply_batch_update(tx, update)?;
-                }
-            }
-        }
-
-        Ok(())
-    })?;
-    Ok(())
-}
-
-/// Decode a stored postage event into the typed [`BatchUpdate`] that maintains
-/// the value-sorted index, or `None` for a non-batch event or a decode miss.
-///
-/// `block` is the row's creation block, used for a `Created` update's
-/// `start_block`. This is the shared decode the live `apply` path and the revert
-/// rebuild both use, so the projection is derived identically whether built
-/// forward or rebuilt from surviving rows.
-pub(crate) fn batch_update_from_event(ev: &StoredEvent, block: u64) -> Option<BatchUpdate> {
-    use alloy_sol_types::SolEvent;
-
-    use crate::registry::abi;
-
-    let data = ev.log_data();
-    if ev.topic0 == abi::BatchCreated::SIGNATURE_HASH {
-        let e = abi::BatchCreated::decode_log_data(&data).ok()?;
-        Some(BatchUpdate::Created {
-            batch_id: e.batchId,
-            owner: e.owner,
-            depth: e.depth,
-            bucket_depth: e.bucketDepth,
-            normalised_balance: e.normalisedBalance,
-            immutable: e.immutableFlag,
-            start_block: block,
-        })
-    } else if ev.topic0 == abi::BatchTopUp::SIGNATURE_HASH {
-        let e = abi::BatchTopUp::decode_log_data(&data).ok()?;
-        Some(BatchUpdate::Balance {
-            batch_id: e.batchId,
-            normalised_balance: e.normalisedBalance,
-        })
-    } else if ev.topic0 == abi::BatchDepthIncrease::SIGNATURE_HASH {
-        let e = abi::BatchDepthIncrease::decode_log_data(&data).ok()?;
-        Some(BatchUpdate::Depth {
-            batch_id: e.batchId,
-            new_depth: e.newDepth,
-            normalised_balance: e.normalisedBalance,
-        })
-    } else {
-        None
-    }
+) -> Result<Vec<(EventKey, StoredEvent)>, DatabaseError> {
+    tx.range::<EventTable>(
+        EventKey::range_start(contract),
+        EventKey::range_end(contract),
+    )
 }
 
 /// Build a [`StoredEvent`] from a provider [`Log`], enforcing the EVM topic

--- a/crates/chain/index-contracts/src/tests.rs
+++ b/crates/chain/index-contracts/src/tests.rs
@@ -203,6 +203,146 @@ fn replayed_log_is_idempotent() {
 }
 
 #[test]
+fn malformed_reducer_body_skips_not_wedges() {
+    // A declared postage topic0 (BatchCreated) with a garbage ABI body must:
+    //  (1) NOT error apply (the cursor advances), and
+    //  (2) still land the verbatim row,
+    //  (3) but produce NO projection row (the reducer decode miss is a skip).
+    // This is the non-negotiable invariant: a malformed body can never wedge the
+    // shared cursor through the reducer path.
+    let (db, indexer) = harness();
+    let topic0 = abi::BatchCreated::SIGNATURE_HASH;
+    let garbage = Bytes::from(vec![0xFFu8; 3]); // far too short for the ABI tail
+    let data = LogData::new_unchecked(vec![topic0], garbage);
+    let log = log_from(12, 0, POSTAGE_ADDR, data);
+    indexer
+        .apply(12, &log)
+        .expect("a malformed reducer body must not error apply");
+
+    // The verbatim row landed (source of truth keeps the bytes).
+    let stored = db
+        .view(|tx| {
+            tx.get::<EventTable>(EventKey {
+                contract: ContractId::Postage,
+                block: 12,
+                log_index: 0,
+            })
+        })
+        .unwrap();
+    assert!(stored.is_some(), "the verbatim row must still be stored");
+
+    // No projection row was fabricated from the undecodable body.
+    let candidates = postage::eviction_candidates(&*db, 10).unwrap();
+    assert!(
+        candidates.is_empty(),
+        "a decode miss must produce no projection row"
+    );
+}
+
+#[test]
+fn postage_all_batches_and_by_owner() {
+    let (db, indexer) = harness();
+    let owner_a = address!("00000000000000000000000000000000000000a1");
+    let owner_b = address!("00000000000000000000000000000000000000b2");
+    let batch_a = B256::repeat_byte(0x1A);
+    let batch_b = B256::repeat_byte(0x2B);
+    let batch_c = B256::repeat_byte(0x3C);
+
+    for (i, id, owner, bal) in [
+        (0u64, batch_a, owner_a, 100u64),
+        (1u64, batch_b, owner_a, 200u64),
+        (2u64, batch_c, owner_b, 300u64),
+    ] {
+        apply(
+            &indexer,
+            1,
+            i,
+            POSTAGE_ADDR,
+            &abi::BatchCreated {
+                batchId: id,
+                totalAmount: U256::from(bal),
+                normalisedBalance: U256::from(bal),
+                owner,
+                depth: 20,
+                bucketDepth: 16,
+                immutableFlag: false,
+            },
+        );
+    }
+
+    // all_batches returns every projection row.
+    let mut all: Vec<B256> = postage::all_batches(&*db)
+        .unwrap()
+        .into_iter()
+        .map(|b| b.batch_id)
+        .collect();
+    all.sort();
+    let mut expected = vec![batch_a, batch_b, batch_c];
+    expected.sort();
+    assert_eq!(all, expected);
+
+    // batches_by_owner filters on the projection's owner field (no second table).
+    let mut a_batches: Vec<B256> = postage::batches_by_owner(&*db, owner_a)
+        .unwrap()
+        .into_iter()
+        .map(|b| b.batch_id)
+        .collect();
+    a_batches.sort();
+    let mut a_expected = vec![batch_a, batch_b];
+    a_expected.sort();
+    assert_eq!(a_batches, a_expected);
+
+    let b_batches: Vec<B256> = postage::batches_by_owner(&*db, owner_b)
+        .unwrap()
+        .into_iter()
+        .map(|b| b.batch_id)
+        .collect();
+    assert_eq!(b_batches, vec![batch_c]);
+}
+
+#[test]
+fn postage_batches_by_balance_bounded_range() {
+    use crate::store::BalanceKey;
+    let (db, indexer) = harness();
+    let low = B256::repeat_byte(0x01);
+    let mid = B256::repeat_byte(0x02);
+    let high = B256::repeat_byte(0x03);
+    for (i, id, bal) in [(0u64, low, 10u64), (1, mid, 50u64), (2, high, 90u64)] {
+        apply(
+            &indexer,
+            1,
+            i,
+            POSTAGE_ADDR,
+            &abi::BatchCreated {
+                batchId: id,
+                totalAmount: U256::from(bal),
+                normalisedBalance: U256::from(bal),
+                owner: Address::ZERO,
+                depth: 20,
+                bucketDepth: 16,
+                immutableFlag: false,
+            },
+        );
+    }
+
+    // A bounded [20 ..= 100] range excludes the balance-10 batch and is limited.
+    let lo = BalanceKey {
+        balance: U256::from(20u64),
+        batch_id: B256::ZERO,
+    };
+    let hi = BalanceKey {
+        balance: U256::from(100u64),
+        batch_id: B256::repeat_byte(0xff),
+    };
+    let got = postage::batches_by_balance(&*db, lo, hi, 10).unwrap();
+    assert_eq!(got, vec![mid, high], "range must exclude balance-10 batch");
+
+    // The limit truncates the ascending head.
+    let head = postage::batches_by_balance(&*db, BalanceKey::min(), BalanceKey::max(), 1).unwrap();
+    assert_eq!(head, vec![low], "limit takes the lowest-balance head only");
+}
+
+#[test]
 fn postage_validity_fold() {
     let (db, indexer) = harness();
     let batch_id = B256::repeat_byte(0xAB);

--- a/crates/chain/index-contracts/src/views/chequebook.rs
+++ b/crates/chain/index-contracts/src/views/chequebook.rs
@@ -13,21 +13,24 @@ use alloy_sol_types::SolEvent;
 use nectar_contracts::IChequebookFactory;
 use vertex_storage::{Database, DatabaseError};
 
+use crate::projection::fold_events;
 use crate::registry::ContractId;
-use crate::store::events_of;
 
 /// Fold the factory-deployed chequebook set from the verbatim rows.
 fn deployed_set<DB: Database>(db: &DB) -> Result<HashSet<Address>, DatabaseError> {
-    let mut set = HashSet::new();
-    for (_key, ev) in events_of(db, ContractId::ChequebookFactory)? {
-        if ev.topic0 != IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH {
-            continue;
-        }
-        if let Ok(e) = IChequebookFactory::SimpleSwapDeployed::decode_log_data(&ev.log_data()) {
-            set.insert(e.contractAddress);
-        }
-    }
-    Ok(set)
+    fold_events(
+        db,
+        ContractId::ChequebookFactory,
+        HashSet::new(),
+        |set, _key, ev| {
+            if ev.topic0 != IChequebookFactory::SimpleSwapDeployed::SIGNATURE_HASH {
+                return;
+            }
+            if let Ok(e) = IChequebookFactory::SimpleSwapDeployed::decode_log_data(&ev.log_data()) {
+                set.insert(e.contractAddress);
+            }
+        },
+    )
 }
 
 /// Whether `chequebook` is in the factory-deployed set.

--- a/crates/chain/index-contracts/src/views/postage.rs
+++ b/crates/chain/index-contracts/src/views/postage.rs
@@ -1,5 +1,6 @@
-//! Postage view: batch validity by lazy fold, and the value-sorted eviction
-//! hint over the one materialized index.
+//! Postage view: batch validity by lazy fold, and the eager batch-set queries
+//! over the [`BatchTable`] projection + its value-sorted [`BatchByBalance`]
+//! index, composed from the query combinators.
 //!
 //! The validity query reconstructs the contract's rising
 //! `currentTotalOutPayment(block)` line from the verbatim `PriceUpdate` cadence
@@ -8,16 +9,19 @@
 //! does. This is the lazy compute-at-time the design mandates: it reads the
 //! verbatim store plus the live block clock and fires nothing.
 //!
-//! The eviction surface reads the [`BatchByBalance`] index head (the
-//! soonest-to-expire batch by balance) as an ordering HINT; the reserve
-//! recomputes truth at dequeue and skip-and-reinserts if stale.
+//! The eager batch queries (`batch_state`, `all_batches`, `batches_by_owner`,
+//! `batches_by_balance`) read the [`PostageReducer`](crate::reducer::PostageReducer)
+//! projection through the combinators. `batches_by_balance` is the value-sorted
+//! eviction HINT; the reserve recomputes truth at dequeue and skip-reinserts if
+//! stale.
 
 use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolEvent;
-use vertex_storage::{Database, DatabaseError, DbTx};
+use vertex_storage::{Database, DatabaseError};
 
+use crate::projection::{fold_events, list_all, list_by, point_get, range_head};
 use crate::registry::{ContractId, abi};
-use crate::store::{BatchByBalance, BatchKey, BatchState, BatchTable, events_of};
+use crate::store::{BalanceKey, BatchKey, BatchState, BatchTable};
 
 /// The contract's pricing chain-state, reconstructed from the `PriceUpdate`
 /// cadence: the per-chunk total-out-payment accumulated up to
@@ -58,28 +62,44 @@ impl ChainState {
 /// Reconstruct the contract's pricing chain-state by folding the verbatim
 /// `PriceUpdate` cadence in canonical order.
 ///
-/// This is the read-time replacement for the branch's `ChainStateTable`: the
-/// position-ordered raw rows are folded on demand, decoding each `PriceUpdate`.
-///
-/// Returns `None` when NO `PriceUpdate` has been indexed yet. This is the
-/// fail-safe the branch had: a zero-default `ChainState` makes
+/// The read-time re-fold over the [`fold_events`] backbone. Returns `None` when
+/// NO `PriceUpdate` has been indexed yet: a zero-default `ChainState` makes
 /// `current_total_out_payment` return 0, which would make every positive-balance
 /// batch validate forever. Distinguishing "no price seen" from "price 0" lets
 /// [`is_batch_valid_now`] answer `None` (not-yet-known) rather than a misleading
 /// `Some(true)` before the price cadence is known.
+//
+// TODO(#326): replace this read-time re-fold with an O(1) read of the incremental
+// `PostageSummary` projection the `PostageReducer` will maintain on each
+// `PriceUpdate`. The signature stays; only the body becomes a `scalar` read.
 pub fn chain_state<DB: Database>(db: &DB) -> Result<Option<ChainState>, DatabaseError> {
-    let mut state: Option<ChainState> = None;
-    for (key, ev) in events_of(db, ContractId::Postage)? {
-        if ev.topic0 != abi::PriceUpdate::SIGNATURE_HASH {
-            continue;
-        }
-        if let Ok(decoded) = abi::PriceUpdate::decode_log_data(&ev.log_data()) {
-            state
-                .get_or_insert_with(ChainState::default)
-                .fold_price_update(decoded.price, key.block);
-        }
-    }
-    Ok(state)
+    fold_events(
+        db,
+        ContractId::Postage,
+        None,
+        |state: &mut Option<ChainState>, key, ev| {
+            if ev.topic0 != abi::PriceUpdate::SIGNATURE_HASH {
+                return;
+            }
+            if let Ok(decoded) = abi::PriceUpdate::decode_log_data(&ev.log_data()) {
+                state
+                    .get_or_insert_with(ChainState::default)
+                    .fold_price_update(decoded.price, key.block);
+            }
+        },
+    )
+}
+
+/// The contract's `currentTotalOutPayment(block)`, the rising line a batch's
+/// `normalisedBalance` must stay above to remain valid, or `None` before any
+/// price cadence is indexed (the fail-safe).
+//
+// TODO(#326): becomes an O(1) extrapolation from the `PostageSummary` row.
+pub fn current_total_out_payment<DB: Database>(
+    db: &DB,
+    block: u64,
+) -> Result<Option<U256>, DatabaseError> {
+    Ok(chain_state(db)?.map(|cs| cs.current_total_out_payment(block)))
 }
 
 /// The folded current state of one batch, from its verbatim lifecycle events.
@@ -100,53 +120,57 @@ pub struct Batch {
 }
 
 /// Fold one batch's lifecycle (`BatchCreated` / `BatchTopUp` /
-/// `BatchDepthIncrease`) from the verbatim rows, in canonical order.
+/// `BatchDepthIncrease`) from the verbatim rows, in canonical order, over the
+/// [`fold_events`] backbone.
 ///
 /// Last-write-wins per field is implicit in the position order: later events
 /// overwrite earlier ones. Returns `None` if the batch was never created in the
 /// indexed window.
 pub fn batch<DB: Database>(db: &DB, batch_id: B256) -> Result<Option<Batch>, DatabaseError> {
-    let mut current: Option<Batch> = None;
-    for (key, ev) in events_of(db, ContractId::Postage)? {
-        let data = ev.log_data();
-        if ev.topic0 == abi::BatchCreated::SIGNATURE_HASH
-            && let Ok(d) = abi::BatchCreated::decode_log_data(&data)
-            && d.batchId == batch_id
-        {
-            let start_block = current.map_or(key.block, |b| b.start_block);
-            current = Some(Batch {
-                owner: d.owner,
-                depth: d.depth,
-                bucket_depth: d.bucketDepth,
-                normalised_balance: d.normalisedBalance,
-                immutable: d.immutableFlag,
-                start_block,
-            });
-        } else if ev.topic0 == abi::BatchTopUp::SIGNATURE_HASH
-            && let Ok(d) = abi::BatchTopUp::decode_log_data(&data)
-            && d.batchId == batch_id
-            && let Some(b) = current.as_mut()
-        {
-            b.normalised_balance = d.normalisedBalance;
-        } else if ev.topic0 == abi::BatchDepthIncrease::SIGNATURE_HASH
-            && let Ok(d) = abi::BatchDepthIncrease::decode_log_data(&data)
-            && d.batchId == batch_id
-            && let Some(b) = current.as_mut()
-        {
-            b.depth = d.newDepth;
-            b.normalised_balance = d.normalisedBalance;
-        }
-    }
-    Ok(current)
+    fold_events(
+        db,
+        ContractId::Postage,
+        None,
+        |current: &mut Option<Batch>, key, ev| {
+            let data = ev.log_data();
+            if ev.topic0 == abi::BatchCreated::SIGNATURE_HASH
+                && let Ok(d) = abi::BatchCreated::decode_log_data(&data)
+                && d.batchId == batch_id
+            {
+                let start_block = current.map_or(key.block, |b| b.start_block);
+                *current = Some(Batch {
+                    owner: d.owner,
+                    depth: d.depth,
+                    bucket_depth: d.bucketDepth,
+                    normalised_balance: d.normalisedBalance,
+                    immutable: d.immutableFlag,
+                    start_block,
+                });
+            } else if ev.topic0 == abi::BatchTopUp::SIGNATURE_HASH
+                && let Ok(d) = abi::BatchTopUp::decode_log_data(&data)
+                && d.batchId == batch_id
+                && let Some(b) = current.as_mut()
+            {
+                b.normalised_balance = d.normalisedBalance;
+            } else if ev.topic0 == abi::BatchDepthIncrease::SIGNATURE_HASH
+                && let Ok(d) = abi::BatchDepthIncrease::decode_log_data(&data)
+                && d.batchId == batch_id
+                && let Some(b) = current.as_mut()
+            {
+                b.depth = d.newDepth;
+                b.normalised_balance = d.normalisedBalance;
+            }
+        },
+    )
 }
 
 /// Whether `batch_id` is valid at `block`, against the verbatim store.
 ///
 /// `Some(valid)` once both the batch AND at least one `PriceUpdate` have been
 /// indexed; `None` while either is not yet known. Returning `None` (rather than
-/// `Some(true)`) before any price is folded is the fail-safe behaviour the branch
-/// had: without it, an absent price cadence makes `currentTotalOutPayment` zero
-/// and every positive-balance batch would validate forever, which would mask a
+/// `Some(true)`) before any price is folded is the fail-safe behaviour: without
+/// it, an absent price cadence makes `currentTotalOutPayment` zero and every
+/// positive-balance batch would validate forever, which would mask a
 /// wrong-address / wrong-ABI failure as "always valid". A consumer treats `None`
 /// as not-yet-known, not expired. The lazy compute-at-time query: it reads the
 /// store plus the live block clock and fires nothing.
@@ -167,16 +191,58 @@ pub fn is_batch_valid_now<DB: Database>(
     ))
 }
 
-/// The materialized batch projection row for `batch_id`, if any.
+/// The materialized batch projection row for `batch_id`, if any (`point_get`).
 ///
-/// Reads the typed [`BatchTable`] (the index's backing row), not the verbatim
-/// fold. This is the cheap point-read the eviction queue uses; for the
+/// Reads the typed [`BatchTable`] projection (the index's backing row), not the
+/// verbatim fold. This is the cheap point-read the eviction queue uses; for the
 /// authoritative balance history use [`batch`].
 pub fn batch_state<DB: Database>(
     db: &DB,
     batch_id: B256,
 ) -> Result<Option<BatchState>, DatabaseError> {
-    db.view(|tx| tx.get::<BatchTable>(BatchKey(batch_id)))
+    point_get::<BatchTable, _>(db, BatchKey(batch_id))
+}
+
+/// Every batch currently in the projection (`list_all`).
+pub fn all_batches<DB: Database>(db: &DB) -> Result<Vec<BatchState>, DatabaseError> {
+    Ok(list_all::<BatchTable, _>(db)?
+        .into_iter()
+        .map(|(_, v)| v)
+        .collect())
+}
+
+/// Every batch owned by `owner` (`list_by` on the projection's `owner` field).
+///
+/// `BatchState` already carries `owner`, so this is a filtered scan of the live
+/// projection with no second table.
+pub fn batches_by_owner<DB: Database>(
+    db: &DB,
+    owner: Address,
+) -> Result<Vec<BatchState>, DatabaseError> {
+    Ok(list_by::<BatchTable, _, _>(db, |b| b.owner == owner)?
+        .into_iter()
+        .map(|(_, v)| v)
+        .collect())
+}
+
+/// Batch ids ordered by ascending `normalisedBalance` within `[lo ..= hi]`,
+/// bounded to `limit` (`range_head` over [`BatchByBalance`]).
+///
+/// The #317 bounded read: it scans only the index's `[lo ..= hi]` window via
+/// `DbTx::range` and `take(limit)`s, instead of materializing the whole index and
+/// sorting in memory. A pure ordering HINT; the reserve recomputes truth at
+/// dequeue. Pass [`BalanceKey::min`]/[`BalanceKey::max`] for an unbounded
+/// balance range.
+pub fn batches_by_balance<DB: Database>(
+    db: &DB,
+    lo: BalanceKey,
+    hi: BalanceKey,
+    limit: usize,
+) -> Result<Vec<B256>, DatabaseError> {
+    Ok(range_head::<BatchTable, _>(db, lo, hi, limit)?
+        .into_iter()
+        .map(|pk| pk.0)
+        .collect())
 }
 
 /// The value-sorted eviction hint: batch ids ordered by ascending
@@ -187,24 +253,19 @@ pub fn batch_state<DB: Database>(
 /// block clock with [`is_batch_valid_now`], and skip-and-reinserts if stale.
 /// This function makes no decision and evicts nothing.
 ///
-/// The index is keyed by `(balance, batch_id)`, so iterating it ascending yields
-/// the soonest-to-expire batches first with a deterministic tie-break. This reads
-/// the whole index then `take(limit)`s the head; unlike `EventTable`, the
-/// `BatchByBalance` index holds at most one entry per LIVE batch (bounded by the
-/// active batch count, not by chain history), so the read is small. The `batchId`
-/// in the key makes it unique per batch, so no equal-balance batch is ever
-/// dropped from the hint (see `store.rs::BalanceKey`).
+/// This is the bounded #317 read: it scans only the head `limit` entries of the
+/// index via [`batches_by_balance`] (which uses `DbTx::range`), instead of a full
+/// `entries()` + in-memory sort.
+///
+/// Note: the `BatchByBalance` index holds one entry per *historically created*
+/// batch, NOT per *live* batch — it grows with chain history because no event
+/// signals expiry, so nothing prunes it here. The bounded read above makes this
+/// query cheap regardless; the unbounded-growth fix (a conservative `on_block`
+/// prune) is tracked separately as the second half of #317 and is NOT in this
+/// change.
 pub fn eviction_candidates<DB: Database>(
     db: &DB,
     limit: usize,
 ) -> Result<Vec<B256>, DatabaseError> {
-    db.view(|tx| {
-        let mut entries = tx.entries::<BatchByBalance>()?;
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
-        Ok(entries
-            .into_iter()
-            .take(limit)
-            .map(|(_, pk)| pk.0)
-            .collect())
-    })
+    batches_by_balance(db, BalanceKey::min(), BalanceKey::max(), limit)
 }

--- a/crates/chain/index-contracts/src/views/redistribution.rs
+++ b/crates/chain/index-contracts/src/views/redistribution.rs
@@ -67,13 +67,16 @@ pub struct RoundState {
 /// Fold the redistribution rows that carry a `roundNumber` into per-round state,
 /// grouped on the raw `U256` round number.
 ///
-/// Rows arrive in canonical position order, so appending commits/reveals
-/// preserves order; a replayed log at an already-seen position overwrites in
-/// place rather than duplicating.
+/// Built on the [`fold_events`](crate::projection::fold_events) backbone, which
+/// walks this contract's rows in canonical position order; appending
+/// commits/reveals therefore preserves order, and a replayed log at an
+/// already-seen position overwrites in place rather than duplicating. A decode
+/// miss on a row is skipped, keeping the running fold.
 fn fold_rounds<DB: Database>(db: &DB) -> Result<Vec<RoundState>, DatabaseError> {
     // Grouped on the raw U256 round number; a Vec keyed by linear search keeps
-    // the full-width key without a u64-narrowing map key.
-    let mut rounds: Vec<RoundState> = Vec::new();
+    // the full-width key without a u64-narrowing map key. This is the
+    // `fold_events` accumulator (`init`), grown by the step closure below.
+    let rounds: Vec<RoundState> = Vec::new();
 
     // Find or create the round bucket for `round`, returning a mutable handle.
     // A `Vec` keyed by linear search keeps the full-width `U256` key (rather
@@ -95,12 +98,12 @@ fn fold_rounds<DB: Database>(db: &DB) -> Result<Vec<RoundState>, DatabaseError> 
         rounds.get_mut(pos)
     }
 
-    for (key, ev) in events_of(db, ContractId::Redistribution)? {
+    crate::projection::fold_events(db, ContractId::Redistribution, rounds, |rounds, key, ev| {
         let data = ev.log_data();
         let pos = (key.block, key.log_index);
         if ev.topic0 == abi::Committed::SIGNATURE_HASH
             && let Ok(e) = abi::Committed::decode_log_data(&data)
-            && let Some(round) = round_mut(&mut rounds, e.roundNumber)
+            && let Some(round) = round_mut(rounds, e.roundNumber)
         {
             upsert_commit(
                 &mut round.commits,
@@ -112,7 +115,7 @@ fn fold_rounds<DB: Database>(db: &DB) -> Result<Vec<RoundState>, DatabaseError> 
             );
         } else if ev.topic0 == abi::Revealed::SIGNATURE_HASH
             && let Ok(e) = abi::Revealed::decode_log_data(&data)
-            && let Some(round) = round_mut(&mut rounds, e.roundNumber)
+            && let Some(round) = round_mut(rounds, e.roundNumber)
         {
             upsert_reveal(
                 &mut round.reveals,
@@ -127,12 +130,11 @@ fn fold_rounds<DB: Database>(db: &DB) -> Result<Vec<RoundState>, DatabaseError> 
             );
         } else if ev.topic0 == abi::CurrentRevealAnchor::SIGNATURE_HASH
             && let Ok(e) = abi::CurrentRevealAnchor::decode_log_data(&data)
-            && let Some(round) = round_mut(&mut rounds, e.roundNumber)
+            && let Some(round) = round_mut(rounds, e.roundNumber)
         {
             round.anchor = Some(e.anchor);
         }
-    }
-    Ok(rounds)
+    })
 }
 
 /// The folded state of round `round_number`, if any of its events were indexed.

--- a/crates/chain/index-contracts/src/views/staking.rs
+++ b/crates/chain/index-contracts/src/views/staking.rs
@@ -15,8 +15,8 @@ use alloy_sol_types::SolEvent;
 use nectar_contracts::IStakeRegistry;
 use vertex_storage::{Database, DatabaseError};
 
+use crate::projection::fold_events;
 use crate::registry::{ContractId, abi};
-use crate::store::events_of;
 
 /// One owner's folded stake state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -49,44 +49,48 @@ impl OwnerStake {
 
 /// Fold the whole staking event stream into a per-owner map.
 ///
-/// The single backbone fold every staking read narrows. Canonical position
-/// order makes last-write-wins implicit.
+/// The single backbone fold every staking read narrows, expressed over the
+/// framework's [`fold_events`] combinator. Canonical position order makes
+/// last-write-wins implicit.
 fn fold_owners<DB: Database>(db: &DB) -> Result<HashMap<Address, OwnerStake>, DatabaseError> {
-    let mut owners: HashMap<Address, OwnerStake> = HashMap::new();
-    for (_key, ev) in events_of(db, ContractId::Staking)? {
-        let data = ev.log_data();
-        if ev.topic0 == IStakeRegistry::StakeUpdated::SIGNATURE_HASH
-            && let Ok(e) = IStakeRegistry::StakeUpdated::decode_log_data(&data)
-        {
-            let s = owners.entry(e.owner).or_default();
-            s.committed = e.committedStake;
-            s.potential = e.potentialStake;
-            s.overlay = e.overlay;
-            s.height = e.height;
-            s.last_updated_block = e.lastUpdatedBlock;
-        } else if ev.topic0 == IStakeRegistry::StakeFrozen::SIGNATURE_HASH
-            && let Ok(e) = IStakeRegistry::StakeFrozen::decode_log_data(&data)
-        {
-            owners.entry(e.frozen).or_default().frozen_until = e.time;
-        } else if ev.topic0 == IStakeRegistry::StakeSlashed::SIGNATURE_HASH
-            && let Ok(e) = IStakeRegistry::StakeSlashed::decode_log_data(&data)
-        {
-            let s = owners.entry(e.slashed).or_default();
-            s.committed = U256::ZERO;
-            s.potential = U256::ZERO;
-        } else if ev.topic0 == IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH
-            && let Ok(e) = IStakeRegistry::StakeWithdrawn::decode_log_data(&data)
-        {
-            let s = owners.entry(e.node).or_default();
-            s.committed = U256::ZERO;
-            s.potential = U256::ZERO;
-        } else if ev.topic0 == abi::OverlayChanged::SIGNATURE_HASH
-            && let Ok(e) = abi::OverlayChanged::decode_log_data(&data)
-        {
-            owners.entry(e.owner).or_default().overlay = e.overlay;
-        }
-    }
-    Ok(owners)
+    fold_events(
+        db,
+        ContractId::Staking,
+        HashMap::<Address, OwnerStake>::new(),
+        |owners, _key, ev| {
+            let data = ev.log_data();
+            if ev.topic0 == IStakeRegistry::StakeUpdated::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeUpdated::decode_log_data(&data)
+            {
+                let s = owners.entry(e.owner).or_default();
+                s.committed = e.committedStake;
+                s.potential = e.potentialStake;
+                s.overlay = e.overlay;
+                s.height = e.height;
+                s.last_updated_block = e.lastUpdatedBlock;
+            } else if ev.topic0 == IStakeRegistry::StakeFrozen::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeFrozen::decode_log_data(&data)
+            {
+                owners.entry(e.frozen).or_default().frozen_until = e.time;
+            } else if ev.topic0 == IStakeRegistry::StakeSlashed::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeSlashed::decode_log_data(&data)
+            {
+                let s = owners.entry(e.slashed).or_default();
+                s.committed = U256::ZERO;
+                s.potential = U256::ZERO;
+            } else if ev.topic0 == IStakeRegistry::StakeWithdrawn::SIGNATURE_HASH
+                && let Ok(e) = IStakeRegistry::StakeWithdrawn::decode_log_data(&data)
+            {
+                let s = owners.entry(e.node).or_default();
+                s.committed = U256::ZERO;
+                s.potential = U256::ZERO;
+            } else if ev.topic0 == abi::OverlayChanged::SIGNATURE_HASH
+                && let Ok(e) = abi::OverlayChanged::decode_log_data(&data)
+            {
+                owners.entry(e.owner).or_default().overlay = e.overlay;
+            }
+        },
+    )
 }
 
 /// The folded stake row for `owner`, if the owner has ever been seen.

--- a/crates/chain/index-contracts/src/views/swap.rs
+++ b/crates/chain/index-contracts/src/views/swap.rs
@@ -10,49 +10,31 @@ use alloy_sol_types::SolEvent;
 use nectar_contracts::ISwapPriceOracle;
 use vertex_storage::{Database, DatabaseError};
 
+use crate::projection::last_event;
 use crate::registry::ContractId;
-use crate::store::events_of;
 
 /// The latest swap exchange rate (`PriceUpdate`), if ever set.
 pub fn exchange_rate<DB: Database>(db: &DB) -> Result<Option<U256>, DatabaseError> {
-    last_scalar(db, ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH, |data| {
-        ISwapPriceOracle::PriceUpdate::decode_log_data(data)
-            .ok()
-            .map(|e| e.price)
+    last_event(db, ContractId::SwapPriceOracle, |ev| {
+        (ev.topic0 == ISwapPriceOracle::PriceUpdate::SIGNATURE_HASH)
+            .then(|| {
+                ISwapPriceOracle::PriceUpdate::decode_log_data(&ev.log_data())
+                    .ok()
+                    .map(|e| e.price)
+            })
+            .flatten()
     })
 }
 
 /// The latest cheque value deduction (`ChequeValueDeductionUpdate`), if ever set.
 pub fn cheque_value_deduction<DB: Database>(db: &DB) -> Result<Option<U256>, DatabaseError> {
-    last_scalar(
-        db,
-        ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH,
-        |data| {
-            ISwapPriceOracle::ChequeValueDeductionUpdate::decode_log_data(data)
-                .ok()
-                .map(|e| e.chequeValueDeduction)
-        },
-    )
-}
-
-/// Walk the swap oracle rows backward and return the first scalar of `topic0`
-/// that decodes; rows are position-ordered, so the last write wins.
-fn last_scalar<DB, F>(
-    db: &DB,
-    topic0: alloy_primitives::B256,
-    decode: F,
-) -> Result<Option<U256>, DatabaseError>
-where
-    DB: Database,
-    F: Fn(&alloy_primitives::LogData) -> Option<U256>,
-{
-    let rows = events_of(db, ContractId::SwapPriceOracle)?;
-    for (_key, ev) in rows.into_iter().rev() {
-        if ev.topic0 == topic0
-            && let Some(v) = decode(&ev.log_data())
-        {
-            return Ok(Some(v));
-        }
-    }
-    Ok(None)
+    last_event(db, ContractId::SwapPriceOracle, |ev| {
+        (ev.topic0 == ISwapPriceOracle::ChequeValueDeductionUpdate::SIGNATURE_HASH)
+            .then(|| {
+                ISwapPriceOracle::ChequeValueDeductionUpdate::decode_log_data(&ev.log_data())
+                    .ok()
+                    .map(|e| e.chequeValueDeduction)
+            })
+            .flatten()
+    })
 }


### PR DESCRIPTION
## What

Generalizes the unified contract indexer from the single hard-coded postage carve-out into a per-contract **reducer** model with a uniform, deduplicated **query surface**, and converts the lazy views onto a shared fold backbone. Implements #325 and the bounded-read half of #317. Stacked on top of `feat/unified-chain-indexer` (#313).

See `CHAIN_INDEXER_PLAN.md` (§3 central decision, §4 Layers 2–3) for the full design and rationale.

## Changes

- **Reducer model** (`reducer.rs`): a `Reducer` enum (one arm per `ContractId`, `#[non_exhaustive]`) with `reduce` (decode-and-fold into typed projections, in the same tx as the verbatim `put_event`) and `rebuild` (clear + replay over surviving raw rows). A decode miss is a skip (`Ok`), never an `Err`, so a malformed body can never wedge the shared cursor; only a genuine storage fault escapes.
- **Dispatch** (`indexer.rs`): `apply` keeps its safety envelope verbatim (address→`ContractId`, topic0-declared check, `MAX_EVENT_DATA` cap, verbatim store) and replaces the hard-coded postage `if` with a generic reducer lookup; `revert` is now generic (per-contract range-delete of the raw tail + `reducer.rebuild`). The verbatim position-keyed `EventTable` remains the source of truth underneath the projections.
- **Query surface** (`projection.rs`): `Projection` / `IndexedProjection` traits, `projection!` / `secondary_index!` macros wrapping the storage primitives, and combinators `point_get` / `contains` / `list_all` / `list_by` / `get_via_index` / `range_head` / `scalar`, plus the lazy backbone `fold_events` / `last_event`.
- **Postage** rewritten onto the model: `PostageReducer` maintains `BatchTable` + `BatchByBalance`; new `all_batches()` and `batches_by_owner()` (no new table — `BatchState` already carries `owner`); `batches_by_balance(range, limit)`.
- **#317 bounded read**: `eviction_candidates` now uses a bounded `range_head` over `BatchByBalance` (`DbTx::range` + `take(limit)`) instead of materializing and sorting the whole index. The rustdoc's incorrect "bounded by live batch count" claim is corrected; the prune that fixes unbounded growth is tracked separately (#317 second half).
- **Lazy views** (staking / swap / chequebook / redistribution) converted from hand-rolled `events_of` folds to the `fold_events` / `last_event` backbone. Pure internal refactor; all public view signatures and behaviour unchanged. `redistribution::raw_events` keeps its direct passthrough to avoid cloning verbatim rows.

## Out of scope (tracked separately)

- Incremental `PostageSummary` running cumulative payment (#326) — `current_total_out_payment` stays a read-time re-fold for now, with a `TODO(#326)` marker.
- Clock-driven eviction prune (#317 second half), block stream / nudge (#327), WebSocket ingestion (#328).
- The `registry.rs` `canonical` address override (#315).

## Verification

`cargo check`, `cargo clippy --all-targets`, and `cargo test` for `vertex-chain-index-contracts` all pass: 24 unit tests green (the original 21 plus new `malformed_reducer_body_skips_not_wedges`, `postage_all_batches_and_by_owner`, `postage_batches_by_balance_bounded_range`), e2e fork test ignored as before. Cursor-wedge, revert, and idempotency tests pass unchanged.

Closes #325.
