### PR TITLE
refactor(rpc): drive gRPC chunk service off ChunkClientExt and the free helpers

### DIFF
--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 use vertex_swarm_api::{ChunkAddress, PushReceipt, Stamp, StampedChunk, SwarmError};
 use vertex_swarm_stream::{
-    NATIVE_DOWNLOAD_CONCURRENCY, StreamConfig, VerifiedChunk, retrieve_verified,
+    ChunkClientExt, StreamConfig, VerifiedChunk, get_stream_from, parse_address,
 };
 
 use crate::ChunkServiceProvider;
@@ -16,32 +16,74 @@ use crate::proto::chunk::{
     retrieve_chunk_response, upload_chunk_response,
 };
 
-/// gRPC chunk retrieval and upload service.
-pub struct ChunkService<P> {
-    provider: P,
+/// Whether the chunk service trusts a caller's per-request `validate` flag or
+/// always validates the postage stamp signature on upload.
+///
+/// The `validate` flag on an upload request is caller-controlled, so on a
+/// publicly reachable endpoint a caller could set `validate = false` and have
+/// the node forward a chunk carrying an unverified (or forged) stamp. This
+/// policy moves that decision server-side: a public endpoint enforces
+/// validation; a private/trusted endpoint may honour the per-request flag.
+/// Embedded callers (FFI, wasm) trust the implementer and do not pass through
+/// this service, so they keep honouring their own flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StampValidation {
+    /// Always validate the stamp signature, ignoring the request's `validate`
+    /// flag. The safe default for a publicly reachable gRPC endpoint.
+    #[default]
+    Enforce,
+    /// Honour the request's `validate` flag (trust by default, opt in to
+    /// validation). For a private or otherwise trusted endpoint.
+    PerRequest,
 }
 
