### PR TITLE
feat(chain): publish a block-tip stream and post-commit index-advance nudge

### DIFF
--- a/crates/chain/index/Cargo.toml
+++ b/crates/chain/index/Cargo.toml
@@ -30,8 +30,10 @@ alloy-rpc-types-eth = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
 # async: the engine selects between its driver loop and shutdown with
-# `tokio::select!` and ticks the follow loop with `tokio::time::interval`.
-tokio = { workspace = true, features = ["macros", "rt", "time"] }
+# `tokio::select!`, ticks the follow loop with `tokio::time::interval`, and
+# publishes the block-tip and index-advance `watch` channels (the `sync`
+# feature).
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tracing = { workspace = true }
 
 # derive macros

--- a/crates/chain/index/src/engine.rs
+++ b/crates/chain/index/src/engine.rs
@@ -47,11 +47,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_rpc_types_eth::Log;
+use tokio::sync::watch;
 use tracing::{debug, info, warn};
 use vertex_storage::{Database, DbTxMut, Tables};
 
 use crate::cursor::{Cursor, CursorTables};
 use crate::metrics;
+use crate::notify::{BlockTip, BlockTipRx, IndexAdvance, IndexAdvanceRx};
 use crate::reader::{ChainReader, FinalizedHead};
 use crate::{IndexError, Indexer};
 
@@ -85,6 +87,13 @@ pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(5);
 pub struct EventEngineBuilder<R, DB> {
     reader: Arc<R>,
     db: Arc<DB>,
+    /// The block-tip clock sender. Always present (the head clock is cheap and
+    /// always-on); the engine republishes the finalized head on every advance.
+    block_tip: watch::Sender<Option<BlockTip>>,
+    /// The post-commit nudge sender, set only when [`with_notifier`] is called.
+    ///
+    /// [`with_notifier`]: EventEngineBuilder::with_notifier
+    index_advance: Option<watch::Sender<Option<IndexAdvance>>>,
 }
 
 impl<R, DB> EventEngineBuilder<R, DB>
@@ -92,6 +101,27 @@ where
     R: ChainReader + 'static,
     DB: Database,
 {
+    /// Subscribe to the raw head clock.
+    ///
+    /// Observes `Some(BlockTip { number, hash })` on every finalized-head
+    /// advance, including a head that indexed zero logs. Always available (a
+    /// cheap, always-on `watch`); starts at `None` until the first finalized head.
+    pub fn block_tip(&self) -> BlockTipRx {
+        self.block_tip.subscribe()
+    }
+
+    /// Opt into the post-commit projection nudge.
+    ///
+    /// Returns the builder (to keep the fluent chain) paired with an
+    /// [`IndexAdvanceRx`] that observes `Some(IndexAdvance { indexer, last_block })`
+    /// only after each page's `tx.commit()` succeeds, never on an empty block.
+    /// Starts at `None`; calling it again replaces the single sender.
+    pub fn with_notifier(mut self) -> (Self, IndexAdvanceRx) {
+        let (tx, rx) = watch::channel(None);
+        self.index_advance = Some(tx);
+        (self, rx)
+    }
+
     /// Attach the indexer this engine drives, producing a runnable engine.
     ///
     /// One engine instance drives one indexer with its own cursor; a
@@ -104,6 +134,8 @@ where
             indexer,
             page_size: DEFAULT_PAGE_SIZE,
             poll_interval: DEFAULT_POLL_INTERVAL,
+            block_tip: self.block_tip,
+            index_advance: self.index_advance,
         }
     }
 }
@@ -119,6 +151,11 @@ pub struct EventEngine<R, DB> {
     indexer: Arc<dyn Indexer>,
     page_size: u64,
     poll_interval: Duration,
+    /// The block-tip clock sender; republished on every finalized-head advance.
+    block_tip: watch::Sender<Option<BlockTip>>,
+    /// The post-commit nudge sender, present only when the builder opted in via
+    /// [`EventEngineBuilder::with_notifier`].
+    index_advance: Option<watch::Sender<Option<IndexAdvance>>>,
 }
 
 impl<R, DB> EventEngine<R, DB>
