### PR TITLE
feat(swarm): add peer-administration gRPC surface (AddPeer/RemovePeer/ListPeers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9502,6 +9502,7 @@ dependencies = [
  "vertex-swarm-api",
  "vertex-swarm-primitives",
  "vertex-swarm-stream",
+ "vertex-swarm-test-utils",
 ]
 
 [[package]]

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -18,8 +18,9 @@ pub use self::pricing::{SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig};
 pub use self::pullsync::{IntervalStore, PullChunkVerifier, PullStorage, VerifyError};
 pub use self::reserve::{BinCursorStore, BinScanItem, ReserveStore, SettableRadius};
 pub use self::topology::{
-    SwarmTopology, SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers,
-    SwarmTopologyReporting, SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats,
+    PeerConnectionDirection, PeerDiagnostics, PeerTrustLevel, SwarmTopology, SwarmTopologyAdmin,
+    SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting,
+    SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats,
 };
 
 use crate::SwarmIdentity;

--- a/crates/swarm/api/src/components/topology.rs
+++ b/crates/swarm/api/src/components/topology.rs
@@ -86,6 +86,65 @@ pub trait SwarmTopologyPeers: SwarmTopologyBins {
     ) -> Vec<(OverlayAddress, Vec<libp2p::Multiaddr>)>;
 }
 
+/// Direction of a peer connection, mirrored here so the diagnostics surface does
+/// not depend on the peer-registry crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerConnectionDirection {
+    /// We dialed the peer.
+    Outbound,
+    /// The peer dialed us.
+    Inbound,
+}
+
+/// Trust level applied to a peer, mirrored here for the diagnostics surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerTrustLevel {
+    /// No special standing.
+    Normal,
+    /// Loopback, link-local, or same-subnet peer.
+    LocalSubnet,
+    /// Explicitly configured trusted peer.
+    Trusted,
+}
+
+/// Per-peer diagnostics assembled from the peer manager and connection registry.
+#[derive(Debug, Clone)]
+pub struct PeerDiagnostics {
+    /// Overlay address.
+    pub overlay: OverlayAddress,
+    /// libp2p peer id, if currently mapped in the connection registry.
+    pub peer_id: Option<libp2p::PeerId>,
+    /// Known multiaddrs from the stored peer record.
+    pub multiaddrs: Vec<libp2p::Multiaddr>,
+    /// First IP parsed from the peer's multiaddrs, if any.
+    pub ip: Option<std::net::IpAddr>,
+    /// Proximity order / bin of this peer relative to the local overlay.
+    pub proximity_order: u8,
+    /// Current reputation score, if tracked.
+    pub score: Option<f64>,
+    /// Whether the peer currently has a handshake-complete connection.
+    pub connected: bool,
+    /// Unix seconds at which the current connection completed its handshake.
+    pub connected_since: Option<u64>,
+    /// Seconds since the current connection completed its handshake.
+    pub uptime_secs: Option<u64>,
+    /// Direction of the current connection.
+    pub direction: Option<PeerConnectionDirection>,
+    /// Trust level applied to this peer.
+    pub trust: PeerTrustLevel,
+    /// Whether a completed handshake has verified this peer in this process.
+    pub verified: bool,
+}
+
+/// Read-only peer-administration diagnostics over the topology, backing the
+/// `ListPeers` operator endpoint.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait SwarmTopologyAdmin: Send + Sync {
+    /// Per-peer diagnostics for every peer the node knows; when `connected_only`
+    /// is true, only peers with a current handshake-complete connection.
+    fn peer_diagnostics(&self, connected_only: bool) -> Vec<PeerDiagnostics>;
+}
+
 /// Connection and storage statistics for topology monitoring.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait SwarmTopologyStats: SwarmTopologyBins {

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -39,10 +39,11 @@ pub use self::accounting::{Au, AuConversionError};
 pub use self::components::{
     AccountingAction, BandwidthDebit, BinCursorStore, BinScanItem, BootnodeComponents,
     ClientComponents, Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology,
-    IntervalStore, PullChunkVerifier, PullStorage, ReserveStore, SettableRadius, StorerComponents,
-    SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore,
-    SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing,
-    SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
+    IntervalStore, PeerConnectionDirection, PeerDiagnostics, PeerTrustLevel, PullChunkVerifier,
+    PullStorage, ReserveStore, SettableRadius, StorerComponents, SwarmAccountingConfig,
+    SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig,
+    SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder,
+    SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology, SwarmTopologyAdmin,
     SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting,
     SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats, VerifyError, construct,
 };

