### PR TITLE
feat(swarm-storer): thread the local overlay into Reserve for proximity eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9382,6 +9382,7 @@ dependencies = [
  "vertex-storage-redb",
  "vertex-swarm-api",
  "vertex-swarm-primitives",
+ "vertex-swarm-test-utils",
 ]
 
 [[package]]

--- a/crates/swarm/storer/Cargo.toml
+++ b/crates/swarm/storer/Cargo.toml
@@ -39,6 +39,7 @@ tracing.workspace = true
 tempfile = "3"
 tokio = { workspace = true, features = ["rt", "macros"] }
 vertex-storage-redb.workspace = true
+vertex-swarm-test-utils.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/swarm/storer/src/reserve.rs
+++ b/crates/swarm/storer/src/reserve.rs
@@ -5,6 +5,8 @@
 
 use parking_lot::RwLock;
 use tracing::{debug, warn};
+use vertex_swarm_api::SwarmIdentity;
+use vertex_swarm_primitives::OverlayAddress;
 
 use crate::{ChunkStore, StorerError, StorerResult};
 
@@ -30,6 +32,10 @@ pub struct Reserve {
     count: RwLock<u64>,
     /// Eviction strategy.
     strategy: EvictionStrategy,
+    /// Local overlay address, threaded from the node identity at construction.
+    /// Required by [`EvictionStrategy::EvictFurthest`] to rank chunks by
+    /// proximity; `None` for the proximity-agnostic strategies.
+    overlay: Option<OverlayAddress>,
 }
 
 impl Reserve {
@@ -39,6 +45,7 @@ impl Reserve {
             capacity,
             count: RwLock::new(0),
             strategy: EvictionStrategy::default(),
+            overlay: None,
         }
     }
 
@@ -48,7 +55,24 @@ impl Reserve {
             capacity,
             count: RwLock::new(0),
             strategy,
+            overlay: None,
         }
+    }
+
+    /// Thread the node identity, enabling proximity-ranked eviction
+    /// ([`EvictionStrategy::EvictFurthest`]). Stores the derived overlay address
+    /// (the reserve only needs its own location in address space, not the
+    /// identity's signing capability), matching how the rest of the node is
+    /// wired off the identity.
+    #[must_use]
+    pub fn with_identity(mut self, identity: &impl SwarmIdentity) -> Self {
+        self.overlay = Some(identity.overlay_address());
+        self
+    }
+
+    /// The local overlay address, if set. Required for `EvictFurthest`.
+    pub fn overlay(&self) -> Option<OverlayAddress> {
+        self.overlay
     }
 
     /// Initialize count from an existing store.
@@ -196,6 +220,18 @@ mod tests {
         assert_eq!(reserve.count(), 0);
         assert_eq!(reserve.available(), 100);
         assert!(reserve.has_room());
+    }
+
+    #[test]
+    fn identity_sets_the_overlay() {
+        use vertex_swarm_test_utils::MockIdentity;
+
+        let identity = MockIdentity::with_first_byte(0x42);
+        let reserve =
+            Reserve::with_strategy(2, EvictionStrategy::EvictFurthest).with_identity(&identity);
+        assert_eq!(reserve.overlay(), Some(identity.overlay_address()));
+        // The proximity-agnostic constructors leave it unset.
+        assert_eq!(Reserve::new(2).overlay(), None);
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Threads the local overlay address into the storer `Reserve` so proximity-ranked eviction has the data it needs.

## Why

`EvictionStrategy::EvictFurthest` must rank chunks by XOR distance from the node's own overlay. The `Reserve` did not carry the overlay, so `EvictFurthest` fell back to `EvictOldest`. This adds the overlay; the furthest-eviction implementation itself lands with the reserve adapter (it needs the store's address enumeration).

## Changes

- `Reserve` gains an optional `overlay: OverlayAddress`, a `with_overlay` builder, and an `overlay()` accessor. The proximity-agnostic strategies leave it `None`.

## Breaking changes

None. Existing constructors are unchanged; the overlay defaults to `None`.

## Testing

- [x] Unit test covering the builder and accessor.
- [x] `cargo test -p vertex-swarm-storer` green; clippy clean.

## AI assistance disclosure

AI Assistance: a Claude Code agent made this change and wrote this description. A human is accountable for the result and has reviewed it.
