### PR TITLE
refactor(swarm-primitives): consume nectar StampedChunk; drop the vertex definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3943,7 +3943,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4905,7 +4905,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 [[package]]
 name = "nectar-contracts"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#fc8fe992463b0d35397a4a2e18db5f7df230b960"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4915,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "nectar-postage"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#fc8fe992463b0d35397a4a2e18db5f7df230b960"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "nectar-primitives"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#fc8fe992463b0d35397a4a2e18db5f7df230b960"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "nectar-swarms"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#79f9f828d506377a2941564e59ffbeda9408dc55"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#fc8fe992463b0d35397a4a2e18db5f7df230b960"
 dependencies = [
  "alloy-chains",
  "num_enum",
@@ -6694,7 +6694,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7468,7 +7468,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/swarm/net/pushsync/src/codec.rs
+++ b/crates/swarm/net/pushsync/src/codec.rs
@@ -58,7 +58,8 @@ impl ProtoMessage for Delivery {
         }
         let address = ChunkAddress::from_slice(&proto.address)?;
         let stamp = nectar_postage::Stamp::try_from_slice(&proto.stamp)?;
-        let chunk = StampedChunk::reconstruct(address, Bytes::from(proto.data), stamp)?;
+        let chunk = StampedChunk::reconstruct(address, Bytes::from(proto.data), stamp)
+            .map_err(|e| PushsyncError::InvalidChunk(e.to_string()))?;
         Ok(Self::new(chunk))
     }
 }

--- a/crates/swarm/net/pushsync/src/error.rs
+++ b/crates/swarm/net/pushsync/src/error.rs
@@ -16,8 +16,13 @@ vertex_net_codec::protocol_error! {
         InvalidStamp(#[from] nectar_postage::StampError),
 
         /// Chunk bytes did not match the delivery's address.
+        ///
+        /// Carries the message string rather than the source error: chunk
+        /// reconstruction now returns nectar's `StampError`, which `InvalidStamp`
+        /// already claims via `#[from]`, so this variant cannot also derive a
+        /// `From<StampError>`. The call site maps the error to its string.
         #[error("invalid chunk: {0}")]
-        InvalidChunk(#[from] vertex_swarm_primitives::ReconstructError),
+        InvalidChunk(String),
 
         /// Malformed receipt signature.
         #[error("invalid signature: {0}")]

--- a/crates/swarm/net/retrieval/src/codec.rs
+++ b/crates/swarm/net/retrieval/src/codec.rs
@@ -12,7 +12,7 @@ use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Bytes, BytesMut};
 use nectar_primitives::{AnyChunk, ChunkAddress};
 use vertex_net_codec::{Codec, ProtoMessage};
-use vertex_swarm_primitives::{Stamp, StampedChunk, reconstruct_chunk};
+use vertex_swarm_primitives::{Stamp, StampedChunk};
 
 use crate::error::RetrievalError;
 
@@ -161,7 +161,8 @@ impl Delivery {
         } else {
             Some(Stamp::try_from_slice(&proto.stamp)?)
         };
-        let chunk = reconstruct_chunk(expected, Bytes::from(proto.data))?;
+        let chunk = AnyChunk::from_wire_bytes(&expected, Bytes::from(proto.data))
+            .map_err(|e| RetrievalError::InvalidChunk(e.to_string()))?;
         Ok(Self::chunk(chunk, stamp))
     }
 }