--- a/crates/swarm/client-behaviour/src/behaviour.rs
+++ b/crates/swarm/client-behaviour/src/behaviour.rs
@@ -169,14 +169,19 @@ impl ClientBehaviour {
                 peer_id,
                 overlay,
                 node_type,
+                trusted,
             } => {
-                debug!(%peer_id, %overlay, ?node_type, "Activating peer");
+                debug!(%peer_id, %overlay, ?node_type, trusted, "Activating peer");
                 self.peer_overlays.insert(peer_id, overlay);
                 self.overlay_peers.insert(overlay, peer_id);
                 self.push_event(ToSwarm::NotifyHandler {
                     peer_id,
                     handler: libp2p::swarm::NotifyHandler::Any,
-                    event: HandlerCommand::Activate { overlay, node_type },
+                    event: HandlerCommand::Activate {
+                        overlay,
+                        node_type,
+                        trusted,
+                    },
                 });
             }
             ClientCommand::AnnouncePricing { peer, threshold } => {
@@ -546,13 +551,31 @@ impl NetworkBehaviour for ClientBehaviour {
             && info.remaining_established == 0
             && let Some(overlay) = self.peer_overlays.remove(&info.peer_id)
         {
-            self.overlay_peers.remove(&overlay);
-            debug!(peer_id = %info.peer_id, %overlay, "Peer disconnected");
-            self.pending_events
-                .push_back(ToSwarm::GenerateEvent(ClientEvent::PeerDisconnected {
-                    peer_id: info.peer_id,
-                    overlay,
-                }));
+            // Only drop the overlay->peer entry when it still points at the
+            // connection that closed. A reconnect dial-race can complete a fresh
+            // handshake for the same overlay (a new `ActivatePeer` re-pointing
+            // `overlay_peers` at the new peer id) before the old connection's
+            // `ConnectionClosed` arrives; removing unconditionally would delete
+            // the freshly re-activated, live entry and leave the overlay
+            // de-activated for retrieval. Guarding on the stored peer id keeps
+            // the live entry and only retracts a genuinely stale mapping.
+            let still_current = self.overlay_peers.get(&overlay) == Some(&info.peer_id);
+            if still_current {
+                self.overlay_peers.remove(&overlay);
+                debug!(peer_id = %info.peer_id, %overlay, "Peer disconnected");
+                self.pending_events.push_back(ToSwarm::GenerateEvent(
+                    ClientEvent::PeerDisconnected {
+                        peer_id: info.peer_id,
+                        overlay,
+                    },
+                ));
+            } else {
+                debug!(
+                    peer_id = %info.peer_id,
+                    %overlay,
+                    "Stale connection closed; overlay already re-activated on a newer connection"
+                );
+            }
         }
     }
 

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -146,6 +146,8 @@ pub enum HandlerCommand {
     Activate {
         overlay: OverlayAddress,
         node_type: SwarmNodeType,
+        /// Whether this is an explicitly configured trusted peer (forces keep-alive).
+        trusted: bool,
     },
     /// Announce our payment threshold to the peer.
     AnnouncePricing { threshold: U256 },
@@ -286,7 +288,11 @@ enum State {
     /// Waiting for activation command.
     Dormant,
     /// Active and processing protocols.
-    Active { overlay: OverlayAddress },
+    Active {
+        overlay: OverlayAddress,
+        /// Whether to force `connection_keep_alive` (set for trusted peers).
+        keep_alive: bool,
+    },
 }
 
 /// A pending inbound pseudosettle response awaiting the application's ack.
@@ -422,11 +428,14 @@ impl ClientHandler {
             .map(|s| s.response)
     }
 
-    fn activate(&mut self, overlay: OverlayAddress, node_type: SwarmNodeType) {
+    fn activate(&mut self, overlay: OverlayAddress, node_type: SwarmNodeType, keep_alive: bool) {
         match &self.state {
             State::Dormant => {
-                debug!(%overlay, ?node_type, "Handler activated");
-                self.state = State::Active { overlay };
+                debug!(%overlay, ?node_type, keep_alive, "Handler activated");
+                self.state = State::Active {
+                    overlay,
+                    keep_alive,
+                };
                 self.pending_events
                     .push_back(HandlerEvent::Activated { overlay });
             }
@@ -804,6 +813,17 @@ impl ConnectionHandler for ClientHandler {
         SubstreamProtocol::new(upgrade, ()).with_timeout(self.config.timeout)
     }
 
+    /// Keep a trusted peer's connection open, exempting it from the idle timeout.
+    fn connection_keep_alive(&self) -> bool {
+        matches!(
+            self.state,
+            State::Active {
+                keep_alive: true,
+                ..
+            }
+        )
+    }
+
     fn poll(
         &mut self,
         cx: &mut Context<'_>,
@@ -852,8 +872,12 @@ impl ConnectionHandler for ClientHandler {
 
         while let Some(cmd) = self.pending_commands.pop_front() {
             match cmd {
-                HandlerCommand::Activate { overlay, node_type } => {
-                    self.activate(overlay, node_type);
+                HandlerCommand::Activate {
+                    overlay,
+                    node_type,
+                    trusted,
+                } => {
+                    self.activate(overlay, node_type, trusted);
                     if let Some(event) = self.pending_events.pop_front() {
                         return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
                     }

--- a/crates/swarm/client-protocol/src/lib.rs
+++ b/crates/swarm/client-protocol/src/lib.rs
@@ -337,6 +337,8 @@ pub enum ClientCommand {
         overlay: OverlayAddress,
         /// The peer's node type.
         node_type: SwarmNodeType,
+        /// Whether this is an explicitly configured trusted peer (kept alive).
+        trusted: bool,
     },
 
     /// Announce our payment threshold to a peer.

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -340,6 +340,7 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
                 overlay,
                 peer_id,
                 node_type,
+                trusted,
                 ..
             } => {
                 self.base
@@ -350,6 +351,7 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
                         peer_id,
                         overlay,
                         node_type,
+                        trusted,
                     });
             }
             TopologyEvent::PeerDisconnected { .. } => {}

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -422,6 +422,7 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
                 overlay,
                 peer_id,
                 node_type,
+                trusted,
                 ..
             } => {
                 self.base.swarm.behaviour_mut().storer.client.on_command(
@@ -429,6 +430,7 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
                         peer_id,
                         overlay,
                         node_type,
+                        trusted,
                     },
                 );
             }

--- a/crates/swarm/node/src/protocol/behaviour_tests.rs
+++ b/crates/swarm/node/src/protocol/behaviour_tests.rs
@@ -89,6 +89,7 @@ async fn connect_and_activate(
             peer_id: server_peer,
             overlay: server_overlay,
             node_type: SwarmNodeType::Client,
+            trusted: false,
         });
     server
         .behaviour_mut()
@@ -96,6 +97,7 @@ async fn connect_and_activate(
             peer_id: client_peer,
             overlay: client_overlay,
             node_type: SwarmNodeType::Client,
+            trusted: false,
         });
 }
 

--- a/crates/swarm/node/src/protocol/timeout_repro.rs
+++ b/crates/swarm/node/src/protocol/timeout_repro.rs
@@ -179,6 +179,7 @@ async fn withholding_peer_resolves_as_timed_out_within_the_deadline() {
             peer_id: server_peer,
             overlay: server_overlay,
             node_type: SwarmNodeType::Client,
+            trusted: false,
         });
 
     let address = ChunkAddress::new([0x11; 32]);

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -2067,6 +2067,81 @@ mod tests {
     }
 
     #[test]
+    fn trusted_peer_is_not_disconnected_on_low_score() {
+        let pm = thresholds_manager();
+        let overlay = test_overlay(1);
+        // Connect as a configured trusted peer.
+        pm.on_peer_connected(
+            test_swarm_peer(1),
+            SwarmNodeType::Client,
+            ConnectionDirection::Outbound,
+            TrustLevel::Trusted,
+            None,
+        );
+        assert_eq!(pm.trust_level(&overlay), TrustLevel::Trusted);
+        let mut rx = pm.subscribe();
+
+        // Drive the score across the disconnect threshold; a Normal peer would
+        // get DisconnectRequested + backoff here.
+        for _ in 0..7 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Topology,
+            );
+        }
+
+        let events = drain_events(&mut rx);
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                PeerLifecycleEvent::DisconnectRequested { overlay: o, .. } if *o == overlay
+            )),
+            "trusted peer must not be disconnected on low score"
+        );
+        assert!(
+            !pm.peer_is_in_backoff(&overlay),
+            "trusted peer disconnect suppression must not arm dial backoff"
+        );
+        assert!(!pm.is_banned(&overlay));
+    }
+
+    #[test]
+    fn trusted_peer_is_not_auto_banned_on_low_score() {
+        let pm = thresholds_manager();
+        let overlay = test_overlay(1);
+        pm.on_peer_connected(
+            test_swarm_peer(1),
+            SwarmNodeType::Client,
+            ConnectionDirection::Outbound,
+            TrustLevel::Trusted,
+            None,
+        );
+        let mut rx = pm.subscribe();
+
+        // Drive well past the ban threshold; a Normal peer would be auto-banned.
+        for _ in 0..15 {
+            pm.report_peer(
+                &overlay,
+                SwarmScoringEvent::ProtocolError,
+                ReportSource::Accounting,
+            );
+        }
+
+        assert!(
+            !pm.is_banned(&overlay),
+            "trusted peer must be exempt from score-driven auto-ban"
+        );
+        let events = drain_events(&mut rx);
+        assert!(
+            !events.iter().any(
+                |e| matches!(e, PeerLifecycleEvent::Banned { overlay: o, .. } if *o == overlay)
+            ),
+            "trusted peer must not emit a Banned lifecycle event from scoring"
+        );
+    }
+
+    #[test]
     fn test_report_peer_unknown_overlay_is_dropped() {
         let pm = manager();
         // No entry exists; the report must be a no-op, not a panic or insert.

--- a/crates/swarm/peers/peer-manager/src/scoring.rs
+++ b/crates/swarm/peers/peer-manager/src/scoring.rs
@@ -16,7 +16,7 @@ use vertex_swarm_api::{
 use vertex_swarm_peer_score::ScoreOutcome;
 use vertex_swarm_primitives::OverlayAddress;
 
-use crate::entry::on_health_changed;
+use crate::entry::{TrustLevel, on_health_changed};
 use crate::manager::PeerManager;
 
 impl<I: SwarmIdentity> PeerManager<I> {
@@ -97,6 +97,25 @@ impl<I: SwarmIdentity> PeerManager<I> {
                 });
             }
             ScoreOutcome::Disconnect => {
+                // A configured trusted peer is never evicted on score: the
+                // operator asked us to keep it connected, so a low score
+                // downgrades to a warning instead of a disconnect request. The
+                // score still moved (the event was applied), but no network-side
+                // eviction is triggered.
+                if self.trust_level(overlay) == TrustLevel::Trusted {
+                    counter!("peer_manager_trusted_disconnect_suppressed_total").increment(1);
+                    warn!(
+                        ?overlay,
+                        score = change.new_score,
+                        source = source_label,
+                        "trusted peer crossed disconnect threshold; suppressing disconnect"
+                    );
+                    self.emit(PeerLifecycleEvent::ScoreWarning {
+                        overlay: *overlay,
+                        score: change.new_score,
+                    });
+                    return;
+                }
                 // Back the peer off so the dialer does not immediately
                 // reconnect the connection topology is about to close.
                 let old_state = entry.health_state();
@@ -114,6 +133,25 @@ impl<I: SwarmIdentity> PeerManager<I> {
                 });
             }
             ScoreOutcome::Ban => {
+                // Trusted peers are exempt from score-driven auto-bans: an
+                // auto-ban removes them from routing and closes the connection,
+                // the opposite of "never evicted". An operator can still ban a
+                // trusted peer explicitly via the ban command
+                // (BanCause::Requested), which does not flow through here.
+                if self.trust_level(overlay) == TrustLevel::Trusted {
+                    counter!("peer_manager_trusted_ban_suppressed_total").increment(1);
+                    warn!(
+                        ?overlay,
+                        score = change.new_score,
+                        source = source_label,
+                        "trusted peer crossed ban threshold; suppressing auto-ban"
+                    );
+                    self.emit(PeerLifecycleEvent::ScoreWarning {
+                        overlay: *overlay,
+                        score: change.new_score,
+                    });
+                    return;
+                }
                 let reason = format!(
                     "score {:+.1} at or below ban threshold after {event_label}",
                     change.new_score

--- a/crates/swarm/rpc/Cargo.toml
+++ b/crates/swarm/rpc/Cargo.toml
@@ -31,6 +31,8 @@ prost.workspace = true
 
 [dev-dependencies]
 bytes = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+vertex-swarm-test-utils = { workspace = true }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/swarm/rpc/proto/node.proto
+++ b/crates/swarm/rpc/proto/node.proto
@@ -8,6 +8,15 @@ service Node {
 
   // GetTopology returns detailed Kademlia topology information.
   rpc GetTopology(GetTopologyRequest) returns (GetTopologyResponse);
+
+  // AddPeer dials a peer by multiaddr and marks the dial for connection.
+  rpc AddPeer(AddPeerRequest) returns (AddPeerResponse);
+
+  // RemovePeer disconnects (closes all connections to) a peer by overlay.
+  rpc RemovePeer(RemovePeerRequest) returns (RemovePeerResponse);
+
+  // ListPeers returns per-peer diagnostics for every known peer.
+  rpc ListPeers(ListPeersRequest) returns (ListPeersResponse);
 }
 
 message GetStatusRequest {}
@@ -68,4 +77,91 @@ message PeerInfo {
 
   // Multiaddrs (including /p2p/<peer_id> suffix).
   repeated string multiaddrs = 2;
+}
+
+// --- Peer administration (operator control over the node's peer set) ---
+
+message AddPeerRequest {
+  // Multiaddr of the peer to dial. Should include a /p2p/<peer_id> component.
+  string multiaddr = 1;
+}
+
+message AddPeerResponse {
+  // Whether the dial command was accepted by the topology. The dial is
+  // fire-and-forget; ListPeers is the authoritative way to observe the
+  // resulting connection.
+  bool accepted = 1;
+}
+
+message RemovePeerRequest {
+  // Overlay address (hex encoded) of the peer to disconnect.
+  string overlay = 1;
+}
+
+message RemovePeerResponse {
+  // Whether the disconnect command was accepted by the topology.
+  bool accepted = 1;
+}
+
+message ListPeersRequest {
+  // When true, include peers that are known but not currently connected.
+  // Defaults to false (connected peers only).
+  bool include_known = 1;
+}
+
+message ListPeersResponse {
+  repeated PeerDiagnostics peers = 1;
+}
+
+// Trust level applied to a peer.
+enum TrustLevel {
+  TRUST_LEVEL_NORMAL = 0;
+  TRUST_LEVEL_LOCAL_SUBNET = 1;
+  TRUST_LEVEL_TRUSTED = 2;
+}
+
+// Direction of a peer connection.
+enum ConnectionDirection {
+  CONNECTION_DIRECTION_UNSPECIFIED = 0;
+  CONNECTION_DIRECTION_INBOUND = 1;
+  CONNECTION_DIRECTION_OUTBOUND = 2;
+}
+
+// Per-peer diagnostics, assembled from the peer manager and connection registry.
+message PeerDiagnostics {
+  // Overlay address (hex encoded).
+  string overlay = 1;
+
+  // libp2p peer id, if currently mapped in the connection registry.
+  optional string peer_id = 2;
+
+  // Known multiaddrs from the stored peer record.
+  repeated string multiaddrs = 3;
+
+  // First IP parsed from the peer's multiaddrs, if any.
+  optional string ip = 4;
+
+  // Proximity order / bin of this peer relative to the local overlay.
+  uint32 proximity_order = 5;
+
+  // Current reputation score, if the peer is tracked.
+  optional double score = 6;
+
+  // Whether the peer currently has a handshake-complete connection.
+  bool connected = 7;
+
+  // Unix seconds at which the current connection completed its handshake.
+  optional uint64 connected_since = 8;
+
+  // Seconds since the current connection completed its handshake.
+  optional uint64 uptime_secs = 9;
+
+  // Direction of the current connection.
+  ConnectionDirection direction = 10;
+
+  // Trust level applied to this peer.
+  TrustLevel trust = 11;
+
+  // Whether a completed handshake has verified this peer in this process.
+  bool verified = 12;
 }

--- a/crates/swarm/rpc/src/adapter.rs
+++ b/crates/swarm/rpc/src/adapter.rs
@@ -9,7 +9,8 @@
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
 use vertex_swarm_api::{
     BinCursorStore, BootnodeComponents, ClientComponents, HasChunkClient, HasReserve, HasStore,
-    HasTopology, StorerComponents, SwarmTopologyPeers, SwarmTopologyState, SwarmTopologyStats,
+    HasTopology, StorerComponents, SwarmTopologyAdmin, SwarmTopologyCommands, SwarmTopologyPeers,
+    SwarmTopologyState, SwarmTopologyStats,
 };
 use vertex_swarm_stream::ChunkClient;
 
@@ -76,6 +77,8 @@ impl<C> GrpcAdapter<C> {
         C::Topology: SwarmTopologyState
             + SwarmTopologyStats
             + SwarmTopologyPeers
+            + SwarmTopologyAdmin
+            + SwarmTopologyCommands
             + Clone
             + Send
             + Sync
@@ -113,7 +116,15 @@ impl<C> GrpcAdapter<C> {
 /// Bootnodes register the node status service only.
 impl<T> RegistersGrpcServices for GrpcAdapter<BootnodeComponents<T>>
 where
-    T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Clone + Send + Sync + 'static,
+    T: SwarmTopologyState
+        + SwarmTopologyStats
+        + SwarmTopologyPeers
+        + SwarmTopologyAdmin
+        + SwarmTopologyCommands
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
         self.register_node(registry);
@@ -123,7 +134,15 @@ where
 /// Client nodes register the node status service and the chunk service.
 impl<T, C> RegistersGrpcServices for GrpcAdapter<ClientComponents<T, C>>
 where
-    T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Clone + Send + Sync + 'static,
+    T: SwarmTopologyState
+        + SwarmTopologyStats
+        + SwarmTopologyPeers
+        + SwarmTopologyAdmin
+        + SwarmTopologyCommands
+        + Clone
+        + Send
+        + Sync
+        + 'static,
     C: ChunkClient + Send + Sync,
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
@@ -136,7 +155,15 @@ where
 /// reserve service over the `R` reserve axis.
 impl<T, C, S, R> RegistersGrpcServices for GrpcAdapter<StorerComponents<T, C, S, R>>
 where
-    T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Clone + Send + Sync + 'static,
+    T: SwarmTopologyState
+        + SwarmTopologyStats
+        + SwarmTopologyPeers
+        + SwarmTopologyAdmin
+        + SwarmTopologyCommands
+        + Clone
+        + Send
+        + Sync
+        + 'static,
     C: ChunkClient + Send + Sync,
     S: Send + Sync,
     R: BinCursorStore + Clone + 'static,

--- a/crates/swarm/rpc/src/grpc/node.rs
+++ b/crates/swarm/rpc/src/grpc/node.rs
@@ -1,13 +1,62 @@
 //! Node service implementation for Swarm topology and status information.
 
+use hex::FromHex;
 use tonic::{Request, Response, Status};
-use vertex_swarm_api::{SwarmTopologyPeers, SwarmTopologyState, SwarmTopologyStats};
-use vertex_swarm_primitives::Bin;
+use vertex_swarm_api::{
+    PeerConnectionDirection, PeerDiagnostics as ApiPeerDiagnostics, PeerTrustLevel,
+    SwarmTopologyAdmin, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyState,
+    SwarmTopologyStats,
+};
+use vertex_swarm_primitives::{Bin, OverlayAddress};
 
 use crate::proto::node::{
-    BinInfo, GetStatusRequest, GetStatusResponse, GetTopologyRequest, GetTopologyResponse,
-    PeerInfo, node_server::Node,
+    AddPeerRequest, AddPeerResponse, BinInfo, ConnectionDirection, GetStatusRequest,
+    GetStatusResponse, GetTopologyRequest, GetTopologyResponse, ListPeersRequest,
+    ListPeersResponse, PeerDiagnostics, PeerInfo, RemovePeerRequest, RemovePeerResponse,
+    TrustLevel, node_server::Node,
 };
+
+/// Parse a hex-encoded overlay address (with optional `0x` prefix).
+#[allow(clippy::result_large_err)]
+fn parse_overlay(hex: &str) -> Result<OverlayAddress, Status> {
+    let trimmed = hex.strip_prefix("0x").unwrap_or(hex);
+    let bytes = <[u8; 32]>::from_hex(trimmed)
+        .map_err(|_| Status::invalid_argument(format!("invalid overlay address: {hex}")))?;
+    Ok(OverlayAddress::from(bytes))
+}
+
+fn proto_direction(direction: Option<PeerConnectionDirection>) -> i32 {
+    match direction {
+        Some(PeerConnectionDirection::Inbound) => ConnectionDirection::Inbound as i32,
+        Some(PeerConnectionDirection::Outbound) => ConnectionDirection::Outbound as i32,
+        None => ConnectionDirection::Unspecified as i32,
+    }
+}
+
+fn proto_trust(trust: PeerTrustLevel) -> i32 {
+    match trust {
+        PeerTrustLevel::Normal => TrustLevel::Normal as i32,
+        PeerTrustLevel::LocalSubnet => TrustLevel::LocalSubnet as i32,
+        PeerTrustLevel::Trusted => TrustLevel::Trusted as i32,
+    }
+}
+
+fn proto_diagnostics(d: ApiPeerDiagnostics) -> PeerDiagnostics {
+    PeerDiagnostics {
+        overlay: d.overlay.to_string(),
+        peer_id: d.peer_id.map(|p| p.to_string()),
+        multiaddrs: d.multiaddrs.iter().map(|m| m.to_string()).collect(),
+        ip: d.ip.map(|ip| ip.to_string()),
+        proximity_order: u32::from(d.proximity_order),
+        score: d.score,
+        connected: d.connected,
+        connected_since: d.connected_since,
+        uptime_secs: d.uptime_secs,
+        direction: proto_direction(d.direction),
+        trust: proto_trust(d.trust),
+        verified: d.verified,
+    }
+}
 
 /// Node service implementation.
 ///
@@ -23,8 +72,16 @@ impl<T> NodeService<T> {
 }
 
 #[tonic::async_trait]
-impl<T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Send + Sync + 'static> Node
-    for NodeService<T>
+impl<T> Node for NodeService<T>
+where
+    T: SwarmTopologyState
+        + SwarmTopologyStats
+        + SwarmTopologyPeers
+        + SwarmTopologyAdmin
+        + SwarmTopologyCommands
+        + Send
+        + Sync
+        + 'static,
 {
     async fn get_status(
         &self,
@@ -81,5 +138,129 @@ impl<T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Send + Sy
             depth: u32::from(self.topology.depth().get()),
             bins,
         }))
+    }
+
+    async fn add_peer(
+        &self,
+        request: Request<AddPeerRequest>,
+    ) -> Result<Response<AddPeerResponse>, Status> {
+        let req = request.into_inner();
+        let addr: libp2p::Multiaddr = req
+            .multiaddr
+            .parse()
+            .map_err(|e| Status::invalid_argument(format!("invalid multiaddr: {e}")))?;
+
+        self.topology
+            .dial(addr)
+            .await
+            .map_err(|e| Status::unavailable(format!("dial command failed: {e}")))?;
+
+        Ok(Response::new(AddPeerResponse { accepted: true }))
+    }
+
+    async fn remove_peer(
+        &self,
+        request: Request<RemovePeerRequest>,
+    ) -> Result<Response<RemovePeerResponse>, Status> {
+        let req = request.into_inner();
+        let overlay = parse_overlay(&req.overlay)?;
+
+        self.topology
+            .disconnect(overlay)
+            .await
+            .map_err(|e| Status::unavailable(format!("disconnect command failed: {e}")))?;
+
+        Ok(Response::new(RemovePeerResponse { accepted: true }))
+    }
+
+    async fn list_peers(
+        &self,
+        request: Request<ListPeersRequest>,
+    ) -> Result<Response<ListPeersResponse>, Status> {
+        let req = request.into_inner();
+        let connected_only = !req.include_known;
+        let peers = self
+            .topology
+            .peer_diagnostics(connected_only)
+            .into_iter()
+            .map(proto_diagnostics)
+            .collect();
+
+        Ok(Response::new(ListPeersResponse { peers }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vertex_swarm_api::{PeerTrustLevel, SwarmTopologyAdmin};
+    use vertex_swarm_test_utils::MockTopology;
+
+    use super::*;
+
+    fn diag(overlay: OverlayAddress, connected: bool) -> ApiPeerDiagnostics {
+        ApiPeerDiagnostics {
+            overlay,
+            peer_id: None,
+            multiaddrs: Vec::new(),
+            ip: None,
+            proximity_order: 0,
+            score: None,
+            connected,
+            connected_since: None,
+            uptime_secs: None,
+            direction: None,
+            trust: PeerTrustLevel::Normal,
+            verified: false,
+        }
+    }
+
+    #[test]
+    fn parse_overlay_accepts_plain_and_prefixed_hex() {
+        let hex = "ff".to_string() + &"00".repeat(31);
+        let plain = parse_overlay(&hex).expect("plain hex parses");
+        let prefixed = parse_overlay(&format!("0x{hex}")).expect("0x-prefixed hex parses");
+        assert_eq!(plain, prefixed);
+    }
+
+    #[test]
+    fn parse_overlay_rejects_invalid_hex() {
+        assert!(parse_overlay("0x").is_err());
+        assert!(parse_overlay("not-hex").is_err());
+        // Wrong length (16 bytes, not 32).
+        assert!(parse_overlay(&"ab".repeat(16)).is_err());
+    }
+
+    #[tokio::test]
+    async fn list_peers_connected_only_filters_disconnected() {
+        let connected = OverlayAddress::from([0x11; 32]);
+        let disconnected = OverlayAddress::from([0x22; 32]);
+        let topology = MockTopology::default()
+            .with_diagnostics(vec![diag(connected, true), diag(disconnected, false)]);
+
+        // connected_only path (include_known = false): only the connected peer.
+        let service = NodeService::new(topology.clone());
+        let resp = service
+            .list_peers(Request::new(ListPeersRequest {
+                include_known: false,
+            }))
+            .await
+            .expect("list_peers succeeds")
+            .into_inner();
+        assert_eq!(resp.peers.len(), 1);
+        assert_eq!(resp.peers[0].overlay, connected.to_string());
+
+        // include_known path: both peers.
+        assert_eq!(
+            SwarmTopologyAdmin::peer_diagnostics(&topology, false).len(),
+            2
+        );
+        let resp = service
+            .list_peers(Request::new(ListPeersRequest {
+                include_known: true,
+            }))
+            .await
+            .expect("list_peers succeeds")
+            .into_inner();
+        assert_eq!(resp.peers.len(), 2);
     }
 }

--- a/crates/swarm/test-utils/src/topology.rs
+++ b/crates/swarm/test-utils/src/topology.rs
@@ -3,8 +3,9 @@
 use nectar_primitives::{ChunkAddress, SwarmAddress};
 use std::sync::Arc;
 use vertex_swarm_api::{
-    SwarmIdentity, SwarmNodeType, SwarmTopologyBins, SwarmTopologyPeers, SwarmTopologyRouting,
-    SwarmTopologyState, SwarmTopologyStats,
+    PeerDiagnostics, SwarmIdentity, SwarmNodeType, SwarmTopologyAdmin, SwarmTopologyBins,
+    SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyRouting, SwarmTopologyState,
+    SwarmTopologyStats,
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
@@ -25,6 +26,7 @@ pub struct MockTopology {
     depth: u8,
     credible: bool,
     closest: Vec<OverlayAddress>,
+    diagnostics: Vec<PeerDiagnostics>,
 }
 
 impl Default for MockTopology {
@@ -38,6 +40,7 @@ impl Default for MockTopology {
             depth: 0,
             credible: true,
             closest: Vec::new(),
+            diagnostics: Vec::new(),
         }
     }
 }
@@ -65,6 +68,7 @@ impl MockTopology {
             depth,
             credible: true,
             closest: Vec::new(),
+            diagnostics: Vec::new(),
         }
     }
 
@@ -122,6 +126,13 @@ impl MockTopology {
     #[must_use]
     pub fn with_closest(mut self, closest: Vec<OverlayAddress>) -> Self {
         self.closest = closest;
+        self
+    }
+
+    /// Set the diagnostics returned by [`SwarmTopologyAdmin::peer_diagnostics`].
+    #[must_use]
+    pub fn with_diagnostics(mut self, diagnostics: Vec<PeerDiagnostics>) -> Self {
+        self.diagnostics = diagnostics;
         self
     }
 
@@ -196,6 +207,56 @@ impl SwarmTopologyStats for MockTopology {
 
     fn stored_peers_count(&self) -> usize {
         self.stored
+    }
+}
+
+impl SwarmTopologyAdmin for MockTopology {
+    fn peer_diagnostics(&self, connected_only: bool) -> Vec<PeerDiagnostics> {
+        self.diagnostics
+            .iter()
+            .filter(|d| !connected_only || d.connected)
+            .cloned()
+            .collect()
+    }
+}
+
+/// Error type for [`MockTopology`]'s [`SwarmTopologyCommands`] impl.
+#[derive(Debug)]
+pub struct MockTopologyError;
+
+impl std::fmt::Display for MockTopologyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("mock topology command error")
+    }
+}
+
+impl std::error::Error for MockTopologyError {}
+
+impl SwarmTopologyCommands for MockTopology {
+    type Error = MockTopologyError;
+
+    async fn connect_bootnodes(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn dial(&self, _addr: libp2p::Multiaddr) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn disconnect(&self, _peer: OverlayAddress) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn ban_peer(
+        &self,
+        _peer: OverlayAddress,
+        _reason: Option<String>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn save_peers(&self) -> Result<(), Self::Error> {
+        Ok(())
     }
 }
 

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -896,6 +896,16 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
             // expired; connection events are the other publication path.
             self.refresh_published_depth();
             self.evaluator_handle.trigger_evaluation();
+            // Keep configured contacts dialable. The known-peer evaluator only
+            // re-dials peers in the routing table; a configured bootnode or
+            // trusted peer that has dropped (or never completed a handshake)
+            // never enters that table, so on a private net with no discovery it
+            // would be abandoned after the initial attempt. `connect_bootnodes`
+            // skips any that are already tracked, so this is a no-op once they
+            // are connected and cannot cause a dial storm. Gated on a known dial
+            // capability so we do not spend attempts the reachability filter
+            // would drop while `ip` is still unknown.
+            self.redial_configured_contacts_if_needed();
         }
 
         // Poll composed protocols and process their events
@@ -1717,6 +1727,60 @@ mod tests {
             assert!(
                 drain_dials(&mut behaviour).is_empty(),
                 "no redial storm: bootnode already tracked after first transition"
+            );
+        }
+
+        /// An untracked trusted peer is re-dialed from the periodic tick.
+        #[tokio::test]
+        async fn untracked_trusted_peer_redialed_from_periodic_tick() {
+            let mut behaviour = test_behaviour_listening();
+
+            let trusted_peer = PeerId::random();
+            let trusted: Multiaddr = format!("/ip4/203.0.113.9/tcp/1634/p2p/{trusted_peer}")
+                .parse()
+                .expect("valid trusted multiaddr");
+            behaviour.trusted_peers = vec![trusted];
+
+            // Make the dial capability known so the reachability filter admits
+            // the address (mirrors a listen address having arrived).
+            behaviour
+                .nat_discovery
+                .on_new_listen_addr("/ip4/192.0.2.1/tcp/1634".parse().expect("valid"));
+
+            // The trusted peer is not tracked yet, so the periodic re-dial path
+            // issues the dial.
+            behaviour.redial_configured_contacts_if_needed();
+            let dialed = drain_dials(&mut behaviour);
+            assert!(
+                dialed.contains(&trusted_peer),
+                "untracked trusted peer must be re-dialed from the periodic path, dialed: {dialed:?}"
+            );
+
+            // It is now in the dial tracker, so a subsequent periodic pass does
+            // not re-dial it: no dial storm.
+            behaviour.redial_configured_contacts_if_needed();
+            assert!(
+                drain_dials(&mut behaviour).is_empty(),
+                "already-tracked trusted peer must not be re-dialed"
+            );
+        }
+
+        /// The periodic re-dial path is a no-op while the dial capability is unknown.
+        #[tokio::test]
+        async fn periodic_redial_noop_while_capability_unknown() {
+            let mut behaviour = test_behaviour_listening();
+
+            let trusted_peer = PeerId::random();
+            let trusted: Multiaddr = format!("/ip4/203.0.113.10/tcp/1634/p2p/{trusted_peer}")
+                .parse()
+                .expect("valid trusted multiaddr");
+            behaviour.trusted_peers = vec![trusted];
+
+            // No listen address yet: capability ip is None.
+            behaviour.redial_configured_contacts_if_needed();
+            assert!(
+                drain_dials(&mut behaviour).is_empty(),
+                "periodic re-dial must not fire while the capability is unknown"
             );
         }
     }

--- a/crates/swarm/topology/src/connection_handlers.rs
+++ b/crates/swarm/topology/src/connection_handlers.rs
@@ -7,10 +7,11 @@ use vertex_net_local::{AddressScope, classify_multiaddr, extract_ip};
 use vertex_net_peer_registry::ConnectionState;
 use vertex_swarm_api::{ReportSource, SwarmIdentity, SwarmScoringEvent};
 use vertex_swarm_net_handshake::HANDSHAKE_TIMEOUT;
+use vertex_swarm_peer_manager::TrustLevel;
 use vertex_swarm_primitives::SwarmNodeType;
 
 use crate::error::{DialError, DisconnectReason};
-use crate::events::TopologyEvent;
+use crate::events::{DialReason, TopologyEvent};
 use crate::gossip::GossipInput;
 use crate::kademlia::{RoutingCapacity, SwarmRouting};
 
@@ -162,36 +163,29 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             }
         };
 
