### PR TITLE
feat(rpc-server): abstract the Transport seam (gRPC as one impl)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8538,7 +8538,6 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tonic-reflection",
  "tracing",
  "vertex-node-api",
  "vertex-node-core",

--- a/crates/ffi/src/api/client.rs
+++ b/crates/ffi/src/api/client.rs
@@ -17,11 +17,12 @@ use nectar_postage::Stamp;
 use tokio::runtime::Runtime;
 use vertex_node_api::InfrastructureContext;
 use vertex_swarm_api::{
-    ChunkAddress, Multiaddr, PushReceipt, StampedChunk, SwarmChunkProvider, SwarmError,
+    ChunkAddress, HasChunkClient, Multiaddr, PushReceipt, StampedChunk, SwarmChunkProvider,
+    SwarmError,
 };
 use vertex_swarm_builder::{
-    ChunkComponents, ChunkVerifyConfig, ClientConfig, DefaultClientBuilder, NetworkChunkProvider,
-    NodeProviders, VerifyingChunkProvider,
+    ChunkVerifyConfig, ClientConfig, DefaultClientBuilder, NetworkChunkProvider,
+    VerifyingChunkProvider,
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
@@ -513,11 +514,9 @@ fn receipt_into_ffi(receipt: PushReceipt) -> VertexPushReceipt {
     }
 }
 
-/// Extract the chunk provider from the built client's providers.
-fn chunks_from(
-    providers: NodeProviders<ChunkComponents<Arc<Identity>, ClientChunks>>,
-) -> ClientChunks {
-    providers.components().chunks().clone()
+/// Extract the chunk provider from the built client's components.
+fn chunks_from(components: impl HasChunkClient<ChunkClient = ClientChunks>) -> ClientChunks {
+    components.chunk_client().clone()
 }
 
 #[cfg(test)]

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -24,7 +24,6 @@ async-trait.workspace = true
 eyre.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tonic-reflection.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["sync", "signal"] }
 

--- a/crates/node/builder/src/builder.rs
+++ b/crates/node/builder/src/builder.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use vertex_node_api::{InfrastructureContext, NodeBuildsProtocol, NodeProtocol, NodeRpcConfig};
 use vertex_node_core::args::DatabaseConfig;
 use vertex_node_core::dirs::DataDirs;
-use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
+use vertex_rpc_server::{GrpcTransport, ServeWith, Transport, TransportServer};
 use vertex_tasks::TaskExecutor;
 
 use crate::{InfrastructureError, LaunchError, NodeHandle};
@@ -156,43 +156,43 @@ where
         &self.ctx
     }
 
-    /// Launch the node with gRPC server for protocol services.
-    pub async fn launch(self) -> Result<NodeHandle<P::Components>, LaunchError<P::BuildError>>
+    /// Launch the node, serving its components with the chosen transport.
+    ///
+    /// The transport is selected by the caller; this path names no transport.
+    pub async fn launch_with<Tr: Transport>(
+        self,
+    ) -> Result<NodeHandle<P::Components>, LaunchError<P::BuildError>>
     where
-        P::Components: RegistersGrpcServices,
+        P::Components: ServeWith<Tr>,
     {
         use tracing::info;
 
         // Infrastructure configuration
         info!("Data directory: {}", self.ctx.dirs.root.display());
-        info!("gRPC address: {}", self.ctx.grpc_addr());
+        info!("RPC address: {}", self.ctx.grpc_addr());
 
-        let grpc_addr = self.ctx.grpc_addr();
+        let addr = self.ctx.grpc_addr();
 
         // Launch the protocol (builds components and spawns services)
         let components = P::launch(self.config, &self.ctx)
             .await
             .map_err(LaunchError::Protocol)?;
 
-        // Create gRPC registry and let components register their services
-        let mut registry = GrpcRegistry::new();
-        components.register_grpc_services(&mut registry);
+        // Populate the transport registry from the components.
+        let mut registry = Tr::Registry::default();
+        components.register(&mut registry);
 
-        // Convert registry to server and spawn as critical task
-        let grpc_handle = registry
-            .into_server(grpc_addr)
-            .map_err(InfrastructureError::GrpcReflection)?;
+        // Bind the server and spawn it as a critical task.
+        let server = Tr::into_server(registry, addr)
+            .map_err(|e| InfrastructureError::Transport(e.into()))?;
 
         self.ctx
             .executor
             .spawn_critical_with_graceful_shutdown_signal(
-                "grpc.server",
+                "rpc.server",
                 move |shutdown| async move {
-                    if let Err(e) = grpc_handle
-                        .serve_with_shutdown(shutdown.ignore_guard())
-                        .await
-                    {
-                        tracing::error!(error = %e, "gRPC server error");
+                    if let Err(e) = server.serve_with_shutdown(shutdown.ignore_guard()).await {
+                        tracing::error!(error = %e, "RPC server error");
                     }
                 },
             );
@@ -201,6 +201,14 @@ where
             components,
             self.ctx.executor.on_shutdown_signal().clone(),
         ))