--- a/crates/swarm/net/retrieval/src/error.rs
+++ b/crates/swarm/net/retrieval/src/error.rs
@@ -16,8 +16,14 @@ vertex_net_codec::protocol_error! {
         InvalidStamp(#[from] nectar_postage::StampError),
 
         /// Chunk bytes did not match the requested address.
+        ///
+        /// Carries the message string rather than the source error: chunk
+        /// reconstruction now goes through nectar's `AnyChunk::from_wire_bytes`,
+        /// which returns `PrimitivesError` — already claimed by `InvalidAddress`
+        /// via `#[from]` — so this variant cannot also derive a
+        /// `From<PrimitivesError>`. The call site maps the error to its string.
         #[error("invalid chunk: {0}")]
-        InvalidChunk(#[from] vertex_swarm_primitives::ReconstructError),
+        InvalidChunk(String),
     }
 }
 

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -1332,7 +1332,7 @@ mod tests {
     use alloy_primitives::{B256, Signature};
     use nectar_postage::Stamp;
     use nectar_primitives::{AnyChunk, ContentChunk};
-    use vertex_swarm_primitives::StampedChunk;
+    use vertex_swarm_primitives::{StampedChunk, StampedChunkExt};
 
     fn stamped(payload: &'static [u8]) -> StampedChunk {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -39,9 +39,7 @@
 mod stamped;
 mod validated;
 
-pub use stamped::{
-    CachedChunk, ReconstructError, StampedChunk, VerifiedStampedChunk, reconstruct_chunk,
-};
+pub use stamped::{CachedChunk, StampedChunk, StampedChunkExt, VerifiedStampedChunk};
 pub use validated::{ValidatedChunk, ValidationError};
 
 // Re-export canonical Swarm primitives from nectar. See the crate-level docs

--- a/crates/swarm/primitives/src/stamped.rs
+++ b/crates/swarm/primitives/src/stamped.rs
@@ -1,97 +1,23 @@
 //! A chunk paired with the postage stamp that authorizes its storage.
 
 use nectar_postage::Stamp;
-use nectar_primitives::{AnyChunk, ChunkAddress, ContentChunk, SingleOwnerChunk, bytes::Bytes};
-
-/// Error rebuilding a chunk from its wire bytes and expected address.
-///
-/// Reconstructing an [`AnyChunk`] from raw bytes is ambiguous without the
-/// address: a [`ContentChunk`] parse almost always succeeds structurally (span
-/// plus arbitrary payload), so the expected address is the disambiguator. The
-/// chunk is whichever variant parses *and* hashes to the expected address; if
-/// neither does, the bytes do not match the address.
-#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
-#[strum(serialize_all = "snake_case")]
-pub enum ReconstructError {
-    /// The bytes did not parse as any known chunk type whose address matches the
-    /// expected address.
-    #[error("chunk bytes do not match expected address {expected}")]
-    AddressMismatch {
-        /// The address the chunk was expected to have.
-        expected: ChunkAddress,
-    },
-}
+use nectar_primitives::{AnyChunk, ChunkAddress};
 
 /// A chunk together with its postage stamp.
 ///
-/// A retrieval, a pushsync delivery, and an upload all move a *chunk plus its
-/// proof of payment* as one unit. [`AnyChunk`] holds the chunk bytes but carries
-/// no stamp, so this pairing is the cohesive value that flows across the node's
-/// command, event, and provider boundaries instead of two loose fields (or raw
-/// `Bytes`).
+/// Re-exported from `nectar-postage`: the canonical `StampedChunk` now lives
+/// upstream (chunk plus stamp, with the typed/wire codec), so vertex consumes
+/// it directly instead of carrying its own copy. The vertex-specific serve-time
+/// and cache type-states ([`VerifiedStampedChunk`], [`CachedChunk`]) wrap it,
+/// and [`StampedChunkExt`] adds the vertex-only `verify_answers` gate.
+pub use nectar_postage::StampedChunk;
+
+/// Vertex-only extensions to nectar's [`StampedChunk`].
 ///
-/// The address is the chunk's own address; [`address`](Self::address) delegates
-/// to it.
-// TODO(nectar): migrate StampedChunk upstream once the postage stamp and chunk
-// types live together there; it is vertex-only for now.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StampedChunk {
-    chunk: AnyChunk,
-    stamp: Stamp,
-}
-
-impl StampedChunk {
-    /// Pair a chunk with its stamp.
-    #[inline]
-    #[must_use]
-    pub fn new(chunk: AnyChunk, stamp: Stamp) -> Self {
-        Self { chunk, stamp }
-    }
-
-    /// The chunk.
-    #[inline]
-    #[must_use]
-    pub fn chunk(&self) -> &AnyChunk {
-        &self.chunk
-    }
-
-    /// The postage stamp.
-    #[inline]
-    #[must_use]
-    pub fn stamp(&self) -> &Stamp {
-        &self.stamp
-    }
-
-    /// The chunk's address (delegates to the chunk).
-    #[inline]
-    #[must_use]
-    pub fn address(&self) -> &ChunkAddress {
-        self.chunk.address()
-    }
-
-    /// Rebuild a stamped chunk from its wire bytes, expected address, and stamp.
-    ///
-    /// The expected address disambiguates the chunk variant: a [`ContentChunk`]
-    /// parse almost always succeeds structurally, so the chunk is accepted only
-    /// if it also hashes to `expected`. Tries content first, then single-owner,
-    /// matching each against `expected`. A lying address makes both attempts
-    /// fail, so the address is self-validating against the bytes.
-    pub fn reconstruct(
-        expected: ChunkAddress,
-        data: Bytes,
-        stamp: Stamp,
-    ) -> Result<Self, ReconstructError> {
-        let chunk = reconstruct_chunk(expected, data)?;
-        Ok(Self::new(chunk, stamp))
-    }
-
-    /// Split into the chunk and its stamp.
-    #[inline]
-    #[must_use]
-    pub fn into_parts(self) -> (AnyChunk, Stamp) {
-        (self.chunk, self.stamp)
-    }
-
+/// `verify_answers` is a vertex serve-time gate, not a property of the chunk
+/// type, so it cannot be an inherent method on the upstream type (the orphan
+/// rule). It is expressed as an extension trait instead.
+pub trait StampedChunkExt {
     /// Prove this chunk answers a request for `requested`, consuming it into a
     /// [`VerifiedStampedChunk`].
     ///
@@ -105,7 +31,14 @@ impl StampedChunk {
     /// Returns the chunk unchanged in [`Err`] on a mismatch so the caller can
     /// treat it as a miss without losing the value. The error is boxed because a
     /// [`StampedChunk`] is large (a full chunk payload plus a stamp).
-    pub fn verify_answers(
+    fn verify_answers(
+        self,
+        requested: ChunkAddress,
+    ) -> Result<VerifiedStampedChunk, Box<StampedChunk>>;
+}
+
+impl StampedChunkExt for StampedChunk {
+    fn verify_answers(
         self,
         requested: ChunkAddress,
     ) -> Result<VerifiedStampedChunk, Box<StampedChunk>> {
@@ -119,7 +52,7 @@ impl StampedChunk {
 
 /// A [`StampedChunk`] proven to answer a specific request.
 ///
-/// Constructed only by [`StampedChunk::verify_answers`], which checks the
+/// Constructed only by [`StampedChunkExt::verify_answers`], which checks the
 /// chunk's content-derived address against the requested address. A responder
 /// accepts only this type, so a chunk that does not match the request can never
 /// be sent down the wire: the gate is a compile-time guarantee rather than a
@@ -217,35 +150,19 @@ impl From<StampedChunk> for CachedChunk {
     }
 }
 
-/// Rebuild an [`AnyChunk`] from wire bytes given the expected address.
-///
-/// See [`StampedChunk::reconstruct`] for the disambiguation rationale.
-pub fn reconstruct_chunk(
-    expected: ChunkAddress,
-    data: Bytes,
-) -> Result<AnyChunk, ReconstructError> {
-    use nectar_primitives::Chunk;
-
-    if let Ok(content) = ContentChunk::try_from(data.clone())
-        && *content.address() == expected
-    {
-        return Ok(AnyChunk::Content(content));
-    }
-    if let Ok(soc) = SingleOwnerChunk::try_from(data)
-        && *soc.address() == expected
-    {
-        return Ok(AnyChunk::SingleOwner(soc));
-    }
-    Err(ReconstructError::AddressMismatch { expected })
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{B256, Signature};
     use alloy_signer_local::PrivateKeySigner;
-    use nectar_primitives::{Chunk, ContentChunk, SingleOwnerChunk};
+    use nectar_postage::{Stamp, StampError};
+    use nectar_primitives::{Chunk, ContentChunk, SingleOwnerChunk, bytes::Bytes};
 
     use super::*;
+
+    // `StampedChunk` is generic over the chunk body size with a default; the
+    // `reconstruct` constructor takes no argument that pins it, so spell the
+    // default-body-size instantiation out for those call sites.
+    type DefaultStampedChunk = StampedChunk;
 
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
@@ -278,7 +195,7 @@ mod tests {
         let chunk = content_chunk();
         let address = *chunk.address();
         let data = Bytes::from(chunk);
-        let rebuilt = StampedChunk::reconstruct(address, data.clone(), test_stamp())
+        let rebuilt = DefaultStampedChunk::reconstruct(address, data.clone(), test_stamp())
             .expect("content reconstruct");
         assert!(rebuilt.chunk().is_content());
         assert_eq!(*rebuilt.address(), address);
@@ -291,7 +208,7 @@ mod tests {
         let chunk = single_owner_chunk();
         let address = *chunk.address();
         let data = Bytes::from(chunk);
-        let rebuilt = StampedChunk::reconstruct(address, data.clone(), test_stamp())
+        let rebuilt = DefaultStampedChunk::reconstruct(address, data.clone(), test_stamp())
             .expect("soc reconstruct");
         assert!(rebuilt.chunk().is_single_owner());
         assert_eq!(*rebuilt.address(), address);
@@ -327,8 +244,8 @@ mod tests {
         let chunk = content_chunk();
         let data = Bytes::from(chunk);
         let wrong = ChunkAddress::new([0xff; 32]);
-        let err = StampedChunk::reconstruct(wrong, data, test_stamp())
+        let err = DefaultStampedChunk::reconstruct(wrong, data, test_stamp())
             .expect_err("wrong address must fail");
-        assert!(matches!(err, ReconstructError::AddressMismatch { .. }));
+        assert!(matches!(err, StampError::Chunk(_)));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Makes vertex consume nectar's `StampedChunk` (merged in nectar PR #96) and deletes vertex's own definition, so the `AnyChunk + Stamp` pairing and its serialization live in one place: nectar.

## Why

`StampedChunk` pairs two nectar types (`AnyChunk` from nectar-primitives, `Stamp` from nectar-postage), and its codec is pure serialization with no vertex-specific framing, so it belongs with the types. nectar now owns `StampedChunk` (+ `to_typed_bytes`/`from_typed_bytes`/`reconstruct`/`batch_id`) and `AnyChunk::from_wire_bytes`. This also supersedes the interim storer value codec that an earlier revision of this PR carried: a reserve value is now simply `StampedChunk::to_typed_bytes()`.

## Changes

- `vertex-swarm-primitives`: delete the local `StampedChunk`, `reconstruct_chunk`, and `ReconstructError`; re-export `nectar_postage::StampedChunk` (the `vertex_swarm_primitives::StampedChunk` path is unchanged for consumers). `verify_answers` becomes the `StampedChunkExt` extension trait (orphan rule). `VerifiedStampedChunk` and `CachedChunk` stay (vertex serve-time type-state and cache policy).
- Re-point the chunk-reconstruct call sites (ffi, swarm-rpc grpc, pushsync codec, retrieval codec) at nectar's `StampedChunk::reconstruct` / `AnyChunk::from_wire_bytes`. The retrieval and pushsync error enums carry the chunk error as `InvalidChunk(String)` (a `#[from]` would conflict with their existing `InvalidStamp`/`InvalidAddress` `From` impls).
- Bump the nectar lock to the commit that includes `StampedChunk`.

## Breaking changes

`vertex-swarm-primitives` API: `ReconstructError` and the free `reconstruct_chunk` are removed; `verify_answers` now requires importing `StampedChunkExt`. The `StampedChunk` type path is unchanged (re-exported). No wire or storage format change.

## Testing

- [x] `cargo check --workspace` and `cargo clippy --workspace --all-targets` clean.
- [x] Touched-crate tests pass (primitives, storer, net-retrieval, net-pushsync, rpc, node, ffi).

## AI assistance disclosure

AI Assistance: this migration was implemented by a Claude Code agent, including this description, following a maintainer architecture decision. A human is accountable for the result and has reviewed it.
