### PR TITLE
refactor(rpc): drop the ChunkServiceProvider alias, use ChunkClient directly

### DIFF
--- a/crates/swarm/rpc/src/adapter.rs
+++ b/crates/swarm/rpc/src/adapter.rs
@@ -14,8 +14,9 @@ use vertex_swarm_api::{
     BootnodeComponents, ClientComponents, HasChunkClient, HasTopology, SwarmTopologyPeers,
     SwarmTopologyState, SwarmTopologyStats,
 };
+use vertex_swarm_stream::ChunkClient;
 
-use crate::{ChunkService, ChunkServiceProvider, NodeService, proto};
+use crate::{ChunkService, NodeService, proto};
 
 /// gRPC transport adapter over an api component container `C`.
 ///
@@ -88,7 +89,7 @@ impl<C> GrpcAdapter<C> {
     pub fn register_chunk(&self, registry: &mut GrpcRegistry)
     where
         C: HasChunkClient,
-        C::ChunkClient: ChunkServiceProvider,
+        C::ChunkClient: ChunkClient,
     {
         let chunk_service = ChunkService::new(self.components.chunk_client().clone());
         let chunk_server = proto::chunk::chunk_server::ChunkServer::new(chunk_service);
@@ -111,7 +112,7 @@ where
 impl<T, C> RegistersGrpcServices for GrpcAdapter<ClientComponents<T, C>>
 where
     T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Clone + Send + Sync + 'static,
-    C: ChunkServiceProvider + Send + Sync,
+    C: ChunkClient + Send + Sync,
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
         self.register_node(registry);

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -2,19 +2,17 @@
 
 use std::pin::Pin;
 
-use futures::StreamExt;
-use tonic::{Request, Response, Status, Streaming};
-use vertex_swarm_api::{ChunkAddress, PushReceipt, Stamp, StampedChunk, SwarmError};
-use vertex_swarm_stream::{
-    ChunkClientExt, NATIVE_DOWNLOAD_CONCURRENCY, StreamConfig, VerifiedChunk, get_stream_from,
-    parse_address,
-};
-
-use crate::ChunkServiceProvider;
 use crate::proto::chunk::{
     ChunkError, HasChunkRequest, HasChunkResponse, RetrieveChunkRequest, RetrieveChunkResponse,
     RetrievedChunk, UploadChunkRequest, UploadChunkResponse, UploadReceipt, chunk_server::Chunk,
     retrieve_chunk_response, upload_chunk_response,
+};
+use futures::StreamExt;
+use tonic::{Request, Response, Status, Streaming};
+use vertex_swarm_api::{ChunkAddress, PushReceipt, Stamp, StampedChunk, SwarmError};
+use vertex_swarm_stream::{
+    ChunkClient, ChunkClientExt, NATIVE_DOWNLOAD_CONCURRENCY, StreamConfig, VerifiedChunk,
+    get_stream_from, parse_address,
 };
 
 /// Whether the chunk service trusts a caller's per-request `validate` flag or
@@ -186,7 +184,7 @@ fn upload_error(address: Vec<u8>, message: String) -> UploadChunkResponse {
 type ResponseStream<T> = Pin<Box<dyn tokio_stream::Stream<Item = Result<T, Status>> + Send>>;
 
 #[tonic::async_trait]
-impl<P: ChunkServiceProvider> Chunk for ChunkService<P> {
+impl<P: ChunkClient> Chunk for ChunkService<P> {
     async fn retrieve_chunk(
         &self,
         request: Request<RetrieveChunkRequest>,

--- a/crates/swarm/rpc/src/lib.rs
+++ b/crates/swarm/rpc/src/lib.rs
@@ -9,16 +9,6 @@ pub use adapter::GrpcAdapter;
 pub use grpc::chunk::{ChunkService, StampValidation};
 pub use grpc::node::NodeService;
 
-/// A chunk provider usable by the chunk gRPC service.
-///
-/// Absorbed into [`vertex_swarm_stream::ChunkClient`]: kept as a re-export so
-/// existing bounds (`P: ChunkServiceProvider`) keep compiling against the one
-/// capability alias. The chunk service drives off [`ChunkClientExt`] and the
-/// free helpers, so this no longer carries its own definition.
-///
-/// [`ChunkClientExt`]: vertex_swarm_stream::ChunkClientExt
-pub use vertex_swarm_stream::ChunkClient as ChunkServiceProvider;
-
 pub mod proto {
     pub mod node {
         tonic::include_proto!("vertex.swarm.node.v1");

--- a/crates/swarm/stream/src/lib.rs
+++ b/crates/swarm/stream/src/lib.rs
@@ -363,10 +363,9 @@ impl<T> MaybeSend for T {}
 /// Capability alias for a lean chunk client: retrieves, sends, cloneable, and
 /// shareable across threads for the lifetime of the program.
 ///
-/// This is the cross-crate replacement for `rpc::ChunkServiceProvider`, which it
-/// absorbs in a later step. A blanket impl means any type satisfying the bound is
-/// a `ChunkClient` without naming it; the alias only exists so the capability is
-/// stated once instead of repeated at every consumer.
+/// A blanket impl means any type satisfying the bound is a `ChunkClient` without
+/// naming it; the alias only exists so the capability is stated once instead of
+/// repeated at every consumer (the gRPC chunk service, the FFI client, etc.).
 ///
 /// `Send + Sync + 'static` is required even on wasm here: a chunk client is held
 /// behind the wasm `Arc<dyn SwarmChunkProvider>` export and shared, so the alias


### PR DESCRIPTION
## What does this PR do?
Final cleanup car of the node API-surface train: removes the transitional `ChunkServiceProvider` alias and names the one capability (`vertex_swarm_stream::ChunkClient`) directly.

## Changes
- Delete `pub use vertex_swarm_stream::ChunkClient as ChunkServiceProvider` from `vertex-swarm-rpc`.
- `adapter.rs` and `grpc/chunk.rs` import `ChunkClient` from `vertex-swarm-stream` and bound on it directly (`impl<P: ChunkClient>`, `C: ChunkClient`, `C::ChunkClient: ChunkClient`).
- Tidy the stale doc reference to the old alias in `vertex-swarm-stream`.

## Breaking changes
None of consequence: the alias had no external consumers (verified). Internal, unreleased.

## Testing
`cargo fmt --all --check`, `cargo check --workspace`, `cargo clippy -p vertex-swarm-rpc --all-targets -- -D warnings`, `cargo test -p vertex-swarm-rpc` all green.
- [x] Unit tests pass
- [ ] Manual testing completed
- [ ] Documentation updated (if needed)

## Related issues
Closes the alias-removal flagged on #366. Top of the node API-surface revision train.

## AI assistance disclosure
AI Assistance: implemented by Claude Code (Anthropic), QA-gated (fmt, clippy -D warnings, check, tests). Reviewed for correctness.

## Notes for reviewers
Pure rename/shim-removal; no behaviour change.

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated
- [x] No debug code left behind
- [x] PR title is descriptive
