### PR TITLE
build: track nectar main branch instead of a pinned rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1829,7 +1829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2285,7 +2285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2716,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3943,7 +3943,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4904,8 +4904,8 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nectar-contracts"
-version = "0.2.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=6a0e0e3d420acb736a8e0c7a9079b7e176552f5e#6a0e0e3d420acb736a8e0c7a9079b7e176552f5e"
+version = "0.2.1"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "nectar-postage"
-version = "0.2.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=6a0e0e3d420acb736a8e0c7a9079b7e176552f5e#6a0e0e3d420acb736a8e0c7a9079b7e176552f5e"
+version = "0.2.1"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4929,8 +4929,8 @@ dependencies = [
 
 [[package]]
 name = "nectar-primitives"
-version = "0.2.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=6a0e0e3d420acb736a8e0c7a9079b7e176552f5e#6a0e0e3d420acb736a8e0c7a9079b7e176552f5e"
+version = "0.2.1"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4951,15 +4951,14 @@ dependencies = [
  "subtle",
  "thiserror 2.0.18",
  "wasm-bindgen",
- "wasm-bindgen-rayon",
  "web-time",
  "zeroize",
 ]
 
 [[package]]
 name = "nectar-swarms"
-version = "0.2.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=6a0e0e3d420acb736a8e0c7a9079b7e176552f5e#6a0e0e3d420acb736a8e0c7a9079b7e176552f5e"
+version = "0.2.1"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
 dependencies = [
  "alloy-chains",
  "num_enum",
@@ -5069,7 +5068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5976,7 +5975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6021,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6034,7 +6033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6183,7 +6182,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6346,7 +6345,6 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
- "wasm_sync",
 ]
 
 [[package]]
@@ -6357,7 +6355,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
- "wasm_sync",
 ]
 
 [[package]]
@@ -6697,7 +6694,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7471,7 +7468,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9616,18 +9613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-rayon"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
-dependencies = [
- "crossbeam-channel",
- "js-sys",
- "rayon",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9695,17 +9680,6 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm_sync"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -9917,15 +9891,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,12 +131,12 @@ indexing_slicing = "warn"
 
 [workspace.dependencies]
 ## nectar
-# Pin all nectar deps to the same rev so the workspace cannot resolve two
-# distinct copies of shared nectar types via independent updates.
-nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "6a0e0e3d420acb736a8e0c7a9079b7e176552f5e" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "6a0e0e3d420acb736a8e0c7a9079b7e176552f5e" }
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "6a0e0e3d420acb736a8e0c7a9079b7e176552f5e" }
-nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "6a0e0e3d420acb736a8e0c7a9079b7e176552f5e" }
+# Track nectar's main branch via a single shared git source so the workspace
+# resolves one copy of shared nectar types; Cargo.lock pins the exact commit.
+nectar-contracts = { git = "https://github.com/nxm-rs/nectar", branch = "main" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", branch = "main" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", branch = "main" }
+nectar-swarms = { git = "https://github.com/nxm-rs/nectar", branch = "main" }
 
 digest = "0.10"
 


### PR DESCRIPTION
## What does this PR do?

Switches all nectar git dependencies from a pinned revision to tracking the `main` branch.

## Why

vertex needs to follow nectar's latest, including the recently merged `SnapshotSink`/`SnapshotSource` rename (nectar PR #94) and the type-tagged `AnyChunk` codec (nectar PR #95) that the storer value codec builds on. A single shared git source still resolves one copy of the shared nectar types across the workspace; `Cargo.lock` pins the exact commit, so builds remain reproducible.

## Changes

- All `nectar-*` workspace dependencies now use `{ git = "https://github.com/nxm-rs/nectar", branch = "main" }`.
- `Cargo.lock` updated to the current nectar `main` commit.

## Breaking changes

None. Public API is unchanged; this only moves the dependency pin.

## Testing

- [x] `cargo check --workspace` is clean against the new nectar pin.

## AI assistance disclosure

AI Assistance: a Claude Code agent made this change and wrote this description. A human is accountable for the result and has reviewed it.

## Notes for reviewers

Base of the storer slice stack (atop #350). The following PRs build on this pin.