@@ -137,7 +174,16 @@ where
     /// fluent construction.
     #[allow(clippy::new_ret_no_self)]
     pub fn new(reader: Arc<R>, db: Arc<DB>) -> EventEngineBuilder<R, DB> {
-        EventEngineBuilder { reader, db }
+        // The block-tip clock is always-on: a `watch` with no live receivers is
+        // a cheap atomic store, so holding the sender unconditionally costs
+        // nothing and keeps `block_tip()` available without an opt-in.
+        let (block_tip, _) = watch::channel(None);
+        EventEngineBuilder {
+            reader,
+            db,
+            block_tip,
+            index_advance: None,
+        }
     }
 
     /// Override the initial `eth_getLogs` page span. Mainly for tests.
@@ -219,6 +265,17 @@ where
         }
     }
 
+    /// Test-only access to [`sync_to`](Self::sync_to) so a unit test can drive a
+    /// single sync against a chosen head without spinning the follow loop.
+    #[cfg(test)]
+    pub(crate) async fn sync_to_for_test(
+        &mut self,
+        indexer: &dyn Indexer,
+        head: FinalizedHead,
+    ) -> Result<(), IndexError> {
+        self.sync_to(indexer, head).await
+    }
+
     /// Index every page from the cursor (or start block) up to `head`.
     async fn sync_to(
         &mut self,
@@ -226,6 +283,23 @@ where
         head: FinalizedHead,
     ) -> Result<(), IndexError> {
         let name = indexer.name();
+
+        // Publish the raw head clock on every finalized-head advance, before any
+        // paging: the tick must fire even if the head's range indexes zero logs.
+        // Skip a republish when the head has not moved so a no-op poll does not
+        // churn the channel. `send_if_modified` only marks the value changed
+        // (waking subscribers' `changed()`) when the head number actually
+        // advanced; a lagging receiver still converges to the latest value.
+        self.block_tip.send_if_modified(|current| {
+            let advanced = current.is_none_or(|tip| tip.number < head.number);
+            if advanced {
+                *current = Some(BlockTip {
+                    number: head.number,
+                    hash: head.hash,
+                });
+            }
+            advanced
+        });
 
         // Resume from one past the last applied block, but never before the
         // contract's deployment block.
@@ -347,6 +421,18 @@ where
         tx.commit()?;
 
         metrics::checkpoints_total(name).increment(1);
+
+        // Post-commit nudge: only after `tx.commit()` succeeded, so consumers
+        // never see an advance the cursor has not yet recorded, and a `?`-bailed
+        // page above this point never fires. `send_replace` is last-value-wins:
+        // a replay republishes the same value (a harmless no-op for consumers).
+        if let Some(notifier) = &self.index_advance {
+            notifier.send_replace(Some(IndexAdvance {
+                indexer: name,
+                last_block,
+            }));
+        }
+
         Ok(())
     }
 }

--- a/crates/chain/index/src/lib.rs
+++ b/crates/chain/index/src/lib.rs
@@ -50,13 +50,15 @@ mod engine;
 mod error;
 mod indexer;
 mod metrics;
+mod notify;
 mod reader;
 
 #[cfg(test)]
 mod tests;
 
 pub use cursor::{Cursor, CursorTable, CursorTables};
-pub use engine::{DEFAULT_PAGE_SIZE, DEFAULT_POLL_INTERVAL, EventEngine};
+pub use engine::{DEFAULT_PAGE_SIZE, DEFAULT_POLL_INTERVAL, EventEngine, EventEngineBuilder};
 pub use error::IndexError;
 pub use indexer::Indexer;
+pub use notify::{BlockTip, BlockTipRx, IndexAdvance, IndexAdvanceRx};
 pub use reader::{ChainReader, FinalizedHead};

