### PR TITLE
perf(chain): maintain postage cumulative out-payment as an incremental summary

### DIFF
--- a/crates/chain/index-contracts/src/lib.rs
+++ b/crates/chain/index-contracts/src/lib.rs
@@ -90,8 +90,8 @@ pub use projection::{
 pub use reducer::{BatchUpdate, PostageReducer, Reducer};
 pub use registry::{ContractId, EventDescriptor, Network, WatchedContract, abi, registry};
 pub use store::{
-    BatchByBalance, BatchKey, BatchState, BatchTable, ContractIndexTables, EventKey, EventTable,
-    MAX_EVENT_DATA, StoredEvent,
+    BatchByBalance, BatchKey, BatchState, BatchTable, ChainState, ContractIndexTables, EventKey,
+    EventTable, MAX_EVENT_DATA, PostageSummary, StoredEvent, SummaryKey,
 };
 
 #[cfg(test)]

--- a/crates/chain/index-contracts/src/reducer.rs
+++ b/crates/chain/index-contracts/src/reducer.rs
@@ -27,7 +27,10 @@ use alloy_sol_types::SolEvent;
 use vertex_storage::{DatabaseError, DbTxMut, IndexedWrite};
 
 use crate::registry::{ContractId, abi};
-use crate::store::{BatchByBalance, BatchKey, BatchState, BatchTable, EventKey, StoredEvent};
+use crate::store::{
+    BatchByBalance, BatchKey, BatchState, BatchTable, EventKey, PostageSummary, StoredEvent,
+    SummaryKey,
+};
 
 /// A delegated per-contract reducer, dispatched by [`ContractId`].
 ///
@@ -92,11 +95,15 @@ impl Reducer {
 /// The `BatchTable` + index are a pure ordering HINT (the reserve recomputes truth
 /// at dequeue); they are not the source of truth, which stays the verbatim
 /// `EventTable`.
-//
-// TODO(#326): the incremental `PostageSummary` running-summary projection
-// (O(1) `current_total_out_payment`) slots in here as a second projection this
-// reducer maintains on each `PriceUpdate`. Until then `current_total_out_payment`
-// / `chain_state` stay a read-time re-fold (see `views::postage`).
+///
+/// It additionally maintains the single-row
+/// [`PostageSummary`](crate::store::PostageSummary) running cumulative-payment
+/// summary: each `PriceUpdate` settles the elapsed cost and adopts the new price
+/// incrementally, so `current_total_out_payment(block)` is an O(1) extrapolation
+/// from the stored triple instead of a re-fold of the entire price history. The
+/// fold cadence lives on [`ChainState`] so apply-time and rebuild share one code
+/// path; the summary stays block-clock-derived at READ, so `reduce` never depends
+/// on wall-clock and stays replay-safe.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PostageReducer;
 
@@ -107,9 +114,13 @@ impl PostageReducer {
         key: EventKey,
         ev: &StoredEvent,
     ) -> Result<(), DatabaseError> {
-        // Decode into a typed update; a non-batch event or a decode miss yields
-        // None and is a skip (never an error), so a malformed body cannot wedge
-        // the cursor.
+        // A PriceUpdate folds into the running summary incrementally; both paths
+        // are skips on a decode miss, so a malformed body never wedges the cursor.
+        if ev.topic0 == abi::PriceUpdate::SIGNATURE_HASH {
+            return fold_price_update(tx, ev, key.block);
+        }
+        // Decode into a typed batch update; a non-batch event or a decode miss
+        // yields None and is a skip (never an error).
         let Some(update) = batch_update_from_event(ev, key.block) else {
             return Ok(());
         };
@@ -121,19 +132,40 @@ impl PostageReducer {
         tx: &TX,
         surviving: &[(EventKey, StoredEvent)],
     ) -> Result<(), DatabaseError> {
-        // Drop the whole projection + index, then re-fold the surviving postage
-        // rows. A batch created BEFORE the revert boundary but mutated within the
-        // reverted range carries a now-stale balance/index slot; keying the drop
-        // on the create block would miss those, so the full rebuild from
-        // surviving rows is the unambiguously-consistent choice.
+        // Drop the whole projection + index AND the running summary, then re-fold
+        // the surviving postage rows through the same `reduce` paths. A batch
+        // created BEFORE the revert boundary but mutated within the reverted range
+        // carries a now-stale balance/index slot; keying the drop on the create
+        // block would miss those, so the full rebuild from surviving rows is the
+        // unambiguously-consistent choice. The summary is re-derived identically
+        // because `fold_price_update` is the same cadence used at apply-time.
         tx.clear_indexed::<BatchByBalance>()?;
+        tx.clear::<PostageSummary>()?;
         for (key, ev) in surviving {
-            if let Some(update) = batch_update_from_event(ev, key.block) {
-                apply_batch_update(tx, update)?;
-            }
+            self.reduce(tx, *key, ev)?;
         }
         Ok(())
     }
+}
+
+/// Fold a decoded `PriceUpdate` at `block` into the single-row
+/// [`PostageSummary`] incrementally: load the current [`ChainState`] (default if
+/// absent), settle the elapsed cost and adopt the new price via
+/// [`ChainState::fold_price_update`], then store it back.
+///
+/// A decode miss is a skip (`Ok(())`), never an error, so a malformed body cannot
+/// wedge the cursor. Runs in the same tx as the verbatim `put_event`.
+fn fold_price_update<TX: DbTxMut>(
+    tx: &TX,
+    ev: &StoredEvent,
+    block: u64,
+) -> Result<(), DatabaseError> {
+    let Ok(decoded) = abi::PriceUpdate::decode_log_data(&ev.log_data()) else {
+        return Ok(());
+    };
+    let mut state = tx.get::<PostageSummary>(SummaryKey)?.unwrap_or_default();
+    state.fold_price_update(decoded.price, block);
+    tx.put::<PostageSummary>(SummaryKey, state)
 }
 
 /// A typed update to the postage batch projection, derived from a decoded batch

--- a/crates/chain/index-contracts/src/store.rs
+++ b/crates/chain/index-contracts/src/store.rs
@@ -61,12 +61,21 @@ crate::secondary_index!(
     }
 );
 
+// The single-row postage pricing summary, declared via the projection framework.
+// One [`ChainState`] row at the constant [`SummaryKey`], maintained incrementally
+// by the [`PostageReducer`](crate::reducer::PostageReducer) on each `PriceUpdate`.
+crate::projection!(pub PostageSummary, "postage_summary", SummaryKey, ChainState);
+
 /// The set of tables this crate persists, for one-shot initialization.
 pub struct ContractIndexTables;
 
 impl Tables for ContractIndexTables {
-    const NAMES: &'static [&'static str] =
-        &[EventTable::NAME, BatchTable::NAME, BatchByBalance::NAME];
+    const NAMES: &'static [&'static str] = &[
+        EventTable::NAME,
+        BatchTable::NAME,
+        BatchByBalance::NAME,
+        PostageSummary::NAME,
+    ];
 }
 
 impl ContractIndexTables {
@@ -295,6 +304,84 @@ pub struct BatchState {
     pub immutable: bool,
     /// The block the batch was created in.
     pub start_block: u64,
+}
+
+/// The [`PostageSummary`] key: a zero-sized constant, since the summary is a
+/// single row.
+///
+/// The projection holds exactly one [`ChainState`] for the postage contract, so
+/// it lives at one well-known key. Encoded as a constant zero-length byte string,
+/// it gives the single-row table a stable, unique slot that
+/// [`scalar`](crate::projection::scalar) reads without naming a sentinel value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+pub struct SummaryKey;
+
+impl Encode for SummaryKey {
+    type Encoded = [u8; 0];
+
+    fn encode(self) -> Self::Encoded {
+        []
+    }
+}
+
+impl Decode for SummaryKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        if value.is_empty() {
+            Ok(Self)
+        } else {
+            Err(DatabaseError::Decode)
+        }
+    }
+}
+
+/// The postage contract's pricing chain-state: the per-chunk total-out-payment
+/// accumulated up to `last_updated_block`, the price in force since, and that
+/// block.
+///
+/// Maintained incrementally by the [`PostageReducer`](crate::reducer::PostageReducer)
+/// as the single-row [`PostageSummary`] projection: each `PriceUpdate` settles the
+/// elapsed cost at the new price's block and adopts the new price (see
+/// [`fold_price_update`](ChainState::fold_price_update)). A read extrapolates the
+/// stored triple to any block ([`current_total_out_payment`](ChainState::current_total_out_payment)),
+/// so the summary is block-clock-derived AT READ and `reduce` never depends on
+/// wall-clock, keeping it replay-safe and idempotent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ChainState {
+    /// Per-chunk total-out-payment accumulated up to `last_updated_block`.
+    pub total_out_payment: U256,
+    /// Per-chunk-per-block price in force since `last_updated_block`.
+    pub last_price: U256,
+    /// The block the price last changed.
+    pub last_updated_block: u64,
+}
+
+impl ChainState {
+    /// The contract's `currentTotalOutPayment(block)`:
+    /// `total_out_payment + last_price * (block - last_updated_block)`.
+    ///
+    /// Blocks at or before `last_updated_block` contribute no elapsed cost,
+    /// matching the contract's saturating behaviour rather than underflowing.
+    /// This is the O(1) extrapolation a read performs on the stored triple.
+    pub fn current_total_out_payment(&self, block: u64) -> U256 {
+        let blocks = block.saturating_sub(self.last_updated_block);
+        self.total_out_payment + self.last_price * U256::from(blocks)
+    }
+
+    /// Fold a `PriceUpdate` at `block`, mirroring the contract's `setPrice`:
+    /// when the previous price is non-zero, settle the elapsed cost into
+    /// `total_out_payment` first, then adopt the new price at `block`.
+    ///
+    /// This is the single fold cadence the reducer's apply-time path and the
+    /// revert rebuild both use, so the summary is derived identically whether
+    /// built forward or replayed from surviving rows. It folds only the discrete
+    /// `PriceUpdate` event, never the wall clock.
+    pub fn fold_price_update(&mut self, price: U256, block: u64) {
+        if !self.last_price.is_zero() {
+            self.total_out_payment = self.current_total_out_payment(block);
+        }
+        self.last_price = price;
+        self.last_updated_block = block;
+    }
 }
 
 /// Write one event verbatim, enforcing the [`MAX_EVENT_DATA`] cap.