-        // Handle early disconnects (post-handshake connections that fail
-        // quickly). Only an early disconnect we can attribute to the *peer or
-        // our own side* is evidence of a bad peer; a remote-induced transport
-        // reset/error is not.
-        //
-        // Under sustained retrieval load, remote peers commonly tear down a
-        // connection with an `ECONNRESET` (errno 104), surfaced by libp2p as
-        // `ConnectionError::IO(_)` and classified above as
-        // `DisconnectReason::ConnectionError`, faster than fresh handshakes
-        // complete. Treating that as an early-disconnect penalty arms the
-        // dial-backoff (`record_early_disconnect` -> `record_dial_failure`),
-        // which removes the peer from `is_dialable()` and starves candidate
-        // selection ("no new connection candidates"). The node then cannot
-        // refill and bleeds down. A remote reset is a transient, not a verdict
-        // on the peer: skip the lifecycle penalty so the peer stays DIALABLE
-        // and is re-included by candidate selection once load subsides.
-        //
-        // We still penalize a `LocalClose` early disconnect: an orderly close
-        // shortly after handshake reflects our-side abort or the peer cleanly
-        // refusing to keep the session, which is the genuinely suspicious case
-        // the early-disconnect heuristic exists to catch. `BinTrimmed` is our
-        // own eviction and is never penalized.
+        // Early disconnect (a post-handshake connection that fails quickly). The
+        // metric is recorded for every such close so the reset-vs-penalty split
+        // stays observable; whether the close arms the dial-backoff penalty is
+        // decided by `early_disconnect_penalty_applies`, which exempts blameless
+        // closes (remote ECONNRESET, keep-alive timeout, our own bin trim), a
+        // configured bootnode (intentionally disconnected after the initial hive
+        // gossip), and a pinned trusted peer. The dial reason is read from the
+        // connection state just removed, so a peer dialed as a bootnode is
+        // recognised even though its stored trust level is Normal.
+        let dial_reason = removed_state.as_ref().and_then(|s| *s.reason());
+        let is_trusted = self.peer_manager.trust_level(&overlay) == TrustLevel::Trusted;
         if let Some(duration) = connection_duration
             && duration < self.early_disconnect_threshold
         {
-            // Always record the metric (even for the transient case) so the
-            // reset-vs-penalty split stays observable.
             self.metrics.record_early_disconnect(disconnect_reason);
 
-            if early_disconnect_penalizes(disconnect_reason) {
+            if early_disconnect_penalty_applies(
+                disconnect_reason,
+                dial_reason,
+                is_trusted,
+                duration,
+                self.early_disconnect_threshold,
+            ) {
                 debug!(
                     %overlay,
                     ?duration,
@@ -201,15 +195,13 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 self.peer_manager
                     .record_early_disconnect(&overlay, duration);
             } else {
-                // Remote-induced transport reset/error (IO ECONNRESET,
-                // keep-alive timeout) or our own bin trim: not evidence of a
-                // bad peer. Do NOT arm dial-backoff; keep the peer dialable so
-                // the node can redial and refill after load subsides.
                 debug!(
                     %overlay,
                     ?duration,
                     ?disconnect_reason,
-                    "early disconnect from a transient/remote cause; keeping peer dialable (no backoff)"
+                    ?dial_reason,
+                    is_trusted,
+                    "early disconnect from a transient/remote/exempt cause; keeping peer dialable (no backoff)"
                 );
             }
         }
@@ -353,6 +345,21 @@ pub(crate) fn early_disconnect_penalizes(reason: DisconnectReason) -> bool {
     }
 }
 
+/// Whether the early-disconnect penalty applies; suppressed for blameless
+/// closes, configured bootnodes, trusted peers, and connections past `threshold`.
+fn early_disconnect_penalty_applies(
+    disconnect_reason: DisconnectReason,
+    dial_reason: Option<DialReason>,
+    is_trusted: bool,
+    duration: std::time::Duration,
+    threshold: std::time::Duration,
+) -> bool {
+    early_disconnect_penalizes(disconnect_reason)
+        && dial_reason != Some(DialReason::Bootnode)
+        && !is_trusted
+        && duration < threshold
+}
+
 /// Map a classified dial error to the scoring event reported against the
 /// peer, or `None` when the failure is not attributable to the peer.
 ///
@@ -460,6 +467,83 @@ mod tests {
     #[test]
     fn local_close_early_disconnect_is_penalized() {
         assert!(early_disconnect_penalizes(DisconnectReason::LocalClose));
+    }
+
+    use std::time::Duration;
+
+    const SHORT: Duration = Duration::from_secs(1);
+    const THRESHOLD: Duration = Duration::from_secs(30);
+
+    /// A fast `LocalClose` of an ordinary peer in the window is penalised.
+    #[test]
+    fn early_disconnect_penalises_an_ordinary_quick_drop() {
+        assert!(early_disconnect_penalty_applies(
+            DisconnectReason::LocalClose,
+            Some(DialReason::Discovery),
+            false,
+            SHORT,
+            THRESHOLD,
+        ));
+    }
+
+    /// A remote-reset quick drop of an ordinary peer is exempt.
+    #[test]
+    fn early_disconnect_exempts_a_remote_reset_quick_drop() {
+        assert!(!early_disconnect_penalty_applies(
+            DisconnectReason::ConnectionError,
+            Some(DialReason::Discovery),
+            false,
+            SHORT,
+            THRESHOLD,
+        ));
+    }
+
+    /// A configured bootnode quick drop must not be penalised.
+    #[test]
+    fn early_disconnect_exempts_a_configured_bootnode() {
+        assert!(!early_disconnect_penalty_applies(
+            DisconnectReason::LocalClose,
+            Some(DialReason::Bootnode),
+            false,
+            SHORT,
+            THRESHOLD,
+        ));
+    }
+
+    /// A trusted peer is never penalised for an early disconnect.
+    #[test]
+    fn early_disconnect_exempts_a_trusted_peer() {
+        assert!(!early_disconnect_penalty_applies(
+            DisconnectReason::LocalClose,
+            Some(DialReason::Trusted),
+            true,
+            SHORT,
+            THRESHOLD,
+        ));
+    }
+
+    /// A local bin-trim eviction is never an early-disconnect penalty.
+    #[test]
+    fn early_disconnect_skips_bin_trimmed_evictions() {
+        assert!(!early_disconnect_penalty_applies(
+            DisconnectReason::BinTrimmed,
+            Some(DialReason::Discovery),
+            false,
+            SHORT,
+            THRESHOLD,
+        ));
+    }
+
+    /// A connection that outlived the threshold is not an *early* disconnect.
+    #[test]
+    fn early_disconnect_ignores_long_lived_connections() {
+        assert!(!early_disconnect_penalty_applies(
+            DisconnectReason::LocalClose,
+            Some(DialReason::Discovery),
+            false,
+            THRESHOLD + Duration::from_secs(1),
+            THRESHOLD,
+        ));
     }
 
     /// Locally-denied dials carry no score penalty; network failures do.

--- a/crates/swarm/topology/src/dialing.rs
+++ b/crates/swarm/topology/src/dialing.rs
@@ -13,6 +13,7 @@ use vertex_util_runtime::rand::non_crypto_rng;
 
 use crate::DialReason;
 use crate::behaviour::BootnodeResolutionFuture;
+use crate::extract_peer_id;
 use crate::gossip::GossipInput;
 use crate::kademlia::RoutingCapacity;
 
@@ -123,6 +124,35 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         }
 
         self.pending_actions.push_back(ToSwarm::Dial { opts });
+    }
+
+    /// Re-dial any untracked configured bootnode or trusted peer from the
+    /// periodic tick, gated on a known dial capability.
+    pub(crate) fn redial_configured_contacts_if_needed(&mut self) {
+        if self.bootnodes.is_empty() && self.trusted_peers.is_empty() {
+            return;
+        }
+
+        // No point dialing until the capability is known; the unknown->known
+        // edge handler already re-issues the attempt.
+        if !self.nat_discovery.dial_capability().ip.is_known() {
+            return;
+        }
+
+        // Skip the work entirely while every configured contact with a
+        // resolvable peer id is already tracked.
+        let any_untracked = self
+            .bootnodes
+            .iter()
+            .chain(self.trusted_peers.iter())
+            .filter_map(extract_peer_id)
+            .any(|peer_id| !self.is_peer_tracked(&peer_id));
+        if !any_untracked {
+            return;
+        }
+
+        debug!("Re-dialing untracked configured bootnodes/trusted peers");
+        self.connect_bootnodes();
     }
 
     pub(crate) fn connect_bootnodes(&mut self) {

--- a/crates/swarm/topology/src/events.rs
+++ b/crates/swarm/topology/src/events.rs
@@ -36,6 +36,8 @@ pub enum TopologyEvent {
         node_type: SwarmNodeType,
         /// Whether we dialed or they dialed us.
         direction: ConnectionDirection,
+        /// Whether this is an explicitly configured trusted peer (kept alive).
+        trusted: bool,
     },
     /// Connection was rejected (bin saturated, duplicate, etc.).
     PeerRejected {

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -5,13 +5,15 @@ use std::sync::Arc;
 use libp2p::{Multiaddr, PeerId};
 use nectar_primitives::ChunkAddress;
 use tokio::sync::{broadcast, mpsc};
+use vertex_net_local::extract_ip;
+use vertex_net_peer_registry::ConnectionDirection;
 use vertex_swarm_api::{
-    PeerReporter, SwarmIdentity, SwarmSpec, SwarmTopologyBins, SwarmTopologyCommands,
-    SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting, SwarmTopologyState,
-    SwarmTopologyStats,
+    PeerConnectionDirection, PeerDiagnostics, PeerReporter, PeerTrustLevel, SwarmIdentity,
+    SwarmSpec, SwarmTopologyAdmin, SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers,
+    SwarmTopologyReporting, SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats,
 };
 use vertex_swarm_net_identify as identify;
-use vertex_swarm_peer_manager::PeerManager;
+use vertex_swarm_peer_manager::{PeerManager, TrustLevel};
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress, all_bins};
 
 use crate::behaviour::ConnectionRegistry;
@@ -398,6 +400,70 @@ impl<I: SwarmIdentity> SwarmTopologyStats for TopologyHandle<I> {
     }
 }
 