--- a/crates/chain/index/src/notify.rs
+++ b/crates/chain/index/src/notify.rs
@@ -1,0 +1,34 @@
+//! Two `watch` push affordances: the block-tip clock and the post-commit nudge.
+//!
+//! Both are last-value-wins `tokio::sync::watch` channels (a lagging subscriber
+//! never blocks the engine) that start at `None` until the first publish.
+//! [`BlockTip`] fires on every finalized-head advance, including a head that
+//! indexed zero logs (the block clock). [`IndexAdvance`] fires only after a
+//! page's `tx.commit()` succeeds (a wakeup to re-query the committed projection).
+
+use alloy_primitives::B256;
+use tokio::sync::watch;
+
+/// A finalized block the engine observed: `(number, hash)`, no domain payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockTip {
+    /// The finalized block number.
+    pub number: u64,
+    /// The finalized block hash.
+    pub hash: B256,
+}
+
+/// Receiver of the block-tip clock; `None` until the first finalized head.
+pub type BlockTipRx = watch::Receiver<Option<BlockTip>>;
+
+/// A post-commit nudge: which indexer advanced, and to which committed block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexAdvance {
+    /// The name of the indexer whose cursor just committed.
+    pub indexer: &'static str,
+    /// The last block committed by the page that triggered this nudge.
+    pub last_block: u64,
+}
+
+/// Receiver of the post-commit nudge; `None` until the first committed page.
+pub type IndexAdvanceRx = watch::Receiver<Option<IndexAdvance>>;

--- a/crates/chain/index/src/tests.rs
+++ b/crates/chain/index/src/tests.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use alloy_primitives::{Address, B256, LogData};
 use alloy_rpc_types_eth::{Filter, Log};
-use vertex_storage::Database;
+use vertex_storage::{Database, Tables};
 use vertex_storage_redb::RedbDatabase;
 
 use crate::reader::{ChainReader, FinalizedHead};
@@ -343,6 +343,112 @@ async fn revert_hook_is_invoked_on_simulated_reorg() {
         *indexer.reverted.lock().unwrap(),
         vec![5],
         "revert hook records the reorged-out block"
+    );
+}
+
+/// After a page commits, the `IndexAdvanceRx` observes the post-commit nudge
+/// with the indexer name and the committed last block.
+#[tokio::test]
+async fn index_advance_fires_after_commit() {
+    let addr = Address::repeat_byte(0x07);
+    let logs = vec![log_at(3, 0, addr)];
+    let reader = Arc::new(MockReader::new(logs, head(10)));
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    let (builder, mut advance_rx) = EventEngine::new(reader, db.clone()).with_notifier();
+    // No value before the engine runs: consumers must tolerate "no value yet".
+    assert_eq!(*advance_rx.borrow_and_update(), None);
+
+    let engine = builder.register(indexer.clone());
+    backfill_once(engine).await;
+
+    let advance = advance_rx
+        .borrow_and_update()
+        .expect("a committed page nudged the notifier");
+    assert_eq!(advance.indexer, "recording");
+    assert_eq!(
+        advance.last_block, 10,
+        "the nudge carries the committed last block (the finalized head)"
+    );
+}
+
+/// The `BlockTipRx` observes the finalized head `(number, hash)` after a sync,
+/// even though it fires before paging.
+#[tokio::test]
+async fn block_tip_observes_finalized_head() {
+    let addr = Address::repeat_byte(0x08);
+    let logs = vec![log_at(5, 0, addr)];
+    let reader = Arc::new(MockReader::new(logs, head(42)));
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    let builder = EventEngine::new(reader, db.clone());
+    let mut tip_rx = builder.block_tip();
+    // Starts at `None` until the engine observes its first finalized head.
+    assert_eq!(*tip_rx.borrow_and_update(), None);
+
+    let engine = builder.register(indexer.clone());
+    backfill_once(engine).await;
+
+    let tip = tip_rx
+        .borrow_and_update()
+        .expect("the engine published the finalized head");
+    assert_eq!(tip.number, 42);
+    assert_eq!(tip.hash, head(42).hash);
+}
+
+/// The block-tip clock fires on a finalized-head advance even when the head's
+/// range indexes zero logs: it is a head clock, not a projection signal.
+#[tokio::test]
+async fn block_tip_fires_on_empty_head() {
+    let addr = Address::repeat_byte(0x09);
+    // No logs at all in the indexed range: the page is empty.
+    let reader = Arc::new(MockReader::new(vec![], head(15)));
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    let builder = EventEngine::new(reader, db.clone());
+    let mut tip_rx = builder.block_tip();
+    let engine = builder.register(indexer.clone());
+    backfill_once(engine).await;
+
+    assert!(indexer.applied().is_empty(), "no logs were indexed");
+    let tip = tip_rx
+        .borrow_and_update()
+        .expect("the head clock ticks even with an empty page");
+    assert_eq!(tip.number, 15);
+}
+
+/// A no-op sync (the finalized head has not advanced) does not mark the
+/// block-tip channel changed, so a lagging consumer is not woken by a head that
+/// did not move. The follow loop re-runs `sync_once` against an unchanged head;
+/// this exercises that path directly.
+#[tokio::test]
+async fn no_op_sync_does_not_churn_block_tip() {
+    let addr = Address::repeat_byte(0x0a);
+    let logs = vec![log_at(5, 0, addr)];
+    let reader = Arc::new(MockReader::new(logs, head(20)));
+    let db = Arc::new(RedbDatabase::in_memory().unwrap());
+    let indexer = RecordingIndexer::new(addr, 0);
+
+    let builder = EventEngine::new(reader, db.clone());
+    let mut tip_rx = builder.block_tip();
+
+    let mut engine = builder.register(indexer.clone());
+    // `sync_to` writes the cursor, so the cursor table must exist; `run` would
+    // init it, but this test drives `sync_to` directly to mimic a follow re-tick.
+    crate::cursor::CursorTables::init(db.as_ref()).unwrap();
+    // Drive two syncs against the identical head, mirroring a follow-loop re-tick.
+    let h = head(20);
+    engine.sync_to_for_test(indexer.as_ref(), h).await.unwrap();
+    let first = tip_rx.borrow_and_update().expect("first head published");
+    assert_eq!(first.number, 20);
+
+    engine.sync_to_for_test(indexer.as_ref(), h).await.unwrap();
+    assert!(
+        !tip_rx.has_changed().unwrap(),
+        "an unchanged finalized head does not churn the block-tip channel"
     );
 }
 