--- a/crates/chain/index-contracts/src/tests.rs
+++ b/crates/chain/index-contracts/src/tests.rs
@@ -616,6 +616,142 @@ fn revert_rebuilds_batch_projection_for_in_range_mutation() {
 }
 
 #[test]
+fn summary_total_out_payment_matches_old_fold() {
+    // The incremental summary must equal what a re-fold of the whole PriceUpdate
+    // cadence would yield, at several read blocks across a price sequence. The
+    // reference fold here is the same cadence the contract / old view used.
+    use crate::store::ChainState;
+    let (db, indexer) = harness();
+
+    // A sequence of price updates: (block, price).
+    let updates = [(100u64, 2u64), (200u64, 5u64), (450u64, 1u64)];
+    for (i, (block, price)) in updates.into_iter().enumerate() {
+        apply(
+            &indexer,
+            block,
+            i as u64,
+            POSTAGE_ADDR,
+            &abi::PriceUpdate {
+                price: U256::from(price),
+            },
+        );
+    }
+
+    // Reference: fold the same updates into a ChainState the long way.
+    let reference = |read_block: u64| -> U256 {
+        let mut cs = ChainState::default();
+        for (block, price) in updates {
+            cs.fold_price_update(U256::from(price), block);
+        }
+        cs.current_total_out_payment(read_block)
+    };
+
+    for read_block in [100u64, 150, 200, 300, 450, 1000] {
+        let got = postage::current_total_out_payment(&*db, read_block)
+            .unwrap()
+            .expect("summary present after price updates");
+        assert_eq!(
+            got,
+            reference(read_block),
+            "incremental summary must match the re-fold at block {read_block}"
+        );
+    }
+}
+
+#[test]
+fn summary_absent_fails_safe_for_positive_balance_batch() {
+    // Fail-safe via the summary: a positive-balance batch with NO PriceUpdate
+    // indexed yields an absent summary row, so validity is None (not Some(true)).
+    let (db, indexer) = harness();
+    let batch_id = B256::repeat_byte(0x7E);
+    apply(
+        &indexer,
+        50,
+        0,
+        POSTAGE_ADDR,
+        &abi::BatchCreated {
+            batchId: batch_id,
+            totalAmount: U256::from(1_000_000u64),
+            normalisedBalance: U256::from(1_000_000u64),
+            owner: Address::ZERO,
+            depth: 20,
+            bucketDepth: 16,
+            immutableFlag: false,
+        },
+    );
+
+    // No summary row, so current_total_out_payment and validity are unknown.
+    assert!(
+        postage::current_total_out_payment(&*db, 1000)
+            .unwrap()
+            .is_none(),
+        "current_total_out_payment must be None with no PriceUpdate (the fail-safe)"
+    );
+    assert_eq!(
+        postage::is_batch_valid_now(&*db, batch_id, 1000).unwrap(),
+        None,
+        "a positive-balance batch must not validate forever without a price cadence"
+    );
+}
+
+#[test]
+fn revert_rederives_summary() {
+    // A revert must re-derive the summary from surviving PriceUpdate rows: the
+    // reverted-out update is dropped and the summary reflects only survivors.
+    use crate::store::ChainState;
+    let (db, indexer) = harness();
+
+    apply(
+        &indexer,
+        100,
+        0,
+        POSTAGE_ADDR,
+        &abi::PriceUpdate {
+            price: U256::from(2u64),
+        },
+    );
+    apply(
+        &indexer,
+        300,
+        0,
+        POSTAGE_ADDR,
+        &abi::PriceUpdate {
+            price: U256::from(9u64),
+        },
+    );
+
+    // Both updates present: total at block 400 = settle(2*(300-100)) then 9*(400-300).
+    let mut full = ChainState::default();
+    full.fold_price_update(U256::from(2u64), 100);
+    full.fold_price_update(U256::from(9u64), 300);
+    assert_eq!(
+        postage::current_total_out_payment(&*db, 400).unwrap(),
+        Some(full.current_total_out_payment(400))
+    );
+
+    // Revert from block 200: the block-300 update is dropped; only the block-100
+    // update survives, and the summary is re-derived to match.
+    indexer.revert(200).expect("revert");
+    let mut survivor = ChainState::default();
+    survivor.fold_price_update(U256::from(2u64), 100);
+    for read_block in [100u64, 250, 400, 1000] {
+        assert_eq!(
+            postage::current_total_out_payment(&*db, read_block).unwrap(),
+            Some(survivor.current_total_out_payment(read_block)),
+            "summary must re-derive from surviving rows at block {read_block}"
+        );
+    }
+
+    // And reverting away the last price update clears the summary back to the
+    // fail-safe absent state.
+    indexer.revert(50).expect("revert all");
+    assert!(
+        postage::chain_state(&*db).unwrap().is_none(),
+        "reverting away every PriceUpdate must restore the absent-summary fail-safe"
+    );
+}
+
+#[test]
 fn staking_last_write_wins_and_overlay_inversion() {
     let (db, indexer) = harness();
     let owner = address!("00000000000000000000000000000000000000b1");

--- a/crates/chain/index-contracts/src/views/postage.rs
+++ b/crates/chain/index-contracts/src/views/postage.rs
@@ -2,12 +2,14 @@
 //! over the [`BatchTable`] projection + its value-sorted [`BatchByBalance`]
 //! index, composed from the query combinators.
 //!
-//! The validity query reconstructs the contract's rising
-//! `currentTotalOutPayment(block)` line from the verbatim `PriceUpdate` cadence
-//! and folds the target batch's lifecycle events, then answers
-//! `normalisedBalance > currentTotalOutPayment(block)` exactly as the contract
-//! does. This is the lazy compute-at-time the design mandates: it reads the
-//! verbatim store plus the live block clock and fires nothing.
+//! The validity query reads the incrementally-maintained
+//! [`PostageSummary`](crate::store::PostageSummary) running cumulative-payment
+//! row, extrapolates the contract's rising `currentTotalOutPayment(block)` line
+//! from its stored triple in O(1), folds the target batch's lifecycle events, and
+//! answers `normalisedBalance > currentTotalOutPayment(block)` exactly as the
+//! contract does. The summary is block-clock-derived AT READ (the stored triple
+//! extrapolates to any block), so it reads the projection plus the live block
+//! clock and fires nothing.
 //!
 //! The eager batch queries (`batch_state`, `all_batches`, `batches_by_owner`,
 //! `batches_by_balance`) read the [`PostageReducer`](crate::reducer::PostageReducer)
@@ -19,82 +21,30 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolEvent;
 use vertex_storage::{Database, DatabaseError};
 
-use crate::projection::{fold_events, list_all, list_by, point_get, range_head};
+use crate::projection::{fold_events, list_all, list_by, point_get, range_head, scalar};
 use crate::registry::{ContractId, abi};
-use crate::store::{BalanceKey, BatchKey, BatchState, BatchTable};
+use crate::store::{
+    BalanceKey, BatchKey, BatchState, BatchTable, ChainState, PostageSummary, SummaryKey,
+};
 
-/// The contract's pricing chain-state, reconstructed from the `PriceUpdate`
-/// cadence: the per-chunk total-out-payment accumulated up to
-/// `last_updated_block`, the price in force since, and that block.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct ChainState {
-    /// Per-chunk total-out-payment accumulated up to `last_updated_block`.
-    pub total_out_payment: U256,
-    /// Per-chunk-per-block price in force since `last_updated_block`.
-    pub last_price: U256,
-    /// The block the price last changed.
-    pub last_updated_block: u64,
-}
-
-impl ChainState {
-    /// The contract's `currentTotalOutPayment(block)`:
-    /// `total_out_payment + last_price * (block - last_updated_block)`.
-    ///
-    /// Blocks at or before `last_updated_block` contribute no elapsed cost,
-    /// matching the contract's saturating behaviour rather than underflowing.
-    pub fn current_total_out_payment(&self, block: u64) -> U256 {
-        let blocks = block.saturating_sub(self.last_updated_block);
-        self.total_out_payment + self.last_price * U256::from(blocks)
-    }
-
-    /// Fold a `PriceUpdate` at `block`, mirroring the contract's `setPrice`:
-    /// when the previous price is non-zero, settle the elapsed cost into
-    /// `total_out_payment` first, then adopt the new price at `block`.
-    fn fold_price_update(&mut self, price: U256, block: u64) {
-        if !self.last_price.is_zero() {
-            self.total_out_payment = self.current_total_out_payment(block);
-        }
-        self.last_price = price;
-        self.last_updated_block = block;
-    }
-}
-
-/// Reconstruct the contract's pricing chain-state by folding the verbatim
-/// `PriceUpdate` cadence in canonical order.
+/// The contract's pricing chain-state, read O(1) from the incremental
+/// [`PostageSummary`] projection.
 ///