+fn map_direction(direction: ConnectionDirection) -> PeerConnectionDirection {
+    match direction {
+        ConnectionDirection::Outbound => PeerConnectionDirection::Outbound,
+        ConnectionDirection::Inbound => PeerConnectionDirection::Inbound,
+    }
+}
+
+fn map_trust(trust: TrustLevel) -> PeerTrustLevel {
+    match trust {
+        TrustLevel::Normal => PeerTrustLevel::Normal,
+        TrustLevel::LocalSubnet => PeerTrustLevel::LocalSubnet,
+        TrustLevel::Trusted => PeerTrustLevel::Trusted,
+    }
+}
+
+impl<I: SwarmIdentity> TopologyHandle<I> {
+    fn diagnostics_for(&self, overlay: OverlayAddress) -> PeerDiagnostics {
+        let multiaddrs = self
+            .peer_manager
+            .get_swarm_peer(&overlay)
+            .map(|p| p.multiaddrs().to_vec())
+            .unwrap_or_default();
+        let ip = multiaddrs.iter().find_map(extract_ip);
+        let connected = self.peer_manager.is_connected(&overlay);
+        let connected_since = self.peer_manager.connected_since(&overlay);
+        let uptime_secs = connected_since.and_then(|since| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()
+                .map(|now| now.as_secs().saturating_sub(since))
+        });
+
+        PeerDiagnostics {
+            overlay,
+            peer_id: self.connection_registry.resolve_peer_id(&overlay),
+            multiaddrs,
+            ip,
+            proximity_order: self.peer_manager.index().bin_for(&overlay).get(),
+            score: self.peer_manager.get_peer_score(&overlay),
+            connected,
+            connected_since,
+            uptime_secs,
+            direction: self
+                .peer_manager
+                .connection_direction(&overlay)
+                .map(map_direction),
+            trust: map_trust(self.peer_manager.trust_level(&overlay)),
+            verified: self.peer_manager.is_verified(&overlay),
+        }
+    }
+}
+
+impl<I: SwarmIdentity> SwarmTopologyAdmin for TopologyHandle<I> {
+    fn peer_diagnostics(&self, connected_only: bool) -> Vec<PeerDiagnostics> {
+        self.peer_manager
+            .index()
+            .all_peers()
+            .into_iter()
+            .map(|overlay| self.diagnostics_for(overlay))
+            .filter(|d| !connected_only || d.connected)
+            .collect()
+    }
+}
+
 impl<I: SwarmIdentity> SwarmTopologyCommands for TopologyHandle<I> {
     type Error = TopologyError;
 
@@ -582,6 +648,7 @@ mod tests {
                 peer_id: test_peer_id(n),
                 node_type,
                 direction: ConnectionDirection::Outbound,
+                trusted: false,
             });
         }
 

