### PR TITLE
fix(swarm-net-pushsync): gate the custody-receipt depth check on a credible neighbourhood view

### DIFF
--- a/crates/swarm/api/src/components/topology.rs
+++ b/crates/swarm/api/src/components/topology.rs
@@ -30,6 +30,17 @@ pub trait SwarmTopologyState: Send + Sync {
     /// Get the current neighborhood depth.
     fn depth(&self) -> NeighborhoodDepth;
 
+    /// Whether the locally observed neighbourhood depth is credible.
+    ///
+    /// The depth is an atomic that begins at zero on a fresh, sparse, or
+    /// just-restarted node and only reflects a real responsibility boundary once
+    /// the neighbourhood has saturated. Custody-receipt depth checks must not
+    /// anchor their floor to a non-credible depth: the receipt's declared radius
+    /// is unsigned wire data and would otherwise become the sole,
+    /// attacker-controlled bar (see the pushsync receipt depth policy). Returns
+    /// true once the neighbourhood is saturated.
+    fn neighbourhood_credible(&self) -> bool;
+
     /// Get the node's overlay address.
     fn overlay_address(&self) -> OverlayAddress {
         self.identity().overlay_address()

--- a/crates/swarm/api/src/error.rs
+++ b/crates/swarm/api/src/error.rs
@@ -23,6 +23,22 @@ pub enum SwarmError {
         chunk_address: ChunkAddress,
     },
 
+    /// A push completed but custody could not be confirmed.
+    ///
+    /// Every candidate returned a custody receipt that the local node could not
+    /// judge: its neighbourhood view is not credible (the neighbourhood has not
+    /// saturated yet), so the receipt's custody depth cannot be anchored against
+    /// a trustworthy floor. This is distinct from success (no receipt was
+    /// trusted) and from [`InvalidSignature`](Self::InvalidSignature) (no proven
+    /// misbehaviour: the receipts may be honest, the local node simply cannot
+    /// verify them). The push should be treated as unconfirmed and retried once
+    /// the local view is credible.
+    #[error("custody unconfirmed for chunk {chunk_address}: neighbourhood view not credible")]
+    UnconfirmedCustody {
+        /// The chunk whose custody could not be confirmed.
+        chunk_address: ChunkAddress,
+    },
+
     /// Every candidate peer failed for a chunk operation.
     #[error("all {attempts} candidate peers failed for chunk {address}")]
     AllPeersFailed {
@@ -173,6 +189,7 @@ impl SwarmError {
                 | Self::Accounting { .. }
                 | Self::NoStorer { .. }
                 | Self::AllPeersFailed { .. }
+                | Self::UnconfirmedCustody { .. }
         )
     }
 

--- a/crates/swarm/builder/src/providers.rs
+++ b/crates/swarm/builder/src/providers.rs
@@ -10,7 +10,7 @@ use vertex_swarm_api::{
     SwarmChunkProvider, SwarmChunkSender, SwarmError, SwarmIdentity, SwarmResult,
     SwarmScoringEvent, SwarmTopologyRouting, SwarmTopologyState,
 };
-use vertex_swarm_net_pushsync::Receipt;
+use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
 use vertex_swarm_node::{ClientHandle, PeerSelector};
 use vertex_swarm_topology::TopologyHandle;
 
@@ -120,10 +120,14 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
 
         // The required custody depth is derived from our locally observed
         // neighbourhood depth (the trusted authority) and trust-but-verified
-        // against the receipt's own claimed `storage_radius`. The receipt's
-        // signer was already recovered at the decode boundary; a malformed
-        // receipt never reaches here (it surfaces as a push error below).
+        // against the receipt's own claimed `storage_radius`. The check is gated
+        // on that depth being credible (the neighbourhood has saturated); a
+        // non-credible view cannot anchor the floor and yields an unverifiable
+        // verdict. The receipt's signer was already recovered at the decode
+        // boundary; a malformed receipt never reaches here (it surfaces as a push
+        // error below).
         let local_depth = self.topology.depth();
+        let neighbourhood_credible = self.topology.neighbourhood_credible();
         let reporter = self.topology.peer_manager();
 
         // Try each closest peer in order and return the first receipt that
@@ -131,29 +135,62 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         // adversely, and the walk continues to the next candidate: this is the
         // retry-via-different-route dynamic the depth check exists to engage (a
         // fabricated shallow receipt no longer convinces the uploader the push
-        // succeeded). The seed error covers the no-candidates case; each failed
-        // attempt replaces it, so the value after the loop is always the last
+        // succeeded). An unverifiable receipt (non-credible local view) is also
+        // not trusted, but the responder is NOT penalised: it may be honest, we
+        // just cannot judge custody depth. If no candidate verifies and at least
+        // one was unverifiable, the push is reported as unconfirmed custody
+        // rather than a hard failure. The seed error covers the no-candidates
+        // case; each attempt replaces it, so the value after the loop is the last
         // failure.
         let mut outcome = Err(SwarmError::NoStorer {
             chunk_address: address,
         });
         for peer in closest {
             match self.client_handle.push_chunk(peer, chunk.clone()).await {
-                Ok(receipt) => match accept_origin_receipt(&receipt, peer, local_depth, reporter) {
-                    Ok(()) => return Ok(push_receipt_of(receipt)),
-                    Err(err) => {
-                        outcome = Err(SwarmError::InvalidSignature {
-                            chunk_address: address,
-                            reason: err.to_string(),
+                Ok(receipt) => {
+                    match accept_origin_receipt(
+                        &receipt,
+                        peer,
+                        local_depth,
+                        neighbourhood_credible,
+                        reporter,
+                    ) {
+                        DepthVerdict::Verified => return Ok(push_receipt_of(receipt)),
+                        DepthVerdict::Shallow(err) => {
+                            outcome = Err(SwarmError::InvalidSignature {
+                                chunk_address: address,
+                                reason: err.to_string(),
+                            });
+                        }
+                        DepthVerdict::Unverifiable => {
+                            // Surface unconfirmed custody distinctly from a hard
+                            // invalid-signature failure. A later shallow verdict
+                            // (a proven finding) takes precedence over this; an
+                            // earlier one is not downgraded.
+                            if !matches!(outcome, Err(SwarmError::InvalidSignature { .. })) {
+                                outcome = Err(SwarmError::UnconfirmedCustody {
+                                    chunk_address: address,
+                                });
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    // A transport-level failure is the weakest signal: it does
+                    // not overwrite a depth verdict (shallow misbehaviour or
+                    // unconfirmed custody) already recorded for an earlier
+                    // candidate.
+                    if !matches!(
+                        outcome,
+                        Err(SwarmError::InvalidSignature { .. })
+                            | Err(SwarmError::UnconfirmedCustody { .. })
+                    ) {
+                        outcome = Err(SwarmError::AllPeersFailed {
+                            address,
+                            attempts,
+                            source: Box::new(e),
                         });
                     }
-                },
-                Err(e) => {
-                    outcome = Err(SwarmError::AllPeersFailed {
-                        address,
-                        attempts,
-                        source: Box::new(e),
-                    });
                 }
             }
         }
@@ -198,18 +235,27 @@ impl<I: SwarmIdentity> SwarmChunkSender for NetworkChunkProvider<I> {
 /// The receipt is a [`Receipt`]: its storer was recovered and verified at the
 /// decode boundary (a malformed receipt never reaches here). This checks the
 /// custody depth against the locally observed neighbourhood depth,
-/// trust-but-verified against the receipt's own declared radius. On rejection the
-/// responding peer is scored adversely for invalid data through the supplied
-/// reporter (the same path #287 uses), so the uploader's caller retries via a
-/// different route instead of believing a fabricated shallow receipt that the
-/// push succeeded.
+/// trust-but-verified against the receipt's own declared radius, gated on that
+/// depth being credible (`neighbourhood_credible`).
+///
+/// The verdict drives the caller:
+/// - [`DepthVerdict::Verified`]: the receipt is trusted; the push succeeded.
+/// - [`DepthVerdict::Shallow`]: the storer is provably too shallow. The
+///   responding peer is scored adversely for invalid data through the supplied
+///   reporter (the same path #287 uses), and the caller retries via a different
+///   route instead of believing a fabricated shallow receipt.
+/// - [`DepthVerdict::Unverifiable`]: the local view is not credible enough to
+///   judge custody depth. The peer is NOT penalised (it may be honest); the
+///   caller treats the push as unconfirmed.
 fn accept_origin_receipt(
     receipt: &Receipt,
     peer: SwarmAddress,
     local_depth: vertex_swarm_api::NeighborhoodDepth,
+    neighbourhood_credible: bool,
     reporter: &dyn PeerReporter,
-) -> Result<(), vertex_swarm_net_pushsync::ShallowReceipt> {
-    receipt.verify_depth(local_depth).inspect_err(|err| {
+) -> DepthVerdict {
+    let verdict = receipt.verify_depth(local_depth, neighbourhood_credible);
+    if let DepthVerdict::Shallow(err) = &verdict {
         warn!(
             %peer,
             address = %receipt.address,
@@ -217,7 +263,8 @@ fn accept_origin_receipt(
             "rejected shallow custody receipt; retrying another route"
         );
         reporter.report_peer(&peer, SwarmScoringEvent::InvalidData, PUSHSYNC_SOURCE);
-    })
+    }
+    verdict
 }
 
 #[cfg(test)]
@@ -228,7 +275,7 @@ mod tests {
     use alloy_signer_local::PrivateKeySigner;
     use nectar_primitives::{Bin, NetworkId, Nonce, compute_overlay};
     use vertex_swarm_api::{NeighborhoodDepth, ReportSource, StorageRadius, SwarmScoringEvent};
-    use vertex_swarm_net_pushsync::{ShallowReceipt, WireReceipt};
+    use vertex_swarm_net_pushsync::WireReceipt;
 
     use super::*;
 
@@ -311,7 +358,11 @@ mod tests {
         let reporter = RecordingReporter::default();
         let peer = SwarmAddress::from([0x11; 32]);
 
-        accept_origin_receipt(&receipt, peer, depth(8), &reporter).expect("deep receipt accepted");
+        assert_eq!(
+            accept_origin_receipt(&receipt, peer, depth(8), true, &reporter),
+            DepthVerdict::Verified,
+            "deep receipt accepted"
+        );
         assert!(reporter.reports.lock().unwrap().is_empty());
     }
 
@@ -319,15 +370,17 @@ mod tests {
     fn origin_rejects_a_shallow_receipt_and_reports_the_peer() {
         let signer = PrivateKeySigner::random();
         let addr = address(0xff);
-        // Shallow signer; the local floor (depth 12) rejects it regardless of the
-        // claimed radius.
+        // Shallow signer; against a credible local view the floor (depth 12)
+        // rejects it regardless of the claimed radius.
         let receipt = signed_receipt(&signer, &addr, 0, radius(8));
         let reporter = RecordingReporter::default();
         let peer = SwarmAddress::from([0x22; 32]);
 
-        let err = accept_origin_receipt(&receipt, peer, depth(12), &reporter)
-            .expect_err("shallow receipt rejected");
-        assert!(matches!(err, ShallowReceipt { .. }));
+        let DepthVerdict::Shallow(_) =
+            accept_origin_receipt(&receipt, peer, depth(12), true, &reporter)
+        else {
+            panic!("shallow receipt rejected");
+        };
 
         let (reported_peer, event, source) = reporter.single();
         assert_eq!(reported_peer, peer, "the responding peer is scored");
@@ -337,17 +390,46 @@ mod tests {
 
     #[test]
     fn origin_rejects_a_shallow_receipt_claiming_radius_zero() {
-        // Regression: an attacker setting storage_radius == 0 must not bypass the
-        // local floor at the origin uploader.
+        // Regression: against a credible local view an attacker setting
+        // storage_radius == 0 must not bypass the local floor at the origin
+        // uploader.
         let signer = PrivateKeySigner::random();
         let addr = address(0xff);
         let receipt = signed_receipt(&signer, &addr, 0, radius(0));
         let reporter = RecordingReporter::default();
         let peer = SwarmAddress::from([0x55; 32]);
 
-        let err = accept_origin_receipt(&receipt, peer, depth(12), &reporter)
-            .expect_err("radius 0 does not bypass the local floor");
-        assert!(matches!(err, ShallowReceipt { .. }));
+        assert!(
+            matches!(
+                accept_origin_receipt(&receipt, peer, depth(12), true, &reporter),
+                DepthVerdict::Shallow(_)
+            ),
+            "radius 0 does not bypass the local floor"
+        );
         assert_eq!(reporter.count(), 1);
+    }
+
+    #[test]
+    fn origin_treats_an_unverifiable_receipt_as_unconfirmed_without_reporting() {
+        // Regression for #316: with a non-credible local view (a fresh or sparse
+        // node, local_depth == 0) a shallow receipt declaring radius 0 must NOT
+        // be accepted, and the responder must NOT be penalised: the verdict is
+        // unverifiable, not a finding of misbehaviour.
+        let signer = PrivateKeySigner::random();
+        let addr = address(0xff);
+        let receipt = signed_receipt(&signer, &addr, 0, radius(0));
+        let reporter = RecordingReporter::default();
+        let peer = SwarmAddress::from([0x66; 32]);
+
+        assert_eq!(
+            accept_origin_receipt(&receipt, peer, depth(0), false, &reporter),
+            DepthVerdict::Unverifiable,
+            "non-credible view yields an unverifiable verdict"
+        );
+        assert_eq!(
+            reporter.count(),
+            0,
+            "an unverifiable receipt does not penalise the peer"
+        );
     }
 }

--- a/crates/swarm/net/pushsync/src/lib.rs
+++ b/crates/swarm/net/pushsync/src/lib.rs
@@ -7,7 +7,7 @@ mod error;
 pub use error::PushsyncError;
 
 mod receipt;
-pub use receipt::{Receipt, SHALLOW_RECEIPT_TOLERANCE, ShallowReceipt};
+pub use receipt::{DepthVerdict, Receipt, SHALLOW_RECEIPT_TOLERANCE, ShallowReceipt};
 
 mod protocol;
 pub use protocol::{

--- a/crates/swarm/net/pushsync/src/receipt.rs
+++ b/crates/swarm/net/pushsync/src/receipt.rs
@@ -22,7 +22,18 @@
 //! only when its storer is deep enough for the chunk, with the bar derived from
 //! the locally observed neighbourhood depth and trust-but-verified against the
 //! receipt's own declared radius. The recovery and the check both live next to
-//! the type so consumers call `receipt.verify_depth(local_depth)` directly.
+//! the type so consumers call
+//! `receipt.verify_depth(local_depth, neighbourhood_credible)` directly.
+//!
+//! The check is gated on a credible neighbourhood view. The local depth is an
+//! atomic that begins at zero on a fresh, sparse, or just-restarted node, and
+//! the receipt's declared radius is unsigned wire data the responder controls.
+//! With a low local floor the radius would become the sole bar, which a
+//! responder can set to zero, so a shallow receipt would be wrongly accepted. A
+//! caller therefore passes whether its neighbourhood view is credible (its
+//! topology has saturated, so the observed depth reflects a real boundary); when
+//! it is not, the check returns [`DepthVerdict::Unverifiable`] rather than
+//! leaning on an attacker-controlled field it cannot anchor.
 //!
 //! # Future wire format
 //!
@@ -74,6 +85,29 @@ impl From<&ShallowReceipt> for &'static str {
     fn from(_: &ShallowReceipt) -> Self {
         "shallow_receipt"
     }
+}
+
+/// The outcome of [`Receipt::verify_depth`].
+///
+/// The check is three-valued because there are two distinct failure modes that
+/// must not be conflated. A [`Shallow`](Self::Shallow) verdict is a positive
+/// finding of misbehaviour: against a credible local view the storer is provably
+/// too shallow, so the responder is penalised. An
+/// [`Unverifiable`](Self::Unverifiable) verdict is the absence of a finding: the
+/// local view is not credible enough to judge custody depth (a fresh, sparse, or
+/// just-restarted node before its neighbourhood saturates), so the receipt is
+/// neither trusted nor blamed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepthVerdict {
+    /// The storer is deep enough for the chunk against a credible local view.
+    Verified,
+    /// The storer is provably too shallow against a credible local view; the
+    /// responder must be penalised.
+    Shallow(ShallowReceipt),
+    /// The local neighbourhood view is not credible, so custody depth cannot be
+    /// judged. The receipt is treated as unconfirmed, not as misbehaviour: the
+    /// responder is not penalised.
+    Unverifiable,
 }
 
 /// A custody receipt whose storer has been recovered and verified.
@@ -147,17 +181,33 @@ impl Receipt {
     /// zero) radius cannot weaken the local floor. Hence
     /// `required = max(local_depth - tolerance, storage_radius)`.
     ///
+    /// The floor is only meaningful when `neighbourhood_credible` is true. The
+    /// local depth is an atomic that begins at zero before the neighbourhood
+    /// saturates, and the declared radius is unsigned wire data the responder
+    /// controls. With a non-credible view the floor would collapse to the
+    /// attacker-controlled radius (which the responder can set to zero), so there
+    /// is no bar to anchor: the check returns [`DepthVerdict::Unverifiable`]
+    /// WITHOUT reading the radius. The caller treats that as unconfirmed custody,
+    /// not as misbehaviour.
+    ///
     /// The depth check is a cheap first filter, not a cryptographic guarantee;
     /// stake-binding and retrievability auditing (storage incentives, tracked in
     /// #75) are the layer that makes forgery unprofitable.
-    pub fn verify_depth(&self, local_depth: NeighborhoodDepth) -> Result<(), ShallowReceipt> {
+    pub fn verify_depth(
+        &self,
+        local_depth: NeighborhoodDepth,
+        neighbourhood_credible: bool,
+    ) -> DepthVerdict {
+        if !neighbourhood_credible {
+            return DepthVerdict::Unverifiable;
+        }
         let floor = local_depth.get().saturating_sub(SHALLOW_RECEIPT_TOLERANCE);
         let required = floor.max(self.storage_radius.get());
         let observed = self.address.proximity(&self.storer).get();
         if observed < required {
-            return Err(ShallowReceipt { required, observed });
+            return DepthVerdict::Shallow(ShallowReceipt { required, observed });
         }
-        Ok(())
+        DepthVerdict::Verified
     }
 
     /// Reproduce the wire receipt for verbatim relay.
@@ -269,9 +319,7 @@ mod tests {
         let address = chunk_address(0xff);
         let (raw, _) = wire(&signer, &address, 8, radius(8));
         let receipt = Receipt::reconstruct(raw, NET).expect("reconstructs");
-        receipt
-            .verify_depth(depth(8))
-            .expect("deep enough accepted");
+        assert_eq!(receipt.verify_depth(depth(8), true), DepthVerdict::Verified);
     }
 
     #[test]
@@ -279,16 +327,34 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let address = chunk_address(0xff);
         // The storer is shallow (grind only to depth 0) and declares radius 0 to
-        // try to bypass the check; the local floor (depth 12) rejects it anyway.
+        // try to bypass the check; against a credible local view the local floor
+        // (depth 12) rejects it anyway.
         let (raw, storer) = wire(&signer, &address, 0, radius(0));
         let observed = address.proximity(&storer).get();
         let local = observed + SHALLOW_RECEIPT_TOLERANCE + 1;
         let receipt = Receipt::reconstruct(raw, NET).expect("reconstructs");
-        let err = receipt
-            .verify_depth(depth(local))
-            .expect_err("radius 0 does not bypass the local floor");
+        let DepthVerdict::Shallow(err) = receipt.verify_depth(depth(local), true) else {
+            panic!("radius 0 does not bypass the local floor");
+        };
         assert_eq!(err.observed, observed);
         assert!(err.required > observed);
+    }
+
+    #[test]
+    fn non_credible_view_returns_unverifiable_even_when_the_floor_collapses() {
+        // Regression for #316: with a non-credible neighbourhood view the local
+        // floor is meaningless and the unsigned radius must not become the sole
+        // bar. Even at the worst case (local_depth == 0, storage_radius == 0, a
+        // storer ground to depth 0) the verdict is Unverifiable, never Verified.
+        let signer = PrivateKeySigner::random();
+        let address = chunk_address(0xff);
+        let (raw, _) = wire(&signer, &address, 0, radius(0));
+        let receipt = Receipt::reconstruct(raw, NET).expect("reconstructs");
+        assert_eq!(
+            receipt.verify_depth(depth(0), false),
+            DepthVerdict::Unverifiable,
+            "a shallow receipt is unverifiable, not accepted, under a non-credible view"
+        );
     }
 
     #[test]
@@ -304,15 +370,13 @@ mod tests {
             "constructed storer sits below the declared radius"
         );
         let receipt = Receipt::reconstruct(raw, NET).expect("reconstructs");
-        let err = receipt
-            .verify_depth(depth(2))
-            .expect_err("below-declared-radius storer rejected");
         assert_eq!(
-            err,
-            ShallowReceipt {
+            receipt.verify_depth(depth(2), true),
+            DepthVerdict::Shallow(ShallowReceipt {
                 required: 12,
                 observed
-            }
+            }),
+            "below-declared-radius storer rejected"
         );
     }
 }

--- a/crates/swarm/node/src/protocol/forward.rs
+++ b/crates/swarm/node/src/protocol/forward.rs
@@ -61,7 +61,7 @@ use vertex_swarm_api::{
     AccountingAction, PeerReporter, ReportSource, SwarmClientAccounting, SwarmScoringEvent,
     SwarmTopologyRouting, SwarmTopologyState,
 };
-use vertex_swarm_net_pushsync::Receipt;
+use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk};
 
 use crate::ClientHandle;
@@ -116,6 +116,17 @@ pub(crate) enum ForwardError {
     /// push failure ([`AllPeersFailed`](Self::AllPeersFailed)).
     #[error("upstream relay returned a shallow custody receipt")]
     ShallowReceipt,
+
+    /// The upstream leg returned a custody receipt that cannot be judged because
+    /// the local neighbourhood view is not credible (the neighbourhood has not
+    /// saturated yet). The receipt is dropped without relaying it, but the
+    /// downstream peer is NOT penalised: the receipt may be honest, the local
+    /// node just lacks a trustworthy depth to anchor the check against. The relay
+    /// continues to the next candidate. Distinct from
+    /// [`ShallowReceipt`](Self::ShallowReceipt), which is a proven, penalised
+    /// finding of misbehaviour.
+    #[error("upstream relay returned an unverifiable custody receipt")]
+    UnverifiableReceipt,
 
     /// Accounting refused one of the two legs (over the disconnect threshold),
     /// so the relay was not attempted. Any reservation already taken is released
@@ -421,9 +432,12 @@ where
         let accounting = Arc::clone(&self.accounting);
         let handle = self.handle.clone();
         // Snapshot the locally observed neighbourhood depth now: it is the
-        // trusted authority for the required receipt depth. Reading it here
-        // keeps the future `'static`.
+        // trusted authority for the required receipt depth. Snapshot whether that
+        // depth is credible alongside it (the neighbourhood has saturated); a
+        // non-credible depth cannot anchor the check. Reading both here keeps the
+        // future `'static`.
         let local_depth = self.topology.depth();
+        let neighbourhood_credible = self.topology.neighbourhood_credible();
         let reporter = Arc::clone(&self.reporter);
 
         Box::pin(async move {
@@ -458,11 +472,11 @@ where
                         // forwarder's remaining duty is the depth policy: it must
                         // never launder a SHALLOW custody receipt. The check runs
                         // against the recovered storer (NOT the immediate
-                        // downstream peer) and our locally observed depth. The
-                        // receipt is relayed VERBATIM by the handler; we never
-                        // re-sign it.
-                        match receipt.verify_depth(local_depth) {
-                            Ok(()) => {
+                        // downstream peer) and our locally observed depth, and is
+                        // gated on that depth being credible. The receipt is
+                        // relayed VERBATIM by the handler; we never re-sign it.
+                        match receipt.verify_depth(local_depth, neighbourhood_credible) {
+                            DepthVerdict::Verified => {
                                 // Downstream leg complete; commit it. Upstream
                                 // `provide` returned un-applied for the handler.
                                 receive.apply();
@@ -472,7 +486,7 @@ where
                                     provide: Box::new(provide),
                                 });
                             }
-                            Err(err) => {
+                            DepthVerdict::Shallow(err) => {
                                 // Drop the downstream leg (release the
                                 // reservation) and never relay this receipt. The
                                 // downstream peer that handed us a shallow receipt
@@ -492,6 +506,20 @@ where
                                     PUSHSYNC_SOURCE,
                                 );
                                 last = ForwardError::ShallowReceipt;
+                            }
+                            DepthVerdict::Unverifiable => {
+                                // The local view is not credible enough to judge
+                                // custody depth, so we cannot relay this receipt,
+                                // but the downstream peer may be honest: drop the
+                                // reservation, do NOT penalise it, and try the
+                                // next candidate.
+                                drop(receive);
+                                debug!(
+                                    %closer,
+                                    %address,
+                                    "relayed receipt unverifiable: neighbourhood view not credible"
+                                );
+                                last = ForwardError::UnverifiableReceipt;
                             }
                         }
                     }
@@ -1094,6 +1122,70 @@ mod tests {
         assert_eq!(reported_peer, closer);
         assert_eq!(event, SwarmScoringEvent::InvalidData);
 
+        assert_eq!(acct.bandwidth().for_peer(pusher).balance(), Au::ZERO);
+        assert_eq!(acct.bandwidth().for_peer(closer).balance(), Au::ZERO);
+    }
+
+    #[tokio::test]
+    async fn push_with_non_credible_view_is_unverifiable_and_does_not_penalise() {
+        // Regression for #316: with a non-credible local view (the neighbourhood
+        // has not saturated) the forwarder cannot judge custody depth, so even a
+        // shallow receipt declaring radius 0 must not be relayed AND the
+        // downstream peer must not be penalised. The forward fails with
+        // `UnverifiableReceipt`, nothing is scored, and no reservation leaks.
+        let chunk = stamped();
+        let address = *chunk.address();
+        let pusher = overlay_at_proximity(&address, 2);
+        let closer = overlay_at_proximity(&address, 16);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        // Non-credible view: a fresh node at depth 0, neighbourhood unsaturated.
+        let topo = Arc::new(
+            MockTopology::default()
+                .with_closest(vec![closer])
+                .with_depth(0)
+                .with_credible(false),
+        );
+        let (tx, rx) = mpsc::channel::<ClientCommand>(4);
+        let handle = ClientHandle::new(tx);
+
+        let reporter = Arc::new(RecordingReporter::default());
+        let forwarder = NetworkForwarder::new(
+            local,
+            topo,
+            Arc::clone(&acct),
+            handle,
+            Arc::clone(&reporter) as Arc<dyn PeerReporter>,
+        );
+
+        let signer = PrivateKeySigner::random();
+        let (shallow, _signer_overlay) = signed_receipt_at_depth(
+            &signer,
+            &address,
+            0,
+            StorageRadius::new(Bin::new(0).unwrap()),
+        );
+        let answer = reconstructed(shallow);
+
+        let err = drive_one_command(
+            rx,
+            forwarder.push(chunk.clone(), pusher),
+            move |cmd| match cmd {
+                ClientCommand::PushChunk { response, .. } => {
+                    response.send(Ok(answer)).expect("receiver alive");
+                }
+                other => panic!("unexpected command: {other:?}"),
+            },
+        )
+        .await
+        .expect_err("an unverifiable receipt is never relayed");
+        assert!(matches!(err, ForwardError::UnverifiableReceipt));
+
+        // The downstream peer is NOT penalised: the receipt may be honest.
+        assert!(reporter.is_empty());
+
+        // Both reservations released on drop: nothing was charged.
         assert_eq!(acct.bandwidth().for_peer(pusher).balance(), Au::ZERO);
         assert_eq!(acct.bandwidth().for_peer(closer).balance(), Au::ZERO);
     }

--- a/crates/swarm/test-utils/src/topology.rs
+++ b/crates/swarm/test-utils/src/topology.rs
@@ -23,6 +23,7 @@ pub struct MockTopology {
     stored: usize,
     pending: usize,
     depth: u8,
+    credible: bool,
     closest: Vec<OverlayAddress>,
 }
 
@@ -35,6 +36,7 @@ impl Default for MockTopology {
             stored: 0,
             pending: 0,
             depth: 0,
+            credible: true,
             closest: Vec::new(),
         }
     }
@@ -61,6 +63,7 @@ impl MockTopology {
             stored: 0,
             pending: 0,
             depth,
+            credible: true,
             closest: Vec::new(),
         }
     }
@@ -107,6 +110,14 @@ impl MockTopology {
         self
     }
 
+    /// Set whether the locally observed neighbourhood depth is credible (the
+    /// neighbourhood has saturated). Defaults to true.
+    #[must_use]
+    pub fn with_credible(mut self, credible: bool) -> Self {
+        self.credible = credible;
+        self
+    }
+
     /// Set the peers returned by [`SwarmTopologyRouting::closest_to`].
     #[must_use]
     pub fn with_closest(mut self, closest: Vec<OverlayAddress>) -> Self {
@@ -140,6 +151,10 @@ impl SwarmTopologyState for MockTopology {
 
     fn depth(&self) -> NeighborhoodDepth {
         NeighborhoodDepth::new(Bin::new(self.depth).unwrap_or(Bin::MAX))
+    }
+
+    fn neighbourhood_credible(&self) -> bool {
+        self.credible
     }
 }
 

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -320,6 +320,10 @@ impl<I: SwarmIdentity> SwarmTopologyState for TopologyHandle<I> {
     fn depth(&self) -> NeighborhoodDepth {
         self.routing.depth()
     }
+
+    fn neighbourhood_credible(&self) -> bool {
+        self.readiness().is_saturated()
+    }
 }
 
 impl<I: SwarmIdentity> SwarmTopologyReporting for TopologyHandle<I> {


### PR DESCRIPTION
Closes #316.

The custody-receipt depth check derived its required signer depth from the locally observed neighbourhood depth and then fell back to the receipt's `storage_radius`. That field is attacker-controlled wire data and is not covered by the receipt signature (the storer signs over the 32-byte chunk address only). When the verifying node's local depth is low (a fresh, post-restart, or sparse node before the neighbourhood saturates, where the depth atomic genuinely starts at 0), the local floor collapses and the unsigned `storage_radius` (which the responder can set to 0) becomes the sole bar, so a shallow custody receipt is accepted as if the push succeeded.

The reference does not have this hole because it anchors its floor to a credible network radius and blocks until that is known, rather than reading a raw observed depth. This fixes the equivalent by gating on a credibility signal.

## Fix (local policy, no wire change, not fork-gated)

`Receipt::verify_depth` is now three-valued: `DepthVerdict { Verified, Shallow(ShallowReceipt), Unverifiable }`. When the neighbourhood view is not credible it returns `Unverifiable` without ever reading `storage_radius`; otherwise it computes the floor as before and returns `Verified` or `Shallow`. The pushsync crate stays topology-free: callers pass a `neighbourhood_credible` bool, derived from a new `SwarmTopologyState::neighbourhood_credible()` accessor that `TopologyHandle` implements as `self.readiness().is_saturated()` (the saturation signal, not the stricter stability-window readiness).

Per-path behaviour:
- Origin upload: `Unverifiable` surfaces as a new `SwarmError::UnconfirmedCustody { chunk_address }` (the push is reported unconfirmed, not success and not a hard invalid-signature error) and does not penalise the peer (an unverifiable receipt may be honest). `Shallow` keeps its penalising path; `Verified` is success.
- Relay: `Unverifiable` drops the reservation, does not penalise, fails that candidate with a non-penalising `ForwardError::UnverifiableReceipt`, and continues. `Shallow` keeps its penalising path.

Option (a), authenticating the radius by signing over it, is wire-visible (the reference signs only the address) and is tracked as post-v1 hardfork work.

`cargo fmt`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo build --workspace --all-targets`, and the affected crate test suites are clean (including a regression that a `local_depth = 0`, `radius = 0`, non-credible view yields `Unverifiable`, never `Verified`).