-/// The read-time re-fold over the [`fold_events`] backbone. Returns `None` when
-/// NO `PriceUpdate` has been indexed yet: a zero-default `ChainState` makes
-/// `current_total_out_payment` return 0, which would make every positive-balance
-/// batch validate forever. Distinguishing "no price seen" from "price 0" lets
-/// [`is_batch_valid_now`] answer `None` (not-yet-known) rather than a misleading
-/// `Some(true)` before the price cadence is known.
-//
-// TODO(#326): replace this read-time re-fold with an O(1) read of the incremental
-// `PostageSummary` projection the `PostageReducer` will maintain on each
-// `PriceUpdate`. The signature stays; only the body becomes a `scalar` read.
+/// Returns `None` when NO `PriceUpdate` has been indexed yet (the summary row is
+/// absent): a zero-default `ChainState` would make `current_total_out_payment`
+/// return 0 and validate every positive-balance batch forever. Distinguishing
+/// "no price seen" from "price 0" lets [`is_batch_valid_now`] answer `None`
+/// (not-yet-known) rather than a misleading `Some(true)` before the price cadence
+/// is known. This is the fail-safe.
 pub fn chain_state<DB: Database>(db: &DB) -> Result<Option<ChainState>, DatabaseError> {
-    fold_events(
-        db,
-        ContractId::Postage,
-        None,
-        |state: &mut Option<ChainState>, key, ev| {
-            if ev.topic0 != abi::PriceUpdate::SIGNATURE_HASH {
-                return;
-            }
-            if let Ok(decoded) = abi::PriceUpdate::decode_log_data(&ev.log_data()) {
-                state
-                    .get_or_insert_with(ChainState::default)
-                    .fold_price_update(decoded.price, key.block);
-            }
-        },
-    )
+    scalar::<PostageSummary, _>(db, SummaryKey)
 }
 
 /// The contract's `currentTotalOutPayment(block)`, the rising line a batch's
 /// `normalisedBalance` must stay above to remain valid, or `None` before any
 /// price cadence is indexed (the fail-safe).