--- a/crates/swarm/topology/src/metrics.rs
+++ b/crates/swarm/topology/src/metrics.rs
@@ -370,6 +370,7 @@ mod tests {
             peer_id: test_peer_id(1),
             node_type: SwarmNodeType::Storer,
             direction: ConnectionDirection::Outbound,
+            trusted: false,
         };
 
         metrics.record_event(&event);
@@ -381,6 +382,7 @@ mod tests {
             peer_id: test_peer_id(2),
             node_type: SwarmNodeType::Client,
             direction: ConnectionDirection::Inbound,
+            trusted: false,
         };
 
         metrics.record_event(&event);
@@ -455,12 +457,14 @@ mod tests {
             peer_id: test_peer_id(1),
             node_type: SwarmNodeType::Storer,
             direction: ConnectionDirection::Outbound,
+            trusted: false,
         });
         metrics.record_event(&TopologyEvent::PeerReady {
             overlay: test_overlay(2),
             peer_id: test_peer_id(2),
             node_type: SwarmNodeType::Client,
             direction: ConnectionDirection::Outbound,
+            trusted: false,
         });
         assert_eq!(metrics.connected_storers(), 1);
         assert_eq!(metrics.connected_clients(), 1);
@@ -491,6 +495,7 @@ mod tests {
                 peer_id: test_peer_id(i),
                 node_type: SwarmNodeType::Storer,
                 direction: ConnectionDirection::Outbound,
+                trusted: false,
             });
         }
         for i in 10..12 {
@@ -499,6 +504,7 @@ mod tests {
                 peer_id: test_peer_id(i),
                 node_type: SwarmNodeType::Client,
                 direction: ConnectionDirection::Inbound,
+                trusted: false,
             });
         }
         assert_eq!(metrics.connected_storers(), 3);
