### PR TITLE
refactor(api,builder,rpc): introduce NodeProviders<C> and collapse gRPC registration

### DIFF
--- a/crates/ffi/src/api/client.rs
+++ b/crates/ffi/src/api/client.rs
@@ -20,8 +20,8 @@ use vertex_swarm_api::{
     ChunkAddress, Multiaddr, PushReceipt, StampedChunk, SwarmChunkProvider, SwarmError,
 };
 use vertex_swarm_builder::{
-    ChunkVerifyConfig, ClientConfig, ClientRpcProviders, DefaultClientBuilder,
-    NetworkChunkProvider, VerifyingChunkProvider,
+    ChunkComponents, ChunkVerifyConfig, ClientConfig, DefaultClientBuilder, NetworkChunkProvider,
+    NodeProviders, VerifyingChunkProvider,
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
@@ -514,8 +514,10 @@ fn receipt_into_ffi(receipt: PushReceipt) -> VertexPushReceipt {
 }
 
 /// Extract the chunk provider from the built client's providers.
-fn chunks_from(providers: ClientRpcProviders<Arc<Identity>, ClientChunks>) -> ClientChunks {
-    providers.chunks().clone()
+fn chunks_from(
+    providers: NodeProviders<ChunkComponents<Arc<Identity>, ClientChunks>>,
+) -> ClientChunks {
+    providers.components().chunks().clone()
 }
 
 #[cfg(test)]

--- a/crates/rpc/server/src/lib.rs
+++ b/crates/rpc/server/src/lib.rs
@@ -124,7 +124,7 @@ impl GrpcServerConfig {
 /// gRPC server framework for Vertex nodes.
 ///
 /// Provides the base infrastructure for running a gRPC server. Protocol-specific
-/// services can be added using the builder pattern or via `GrpcServiceProvider`.
+/// services can be added using the builder pattern or via [`RegistersGrpcServices`].
 ///
 /// Implements the [`RpcServer`] trait for lifecycle management.
 pub struct GrpcServer {

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -30,6 +30,19 @@ pub trait HasTopology: Send + Sync {
     fn topology(&self) -> &Self::Topology;
 }
 
+/// Chunk client access (client/storer levels).
+///
+/// Exposes the components' chunk client so the gRPC chunk service and embedders
+/// (FFI) can drive uploads and downloads. Mirrors [`HasTopology`].
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait HasChunkClient: Send + Sync {
+    /// The chunk client type.
+    type ChunkClient: Send + Sync;
+
+    /// Get the chunk client.
+    fn chunk_client(&self) -> &Self::ChunkClient;
+}
+
 /// Identity access.
 pub trait HasIdentity: Send + Sync {
     /// The identity type.

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -59,12 +59,12 @@ mod types;
 pub use self::accounting::{Au, AuConversionError};
 pub use self::components::{
     AccountingAction, BandwidthMode, BootnodeComponents, ClientComponents, Direction,
-    HasAccounting, HasIdentity, HasStore, HasTopology, StorerComponents, SwarmAccountingConfig,
-    SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig,
-    SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder,
-    SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins,
-    SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting,
-    SwarmTopologyState, SwarmTopologyStats,
+    HasAccounting, HasChunkClient, HasIdentity, HasStore, HasTopology, StorerComponents,
+    SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore,
+    SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing,
+    SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
+    SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting,
+    SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats,
 };
 pub use self::config::{
     DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN,
@@ -86,7 +86,7 @@ pub use self::reporting::{
     BanCause, DisconnectCause, PeerAffordability, PeerLifecycleEvent, PeerReporter, ReportSource,
     SwarmScoringEvent,
 };
-pub use self::rpc::RpcProviders;
+pub use self::rpc::{Bootnode, Client, Storer};
 pub use self::spec::{
     DEFAULT_SATURATION_PEERS, StaticSwarmSpecProvider, SwarmSpec, SwarmSpecParser,
     SwarmSpecProvider, SwarmToken,

--- a/crates/swarm/api/src/rpc.rs
+++ b/crates/swarm/api/src/rpc.rs
@@ -1,25 +1,19 @@
-//! RPC providers container for Swarm protocol.
+//! Role trait aliases for a node's gRPC surface.
+//!
+//! The generic providers container (`NodeProviders<C>`) lives in
+//! `vertex-swarm-builder`, where the gRPC registration impl is orphan-legal.
+//! These aliases name the capability hierarchy its components type `C` walks.
 
-/// RPC providers container for the Swarm protocol.
-#[derive(Debug, Clone)]
-pub struct RpcProviders<Topo, Chunk> {
-    topology: Topo,
-    chunk: Chunk,
-}
+use crate::{HasChunkClient, HasStore, HasTopology};
 
-impl<Topo, Chunk> RpcProviders<Topo, Chunk> {
-    /// Create new RPC providers.
-    pub fn new(topology: Topo, chunk: Chunk) -> Self {
-        Self { topology, chunk }
-    }
+/// Role alias: a bootnode exposes topology only.
+pub trait Bootnode: HasTopology {}
+impl<C: HasTopology> Bootnode for C {}
 
-    /// Get reference to the topology provider.
-    pub fn topology(&self) -> &Topo {
-        &self.topology
-    }
+/// Role alias: a client adds a chunk client on top of the bootnode surface.
+pub trait Client: Bootnode + HasChunkClient {}
+impl<C: Bootnode + HasChunkClient> Client for C {}
 
-    /// Get reference to the chunk provider.
-    pub fn chunk(&self) -> &Chunk {
-        &self.chunk
-    }
-}
+/// Role alias: a storer adds a local store on top of the client surface.
+pub trait Storer: Client + HasStore {}
+impl<C: Client + HasStore> Storer for C {}

--- a/crates/swarm/builder/examples/download_chunk.rs
+++ b/crates/swarm/builder/examples/download_chunk.rs
@@ -82,7 +82,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let address = ChunkAddress::new([0u8; 32]);
     println!("Retrieving chunk {address}");
-    match providers.chunks().retrieve_chunk(&address).await {
+    match providers
+        .components()
+        .chunks()
+        .retrieve_chunk(&address)
+        .await
+    {
         Ok(result) => {
             println!("Served by {}", result.served_by);
             println!("Chunk address {}", result.chunk.address());

--- a/crates/swarm/builder/examples/upload_chunk.rs
+++ b/crates/swarm/builder/examples/upload_chunk.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stamped = StampedChunk::new(AnyChunk::Content(chunk), sign_stamp(&address)?);
 
     println!("Uploading chunk {address}");
-    let receipt = providers.chunks().send_chunk(stamped).await?;
+    let receipt = providers.components().chunks().send_chunk(stamped).await?;
     println!("Accepted by storer {}", receipt.storer);
     println!("Signature {}", receipt.signature);
     println!("Storage radius {}", receipt.storage_radius);

--- a/crates/swarm/builder/src/handle.rs
+++ b/crates/swarm/builder/src/handle.rs
@@ -7,7 +7,7 @@ use vertex_swarm_identity::Identity;
 use vertex_tasks::{GracefulShutdown, NodeTask, NodeTaskFn};
 
 use crate::providers::NetworkChunkProvider;
-use crate::rpc::{BootnodeRpcProviders, ClientRpcProviders, StorerRpcProviders};
+use crate::rpc::{ChunkComponents, NodeProviders, TopologyComponents};
 use crate::verify::VerifyingChunkProvider;
 
 /// Network chunk provider wrapped with config-gated download verification.
@@ -59,10 +59,12 @@ impl<P: HasTopology> BuiltNode<P> {
 }
 
 /// Built bootnode (topology only).
-pub type BuiltBootnode = BuiltNode<BootnodeRpcProviders<Arc<Identity>>>;
+pub type BuiltBootnode = BuiltNode<NodeProviders<TopologyComponents<Arc<Identity>>>>;
 
 /// Built client node (topology + chunk retrieval).
-pub type BuiltClient = BuiltNode<ClientRpcProviders<Arc<Identity>, VerifiedChunkProvider>>;
+pub type BuiltClient =
+    BuiltNode<NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>>;
 
 /// Built storer node (topology + chunks + storage).
-pub type BuiltStorer = BuiltNode<StorerRpcProviders<Arc<Identity>, VerifiedChunkProvider>>;
+pub type BuiltStorer =
+    BuiltNode<NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>>;

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -28,7 +28,7 @@ use vertex_tasks::{GracefulShutdown, NodeTaskFn};
 use crate::config::{BootnodeConfig, ClientConfig, StorerConfig};
 use crate::error::SwarmNodeError;
 use crate::providers::NetworkChunkProvider;
-use crate::rpc::{BootnodeRpcProviders, ClientRpcProviders, StorerRpcProviders};
+use crate::rpc::{ChunkComponents, NodeProviders, TopologyComponents};
 use crate::verify::{ChunkVerifyConfig, VerifyingChunkProvider};
 
 /// Network chunk provider wrapped with config-gated download verification.
@@ -421,7 +421,7 @@ async fn build_client_backed_node(
 
 impl SwarmLaunchConfig for BootnodeConfig {
     type Types = BootnodeLaunchTypes;
-    type Providers = BootnodeRpcProviders<Arc<Identity>>;
+    type Providers = NodeProviders<TopologyComponents<Arc<Identity>>>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -444,7 +444,7 @@ impl SwarmLaunchConfig for BootnodeConfig {
             DEFAULT_TICK_INTERVAL,
             ctx.executor(),
         );
-        let providers = BootnodeRpcProviders::new(topology);
+        let providers = NodeProviders::new(TopologyComponents::new(topology));
 
         let task = single_task(move |shutdown| async move {
             if let Err(e) = node.start_and_run(shutdown).await {
@@ -459,7 +459,7 @@ impl SwarmLaunchConfig for BootnodeConfig {
 
 impl SwarmLaunchConfig for ClientConfig {
     type Types = ClientLaunchTypes;
-    type Providers = ClientRpcProviders<Arc<Identity>, VerifiedChunkProvider>;
+    type Providers = NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -483,14 +483,14 @@ impl SwarmLaunchConfig for ClientConfig {
         )
         .await?;
 
-        let providers = ClientRpcProviders::new(parts.topology, parts.chunks);
+        let providers = NodeProviders::new(ChunkComponents::new(parts.topology, parts.chunks));
         Ok((parts.task, providers))
     }
 }
 
 impl SwarmLaunchConfig for StorerConfig {
     type Types = StorerLaunchTypes;
-    type Providers = StorerRpcProviders<Arc<Identity>, VerifiedChunkProvider>;
+    type Providers = NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -520,7 +520,7 @@ impl SwarmLaunchConfig for StorerConfig {
         )
         .await?;
 
-        let providers = StorerRpcProviders::new(parts.topology, parts.chunks);
+        let providers = NodeProviders::new(ChunkComponents::new(parts.topology, parts.chunks));
         Ok((parts.task, providers))
     }
 }

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -55,7 +55,7 @@ pub use handle::{BuiltBootnode, BuiltClient, BuiltNode, BuiltStorer};
 
 // Providers
 pub use providers::NetworkChunkProvider;
-pub use rpc::{BootnodeRpcProviders, ClientRpcProviders, StorerRpcProviders};
+pub use rpc::{ChunkComponents, NodeProviders, RegisterSwarmServices, TopologyComponents};
 pub use verify::{ChunkVerifyConfig, VerifyingChunkProvider};
 
 // Configs

--- a/crates/swarm/builder/src/rpc.rs
+++ b/crates/swarm/builder/src/rpc.rs
@@ -1,15 +1,22 @@
-//! RPC providers for Swarm nodes.
+//! The generic [`NodeProviders`] container and the single gRPC registration
+//! path.
+//!
+//! One [`NodeProviders<C>`] wraps a role components type `C`; one
+//! [`RegistersGrpcServices`] impl drives every role by delegating to `C`'s
+//! [`RegisterSwarmServices`] impl. The node status service is always registered;
+//! the chunk service is registered only by components that carry a chunk client
+//! (`C: HasChunkClient`). Role-specific components types ([`TopologyComponents`],
+//! [`ChunkComponents`]) decide which capabilities are registered.
 
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
-use vertex_swarm_api::{HasTopology, SwarmIdentity};
+use vertex_swarm_api::{HasChunkClient, HasTopology, SwarmIdentity, SwarmTopology};
 use vertex_swarm_rpc::{ChunkService, ChunkServiceProvider, NodeService, proto};
 use vertex_swarm_topology::TopologyHandle;
 
-/// Register the node status service and the reflection descriptor that every
-/// node type's gRPC surface shares.
-fn register_node_service<I: SwarmIdentity>(
+/// Register the node status service and the shared reflection descriptor.
+fn register_node_service<T: SwarmTopology + Clone + 'static>(
     registry: &mut GrpcRegistry,
-    topology: &TopologyHandle<I>,
+    topology: &T,
 ) {
     let node_service = NodeService::new(topology.clone());
     let node_server = proto::node::node_server::NodeServer::new(node_service);
@@ -20,39 +27,115 @@ fn register_node_service<I: SwarmIdentity>(
 
 /// Register the chunk upload/download service that backs client and storer
 /// nodes.
-fn register_chunk_service<C>(registry: &mut GrpcRegistry, chunks: &C)
-where
-    C: ChunkServiceProvider,
-{
+fn register_chunk_service<C: ChunkServiceProvider>(registry: &mut GrpcRegistry, chunks: &C) {
     let chunk_service = ChunkService::new(chunks.clone());
     let chunk_server = proto::chunk::chunk_server::ChunkServer::new(chunk_service);
     registry.add_service(chunk_server);
 }
 
-/// RPC providers for client nodes (topology status + chunk retrieval).
-pub struct ClientRpcProviders<I: SwarmIdentity, C> {
+/// One generic providers container over a role components type `C`.
+///
+/// Replaces the per-role `*RpcProviders` containers: the gRPC surface is driven
+/// by the capabilities `C` exposes. Capability access ([`HasTopology`],
+/// [`HasChunkClient`]) delegates to `C`.
+#[derive(Debug, Clone)]
+pub struct NodeProviders<C> {
+    components: C,
+}
+
+impl<C> NodeProviders<C> {
+    /// Wrap a components container.
+    pub fn new(components: C) -> Self {
+        Self { components }
+    }
+
+    /// Access the wrapped components.
+    pub fn components(&self) -> &C {
+        &self.components
+    }
+
+    /// Consume and return the wrapped components.
+    pub fn into_components(self) -> C {
+        self.components
+    }
+}
+
+impl<C: HasTopology> HasTopology for NodeProviders<C> {
+    type Topology = C::Topology;
+
+    fn topology(&self) -> &Self::Topology {
+        self.components.topology()
+    }
+}
+
+impl<C: HasChunkClient> HasChunkClient for NodeProviders<C> {
+    type ChunkClient = C::ChunkClient;
+
+    fn chunk_client(&self) -> &Self::ChunkClient {
+        self.components.chunk_client()
+    }
+}
+
+/// Per-components registration of the Swarm gRPC surface.
+///
+/// Each concrete components type registers exactly the services its role
+/// exposes, so [`NodeProviders`] needs only one delegating
+/// [`RegistersGrpcServices`] impl. This sidesteps the overlapping-impl problem
+/// of gating chunk registration on `HasChunkClient` at the `NodeProviders<C>`
+/// level.
+pub trait RegisterSwarmServices {
+    /// Register this role's gRPC services with the registry.
+    fn register_swarm_services(&self, registry: &mut GrpcRegistry);
+}
+
+/// Components for bootnodes: topology only.
+pub struct TopologyComponents<I: SwarmIdentity> {
+    topology: TopologyHandle<I>,
+}
+
+impl<I: SwarmIdentity> TopologyComponents<I> {
+    /// Create from the topology handle of a built bootnode.
+    pub fn new(topology: TopologyHandle<I>) -> Self {
+        Self { topology }
+    }
+}
+
+impl<I: SwarmIdentity> HasTopology for TopologyComponents<I> {
+    type Topology = TopologyHandle<I>;
+
+    fn topology(&self) -> &TopologyHandle<I> {
+        &self.topology
+    }
+}
+
+impl<I: SwarmIdentity> RegisterSwarmServices for TopologyComponents<I> {
+    fn register_swarm_services(&self, registry: &mut GrpcRegistry) {
+        register_node_service(registry, &self.topology);
+    }
+}
+
+/// Components for client and storer nodes: topology + chunk client.
+pub struct ChunkComponents<I: SwarmIdentity, C> {
     topology: TopologyHandle<I>,
     chunks: C,
 }
 
-impl<I: SwarmIdentity, C> ClientRpcProviders<I, C> {
-    /// Create providers from the topology handle and chunk provider of a built
-    /// client node.
+impl<I: SwarmIdentity, C> ChunkComponents<I, C> {
+    /// Create from the topology handle and chunk provider of a built node.
     pub fn new(topology: TopologyHandle<I>, chunks: C) -> Self {
         Self { topology, chunks }
     }
 
     /// Access the chunk provider that backs uploads and downloads.
     ///
-    /// Embedders that drive a client directly (FFI, gRPC, or an example) borrow
-    /// this to call [`SwarmChunkSender`] and [`SwarmChunkProvider`] without going
-    /// through the gRPC surface.
+    /// Embedders that drive a node directly (FFI, gRPC, or an example) borrow
+    /// this to call the chunk client without going through the gRPC surface.
     pub fn chunks(&self) -> &C {
         &self.chunks
     }
 }
 
-impl<I: SwarmIdentity, C: Send + Sync> HasTopology for ClientRpcProviders<I, C> {
+impl<I: SwarmIdentity, C: Send + Sync> HasTopology for ChunkComponents<I, C> {
     type Topology = TopologyHandle<I>;
 
     fn topology(&self) -> &TopologyHandle<I> {
@@ -60,66 +143,27 @@ impl<I: SwarmIdentity, C: Send + Sync> HasTopology for ClientRpcProviders<I, C> 
     }
 }
 
-impl<I: SwarmIdentity, C: ChunkServiceProvider> RegistersGrpcServices for ClientRpcProviders<I, C> {
-    fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
-        register_node_service(registry, &self.topology);
-        register_chunk_service(registry, &self.chunks);
+impl<I: SwarmIdentity, C: Send + Sync> HasChunkClient for ChunkComponents<I, C> {
+    type ChunkClient = C;
+
+    fn chunk_client(&self) -> &C {
+        &self.chunks
     }
 }
 
-/// RPC providers for bootnodes (topology status only).
-pub struct BootnodeRpcProviders<I: SwarmIdentity> {
-    topology: TopologyHandle<I>,
-}
-
-impl<I: SwarmIdentity> BootnodeRpcProviders<I> {
-    /// Create providers from the topology handle of a built bootnode.
-    pub fn new(topology: TopologyHandle<I>) -> Self {
-        Self { topology }
-    }
-}
-
-impl<I: SwarmIdentity> HasTopology for BootnodeRpcProviders<I> {
-    type Topology = TopologyHandle<I>;
-
-    fn topology(&self) -> &TopologyHandle<I> {
-        &self.topology
-    }
-}
-
-impl<I: SwarmIdentity> RegistersGrpcServices for BootnodeRpcProviders<I> {
-    fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
-        register_node_service(registry, &self.topology);
-    }
-}
-
-/// RPC providers for storer (full) nodes (topology + chunks + storage).
-pub struct StorerRpcProviders<I: SwarmIdentity, C> {
-    topology: TopologyHandle<I>,
-    chunks: C,
-}
-
-impl<I: SwarmIdentity, C> StorerRpcProviders<I, C> {
-    /// Create providers from the topology handle and chunk provider of a built
-    /// storer node.
-    pub fn new(topology: TopologyHandle<I>, chunks: C) -> Self {
-        Self { topology, chunks }
-    }
-}
-
-impl<I: SwarmIdentity, C: Send + Sync> HasTopology for StorerRpcProviders<I, C> {
-    type Topology = TopologyHandle<I>;
-
-    fn topology(&self) -> &TopologyHandle<I> {
-        &self.topology
-    }
-}
-
-impl<I: SwarmIdentity, C: ChunkServiceProvider> RegistersGrpcServices for StorerRpcProviders<I, C> {
-    fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
+impl<I: SwarmIdentity, C: ChunkServiceProvider> RegisterSwarmServices for ChunkComponents<I, C> {
+    fn register_swarm_services(&self, registry: &mut GrpcRegistry) {
         register_node_service(registry, &self.topology);
         register_chunk_service(registry, &self.chunks);
 
         // TODO: Add storer-specific RPC services (storage, redistribution, etc.)
+    }
+}
+
+/// Single registration path for every node role: delegate to the wrapped
+/// components, which register exactly the services their role exposes.
+impl<C: RegisterSwarmServices + Send + Sync> RegistersGrpcServices for NodeProviders<C> {
+    fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
+        self.components.register_swarm_services(registry);
     }
 }

--- a/crates/swarm/rpc/src/lib.rs
+++ b/crates/swarm/rpc/src/lib.rs
@@ -29,31 +29,3 @@ pub mod proto {
     /// File descriptor set for gRPC reflection.
     pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("swarm_descriptor");
 }
-
-/// Trait for types that can register gRPC services with a tonic router.
-pub trait GrpcServiceProvider {
-    /// Register this provider's gRPC services with a tonic router.
-    fn register_grpc_services(
-        &self,
-        router: tonic::transport::server::Router,
-    ) -> tonic::transport::server::Router;
-}
-
-impl<Topo, Chunk> GrpcServiceProvider for vertex_swarm_api::RpcProviders<Topo, Chunk>
-where
-    Topo: vertex_swarm_api::SwarmTopology + Clone + Send + Sync + 'static,
-    Chunk: ChunkServiceProvider,
-{
-    fn register_grpc_services(
-        &self,
-        router: tonic::transport::server::Router,
-    ) -> tonic::transport::server::Router {
-        let node_service = NodeService::new(self.topology().clone());
-        let node_server = proto::node::node_server::NodeServer::new(node_service);
-
-        let chunk_service = ChunkService::new(self.chunk().clone());
-        let chunk_server = proto::chunk::chunk_server::ChunkServer::new(chunk_service);
-
-        router.add_service(node_server).add_service(chunk_server)
-    }
-}


### PR DESCRIPTION
## What does this PR do?

Replaces the three concrete RPC-provider containers and the dead generic `api::RpcProviders` with one generic `NodeProviders<C>`, and collapses the two gRPC registration mechanisms onto the live one.

## Changes

- Introduce `NodeProviders<C>` over a role components type `C`, replacing `BootnodeRpcProviders`, `ClientRpcProviders`, `StorerRpcProviders`, and the dead generic.
- Express role capabilities as trait-alias bounds: Bootnode (`HasTopology`) -> Client (`+ HasChunkClient`) -> Storer (`+ HasStore`), with the new `HasChunkClient` access trait mirroring `HasTopology`/`HasAccounting`/`HasStore`.
- `NodeProviders<C>` implements `RegistersGrpcServices` by delegating to the wrapped components' `RegisterSwarmServices` impl, so the node service is always registered and the chunk service only by components that carry a chunk client.
- Delete the dead `rpc::GrpcServiceProvider` and its `api::RpcProviders` impl.
- Update `launch.rs`, the `SwarmLaunchConfig` `Providers` assoc types, and the FFI and builder examples to drive off `NodeProviders::components()`.

## Breaking changes

None at runtime: the same services are registered for each role. Internal provider types are renamed/unified, so out-of-tree code referencing the old concrete containers would need updating.

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] Documentation updated (if needed)

Built and tested under the workspace toolchain with `protoc`. The builder examples (`download_chunk`, `upload_chunk`) and the FFI client compile and run against the new `NodeProviders` construction.

## Related issues

Part of the client-core refactor stack.

Related: #371

## AI assistance disclosure

AI Assistance: Claude Code agents implemented this change end to end (code, commit message, and this PR description) under an orchestrated workflow that includes automated QA and security review gates. A human is accountable for the result and has reviewed it.

## Notes for reviewers

Base is r06. `NodeProviders` and the role components types live in `vertex-swarm-builder` (where the `RegistersGrpcServices` impl is orphan-legal); the role aliases and `HasChunkClient` stay in the api. Please confirm the orphan-rule placement.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated
- [x] No console.logs or debug code left behind
- [x] PR title is descriptive