-//
-// TODO(#326): becomes an O(1) extrapolation from the `PostageSummary` row.
+///
+/// An O(1) extrapolation of the stored [`PostageSummary`] triple to `block`.
 pub fn current_total_out_payment<DB: Database>(
     db: &DB,
     block: u64,


### PR DESCRIPTION
## What

Turns the postage cumulative out-payment from a per-read re-fold of the entire `PriceUpdate` history into an incrementally-maintained single-row summary, so `current_total_out_payment(block)` becomes an `O(1)` read. Implements #326. Stacked on #330 (the reducer framework).

`current_total_out_payment` is on the hottest path in the system — every stamp-validity check (`is_batch_valid_now`, the pushsync/storer acceptance gates) calls it — so an unbounded per-read fold over all-of-history price events is exactly the hot path to remove.

## Changes

- New single-row projection `PostageSummary` (`"postage_summary"`, `SummaryKey -> ChainState`) holding `ChainState { total_out_payment, last_price, last_updated_block }`. `ChainState` moves to `store.rs` (the value type lives with its table) and gains `Serialize`/`Deserialize`.
- `PostageReducer::reduce`: on a `PriceUpdate`, loads the current `ChainState` (default if absent), settles elapsed cost and adopts the new price via the shared `fold_price_update` cadence, stores it back — in the same tx as the verbatim `put_event`. A decode miss stays a skip, never an `Err`.
- `PostageReducer::rebuild`: clears `BatchByBalance` and `PostageSummary`, then replays `reduce` over surviving raw rows, so the summary re-derives for free.
- `views/postage.rs`: `current_total_out_payment` / `is_batch_valid_now` now read the summary (`O(1)`) and extrapolate on the stored triple; the re-fold and the `TODO(#326)` markers are removed.

## Invariants preserved

- Summary is block-clock-derived **at read** (the stored triple extrapolates to any block); `reduce` never depends on wall-clock, so it stays replay-safe and idempotent.
- Fail-safe exact: an absent summary row (no `PriceUpdate` seen yet) ⇒ `current_total_out_payment` / `is_batch_valid_now` return `None`.
- Verbatim `EventTable` stays the source of truth; the summary is a derived, rebuildable projection.

## Verification

`cargo fmt`, `cargo check`, `cargo clippy --all-targets`, `cargo test` for `vertex-chain-index-contracts` all pass: 27 unit tests green, including new `summary_total_out_payment_matches_old_fold`, `summary_absent_fails_safe_for_positive_balance_batch`, and `revert_rederives_summary`.

Closes #326.