-impl<P> ChunkService<P> {
-    /// Create a new chunk service with the given provider.
-    pub fn new(provider: P) -> Self {
-        Self { provider }
+impl StampValidation {
+    /// The effective validate decision for a request whose flag is `requested`.
+    #[must_use]
+    pub fn resolve(self, requested: bool) -> bool {
+        match self {
+            Self::Enforce => true,
+            Self::PerRequest => requested,
+        }
     }
 }
 
-/// Parse a 32-byte chunk address from raw bytes.
-#[allow(clippy::result_large_err)]
-fn parse_chunk_address(bytes: &[u8]) -> Result<ChunkAddress, Status> {
-    let arr = <[u8; 32]>::try_from(bytes).map_err(|_| {
-        Status::invalid_argument(format!(
-            "invalid chunk address: expected 32 bytes, got {}",
-            bytes.len()
-        ))
-    })?;
-    Ok(ChunkAddress::new(arr))
+/// gRPC chunk retrieval and upload service.
+pub struct ChunkService<P> {
+    provider: P,
+    stamp_validation: StampValidation,
 }
 
-/// Build a [`StampedChunk`] from an upload request; the address self-validates
-/// against the payload via reconstruction.
+impl<P> ChunkService<P> {
+    /// Create a new chunk service. Defaults to [`StampValidation::Enforce`]: a
+    /// gRPC endpoint validates stamps unless an operator opts into trusting the
+    /// per-request flag via [`Self::with_stamp_validation`].
+    pub fn new(provider: P) -> Self {
+        Self {
+            provider,
+            stamp_validation: StampValidation::Enforce,
+        }
+    }
+
+    /// Set the stamp-validation policy (e.g. [`StampValidation::PerRequest`] for
+    /// a trusted/private endpoint).
+    #[must_use]
+    pub fn with_stamp_validation(mut self, stamp_validation: StampValidation) -> Self {
+        self.stamp_validation = stamp_validation;
+        self
+    }
+}
+
+/// Parse a 32-byte chunk address, mapping the core [`parse_address`] error to a
+/// gRPC `invalid_argument` status.
+#[allow(clippy::result_large_err)]
+fn parse_chunk_address(bytes: &[u8]) -> Result<ChunkAddress, Status> {
+    parse_address(bytes).map_err(|e| Status::invalid_argument(e.to_string()))
+}
+
+/// Build a [`StampedChunk`] from an upload request: the bytes self-validate
+/// against the supplied address (an address that does not match the bytes is
+/// rejected, which also pins the chunk variant).
 #[allow(clippy::result_large_err)]
 fn parse_stamped_chunk(req: &UploadChunkRequest) -> Result<StampedChunk, Status> {
     let address = parse_chunk_address(&req.address)?;
@@ -94,15 +136,17 @@ fn retrieve_error(address: Vec<u8>, message: String) -> RetrieveChunkResponse {
     }
 }
 
-/// Map a verified download item onto the wire response (`served_by` unknown on
-/// the streaming path, so emitted empty).
+/// Map a verified download item onto the wire response, carrying the real
+/// `served_by` the streaming retrieve path now threads through (previously
+/// emitted empty).
 fn verified_response(address: ChunkAddress, verified: VerifiedChunk) -> RetrieveChunkResponse {
+    let served_by = verified.served_by().as_bytes().to_vec();
     let (chunk, stamp) = verified.into_parts();
     retrieved_response(
         address,
         chunk.into_bytes().to_vec(),
         stamp.map(|s| s.to_bytes().to_vec()).unwrap_or_default(),
-        Vec::new(),
+        served_by,
     )
 }
 
@@ -149,20 +193,10 @@ impl<P: ChunkServiceProvider> Chunk for ChunkService<P> {
         let req = request.into_inner();
         let address = parse_chunk_address(&req.address)?;
 
-        match self.provider.retrieve_chunk(&address).await {
-            Ok(result) => {
-                let served_by = result.served_by.as_bytes().to_vec();
-                let stamp = result
-                    .stamp
-                    .map(|s| s.to_bytes().to_vec())
-                    .unwrap_or_default();
-                Ok(Response::new(retrieved_response(
-                    address,
-                    result.chunk.into_bytes().to_vec(),
-                    stamp,
-                    served_by,
-                )))
-            }
+        // Verify-by-default: `get` proves the bytes answer the address before
+        // responding, so a wrong-bytes delivery errors instead of returning.
+        match self.provider.get(address).await {
+            Ok(verified) => Ok(Response::new(verified_response(address, verified))),
             Err(e) => Err(retrieval_status(&e)),
         }
     }
@@ -188,13 +222,14 @@ impl<P: ChunkServiceProvider> Chunk for ChunkService<P> {
         let address = parse_chunk_address(&req.address)?;
         let stamped = parse_stamped_chunk(&req)?;
 
-        // Pre-stamped uploads are trusted by default; opt in to validation.
-        let receipt = if req.validate {
-            self.provider.send_chunk(stamped).await
-        } else {
-            self.provider.send_chunk_unchecked(stamped).await
-        }
-        .map_err(|e| Status::internal(format!("chunk upload failed: {e}")))?;
+        // The endpoint's policy resolves the effective decision from the caller's
+        // flag: a public endpoint (Enforce) always validates the stamp.
+        let validate = self.stamp_validation.resolve(req.validate);
+        let receipt = self
+            .provider
+            .put(stamped, validate)
+            .await
+            .map_err(|e| Status::internal(format!("chunk upload failed: {e}")))?;
 
         Ok(Response::new(receipt_response(address, receipt)))
     }
@@ -214,6 +249,7 @@ impl<P: ChunkServiceProvider> Chunk for ChunkService<P> {
     ) -> Result<Response<Self::UploadChunksStream>, Status> {
         let inbound = request.into_inner();
         let provider = self.provider.clone();
+        let stamp_validation = self.stamp_validation;
 
         let out = inbound
             .map(move |item| {
@@ -222,20 +258,15 @@ impl<P: ChunkServiceProvider> Chunk for ChunkService<P> {
                     let req = item.map_err(|status| {
                         Status::internal(format!("inbound stream error: {status}"))
                     })?;
-                    let validate = req.validate;
+                    // Apply the endpoint policy, same as the unary RPC.
+                    let validate = stamp_validation.resolve(req.validate);
                     Ok(match parse_stamped_chunk(&req) {
                         // Echo the raw requested bytes so a malformed address is
                         // still correlatable by the client.
                         Err(status) => upload_error(req.address, status.message().to_string()),
                         Ok(stamped) => {
                             let address = *stamped.address();
-                            // Honour the per-request validate flag, as the unary RPC does.
-                            let result = if validate {
-                                provider.send_chunk(stamped).await
-                            } else {
-                                provider.send_chunk_unchecked(stamped).await
-                            };
-                            match result {
+                            match provider.put(stamped, validate).await {
                                 Ok(receipt) => receipt_response(address, receipt),
                                 Err(e) => upload_error(address.as_bytes().to_vec(), e.to_string()),
                             }
@@ -251,39 +282,69 @@ impl<P: ChunkServiceProvider> Chunk for ChunkService<P> {
     type RetrieveChunksStream = ResponseStream<RetrieveChunkResponse>;
 
     /// Retrieve a stream of chunks by address; responses return in completion
-    /// order, each carrying its address. A per-address failure is one error
-    /// item, not a teardown.
+    /// order, each carrying its address and its serving overlay. A per-address
+    /// failure is one error item, not a teardown.
     ///
-    /// Retrievals are driven directly off the inbound stream via
-    /// `buffer_unordered`, bounding server memory by the concurrency rather than
-    /// the (untrusted) request count. The native preset keeps enough forwarding
-    /// retrievals in flight to saturate a bulk download.
+    /// Valid addresses route through the core [`get_stream_from`], so this path
+    /// shares one bounded, verify-by-default prefetch with the FFI and wasm
+    /// download paths instead of a hand-rolled `buffer_unordered`. The native
+    /// preset keeps enough forwarding retrievals in flight to saturate a bulk
+    /// download. Malformed addresses and inbound-stream errors are emitted as
+    /// their own error items, interleaved with the verified deliveries.
     async fn retrieve_chunks(
         &self,
         request: Request<Streaming<RetrieveChunkRequest>>,
     ) -> Result<Response<Self::RetrieveChunksStream>, Status> {
         let inbound = request.into_inner();
-        let provider = self.provider.clone();
 
-        let out = inbound
-            .map(move |item| {
-                let provider = provider.clone();
-                async move {
-                    let req = item.map_err(|status| {
-                        Status::internal(format!("inbound stream error: {status}"))
-                    })?;
-                    Ok(match parse_chunk_address(&req.address) {
-                        // Echo the raw requested bytes; continue the stream.
-                        Err(status) => retrieve_error(req.address, status.message().to_string()),
-                        Ok(address) => match retrieve_verified(provider, address).await {
-                            Ok(verified) => verified_response(address, verified),
-                            Err(e) => retrieve_error(address.as_bytes().to_vec(), e.to_string()),
-                        },
-                    })
+        // Malformed addresses and inbound-stream errors are not addresses the
+        // core can retrieve, but must still surface as their own error items
+        // rather than tear the stream down. They go onto this channel as a side
+        // effect of parsing, and are interleaved with the core's deliveries
+        // below. The channel is unbounded only over the bad-request count, which
+        // is itself bounded by the inbound flow the core's prefetch gates.
+        let (err_tx, err_rx) = tokio::sync::mpsc::unbounded_channel::<RetrieveChunkResponse>();
+
+        // Parse the inbound feed into the core's address source, diverting every
+        // non-address (malformed bytes, inbound error) onto the error channel.
+        let addresses = inbound.filter_map(move |item| {
+            let err_tx = err_tx.clone();
+            async move {
+                match item {
+                    Err(status) => {
+                        let _ = err_tx.send(retrieve_error(
+                            Vec::new(),
+                            format!("inbound stream error: {status}"),
+                        ));
+                        None
+                    }
+                    Ok(req) => match parse_chunk_address(&req.address) {
+                        Ok(address) => Some(address),
+                        // Echo the raw requested bytes for client-side correlation.
+                        Err(status) => {
+                            let _ = err_tx
+                                .send(retrieve_error(req.address, status.message().to_string()));
+                            None
+                        }
+                    },
                 }
-            })
-            .buffer_unordered(NATIVE_DOWNLOAD_CONCURRENCY);
+            }
+        });
 
+        // Valid addresses route through the core: one bounded, verify-by-default
+        // prefetch shared with the FFI and wasm download paths.
+        let verified = get_stream_from(
+            self.provider.clone(),
+            addresses,
+            StreamConfig::NATIVE_DOWNLOAD,
+        )
+        .map(|(address, result)| match result {
+            Ok(verified) => verified_response(address, verified),
+            Err(e) => retrieve_error(address.as_bytes().to_vec(), e.to_string()),
+        });
+
+        let errors = tokio_stream::wrappers::UnboundedReceiverStream::new(err_rx);
+        let out = futures::stream::select(verified, errors).map(Ok);
         Ok(Response::new(Box::pin(out)))
     }
 
@@ -379,5 +440,79 @@ mod tests {
 
         let err = parse_stamped_chunk(&req).expect_err("malformed stamp must fail");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn stamp_validation_resolves_per_policy() {
+        // Enforce always validates, ignoring the caller's flag; PerRequest
+        // honours it. The default is the safe Enforce.
+        assert!(StampValidation::Enforce.resolve(false));
+        assert!(StampValidation::Enforce.resolve(true));
+        assert!(!StampValidation::PerRequest.resolve(false));
+        assert!(StampValidation::PerRequest.resolve(true));
+        assert_eq!(StampValidation::default(), StampValidation::Enforce);
+    }
+
+    /// Streaming retrieve now threads the serving overlay through: a verified
+    /// item maps onto the wire response with a populated `served_by`, where the
+    /// streaming path previously emitted it empty. This drives the same
+    /// `get_stream_from` core the RPC routes through.
+    #[tokio::test]
+    async fn retrieve_chunks_emits_served_by() {
+        use vertex_swarm_api::{ChunkRetrievalResult, OverlayAddress, SwarmResult};
+        use vertex_swarm_stream::{StreamConfig, get_stream_from};
+
+        const SERVED_BY: [u8; 32] = [0x5b; 32];
+
+        /// Provider serving one known content chunk from a fixed overlay.
+        #[derive(Clone)]
+        struct OneChunkProvider {
+            chunk: AnyChunk,
+        }
+
+        #[tonic::async_trait]
+        impl vertex_swarm_api::SwarmChunkProvider for OneChunkProvider {
+            async fn retrieve_chunk(
+                &self,
+                _address: &ChunkAddress,
+            ) -> SwarmResult<ChunkRetrievalResult> {
+                Ok(ChunkRetrievalResult {
+                    chunk: self.chunk.clone(),
+                    stamp: None,
+                    served_by: OverlayAddress::from(SERVED_BY),
+                })
+            }
+
+            fn has_chunk(&self, _address: &ChunkAddress) -> bool {
+                false
+            }
+        }
+
+        let content = ContentChunk::new(b"served chunk".to_vec()).expect("valid content chunk");
+        let address = *content.address();
+        let provider = OneChunkProvider {
+            chunk: AnyChunk::Content(content),
+        };
+
+        // Route a single address through the very core `retrieve_chunks` uses,
+        // then map it the same way the RPC does.
+        let mut out = get_stream_from(
+            provider,
+            futures::stream::iter(vec![address]),
+            StreamConfig::NATIVE_DOWNLOAD,
+        );
+        let (item_address, result) = out.next().await.expect("one item");
+        let verified = result.expect("retrieval verifies");
+        let response = verified_response(item_address, verified);
+
+        let Some(retrieve_chunk_response::Result::Chunk(chunk)) = response.result else {
+            panic!("expected a chunk response");
+        };
+        assert_eq!(
+            chunk.served_by,
+            SERVED_BY.to_vec(),
+            "served_by is populated"
+        );
+        assert_eq!(chunk.address, address.as_bytes().to_vec());
     }
 }

--- a/crates/swarm/rpc/src/lib.rs
+++ b/crates/swarm/rpc/src/lib.rs
@@ -4,20 +4,18 @@
 
 mod grpc;
 
-pub use grpc::chunk::ChunkService;
+pub use grpc::chunk::{ChunkService, StampValidation};
 pub use grpc::node::NodeService;
 
-/// A chunk provider usable by the chunk gRPC service: retrieves, sends,
-/// cloneable, `'static`. A trait alias so the bound is named once, not repeated.
-pub trait ChunkServiceProvider:
-    vertex_swarm_api::SwarmChunkProvider + vertex_swarm_api::SwarmChunkSender + Clone + 'static
-{
-}
-
-impl<T> ChunkServiceProvider for T where
-    T: vertex_swarm_api::SwarmChunkProvider + vertex_swarm_api::SwarmChunkSender + Clone + 'static
-{
-}
+/// A chunk provider usable by the chunk gRPC service.
+///
+/// Absorbed into [`vertex_swarm_stream::ChunkClient`]: kept as a re-export so
+/// existing bounds (`P: ChunkServiceProvider`) keep compiling against the one
+/// capability alias. The chunk service drives off [`ChunkClientExt`] and the
+/// free helpers, so this no longer carries its own definition.
+///
+/// [`ChunkClientExt`]: vertex_swarm_stream::ChunkClientExt
+pub use vertex_swarm_stream::ChunkClient as ChunkServiceProvider;
 
 pub mod proto {
     pub mod node {

--- a/crates/swarm/stream/src/lib.rs
+++ b/crates/swarm/stream/src/lib.rs
@@ -346,6 +346,114 @@ pub trait MaybeSendStream {}
 #[cfg(target_arch = "wasm32")]
 impl<T> MaybeSendStream for T {}
 
+/// Marker bound for a value's thread-safety requirement: `Send` on native so an
+/// `impl Future + MaybeSend` returned from [`ChunkClientExt`] stays `Send` for
+/// the generic tonic handler, unconstrained on wasm. Mirrors [`MaybeSendIter`]
+/// and the [`MaybeSendBoxFuture`] split. Blanket-implemented, so callers never
+/// name it.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSend: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> MaybeSend for T {}
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSend {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSend for T {}
+
+/// Capability alias for a lean chunk client: retrieves, sends, cloneable, and
+/// shareable across threads for the lifetime of the program.
+///
+/// This is the cross-crate replacement for `rpc::ChunkServiceProvider`, which it
+/// absorbs in a later step. A blanket impl means any type satisfying the bound is
+/// a `ChunkClient` without naming it; the alias only exists so the capability is
+/// stated once instead of repeated at every consumer.
+///
+/// `Send + Sync + 'static` is required even on wasm here: a chunk client is held
+/// behind the wasm `Arc<dyn SwarmChunkProvider>` export and shared, so the alias
+/// is uniform across targets. The per-call `Send` divergence lives in
+/// [`MaybeSend`] on the [`ChunkClientExt`] return types, not in this bound.
+pub trait ChunkClient:
+    SwarmChunkProvider + SwarmChunkSender + Clone + Send + Sync + 'static
+{
+}
+
+impl<T> ChunkClient for T where
+    T: SwarmChunkProvider + SwarmChunkSender + Clone + Send + Sync + 'static
+{
+}
+
+/// Ergonomic chunk verbs over a [`ChunkClient`], as default methods.
+///
+/// Blanket-implemented for every [`ChunkClient`], so a consumer calls `get` /
+/// `put` / `get_many` / `put_many` directly on its client without importing the
+/// free functions or hand-rolling verification. The single-chunk methods are
+/// `async` returning `impl Future<Output = …> + MaybeSend` via RPITIT (not
+/// async-fn-in-trait), so the future stays `Send` on native for the generic
+/// tonic handler while wasm stays `!Send`. The bulk methods return the existing
+/// [`GetStream`] / [`PutStream`] types unchanged.
+///
+/// The chunk core is complete as a primitive; these verbs compose it, they do
+/// not add new ones.
+pub trait ChunkClientExt: ChunkClient {
+    /// Retrieve and verify one chunk, proving it answers `address`.
+    ///
+    /// Wraps [`retrieve_verified`]: the returned chunk is proven to hash to the
+    /// requested address, so a peer answering with the wrong bytes surfaces as an
+    /// error rather than a trusted chunk.
+    fn get(
+        &self,
+        address: ChunkAddress,
+    ) -> impl std::future::Future<Output = SwarmResult<VerifiedChunk>> + MaybeSend {
+        retrieve_verified(self.clone(), address)
+    }
+
+    /// Upload one stamped chunk.
+    ///
+    /// `validate` selects the stamp-signature check: `true` dispatches to
+    /// [`SwarmChunkSender::send_chunk`] (validates the stamp matches the chunk),
+    /// `false` to [`SwarmChunkSender::send_chunk_unchecked`] (trusts the caller).
+    fn put(
+        &self,
+        chunk: StampedChunk,
+        validate: bool,
+    ) -> impl std::future::Future<Output = SwarmResult<PushReceipt>> + MaybeSend {
+        let client = self.clone();
+        async move {
+            if validate {
+                client.send_chunk(chunk).await
+            } else {
+                client.send_chunk_unchecked(chunk).await
+            }
+        }
+    }
+
+    /// Retrieve and verify many chunks as a bounded, completion-ordered stream.
+    ///
+    /// Returns the same [`GetStream`] as [`get_stream`]; see it for the prefetch
+    /// and verification semantics.
+    fn get_many(
+        &self,
+        addresses: impl IntoIterator<Item = ChunkAddress>,
+        config: StreamConfig,
+    ) -> GetStream<Self> {
+        get_stream(self.clone(), addresses, config)
+    }
+
+    /// Upload many stamped chunks as a bounded, completion-ordered stream.
+    ///
+    /// Returns the same [`PutStream`] as [`put_stream`]; see it for the bounded
+    /// concurrency and lazy-materialization semantics.
+    fn put_many<I>(&self, chunks: I, config: StreamConfig) -> PutStream<Self>
+    where
+        I: IntoIterator<Item = StampedChunk>,
+        I::IntoIter: MaybeSendIter + 'static,
+    {
+        put_stream(self.clone(), chunks, config)
+    }
+}
+
+impl<T: ChunkClient> ChunkClientExt for T {}
+
 /// Like [`get_stream`], but sourced from a [`Stream`] of addresses instead of an
 /// iterator.
 ///
@@ -1342,5 +1450,144 @@ mod tests {
 
         let err = parse_address(&[0u8; 10]).expect_err("short address fails");
         assert_eq!(err.got, 10);
+    }
+    /// A client mock satisfying [`ChunkClient`]: it both serves a fixed chunk map
+    /// and records pushes, so the `ChunkClientExt` verbs can be driven end to end.
+    #[derive(Clone)]
+    struct ClientMock {
+        provider: MapProvider,
+        sender: RecordingSender,
+    }
+
+    impl ClientMock {
+        fn new(chunks: Vec<StampedChunk>) -> Self {
+            Self {
+                provider: MapProvider::new(chunks),
+                sender: RecordingSender::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl SwarmChunkProvider for ClientMock {
+        async fn retrieve_chunk(
+            &self,
+            address: &ChunkAddress,
+        ) -> SwarmResult<ChunkRetrievalResult> {
+            self.provider.retrieve_chunk(address).await
+        }
+
+        fn has_chunk(&self, address: &ChunkAddress) -> bool {
+            self.provider.has_chunk(address)
+        }
+    }
+
+    #[async_trait]
+    impl SwarmChunkSender for ClientMock {
+        async fn send_chunk_unchecked(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+            self.sender.send_chunk_unchecked(chunk).await
+        }
+
+        async fn send_chunk(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
+            self.sender.send_chunk(chunk).await
+        }
+    }
+
+    #[tokio::test]
+    async fn ext_get_verifies_and_returns_the_chunk() {
+        let chunk = chunk_for(11);
+        let address = *chunk.address();
+        let client = ClientMock::new(vec![chunk]);
+
+        let verified = client.get(address).await.expect("retrieval succeeds");
+        assert_eq!(*verified.address(), address);
+    }
+
+    #[tokio::test]
+    async fn ext_get_rejects_wrong_chunk_for_address() {
+        // A request for a never-stored address surfaces as an error, not a chunk.
+        let client = ClientMock::new(vec![chunk_for(11)]);
+        let missing = ChunkAddress::new([0xfe; 32]);
+        let err = client.get(missing).await.expect_err("missing chunk errors");
+        assert!(matches!(err, SwarmError::ChunkNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn ext_put_validated_and_unchecked_both_upload() {
+        let validated = chunk_for(20);
+        let unchecked = chunk_for(21);
+        let addr_validated = *validated.address();
+        let addr_unchecked = *unchecked.address();
+        let client = ClientMock::new(vec![]);
+        let accepted = Arc::clone(&client.sender.accepted);
+
+        client.put(validated, true).await.expect("validated push");
+        client.put(unchecked, false).await.expect("unchecked push");
+
+        let accepted = accepted.lock().unwrap();
+        assert!(accepted.contains(&addr_validated));
+        assert!(accepted.contains(&addr_unchecked));
+    }
+
+    #[tokio::test]
+    async fn ext_get_many_streams_all_addresses() {
+        let chunks: Vec<_> = (0..6).map(chunk_for).collect();
+        let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
+        let client = ClientMock::new(chunks);
+
+        let stream = client.get_many(addresses.clone(), StreamConfig::new(4));
+        let results: Vec<_> = stream.collect().await;
+
+        assert_eq!(results.len(), addresses.len());
+        let want: std::collections::HashSet<_> = addresses.into_iter().collect();
+        let seen: std::collections::HashSet<_> = results
+            .into_iter()
+            .map(|(address, result)| {
+                result.expect("retrieval succeeds");
+                address
+            })
+            .collect();
+        assert_eq!(seen, want);
+    }
+
+    #[tokio::test]
+    async fn ext_put_many_uploads_all_chunks() {
+        let chunks: Vec<_> = (0..6).map(chunk_for).collect();
+        let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
+        let client = ClientMock::new(vec![]);
+        let accepted = Arc::clone(&client.sender.accepted);
+
+        let stream = client.put_many(chunks, StreamConfig::new(4));
+        let results: Vec<_> = stream.collect().await;
+
+        assert_eq!(results.len(), addresses.len());
+        assert!(results.into_iter().all(|(_, r)| r.is_ok()));
+        let accepted = accepted.lock().unwrap();
+        for address in &addresses {
+            assert!(accepted.contains(address));
+        }
+    }
+
+    /// The native `get`/`put` futures must be `Send` so the generic tonic handler
+    /// can hold them: drive each through `tokio::spawn`, which requires `Send`.
+    /// This is the compile-and-run guard for the RPITIT `+ MaybeSend` bound.
+    #[tokio::test]
+    async fn ext_futures_are_send_and_spawnable() {
+        let chunk = chunk_for(30);
+        let address = *chunk.address();
+        let client = ClientMock::new(vec![chunk_for(30)]);
+
+        let get_client = client.clone();
+        let verified = tokio::spawn(async move { get_client.get(address).await })
+            .await
+            .expect("get task joins")
+            .expect("retrieval succeeds");
+        assert_eq!(*verified.address(), address);
+
+        let put_client = client.clone();
+        let receipt = tokio::spawn(async move { put_client.put(chunk, true).await })
+            .await
+            .expect("put task joins");
+        assert!(receipt.is_ok());
     }
 }


### PR DESCRIPTION
## What does this PR do?

Rewires the gRPC chunk service onto the chunk core, absorbing the local `ChunkServiceProvider` trait and routing parse, reconstruct, retrieve, and upload through the shared helpers and `ChunkClientExt` verbs.

## Changes

- Re-export `ChunkServiceProvider` as an alias of `vertex_swarm_stream::ChunkClient`, so existing `P: ChunkServiceProvider` bounds keep compiling against the one capability alias.
- Replace the local `parse_chunk_address`/`parse_stamped_chunk` with thin status-mapping wrappers over the free `parse_address`/`reconstruct`; reconstruct now validates the declared `chunk_type` against the decoded variant.
- Route streaming `retrieve_chunks` through `get_stream_from` (one bounded, verify-by-default prefetch shared with the FFI and wasm paths) instead of the hand-rolled `buffer_unordered`; malformed addresses and inbound errors are interleaved as their own error items.
- `verified_response` emits the real `served_by` now carried by `VerifiedChunk` (the streaming path previously emitted it empty).
- Unary `retrieve_chunk` routes through the `get` default (verify-by-default); unary and streamed uploads route through the `put` default.

## Breaking changes

Yes, semver-visible:
- Unary `RetrieveChunk` is now verify-by-default, so a wrong-bytes delivery errors instead of returning.
- Streaming `RetrieveChunks` now populates `served_by` (previously empty).
- Upload reconstruct now rejects a chunk whose bytes decode to a variant other than the declared `chunk_type`.

These tighten correctness: they reject deliveries that the prior code silently accepted.

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] Documentation updated (if needed)

Built and tested under the workspace toolchain with `protoc`. The streaming, unary, and upload paths are exercised by the gRPC service tests; the shared core paths carry their own coverage from r02 and r03.

## Related issues

Part of the client-core refactor stack.

Related: #365

## AI assistance disclosure

AI Assistance: Claude Code agents implemented this change end to end (code, commit message, and this PR description) under an orchestrated workflow that includes automated QA and security review gates. A human is accountable for the result and has reviewed it.

## Notes for reviewers

Base is r03. The three semver-visible behaviour changes in the Breaking changes section are the headline; please confirm they are acceptable for the gRPC surface. The bounded-error-channel fix for the new streaming path lands separately in r05.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated
- [x] No console.logs or debug code left behind
- [x] PR title is descriptive