### PR DESCRIPTION
## What

Add two `tokio::sync::watch` channels to the chain event engine: a raw block-`(number, hash)` stream and a post-commit `IndexAdvance` nudge. HTTP-poll only, no WebSocket (that is #328).

Consumers need two distinct push affordances that did not exist: a block clock (the redistribution agent is `phase = block % blocksPerRound` and must tick on every finalised block, including empty ones; stamp validators want a block clock too) and a post-commit nudge (the storer reserve and postage want to re-query the projection only after a committed page).

## Changes

- New module `notify.rs` (re-exported from `lib.rs`): `BlockTip { number, hash }` with `BlockTipRx`, and `IndexAdvance { indexer, last_block }` with `IndexAdvanceRx` (a `watch`, not a `broadcast`, published after `tx.commit()`).
- `block_tip(&self) -> BlockTipRx`: the always-on raw head clock (a `watch` with no receivers is a cheap atomic store). Published in `sync_to` on each finalised-head advance via `send_if_modified`, so it fires even on a zero-log page and does not churn when the head is unchanged.
- `with_notifier(self) -> (Self, IndexAdvanceRx)`: opt-in, activates the post-commit sender (returned alongside the builder to keep the fluent chain). Published in `commit_page` only after `tx.commit()` succeeds; a bail-out before commit never fires it.
- The `Indexer` trait is untouched; finalised-only behaviour and `run`/`follow` shutdown semantics are intact. Added the tokio `sync` feature.

## Design notes

- The two channels stay separate: the head clock fires on every block (including empty), the nudge only post-commit. Collapsing them would either spam projection consumers on empty blocks or starve the clock during quiet periods.
- `watch` channels start at `None`; consumers must tolerate "no value yet".
- Nothing is wired to a consumer yet. These land with the redistribution clock and the reserve.

## Testing

`cargo fmt --all --check`, `cargo clippy --all-targets`, and `cargo test -p vertex-chain-index` all pass: 11 tests green, including `index_advance_fires_after_commit`, `block_tip_observes_finalized_head`, `block_tip_fires_on_empty_head`, and `no_op_sync_does_not_churn_block_tip`.

Closes #327.

## AI Assistance

Claude Code (Opus 4.8) used to rebase the branch onto `main` (dropping the already-merged self-throttle commits) and to verify the build.