@@ -555,6 +561,7 @@ mod tests {
             peer_id: test_peer_id(1),
             node_type: pm.node_type(&overlay).unwrap(),
             direction: ConnectionDirection::Outbound,
+            trusted: false,
         });
         assert_eq!(metrics.connected_storers(), 1);
         assert_eq!(metrics.connected_clients(), 0);

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -357,6 +357,10 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             peer_id,
             node_type,
             direction,
+            // A configured trusted peer is pinned for the session; the client
+            // handler keeps its connection warm so the idle-connection timeout
+            // never closes it (and a trusted re-dial re-activates it).
+            trusted: trust == TrustLevel::Trusted,
         });
 
         // Notify gossip task -- exchange happens immediately or after delay (for gossip dials)


### PR DESCRIPTION
## What does this PR do?

Adds a runtime peer-administration gRPC surface and trusted-peer handling so operators can manage peers live without restarting the node and so bootnode/trusted peers are no longer penalised on intentional disconnect.

## Changes
- Add an admin gRPC surface for runtime peer management: `AddPeer`, `RemovePeer`, and `ListPeers` with full diagnostics.
- Add `--network.trusted-peers` and `--network.mdns` configuration flags.
- Pin trusted peers so they are never evicted and are exempt from connection limits.
- Stop penalising bootnode and trusted peers on intentional disconnect.
- Combine the remote-reset exemption from the previous PR with the new bootnode and trusted exemptions.