+    }
+
+    /// Launch the node with the gRPC transport (back-compat alias).
+    pub async fn launch(self) -> Result<NodeHandle<P::Components>, LaunchError<P::BuildError>>
+    where
+        P::Components: ServeWith<GrpcTransport>,
+    {
+        self.launch_with::<GrpcTransport>().await
     }
 }
 

--- a/crates/node/builder/src/error.rs
+++ b/crates/node/builder/src/error.rs
@@ -18,7 +18,7 @@ pub enum LaunchError<E: std::error::Error + 'static> {
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum InfrastructureError {
-    /// Failed to build gRPC reflection service.
-    #[error("gRPC reflection service: {0}")]
-    GrpcReflection(#[from] tonic_reflection::server::Error),
+    /// Failed to build the transport server (e.g. gRPC reflection).
+    #[error("transport server: {0}")]
+    Transport(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/crates/rpc/server/src/lib.rs
+++ b/crates/rpc/server/src/lib.rs
@@ -39,6 +39,7 @@
 mod grpc_protocol;
 mod health;
 mod registry;
+mod transport;
 
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -56,6 +57,7 @@ pub use vertex_node_api::NodeRpcConfig;
 pub use grpc_protocol::GrpcProtocol;
 pub use health::HealthService;
 pub use registry::{GrpcRegistry, GrpcServerHandle};
+pub use transport::{GrpcTransport, ServeWith, Transport, TransportServer};
 
 /// Trait for types that can register their gRPC services with a registry.
 ///

--- a/crates/rpc/server/src/transport.rs
+++ b/crates/rpc/server/src/transport.rs
@@ -1,0 +1,75 @@
+//! Generic transport seam for serving node components.
+//!
+//! A node is launched with a [`Transport`]: components register into a
+//! per-launch [`Transport::Registry`] via [`ServeWith`], the registry is turned
+//! into a bound [`Transport::Server`], and the server is driven to completion.
+//! gRPC is one concrete impl ([`GrpcTransport`]); the launch path names no
+//! transport, so a node can be served with any transport.
+
+use std::future::Future;
+use std::net::SocketAddr;
+
+use crate::RegistersGrpcServices;
+use crate::registry::{GrpcRegistry, GrpcServerHandle};
+
+/// A transport a node can be served with.
+pub trait Transport: Send + Sync + 'static {
+    /// Per-launch registry the components register into.
+    type Registry: Default + Send;
+    /// Bound server produced from a populated registry.
+    type Server: TransportServer;
+    /// Error building the bound server.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Build the bound server from a populated registry and bind address.
+    fn into_server(reg: Self::Registry, addr: SocketAddr) -> Result<Self::Server, Self::Error>;
+}
+
+/// A bound server ready to serve until a shutdown signal fires.
+pub trait TransportServer: Send + 'static {
+    /// Error returned while serving.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Serve until `signal` resolves.
+    fn serve_with_shutdown(
+        self,
+        signal: impl Future<Output = ()> + Send + 'static,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+/// Components that can register themselves into a [`Transport`]'s registry.
+pub trait ServeWith<Tr: Transport>: Send + Sync {
+    /// Register services into the transport's registry.
+    fn register(&self, reg: &mut Tr::Registry);
+}
+
+/// gRPC transport: serves components over tonic.
+pub struct GrpcTransport;
+
+impl Transport for GrpcTransport {
+    type Registry = GrpcRegistry;
+    type Server = GrpcServerHandle;
+    type Error = tonic_reflection::server::Error;
+
+    fn into_server(reg: Self::Registry, addr: SocketAddr) -> Result<Self::Server, Self::Error> {
+        reg.into_server(addr)
+    }
+}
+
+impl TransportServer for GrpcServerHandle {
+    type Error = tonic::transport::Error;
+
+    fn serve_with_shutdown(
+        self,
+        signal: impl Future<Output = ()> + Send + 'static,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        GrpcServerHandle::serve_with_shutdown(self, signal)
+    }
+}
+
+/// Bridge existing gRPC registrants into the generic seam with zero churn.
+impl<C: RegistersGrpcServices> ServeWith<GrpcTransport> for C {
+    fn register(&self, reg: &mut GrpcRegistry) {
+        self.register_grpc_services(reg);
+    }
+}

--- a/crates/swarm/builder/examples/download_chunk.rs
+++ b/crates/swarm/builder/examples/download_chunk.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 
 use vertex_node_api::InfrastructureContext;
 use vertex_swarm_api::{
-    ChunkAddress, HasTopology, SwarmChunkProvider, SwarmNodeType, SwarmTopologyCommands,
+    ChunkAddress, HasChunkClient, HasTopology, SwarmChunkProvider, SwarmNodeType,
+    SwarmTopologyCommands,
 };
 use vertex_swarm_builder::{ChunkVerifyConfig, ClientConfig, DefaultClientBuilder};
 use vertex_swarm_identity::Identity;
@@ -82,12 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let address = ChunkAddress::new([0u8; 32]);
     println!("Retrieving chunk {address}");
-    match providers
-        .components()
-        .chunks()
-        .retrieve_chunk(&address)
-        .await
-    {
+    match providers.chunk_client().retrieve_chunk(&address).await {
         Ok(result) => {
             println!("Served by {}", result.served_by);
             println!("Chunk address {}", result.chunk.address());

--- a/crates/swarm/builder/examples/upload_chunk.rs
+++ b/crates/swarm/builder/examples/upload_chunk.rs
@@ -21,8 +21,8 @@ use alloy_signer_local::PrivateKeySigner;
 use nectar_postage::{Stamp, StampDigest, StampIndex};
 use vertex_node_api::InfrastructureContext;
 use vertex_swarm_api::{
-    AnyChunk, Chunk, ChunkAddress, ContentChunk, HasTopology, StampedChunk, SwarmChunkSender,
-    SwarmNodeType, SwarmTopologyCommands,
+    AnyChunk, Chunk, ChunkAddress, ContentChunk, HasChunkClient, HasTopology, StampedChunk,
+    SwarmChunkSender, SwarmNodeType, SwarmTopologyCommands,
 };
 use vertex_swarm_builder::{ChunkVerifyConfig, ClientConfig, DefaultClientBuilder};
 use vertex_swarm_identity::Identity;
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stamped = StampedChunk::new(AnyChunk::Content(chunk), sign_stamp(&address)?);
 
     println!("Uploading chunk {address}");
-    let receipt = providers.components().chunks().send_chunk(stamped).await?;
+    let receipt = providers.chunk_client().send_chunk(stamped).await?;
     println!("Accepted by storer {}", receipt.storer);
     println!("Signature {}", receipt.signature);
     println!("Storage radius {}", receipt.storage_radius);

--- a/crates/swarm/builder/src/handle.rs
+++ b/crates/swarm/builder/src/handle.rs
@@ -2,12 +2,13 @@
 
 use std::sync::Arc;
 
-use vertex_swarm_api::HasTopology;
+use vertex_swarm_api::{BootnodeComponents, ClientComponents, HasTopology};
 use vertex_swarm_identity::Identity;
+use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::{GracefulShutdown, NodeTask, NodeTaskFn};
 
 use crate::providers::NetworkChunkProvider;
-use crate::rpc::{ChunkComponents, NodeProviders, TopologyComponents};
+use crate::rpc::NodeProviders;
 use crate::verify::VerifyingChunkProvider;
 
 /// Network chunk provider wrapped with config-gated download verification.
@@ -59,12 +60,15 @@ impl<P: HasTopology> BuiltNode<P> {
 }
 
 /// Built bootnode (topology only).
-pub type BuiltBootnode = BuiltNode<NodeProviders<TopologyComponents<Arc<Identity>>>>;
+pub type BuiltBootnode =
+    BuiltNode<NodeProviders<BootnodeComponents<TopologyHandle<Arc<Identity>>>>>;
 
 /// Built client node (topology + chunk retrieval).
-pub type BuiltClient =
-    BuiltNode<NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>>;
+pub type BuiltClient = BuiltNode<
+    NodeProviders<ClientComponents<TopologyHandle<Arc<Identity>>, VerifiedChunkProvider>>,
+>;
 
 /// Built storer node (topology + chunks + storage).
-pub type BuiltStorer =
-    BuiltNode<NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>>;
+pub type BuiltStorer = BuiltNode<
+    NodeProviders<ClientComponents<TopologyHandle<Arc<Identity>>, VerifiedChunkProvider>>,
+>;

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -9,7 +9,10 @@ use tracing::{info, warn};
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_node_api::InfrastructureContext;
 use vertex_storage_redb::RedbDatabase;
-use vertex_swarm_api::{PeerReporter, SwarmClientAccounting, SwarmLaunchConfig, SwarmNodeType};
+use vertex_swarm_api::{
+    BootnodeComponents, ClientComponents, PeerReporter, SwarmClientAccounting, SwarmLaunchConfig,
+    SwarmNodeType, construct,
+};
 #[cfg(feature = "chain")]
 use vertex_swarm_api::{SwarmAccountingConfig, SwarmSpec};
 use vertex_swarm_bandwidth::{
@@ -28,7 +31,7 @@ use vertex_tasks::{GracefulShutdown, NodeTaskFn};
 use crate::config::{BootnodeConfig, ClientConfig, StorerConfig};
 use crate::error::SwarmNodeError;
 use crate::providers::NetworkChunkProvider;
-use crate::rpc::{ChunkComponents, NodeProviders, TopologyComponents};
+use crate::rpc::NodeProviders;
 use crate::verify::{ChunkVerifyConfig, VerifyingChunkProvider};
 
 /// Network chunk provider wrapped with config-gated download verification.
@@ -421,7 +424,7 @@ async fn build_client_backed_node(
 
 impl SwarmLaunchConfig for BootnodeConfig {
     type Types = BootnodeLaunchTypes;
-    type Providers = NodeProviders<TopologyComponents<Arc<Identity>>>;
+    type Providers = NodeProviders<BootnodeComponents<TopologyHandle<Arc<Identity>>>>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -444,7 +447,7 @@ impl SwarmLaunchConfig for BootnodeConfig {
             DEFAULT_TICK_INTERVAL,
             ctx.executor(),
         );
-        let providers = NodeProviders::new(TopologyComponents::new(topology));
+        let providers = NodeProviders::new(construct::bootnode(topology));
 
         let task = single_task(move |shutdown| async move {
             if let Err(e) = node.start_and_run(shutdown).await {
@@ -459,7 +462,8 @@ impl SwarmLaunchConfig for BootnodeConfig {
 
 impl SwarmLaunchConfig for ClientConfig {
     type Types = ClientLaunchTypes;
-    type Providers = NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>;
+    type Providers =
+        NodeProviders<ClientComponents<TopologyHandle<Arc<Identity>>, VerifiedChunkProvider>>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -483,14 +487,15 @@ impl SwarmLaunchConfig for ClientConfig {
         )
         .await?;
 
-        let providers = NodeProviders::new(ChunkComponents::new(parts.topology, parts.chunks));
+        let providers = NodeProviders::new(construct::client(parts.topology, parts.chunks));
         Ok((parts.task, providers))
     }
 }
 
 impl SwarmLaunchConfig for StorerConfig {
     type Types = StorerLaunchTypes;
-    type Providers = NodeProviders<ChunkComponents<Arc<Identity>, VerifiedChunkProvider>>;
+    type Providers =
+        NodeProviders<ClientComponents<TopologyHandle<Arc<Identity>>, VerifiedChunkProvider>>;
     type Error = SwarmNodeError;
 
     async fn build(
@@ -520,7 +525,7 @@ impl SwarmLaunchConfig for StorerConfig {
         )
         .await?;
 
-        let providers = NodeProviders::new(ChunkComponents::new(parts.topology, parts.chunks));
+        let providers = NodeProviders::new(construct::client(parts.topology, parts.chunks));
         Ok((parts.task, providers))
     }
 }

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -55,7 +55,7 @@ pub use handle::{BuiltBootnode, BuiltClient, BuiltNode, BuiltStorer};
 
 // Providers
 pub use providers::NetworkChunkProvider;
-pub use rpc::{ChunkComponents, NodeProviders, RegisterSwarmServices, TopologyComponents};
+pub use rpc::{NodeProviders, RegisterSwarmServices};
 pub use verify::{ChunkVerifyConfig, VerifyingChunkProvider};
 
 // Configs

--- a/crates/swarm/builder/src/rpc.rs
+++ b/crates/swarm/builder/src/rpc.rs
@@ -1,17 +1,20 @@
 //! The generic [`NodeProviders`] container and the single gRPC registration
 //! path.
 //!
-//! One [`NodeProviders<C>`] wraps a role components type `C`; one
+//! One [`NodeProviders<C>`] wraps an api component container `C`; one
 //! [`RegistersGrpcServices`] impl drives every role by delegating to `C`'s
 //! [`RegisterSwarmServices`] impl. The node status service is always registered;
 //! the chunk service is registered only by components that carry a chunk client
-//! (`C: HasChunkClient`). Role-specific components types ([`TopologyComponents`],
-//! [`ChunkComponents`]) decide which capabilities are registered.
+//! ([`ClientComponents`]). The api component containers
+//! ([`BootnodeComponents`](vertex_swarm_api::BootnodeComponents),
+//! [`ClientComponents`]) decide which capabilities are registered through their
+//! [`RegisterSwarmServices`] impls.
 
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
-use vertex_swarm_api::{HasChunkClient, HasTopology, SwarmIdentity, SwarmTopology};
+use vertex_swarm_api::{
+    BootnodeComponents, ClientComponents, HasChunkClient, HasTopology, SwarmTopology,
+};
 use vertex_swarm_rpc::{ChunkService, ChunkServiceProvider, NodeService, proto};
-use vertex_swarm_topology::TopologyHandle;
 
 /// Register the node status service and the shared reflection descriptor.
 fn register_node_service<T: SwarmTopology + Clone + 'static>(
@@ -33,11 +36,10 @@ fn register_chunk_service<C: ChunkServiceProvider>(registry: &mut GrpcRegistry, 
     registry.add_service(chunk_server);
 }
 
-/// One generic providers container over a role components type `C`.
+/// One generic providers container over an api component container `C`.
 ///
-/// Replaces the per-role `*RpcProviders` containers: the gRPC surface is driven
-/// by the capabilities `C` exposes. Capability access ([`HasTopology`],
-/// [`HasChunkClient`]) delegates to `C`.
+/// The gRPC surface is driven by the capabilities `C` exposes. Capability access
+/// ([`HasTopology`], [`HasChunkClient`]) delegates to `C`.
 #[derive(Debug, Clone)]
 pub struct NodeProviders<C> {
     components: C,
@@ -78,83 +80,30 @@ impl<C: HasChunkClient> HasChunkClient for NodeProviders<C> {
 
 /// Per-components registration of the Swarm gRPC surface.
 ///
-/// Each concrete components type registers exactly the services its role
-/// exposes, so [`NodeProviders`] needs only one delegating
-/// [`RegistersGrpcServices`] impl. This sidesteps the overlapping-impl problem
-/// of gating chunk registration on `HasChunkClient` at the `NodeProviders<C>`
-/// level.
+/// Each api component container registers exactly the services its role exposes,
+/// so [`NodeProviders`] needs only one delegating [`RegistersGrpcServices`]
+/// impl. This sidesteps the overlapping-impl problem of gating chunk
+/// registration on `HasChunkClient` at the `NodeProviders<C>` level.
 pub trait RegisterSwarmServices {
     /// Register this role's gRPC services with the registry.
     fn register_swarm_services(&self, registry: &mut GrpcRegistry);
 }
 
-/// Components for bootnodes: topology only.
-pub struct TopologyComponents<I: SwarmIdentity> {
-    topology: TopologyHandle<I>,
-}
-
-impl<I: SwarmIdentity> TopologyComponents<I> {
-    /// Create from the topology handle of a built bootnode.
-    pub fn new(topology: TopologyHandle<I>) -> Self {
-        Self { topology }
-    }
-}
-
-impl<I: SwarmIdentity> HasTopology for TopologyComponents<I> {
-    type Topology = TopologyHandle<I>;
-
-    fn topology(&self) -> &TopologyHandle<I> {
-        &self.topology
-    }
-}
-
-impl<I: SwarmIdentity> RegisterSwarmServices for TopologyComponents<I> {
+/// Bootnodes register the node status service only.
+impl<T: SwarmTopology + Clone + 'static> RegisterSwarmServices for BootnodeComponents<T> {
     fn register_swarm_services(&self, registry: &mut GrpcRegistry) {
-        register_node_service(registry, &self.topology);
+        register_node_service(registry, self.topology());
     }
 }
 
-/// Components for client and storer nodes: topology + chunk client.
-pub struct ChunkComponents<I: SwarmIdentity, C> {
-    topology: TopologyHandle<I>,
-    chunks: C,
-}
-
-impl<I: SwarmIdentity, C> ChunkComponents<I, C> {
-    /// Create from the topology handle and chunk provider of a built node.
-    pub fn new(topology: TopologyHandle<I>, chunks: C) -> Self {
-        Self { topology, chunks }
-    }
-
-    /// Access the chunk provider that backs uploads and downloads.
-    ///
-    /// Embedders that drive a node directly (FFI, gRPC, or an example) borrow
-    /// this to call the chunk client without going through the gRPC surface.
-    pub fn chunks(&self) -> &C {
-        &self.chunks
-    }
-}
-
-impl<I: SwarmIdentity, C: Send + Sync> HasTopology for ChunkComponents<I, C> {
-    type Topology = TopologyHandle<I>;
-
-    fn topology(&self) -> &TopologyHandle<I> {
-        &self.topology
-    }
-}
-
-impl<I: SwarmIdentity, C: Send + Sync> HasChunkClient for ChunkComponents<I, C> {
-    type ChunkClient = C;
-
-    fn chunk_client(&self) -> &C {
-        &self.chunks
-    }
-}
-
-impl<I: SwarmIdentity, C: ChunkServiceProvider> RegisterSwarmServices for ChunkComponents<I, C> {
+/// Client and storer nodes register the node status service and the chunk
+/// service.
+impl<T: SwarmTopology + Clone + 'static, C: ChunkServiceProvider> RegisterSwarmServices
+    for ClientComponents<T, C>
+{
     fn register_swarm_services(&self, registry: &mut GrpcRegistry) {
-        register_node_service(registry, &self.topology);
-        register_chunk_service(registry, &self.chunks);
+        register_node_service(registry, self.topology());
+        register_chunk_service(registry, self.chunk_client());
 
         // TODO: Add storer-specific RPC services (storage, redistribution, etc.)
     }


### PR DESCRIPTION
## What does this PR do?
Abstracts the transport seam so gRPC is no longer baked into the generic node launch path.

## Changes
- `vertex-rpc-server`: add a generic `Transport` / `TransportServer` / `ServeWith` seam (`transport.rs`); `GrpcTransport` is the sole concrete impl. A blanket `impl ServeWith<GrpcTransport> for any RegistersGrpcServices` bridges existing impls with no churn.
- `vertex-node-builder`: the framework launch becomes `launch_with::<Tr: Transport>()` bounded `where Components: ServeWith<Tr>`, instead of naming gRPC directly; `launch_without_grpc` retained.

## Breaking changes
Internal (unreleased). The generic launch bound changes; no live binary used it (the active path is bin/vertex's own selection point).

## Testing
`cargo check/clippy -D warnings/test --workspace` green.
- [x] Unit tests pass
- [ ] Manual testing completed
- [ ] Documentation updated (if needed)

## Related issues
Part of the node API-surface revision train.

## AI assistance disclosure
AI Assistance: implemented by Claude Code (Anthropic) agents under a workflow with per-step QA gates (fmt, clippy -D warnings, cargo check/test). Reviewed for correctness.

## Notes for reviewers
This is the guard-rail-4 fix from the architecture review: gRPC becomes one Transport impl rather than a framework assumption. The seam is capability-agnostic; capability gating lives in the adapter (next car).

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated
- [x] No debug code left behind
- [x] PR title is descriptive