## Breaking changes

None. The new gRPC methods and configuration flags are additive; existing behaviour is unchanged when the new flags are unset.

## Testing

`cargo clippy --all-targets --all-features` and `cargo test --all-features` pass for the affected crates (`rpc`, `api`, `peer-manager`, `client-behaviour`, `topology`, `node`) on the rebuilt tip. The gRPC handlers are covered by unit tests (`parse_overlay` valid and invalid, `list_peers` connected-only filter), and the exemption and trusted-peer logic is covered by the peer-manager and topology unit tests. No additional manual end-to-end testing was performed for this change.

- [x] Unit tests pass
- [ ] Manual testing completed
- [ ] Documentation updated (if needed)

## Related issues

Closes #348
Stacked on #356
Part of the vertex stack: based on `stack/07-per-ip-connection-cap`.

## AI assistance disclosure

AI Assistance: Claude Code (Opus 4.8) used for implementation.

## Notes for reviewers

This PR is part of a stack and is based on `stack/07-per-ip-connection-cap`; review it after #356. Focus on the admin gRPC surface (`AddPeer`/`RemovePeer`/`ListPeers`) and the exemption logic that prevents bootnode and trusted peers from being penalised or evicted. Note that the per-IP connection cap from the underlying PR remains off by default pending redesign, so trusted-peer exemption from that cap is only meaningful once it is enabled.

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated
- [x] No debug code left behind
- [x] PR title is descriptive


