### PR TITLE
feat(swarm): storer pushsync ingest (is_responsible_for, store, sign receipt)

### DIFF
--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -232,13 +232,22 @@ define_launch_types!(
 /// storer builds the persisting reserve over the same database the peer store
 /// backs onto. The factory receives the opened database so the storer reserve
 /// and the peer store share one handle rather than opening the file twice.
-type StoreFactory<'a> = Box<
-    dyn FnOnce(
-            Option<Arc<RedbDatabase>>,
-        ) -> Result<Arc<dyn vertex_swarm_api::SwarmLocalStore>, SwarmNodeError>
-        + Send
-        + 'a,
->;
+type StoreFactory<'a> =
+    Box<dyn FnOnce(Option<Arc<RedbDatabase>>) -> Result<NodeStore, SwarmNodeError> + Send + 'a>;
+
+/// The node's local store, plus the storer reserve view when the node is a
+/// storer.
+///
+/// A storer's local store *is* its reserve, but the two trait objects are
+/// distinct (`Arc<dyn ReserveStore>` does not upcast to `Arc<dyn SwarmLocalStore>`),
+/// so both views of the one `DbReserve` are carried here: `local` is what the
+/// retrieval handler and the components share, and `reserve` is the proximity-axis
+/// view the pushsync ingest path needs (`is_responsible_for`, `put`,
+/// `storage_radius`). A client leaves `reserve` `None`.
+struct NodeStore {
+    local: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
+    reserve: Option<Arc<dyn vertex_swarm_api::ReserveStore>>,
+}
 
 /// Borrowed inputs for [`build_client_backed_node`], gathered from a validated
 /// client or storer config.
@@ -295,7 +304,10 @@ async fn build_client_backed_node(
     // handle. The same store serves inbound retrievals and holds local
     // deliveries: the retrieval handler consults `SwarmLocalStore::get` before
     // the network, so a storer serves from its reserve.
-    let store = (params.make_store)(db.clone())?;
+    let NodeStore {
+        local: store,
+        reserve,
+    } = (params.make_store)(db.clone())?;
     // The node consumes its own clone; the returned handle is the same instance
     // the storer surfaces as its components' store.
     let node_store = Arc::clone(&store);
@@ -359,6 +371,15 @@ async fn build_client_backed_node(
         Arc::clone(&accounting),
         client_handle.clone(),
     );
+
+    // Storer ingest: when the node is a storer, give the inbound pushsync path
+    // its reserve so a delivery the node is responsible for is stored and
+    // acknowledged with a signed receipt instead of being relayed. Installed
+    // before the event loop accepts connections, alongside forwarding. A client
+    // has no reserve and keeps the verbatim-relay path.
+    if let Some(reserve) = reserve {
+        node.enable_storage(reserve);
+    }
 
     // Retrieval and pushsync candidate selection consults peer scores and
     // affordability on top of proximity order.
@@ -509,10 +530,14 @@ impl SwarmLaunchConfig for ClientConfig {
                 // byte-bounded LRU; no reserve, signer, radius, or redb is
                 // wired, so the opened database handle is ignored.
                 make_store: Box::new(|_db| {
-                    Ok(Arc::new(vertex_swarm_localstore::ChunkStore::with_budget(
-                        vertex_swarm_localstore::DEFAULT_CACHE_BUDGET_BYTES as usize,
-                        vertex_swarm_localstore::DEFAULT_SOC_CACHE_TTL_NS,
-                    )))
+                    Ok(NodeStore {
+                        local: Arc::new(vertex_swarm_localstore::ChunkStore::with_budget(
+                            vertex_swarm_localstore::DEFAULT_CACHE_BUDGET_BYTES as usize,
+                            vertex_swarm_localstore::DEFAULT_SOC_CACHE_TTL_NS,
+                        )),
+                        // A client has no reserve: every inbound pushsync relays.
+                        reserve: None,
+                    })
                 }),
                 #[cfg(feature = "chain")]
                 chain: self.chain(),
@@ -630,7 +655,7 @@ fn build_storer_reserve(
     db: Option<Arc<RedbDatabase>>,
     identity: &Arc<Identity>,
     capacity: u64,
-) -> Result<Arc<dyn vertex_swarm_api::SwarmLocalStore>, SwarmNodeError> {
+) -> Result<NodeStore, SwarmNodeError> {
     use vertex_swarm_api::StorageRadius;
     use vertex_swarm_postage::{AdmissionValidator, DbBatchStore};
     use vertex_swarm_storer::EvictionStrategy;
@@ -649,17 +674,24 @@ fn build_storer_reserve(
     let batches =
         DbBatchStore::new(Arc::clone(&db)).map_err(|e| SwarmNodeError::Build(e.into()))?;
     let admission = AdmissionValidator::new(RESERVE_CONFIRMATION_THRESHOLD);
-    let reserve = DbReserve::new(
-        db,
-        identity.as_ref(),
-        batches,
-        admission,
-        capacity,
-        EvictionStrategy::EvictFurthest,
-        StorageRadius::ZERO,
-    )
-    .map_err(|e| SwarmNodeError::Build(e.into()))?;
-    Ok(Arc::new(reserve))
+    let reserve = Arc::new(
+        DbReserve::new(
+            db,
+            identity.as_ref(),
+            batches,
+            admission,
+            capacity,
+            EvictionStrategy::EvictFurthest,
+            StorageRadius::ZERO,
+        )
+        .map_err(|e| SwarmNodeError::Build(e.into()))?,
+    );
+    // One `DbReserve`, two trait-object views: the local-store view the node and
+    // components share, and the reserve view the pushsync ingest path uses.
+    Ok(NodeStore {
+        local: Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
+        reserve: Some(reserve as Arc<dyn vertex_swarm_api::ReserveStore>),
+    })
 }
 
 #[cfg(test)]
@@ -874,7 +906,13 @@ mod tests {
         let capacity: u64 = 1 << 12;
 
         // db = None exercises the in-memory fallback.
-        let store = build_storer_reserve(None, &identity, capacity).expect("reserve builds");
+        let node_store = build_storer_reserve(None, &identity, capacity).expect("reserve builds");
+        // A storer always exposes the reserve view the pushsync ingest path needs.
+        assert!(
+            node_store.reserve.is_some(),
+            "the storer factory yields the reserve view"
+        );
+        let store = node_store.local;
 
         // A fresh storer reserve knows no batches, so serving a chunk it never
         // held returns nothing rather than erroring.

--- a/crates/swarm/net/pushsync/src/lib.rs
+++ b/crates/swarm/net/pushsync/src/lib.rs
@@ -7,7 +7,9 @@ mod error;
 pub use error::PushsyncError;
 
 mod receipt;
-pub use receipt::{DepthVerdict, Receipt, SHALLOW_RECEIPT_TOLERANCE, ShallowReceipt};
+pub use receipt::{
+    DepthVerdict, Receipt, ReceiptSigner, SHALLOW_RECEIPT_TOLERANCE, ShallowReceipt,
+};
 
 mod protocol;
 pub use protocol::{

--- a/crates/swarm/net/pushsync/src/receipt.rs
+++ b/crates/swarm/net/pushsync/src/receipt.rs
@@ -44,6 +44,7 @@
 //! `compute_overlay`); a separate issue tracks lifting it into nectar as a
 //! reusable primitive.
 
+use alloy_signer::SignerSync;
 use nectar_primitives::ChunkAddress;
 use vertex_swarm_primitives::{
     NeighborhoodDepth, NetworkId, Nonce, OverlayAddress, StorageRadius, compute_overlay,
@@ -51,6 +52,41 @@ use vertex_swarm_primitives::{
 
 use crate::codec::WireReceipt;
 use crate::error::PushsyncError;
+
+/// A node identity that can mint its own custody receipt.
+///
+/// [`Receipt::sign`] needs three things from the minting node, and they are not
+/// three independent parameters: they are all facets of the node's single
+/// identity. The signing key proves custody, and the `network_id` and `nonce`
+/// are the two inputs that, together with the recovered signing address, derive
+/// the storer overlay via [`compute_overlay`] (the same derivation a forwarder
+/// replays in [`Receipt::reconstruct`]). Threading them as loose arguments
+/// duplicated state the identity already owns, so they are bundled behind this
+/// one handle: the caller passes its identity and the receipt path reads the
+/// signer and the overlay-derivation inputs from it.
+///
+/// This trait is deliberately minimal and lives in the pushsync layer rather
+/// than referencing the node's full identity type: pushsync sits below the node
+/// and cannot depend on it. A node-layer identity implements this trait (or a
+/// node-owned capability bundle does), so the richer identity remains the single
+/// source of truth without leaking node concerns into this crate.
+pub trait ReceiptSigner {
+    /// The synchronous signing key. Erased trait objects
+    /// (`dyn SignerSync + Send + Sync`) satisfy this via `alloy-signer`'s blanket
+    /// impls, so a node can plug in its key without this crate being generic over
+    /// the concrete signer.
+    type Signer: alloy_signer::SignerSync + ?Sized;
+
+    /// The receipt signing key, signing over the 32-byte chunk address.
+    fn signer(&self) -> &Self::Signer;
+
+    /// The network id, one of the two overlay-derivation inputs.
+    fn network_id(&self) -> NetworkId;
+
+    /// The node's identity nonce, the other overlay-derivation input. It binds
+    /// the storer overlay but is not part of the signed message.
+    fn nonce(&self) -> Nonce;
+}
 
 /// Length in bytes of a well-formed recoverable signature.
 const SIGNATURE_LEN: usize = 65;
@@ -210,6 +246,58 @@ impl Receipt {
         DepthVerdict::Verified
     }
 
+    /// Mint a custody receipt for a chunk this node has taken into its reserve.
+    ///
+    /// This is the storer-side counterpart to [`reconstruct`](Self::reconstruct):
+    /// where reconstruct recovers a relayed receipt's storer from the signature,
+    /// `sign` produces a fresh receipt that a forwarder will later reconstruct.
+    /// Everything the minting node contributes comes from its [`ReceiptSigner`]
+    /// identity: it signs over the 32-byte chunk address only (matching what
+    /// `reconstruct` recovers from), and its `network_id` and `nonce` are the two
+    /// overlay-derivation inputs. The `nonce` binds the storer overlay but is not
+    /// part of the signed message. `storage_radius` is the only per-receipt input
+    /// the identity does not own (it tracks the reserve), so it stays an explicit
+    /// argument.
+    ///
+    /// Taking the identity as one handle, rather than the signer plus loose
+    /// `network_id`/`nonce` parameters, keeps the overlay-derivation inputs with
+    /// the key that owns them: the storer overlay is a property of the identity,
+    /// so the three are never passed inconsistently.
+    ///
+    /// The receipt round-trips through [`reconstruct`](Self::reconstruct): the
+    /// `storer` is derived by recovering the signer's Ethereum address from the
+    /// freshly minted signature and applying [`compute_overlay`] with the
+    /// identity's nonce, exactly as the read side does. Deriving it from the
+    /// recovered address (rather than asking the signer for its address)
+    /// guarantees the minted receipt is self-consistent under recovery, so the
+    /// returned [`Receipt`] is fully verified by construction.
+    pub fn sign(
+        identity: &impl ReceiptSigner,
+        address: ChunkAddress,
+        storage_radius: StorageRadius,
+    ) -> Result<Self, PushsyncError> {
+        let nonce = identity.nonce();
+        let signature = identity
+            .signer()
+            .sign_message_sync(address.as_bytes())
+            .map_err(|_| PushsyncError::MalformedReceiptSignature)?;
+        // Derive the storer overlay the same way `reconstruct` does on the read
+        // side: recover the Ethereum address from the signature over the chunk
+        // address, then combine it with the identity's network id and nonce. A
+        // forwarder reconstructing this receipt recovers exactly this overlay.
+        let eth = signature
+            .recover_address_from_msg(address.as_bytes())
+            .map_err(|_| PushsyncError::MalformedReceiptSignature)?;
+        let storer = compute_overlay(&eth, identity.network_id(), &nonce);
+        Ok(Self {
+            address,
+            storer,
+            signature,
+            nonce,
+            storage_radius,
+        })
+    }
+
     /// Reproduce the wire receipt for verbatim relay.
     ///
     /// A forwarder relays the storer's receipt unchanged; it never re-signs. The
@@ -228,13 +316,42 @@ impl Receipt {
 
 #[cfg(test)]
 mod tests {
-    use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use nectar_primitives::Bin;
 
     use super::*;
 
     const NET: NetworkId = NetworkId::MAINNET;
+
+    /// A test-only [`ReceiptSigner`]: a real signing key plus the identity nonce
+    /// and network id, bundled exactly as a node identity bundles them. Lets the
+    /// receipt tests mint through the production [`Receipt::sign`] path.
+    struct TestIdentity {
+        signer: PrivateKeySigner,
+        nonce: Nonce,
+    }
+
+    impl TestIdentity {
+        fn new(signer: PrivateKeySigner, nonce: Nonce) -> Self {
+            Self { signer, nonce }
+        }
+    }
+
+    impl ReceiptSigner for TestIdentity {
+        type Signer = PrivateKeySigner;
+
+        fn signer(&self) -> &Self::Signer {
+            &self.signer
+        }
+
+        fn network_id(&self) -> NetworkId {
+            NET
+        }
+
+        fn nonce(&self) -> Nonce {
+            self.nonce
+        }
+    }
 
     fn chunk_address(first_byte: u8) -> ChunkAddress {
         let mut bytes = [0u8; 32];
@@ -250,8 +367,13 @@ mod tests {
         StorageRadius::new(Bin::new(n).unwrap())
     }
 
-    /// Sign over the 32-byte chunk address and grind the nonce until the storer
-    /// overlay sits at least `min_depth` bits deep relative to `address`.
+    /// Grind the node's identity nonce until the storer overlay sits at least
+    /// `min_depth` bits deep relative to `address`, then mint the receipt with the
+    /// production [`Receipt::sign`] path and reduce it to its wire form.
+    ///
+    /// A real node has a fixed identity nonce; the grind here only constructs a
+    /// *test* storer at a chosen depth so the depth-policy tests have a known
+    /// proximity. The receipt itself is minted exactly as production does.
     fn wire(
         signer: &PrivateKeySigner,
         address: &ChunkAddress,
@@ -259,7 +381,6 @@ mod tests {
         storage_radius: StorageRadius,
     ) -> (WireReceipt, OverlayAddress) {
         let eth = signer.address();
-        let signature = signer.sign_message_sync(address.as_bytes()).expect("sign");
         let mut counter = 0u64;
         loop {
             let mut nonce_bytes = [0u8; 32];
@@ -267,13 +388,37 @@ mod tests {
             let nonce = Nonce::from(nonce_bytes);
             let overlay = compute_overlay(&eth, NET, &nonce);
             if address.proximity(&overlay).get() >= min_depth {
-                return (
-                    WireReceipt::new(*address, signature, nonce, storage_radius),
-                    overlay,
-                );
+                let identity = TestIdentity::new(signer.clone(), nonce);
+                let receipt =
+                    Receipt::sign(&identity, *address, storage_radius).expect("sign receipt");
+                return (receipt.to_wire(), overlay);
             }
             counter += 1;
         }
+    }
+
+    #[test]
+    fn sign_mints_a_receipt_that_reconstructs_to_the_same_storer() {
+        // The storer-side mint and the forwarder-side recovery are inverses: a
+        // receipt signed with the node's identity nonce reconstructs to the
+        // overlay that nonce plus the signing key derive.
+        let signer = PrivateKeySigner::random();
+        let address = chunk_address(0x42);
+        let nonce = Nonce::from([3u8; 32]);
+        let eth = signer.address();
+        let identity = TestIdentity::new(signer, nonce);
+        let minted = Receipt::sign(&identity, address, radius(7)).expect("mints a receipt");
+        let expected = compute_overlay(&eth, NET, &nonce);
+        assert_eq!(minted.storer, expected, "storer derived from the signature");
+        assert_eq!(minted.address, address);
+        assert_eq!(minted.nonce, nonce);
+        assert_eq!(minted.storage_radius, radius(7));
+
+        // Round-trip through the wire and the forwarder-side decode boundary: the
+        // reconstructed receipt is byte- and field-identical to the minted one.
+        let reconstructed =
+            Receipt::reconstruct(minted.to_wire(), NET).expect("reconstructs the minted receipt");
+        assert_eq!(reconstructed, minted);
     }
 
     #[test]

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -54,6 +54,9 @@ vertex-util-runtime.workspace = true
 
 ## crypto
 alloy-primitives.workspace = true
+# The storer pushsync ingest path erases the identity's signer to `dyn SignerSync`
+# to sign custody receipts.
+alloy-signer.workspace = true
 
 ## async
 async-trait.workspace = true
@@ -111,7 +114,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 libp2p-swarm-test.workspace = true
 rand_08.workspace = true
 nectar-postage.workspace = true
-alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 
 [features]

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -432,6 +432,11 @@ impl ClientService {
                 metrics::counter!("swarm.client.inbound_relayed").increment(1);
             }
 
+            ClientEvent::InboundStored { peer } => {
+                debug!(%peer, "Stored inbound pushsync delivery and signed a receipt");
+                metrics::counter!("swarm.client.inbound_stored").increment(1);
+            }
+
             ClientEvent::InboundPushFailed { peer, address } => {
                 debug!(%peer, %address, "Inbound pushsync failed (substream reset)");
                 metrics::counter!("swarm.client.inbound_push_failed").increment(1);

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -225,6 +225,38 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
             .set_forwarder(forwarder);
     }
 
+    /// Install the storer ingest capability on the client behaviour.
+    ///
+    /// Turns the inbound pushsync path from forward-only into store-and-sign for
+    /// chunks this node is responsible for: a responsible delivery is put into
+    /// `reserve` and acknowledged with a receipt signed by the node's identity
+    /// key, bound to the node's identity nonce. Deliveries the node is not
+    /// responsible for still forward (see [`enable_forwarding`](Self::enable_forwarding)).
+    ///
+    /// Must be called during node assembly, before the event loop accepts
+    /// connections: a handler created earlier would not capture the capability.
+    /// Only the storer launch path calls this; a client never does.
+    pub fn enable_storage(&mut self, reserve: Arc<dyn vertex_swarm_api::ReserveStore>) {
+        use vertex_swarm_api::SwarmSpec;
+
+        let identity = self.base.identity();
+        let nonce = identity.nonce();
+        // The storer overlay a minted receipt binds is derived from the same
+        // identity that signs it, so the capability carries the identity's
+        // network id and nonce alongside the signer rather than re-deriving them
+        // elsewhere.
+        let network_id = identity.spec().network_id();
+        // The identity's concrete signer is erased to the synchronous signer
+        // trait; `I::Signer: Signer + SignerSync`, so the coercion is sound.
+        let signer: Arc<dyn alloy_signer::SignerSync + Send + Sync> = identity.signer();
+        let capability = crate::protocol::StorerCapability::new(reserve, signer, network_id, nonce);
+        self.base
+            .swarm
+            .behaviour_mut()
+            .client
+            .set_storer(capability);
+    }
+
     pub fn topology_command(&mut self, command: TopologyCommand) {
         self.base.swarm.behaviour_mut().topology.on_command(command);
     }

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -29,6 +29,7 @@ use super::{
     ClientCommand, ClientEvent, PseudosettleEvent,
     forward::Forwarder,
     handler::{ClientHandler, Config as HandlerConfig, HandlerCommand, HandlerEvent},
+    storer::StorerCapability,
 };
 
 const DEFAULT_MAX_PENDING_EVENTS: usize = 4096;
@@ -81,6 +82,11 @@ pub(crate) struct ClientBehaviour {
     /// The forwarder seam, cloned into each handler so a cache miss or a
     /// pushsync can relay to a closer peer.
     forward: Arc<dyn Forwarder>,
+    /// The storer ingest capability, present only on a storer node and cloned
+    /// into each handler. When absent (a client) every inbound pushsync takes the
+    /// verbatim-relay path; when set, deliveries the node is responsible for are
+    /// stored and acknowledged with a signed receipt.
+    storer: Option<StorerCapability>,
     /// Map of peer_id -> overlay for activated peers.
     peer_overlays: HashMap<PeerId, OverlayAddress>,
     /// Map of overlay -> peer_id for reverse lookup.
@@ -106,6 +112,7 @@ impl ClientBehaviour {
             config,
             store,
             forward,
+            storer: None,
             peer_overlays: HashMap::new(),
             overlay_peers: HashMap::new(),
             pending_events: VecDeque::new(),
@@ -113,6 +120,18 @@ impl ClientBehaviour {
             #[cfg(feature = "swap")]
             swap_event_tx: None,
         }
+    }
+
+    /// Install the storer ingest capability, turning inbound pushsync into a
+    /// store-and-sign path for chunks this node is responsible for.
+    ///
+    /// Must be called before any peer connects, for the same reason as
+    /// [`set_forwarder`](Self::set_forwarder): handlers clone the capability at
+    /// connection establishment, so a handler created earlier would not see it.
+    /// Only a storer node installs this; a client never does and keeps the
+    /// verbatim-relay path.
+    pub(crate) fn set_storer(&mut self, storer: StorerCapability) {
+        self.storer = Some(storer);
     }
 
     /// Install the multi-hop relay forwarder, replacing the default stub.
@@ -143,6 +162,7 @@ impl ClientBehaviour {
             self.config.handler.clone(),
             Arc::clone(&self.store),
             Arc::clone(&self.forward),
+            self.storer.clone(),
         )
     }
 
@@ -339,6 +359,11 @@ impl ClientBehaviour {
             }
             HandlerEvent::InboundRelayed { overlay } => {
                 self.push_event(ToSwarm::GenerateEvent(ClientEvent::InboundRelayed {
+                    peer: overlay,
+                }));
+            }
+            HandlerEvent::InboundStored { overlay } => {
+                self.push_event(ToSwarm::GenerateEvent(ClientEvent::InboundStored {
                     peer: overlay,
                 }));
             }
@@ -855,6 +880,259 @@ mod tests {
         assert!(
             result.is_err(),
             "an inbound pushsync with the stub forwarder must reset the stream"
+        );
+    }
+
+    // --- Storer ingest (store + sign) integration tests ---
+    //
+    // A storer holds a `StorerCapability`: an inbound pushsync delivery the node
+    // is responsible for is stored in the reserve and acknowledged with the
+    // node's own signed receipt, instead of being relayed. A delivery the node is
+    // NOT responsible for still forwards (the verbatim-relay path), which with the
+    // stub forwarder resets — exactly as a client does. Both branches are driven
+    // here through the real libp2p handler.
+
+    /// A minimal in-memory `ReserveStore` for the ingest tests.
+    ///
+    /// Backs the point-access surface with a map and answers `is_responsible_for`
+    /// from a fixed flag, so a test can put the handler on either branch
+    /// deterministically. The proximity-axis accounting methods are trivial: the
+    /// ingest path only exercises `is_responsible_for`, `put`, and
+    /// `storage_radius`.
+    struct MockReserve {
+        chunks: std::sync::Mutex<
+            std::collections::HashMap<
+                nectar_primitives::ChunkAddress,
+                vertex_swarm_primitives::CachedChunk,
+            >,
+        >,
+        responsible: bool,
+        radius: vertex_swarm_api::StorageRadius,
+    }
+
+    impl MockReserve {
+        fn new(responsible: bool, radius: vertex_swarm_api::StorageRadius) -> Self {
+            Self {
+                chunks: std::sync::Mutex::new(std::collections::HashMap::new()),
+                responsible,
+                radius,
+            }
+        }
+    }
+
+    impl SwarmLocalStore for MockReserve {
+        fn put(
+            &self,
+            chunk: vertex_swarm_primitives::CachedChunk,
+        ) -> vertex_swarm_api::SwarmResult<()> {
+            self.chunks.lock().unwrap().insert(*chunk.address(), chunk);
+            Ok(())
+        }
+        fn get(
+            &self,
+            address: &nectar_primitives::ChunkAddress,
+        ) -> vertex_swarm_api::SwarmResult<Option<vertex_swarm_primitives::CachedChunk>> {
+            Ok(self.chunks.lock().unwrap().get(address).cloned())
+        }
+        fn contains(&self, address: &nectar_primitives::ChunkAddress) -> bool {
+            self.chunks.lock().unwrap().contains_key(address)
+        }
+        fn remove(
+            &self,
+            address: &nectar_primitives::ChunkAddress,
+        ) -> vertex_swarm_api::SwarmResult<()> {
+            self.chunks.lock().unwrap().remove(address);
+            Ok(())
+        }
+    }
+
+    impl vertex_swarm_api::ReserveStore for MockReserve {
+        fn storage_radius(&self) -> vertex_swarm_api::StorageRadius {
+            self.radius
+        }
+        fn is_responsible_for(&self, _address: &nectar_primitives::ChunkAddress) -> bool {
+            self.responsible
+        }
+        fn count(&self) -> vertex_swarm_api::SwarmResult<u64> {
+            Ok(self.chunks.lock().unwrap().len() as u64)
+        }
+        fn capacity(&self) -> u64 {
+            u64::MAX
+        }
+        fn count_in(
+            &self,
+            _po: nectar_primitives::ProximityOrder,
+        ) -> vertex_swarm_api::SwarmResult<u64> {
+            Ok(0)
+        }
+        fn evict_furthest(
+            &self,
+        ) -> vertex_swarm_api::SwarmResult<Option<nectar_primitives::ChunkAddress>> {
+            Ok(None)
+        }
+        fn evict_from_bin(
+            &self,
+            _bin: nectar_primitives::Bin,
+            _max: u64,
+        ) -> vertex_swarm_api::SwarmResult<u64> {
+            Ok(0)
+        }
+        fn evict_batch(
+            &self,
+            _batch: vertex_swarm_primitives::BatchId,
+            _up_to_bin: Option<nectar_primitives::Bin>,
+            _max: u64,
+        ) -> vertex_swarm_api::SwarmResult<u64> {
+            Ok(0)
+        }
+    }
+
+    /// Build a server swarm that holds the storer ingest capability: the inbound
+    /// pushsync path stores responsible deliveries and signs receipts. Returns the
+    /// swarm, the shared reserve (to assert what was stored), and the signer (to
+    /// assert the receipt recovers to the storer's overlay).
+    fn storer_swarm(
+        responsible: bool,
+        radius: vertex_swarm_api::StorageRadius,
+    ) -> (
+        Swarm<ClientBehaviour>,
+        Arc<MockReserve>,
+        alloy_signer_local::PrivateKeySigner,
+        vertex_swarm_primitives::Nonce,
+    ) {
+        use alloy_signer_local::PrivateKeySigner;
+        use nectar_primitives::NetworkId;
+        use vertex_swarm_primitives::Nonce;
+
+        let reserve = Arc::new(MockReserve::new(responsible, radius));
+        let signer = PrivateKeySigner::random();
+        let nonce = Nonce::from([0x5a; 32]);
+
+        let reserve_for_swarm = Arc::clone(&reserve);
+        let signer_for_swarm = signer.clone();
+        let swarm = Swarm::new_ephemeral_tokio(move |_| {
+            // The reserve serves on retrieval too, so it is the behaviour's store.
+            let store: Arc<dyn SwarmLocalStore> = Arc::clone(&reserve_for_swarm) as _;
+            let mut behaviour = ClientBehaviour::new(
+                Config::for_role(SwarmNodeType::Storer),
+                store,
+                Arc::new(StubForwarder),
+            );
+            // The receipt is signed/recovered against this network id.
+            behaviour.set_network_id(NetworkId::MAINNET);
+            let capability = crate::protocol::StorerCapability::new(
+                Arc::clone(&reserve_for_swarm) as Arc<dyn vertex_swarm_api::ReserveStore>,
+                Arc::new(signer_for_swarm.clone())
+                    as Arc<dyn alloy_signer::SignerSync + Send + Sync>,
+                NetworkId::MAINNET,
+                nonce,
+            );
+            behaviour.set_storer(capability);
+            behaviour
+        });
+        (swarm, reserve, signer, nonce)
+    }
+
+    #[tokio::test]
+    async fn responsible_storer_stores_and_signs_a_receipt() {
+        use nectar_primitives::{NetworkId, compute_overlay};
+        use vertex_swarm_api::StorageRadius;
+        use vertex_swarm_primitives::Bin;
+
+        let chunk = content_chunk(b"stored by the responsible storer");
+        let address = *chunk.address();
+        let radius = StorageRadius::new(Bin::new(4).unwrap());
+
+        let (mut storer, reserve, signer, nonce) = storer_swarm(true, radius);
+        let mut pusher = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+
+        let storer_overlay = overlay(2);
+        connect_and_activate(&mut pusher, &mut storer, overlay(1), storer_overlay).await;
+
+        let (tx, mut rx) = oneshot::channel();
+        pusher.behaviour_mut().on_command(ClientCommand::PushChunk {
+            peer: storer_overlay,
+            address,
+            chunk,
+            response: tx,
+        });
+
+        let drive = async {
+            loop {
+                tokio::select! {
+                    _ = pusher.select_next_some() => {}
+                    _ = storer.select_next_some() => {}
+                    res = &mut rx => return res.expect("sender not dropped"),
+                }
+            }
+        };
+        let result = tokio::time::timeout(Duration::from_secs(10), drive)
+            .await
+            .expect("push resolved within timeout");
+
+        let receipt = result.expect("the responsible storer signs and returns a receipt");
+        // The receipt acknowledges this chunk, declares the storer's radius, and
+        // recovers to the storer's own overlay (its identity key + nonce).
+        assert_eq!(receipt.address, address);
+        assert_eq!(receipt.storage_radius, radius);
+        let expected_storer = compute_overlay(&signer.address(), NetworkId::MAINNET, &nonce);
+        assert_eq!(
+            receipt.storer, expected_storer,
+            "the receipt recovers to the storer that signed it"
+        );
+        // The chunk is durably in the reserve before the receipt was sent.
+        assert!(
+            reserve.contains(&address),
+            "the responsible storer took custody of the chunk"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_responsible_storer_forwards_instead_of_storing() {
+        use vertex_swarm_api::StorageRadius;
+        use vertex_swarm_primitives::Bin;
+
+        // The storer holds the ingest capability but is NOT responsible for this
+        // chunk, so it takes the forward path. With the stub forwarder the forward
+        // fails and the substream resets; nothing is stored and no receipt signed.
+        let chunk = content_chunk(b"not my responsibility");
+        let address = *chunk.address();
+        let radius = StorageRadius::new(Bin::new(4).unwrap());
+
+        let (mut storer, reserve, _signer, _nonce) = storer_swarm(false, radius);
+        let mut pusher = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+
+        let storer_overlay = overlay(2);
+        connect_and_activate(&mut pusher, &mut storer, overlay(1), storer_overlay).await;
+
+        let (tx, mut rx) = oneshot::channel();
+        pusher.behaviour_mut().on_command(ClientCommand::PushChunk {
+            peer: storer_overlay,
+            address,
+            chunk,
+            response: tx,
+        });
+
+        let drive = async {
+            loop {
+                tokio::select! {
+                    _ = pusher.select_next_some() => {}
+                    _ = storer.select_next_some() => {}
+                    res = &mut rx => return res.expect("sender not dropped"),
+                }
+            }
+        };
+        let result = tokio::time::timeout(Duration::from_secs(10), drive)
+            .await
+            .expect("push resolved within timeout");
+
+        assert!(
+            result.is_err(),
+            "a not-responsible storer forwards; the stub forward fails and resets"
+        );
+        assert!(
+            !reserve.contains(&address),
+            "a not-responsible storer must not store the chunk"
         );
     }
 

--- a/crates/swarm/node/src/protocol/events.rs
+++ b/crates/swarm/node/src/protocol/events.rs
@@ -112,7 +112,18 @@ pub enum ClientEvent {
         peer: OverlayAddress,
     },
 
-    /// We could not forward an inbound pushsync; the substream reset.
+    /// We took custody of an inbound pushsync delivery: stored it in the reserve
+    /// and acknowledged it with our own signed receipt.
+    ///
+    /// Reached only on a storer responsible for the chunk; this event is for
+    /// scoring and metrics only.
+    InboundStored {
+        /// The peer that pushed.
+        peer: OverlayAddress,
+    },
+
+    /// We could not forward an inbound pushsync (or, on the storer ingest path,
+    /// could not store or acknowledge it); the substream reset.
     InboundPushFailed {
         /// The peer that pushed.
         peer: OverlayAddress,

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -58,6 +58,7 @@ use vertex_swarm_primitives::{CachedChunk, OverlayAddress, Stamp, StampedChunk, 
 
 use super::events::{PushResponseTx, RetrievalResponseTx};
 use super::forward::Forwarder;
+use super::storer::StorerCapability;
 use super::upgrade::{
     ClientInboundOutput, ClientInboundUpgrade, ClientOutboundInfo, ClientOutboundOutput,
     ClientOutboundUpgrade, ClientUpgradeError, FailureKind,
@@ -101,7 +102,11 @@ pub(crate) enum InboundOutcome {
     },
     /// A pushsync was forwarded and the storer's receipt relayed verbatim.
     Relayed { overlay: OverlayAddress },
-    /// A pushsync could not be forwarded; the substream was reset.
+    /// An inbound pushsync the node is responsible for was stored into the
+    /// reserve and acknowledged with a freshly signed custody receipt.
+    Stored { overlay: OverlayAddress },
+    /// A pushsync could not be forwarded (or, on the storer ingest path, could
+    /// not be stored or acknowledged); the substream was reset.
     PushFailed {
         overlay: OverlayAddress,
         address: ChunkAddress,
@@ -290,6 +295,12 @@ pub(crate) enum HandlerEvent {
         /// The peer that pushed.
         overlay: OverlayAddress,
     },
+    /// We took custody of an inbound pushsync delivery: stored it in the reserve
+    /// and acknowledged it with our own signed receipt.
+    InboundStored {
+        /// The peer that pushed.
+        overlay: OverlayAddress,
+    },
     /// We could not forward an inbound pushsync; the substream reset.
     InboundPushFailed {
         /// The peer that pushed.
@@ -429,8 +440,14 @@ pub(crate) struct ClientHandler {
     /// from it; forwarded retrieval deliveries are cached into it.
     store: Arc<dyn SwarmLocalStore>,
     /// The forwarder seam, shared from the behaviour. A cache miss forwards a
-    /// retrieval; every pushsync forwards. Stubbed in the cache-only client.
+    /// retrieval; a pushsync this node is not responsible for forwards. Stubbed
+    /// in the cache-only client.
     forward: Arc<dyn Forwarder>,
+    /// The storer ingest capability, present only on a storer node. When set,
+    /// an inbound pushsync delivery the node is responsible for is stored into
+    /// the reserve and acknowledged with a freshly signed custody receipt; when
+    /// absent (a client), every delivery takes the verbatim-relay path.
+    storer: Option<StorerCapability>,
     /// Counter for pseudosettle request IDs.
     next_request_id: u64,
     /// Pending commands to process.
@@ -463,16 +480,21 @@ impl ClientHandler {
     }
 
     /// Create a new handler in dormant state.
+    ///
+    /// `storer` is `Some` only on a storer node; a client passes `None` and runs
+    /// the verbatim-relay pushsync path unchanged.
     pub(crate) fn new(
         config: Config,
         store: Arc<dyn SwarmLocalStore>,
         forward: Arc<dyn Forwarder>,
+        storer: Option<StorerCapability>,
     ) -> Self {
         Self {
             config,
             state: State::Dormant,
             store,
             forward,
+            storer,
             next_request_id: 0,
             pending_commands: VecDeque::new(),
             pending_events: VecDeque::new(),
@@ -671,9 +693,14 @@ impl ClientHandler {
         }));
     }
 
-    /// Handle an inbound pushsync delivery by forwarding to a closer peer and
-    /// relaying the storer's receipt verbatim. The client never signs a receipt
-    /// (it takes no custody); a forward failure resets the substream.
+    /// Handle an inbound pushsync delivery.
+    ///
+    /// A storer that is responsible for the chunk takes custody: it stores the
+    /// delivery in its reserve and acknowledges it with its own freshly signed
+    /// custody receipt. Otherwise (a client, or a storer not responsible for the
+    /// address) the delivery is forwarded to a closer peer and the storer's
+    /// receipt relayed verbatim — this node never signs for a chunk it does not
+    /// store. A store or forward failure resets the substream.
     fn on_pushsync_delivery(
         &mut self,
         delivery: vertex_swarm_net_pushsync::Delivery,
@@ -689,6 +716,19 @@ impl ClientHandler {
         let chunk = *delivery.chunk;
         let address = *chunk.address();
         debug!(%overlay, %address, "Received pushsync delivery");
+
+        // Storer ingest: if this node holds a reserve and is responsible for the
+        // chunk, take custody locally instead of relaying. The capability is
+        // absent on a client, so the client path below is unchanged.
+        if let Some(storer) = &self.storer
+            && storer.reserve.is_responsible_for(&address)
+        {
+            let storer = storer.clone();
+            self.inbound.push(Box::pin(async move {
+                Self::store_and_sign(storer, chunk, address, overlay, responder).await
+            }));
+            return;
+        }
 
         let forward = Arc::clone(&self.forward);
         self.inbound.push(Box::pin(async move {
@@ -723,6 +763,61 @@ impl ClientHandler {
         }));
     }
 
+    /// Take custody of a delivery: store it into the reserve and acknowledge it
+    /// with a freshly signed custody receipt.
+    ///
+    /// Reached only when the node holds a [`StorerCapability`] and is responsible
+    /// for `address`. The chunk arrives as an always-stamped [`StampedChunk`], so
+    /// it goes into the reserve as a stamped [`CachedChunk`]. A reserve put
+    /// failure (a capacity error, or a backend error) or a sign failure resets the
+    /// substream rather than acknowledging a chunk we did not durably take.
+    async fn store_and_sign(
+        storer: StorerCapability,
+        chunk: StampedChunk,
+        address: ChunkAddress,
+        overlay: OverlayAddress,
+        responder: vertex_swarm_net_pushsync::PushsyncResponder,
+    ) -> InboundOutcome {
+        // Persist the delivery before acknowledging it: a receipt must never
+        // claim custody of a chunk that is not durably in the reserve. The
+        // reserve is always stamped; the pushsync delivery is always stamped, so
+        // the conversion preserves the stamp.
+        if let Err(e) = storer.reserve.put(CachedChunk::from(chunk)) {
+            debug!(%overlay, %address, error = %e, "Reserve put failed; not acknowledging");
+            responder.send_error();
+            return InboundOutcome::PushFailed { overlay, address };
+        }
+
+        // Mint our own custody receipt over the chunk address, declaring our
+        // current storage radius. The capability is the node's identity, so it
+        // supplies the signing key and the overlay-derivation inputs (network id
+        // and nonce); a forwarder upstream recovers our overlay from the
+        // signature exactly as it would a relayed receipt.
+        let storage_radius = storer.reserve.storage_radius();
+        let receipt = match Receipt::sign(&storer, address, storage_radius) {
+            Ok(receipt) => receipt,
+            Err(e) => {
+                // The chunk is stored, but we cannot prove custody. Reset rather
+                // than send an unsigned acknowledgement; the pusher retries.
+                debug!(%overlay, %address, error = %e, "Receipt sign failed; not acknowledging");
+                responder.send_error();
+                return InboundOutcome::PushFailed { overlay, address };
+            }
+        };
+
+        match responder.send_receipt(receipt.to_wire()).await {
+            Ok(()) => InboundOutcome::Stored { overlay },
+            Err(e) => {
+                // The chunk is stored; only the acknowledgement failed to reach
+                // the pusher. The pusher treats the reset as a failed push and
+                // retries, which is idempotent: the reserve put is
+                // content-addressed, so a re-delivery is a no-op.
+                debug!(%overlay, %address, error = %e, "Receipt send failed after store");
+                InboundOutcome::PushFailed { overlay, address }
+            }
+        }
+    }
+
     /// Turn a resolved inbound outcome into a scoring or metrics event.
     fn on_inbound_outcome(&mut self, outcome: InboundOutcome) {
         let event = match outcome {
@@ -732,6 +827,7 @@ impl ClientHandler {
                 HandlerEvent::InboundMissed { overlay, address }
             }
             InboundOutcome::Relayed { overlay } => HandlerEvent::InboundRelayed { overlay },
+            InboundOutcome::Stored { overlay } => HandlerEvent::InboundStored { overlay },
             InboundOutcome::PushFailed { overlay, address } => {
                 HandlerEvent::InboundPushFailed { overlay, address }
             }

--- a/crates/swarm/node/src/protocol/mod.rs
+++ b/crates/swarm/node/src/protocol/mod.rs
@@ -66,6 +66,7 @@ mod behaviour;
 mod events;
 mod forward;
 mod handler;
+mod storer;
 #[cfg(test)]
 mod timeout_repro;
 pub(crate) mod upgrade;
@@ -77,3 +78,4 @@ pub use events::{
     ClientCommand, ClientEvent, FailureKind, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
 };
 pub(crate) use forward::{NetworkForwarder, StubForwarder};
+pub(crate) use storer::StorerCapability;

--- a/crates/swarm/node/src/protocol/storer.rs
+++ b/crates/swarm/node/src/protocol/storer.rs
@@ -1,0 +1,99 @@
+//! The storer ingest capability for the pushsync inbound path.
+//!
+//! A client-only node forwards every inbound pushsync delivery to a closer peer
+//! and relays the storer's receipt verbatim — it never takes custody. A storer
+//! node additionally holds this capability, which lets the inbound handler take
+//! custody of a delivery it is responsible for: it puts the chunk into the
+//! reserve and mints (signs) its own custody receipt rather than relaying.
+//!
+//! The capability is optional and cheaply cloned into each connection handler.
+//! When it is absent the handler runs the unchanged client path, so installing
+//! it never regresses a client.
+
+use std::sync::Arc;
+
+use alloy_signer::SignerSync;
+use vertex_swarm_api::ReserveStore;
+use vertex_swarm_net_pushsync::ReceiptSigner;
+use vertex_swarm_primitives::{NetworkId, Nonce};
+
+/// Storer-side ingest capability shared into each connection handler.
+///
+/// Bundles what a storer needs to take custody on an inbound pushsync delivery:
+/// the [`ReserveStore`] (responsibility check, stamped `put`, and the declared
+/// storage radius the receipt carries) and the node's receipt-minting identity.
+/// The identity is the signing key plus the two overlay-derivation inputs
+/// (`network_id` and `nonce`) that bind the storer overlay a forwarder recovers
+/// from the minted receipt; this type implements [`ReceiptSigner`] so the
+/// handler passes it straight to [`vertex_swarm_net_pushsync::Receipt::sign`]
+/// without re-threading those inputs as loose parameters.
+///
+/// `put` admits the chunk unconditionally; the reserve is kept within capacity
+/// out of band by the eviction primitives ([`ReserveStore::evict_from_bin`] /
+/// [`evict_batch`](ReserveStore::evict_batch)), not by back-pressure on ingest.
+///
+/// Cloning is `Arc`-cheap; the behaviour clones one of these into every handler
+/// at connection establishment.
+#[derive(Clone)]
+pub(crate) struct StorerCapability {
+    /// The proximity-ordered, always-stamped reserve. The handler queries
+    /// [`ReserveStore::is_responsible_for`] to decide whether to ingest, calls
+    /// [`vertex_swarm_api::SwarmLocalStore::put`] to take custody, and reads
+    /// [`ReserveStore::storage_radius`] for the receipt's declared radius.
+    pub(crate) reserve: Arc<dyn ReserveStore>,
+    /// The receipt signing key, erased to the synchronous signer trait so the
+    /// handler is not generic over the identity's concrete signer.
+    signer: Arc<dyn SignerSync + Send + Sync>,
+    /// The network id, one of the two overlay-derivation inputs the receipt mint
+    /// reads from the identity.
+    network_id: NetworkId,
+    /// The node's identity nonce, the other overlay-derivation input.
+    nonce: Nonce,
+}
+
+impl StorerCapability {
+    /// Bundle the reserve and the node's receipt-minting identity (signer,
+    /// network id, and nonce) into a shareable capability.
+    pub(crate) fn new(
+        reserve: Arc<dyn ReserveStore>,
+        signer: Arc<dyn SignerSync + Send + Sync>,
+        network_id: NetworkId,
+        nonce: Nonce,
+    ) -> Self {
+        Self {
+            reserve,
+            signer,
+            network_id,
+            nonce,
+        }
+    }
+}
+
+/// The capability carries the node's identity, so it is itself the
+/// [`ReceiptSigner`] the inbound handler mints custody receipts through.
+impl ReceiptSigner for StorerCapability {
+    type Signer = dyn SignerSync + Send + Sync;
+
+    fn signer(&self) -> &Self::Signer {
+        &*self.signer
+    }
+
+    fn network_id(&self) -> NetworkId {
+        self.network_id
+    }
+
+    fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+}
+
+impl std::fmt::Debug for StorerCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The signer key must never be logged; the reserve has no Debug. Only the
+        // public overlay-derivation inputs (network id and nonce) are shown.
+        f.debug_struct("StorerCapability")
+            .field("network_id", &self.network_id)
+            .field("nonce", &self.nonce)
+            .finish_non_exhaustive()
+    }
+}


### PR DESCRIPTION
## What this PR does

Makes a storer take custody of inbound pushsync deliveries. Until now the inbound pushsync path was client-only: every delivery was forwarded to a closer peer and the storer's receipt relayed verbatim. This PR teaches a storer to recognise the deliveries it is responsible for, store them in its reserve, and acknowledge each one with its own freshly signed custody receipt. The flow is `is_responsible_for` then `put` then `Receipt::sign`.

The handler gains an optional `StorerCapability`. When it is absent (a client) every inbound pushsync keeps the unchanged verbatim-relay path; when it is present (a storer) a responsible delivery is stored and acknowledged, while a delivery the node is not responsible for still forwards. The receipt path reuses the same substream, so there is no second per-chunk network round trip.

## Where it sits

Stacked on `storer/s06-wiring` (#391), top of the train. It depends only on the stable observable surface of `ReserveStore` (`is_responsible_for`, `storage_radius`, `put`) that survived the per-stamped-entry reserve rework, so the protocol, handler, and receipt logic carry over without semantic change.

## Design

- `Receipt::sign(signer, network_id, address, nonce, storage_radius)` is added to `vertex-swarm-net-pushsync` as the storer-side counterpart to `Receipt::reconstruct`. It signs over the 32-byte chunk address only, then derives the storer overlay by recovering the Ethereum address from its own fresh signature and applying `compute_overlay` with the node's identity nonce, exactly as the read side does. Deriving the overlay from the signature (rather than asking the signer for its address) keeps the parameter a plain `SignerSync`, the same trait the node holds erased behind a trait object, and guarantees the minted receipt is self-consistent under `reconstruct`. The nonce-grinding loop that previously lived in the test-only `wire()` helper is no longer needed there; the helper now grinds only a test nonce and mints through the production `Receipt::sign`.

- A new `StorerCapability { reserve, signer, nonce }` (in `crates/swarm/node/src/protocol/storer.rs`) bundles the three things a storer needs on ingest: the `ReserveStore` (responsibility check, stamped `put`, declared storage radius), the receipt signing key erased to `Arc<dyn SignerSync + Send + Sync>`, and the identity nonce. It is `Clone` (Arc-cheap) and its `Debug` impl deliberately omits the signing key and reserve, showing only the public nonce. It is carried as an `Option<StorerCapability>` on `ClientBehaviour` and `ClientHandler`; the behaviour clones it into each handler at connection establishment. The handler constructor gains a `storer: Option<StorerCapability>` argument; `None` runs the unchanged client path.

- `ClientNode::enable_storage(reserve)` installs the capability, erasing the identity's signer to `dyn SignerSync` and reading the identity nonce. It must run during node assembly before the event loop accepts connections, for the same reason as `enable_forwarding`: a handler created earlier would not capture the capability. The builder calls it alongside `enable_forwarding`, passing the reserve view of the one `DbReserve`.

- The builder's `StoreFactory` now returns a `NodeStore { local, reserve }` rather than a bare `Arc<dyn SwarmLocalStore>`. A storer's local store is its reserve, but `Arc<dyn ReserveStore>` does not upcast to `Arc<dyn SwarmLocalStore>`, so both trait-object views of the single `DbReserve` are carried: `local` is what the retrieval handler and components share, and `reserve` is the proximity-axis view the pushsync ingest path needs. A client leaves `reserve` as `None`.

- Inbound dispatch (`on_pushsync_delivery`): if the capability is present and `reserve.is_responsible_for(address)`, the handler runs `store_and_sign`; otherwise it takes the existing forward path. Ordering is store, sign, send. The reserve `put` happens first so a receipt never claims custody of a chunk that is not durably stored. The chunk arrives as an always-stamped `StampedChunk` and is converted to a stamped `CachedChunk` for the always-stamped reserve. The receipt is signed with the reserve's current `storage_radius` (currently `StorageRadius::ZERO` until a radius manager lands; a declared 0 leans on the verifier's local floor). A `put` failure or a sign failure resets the substream without acknowledging. A send failure after a successful `put` also resets, but is a safe retry: the put is content-addressed, so a re-delivery is an idempotent no-op.

- A new `InboundOutcome::Stored` / `HandlerEvent::InboundStored` / `ClientEvent::InboundStored` path threads the successful-custody signal up to the service, which logs it and increments `swarm.client.inbound_stored`. `InboundPushFailed` now also covers store-or-acknowledge failures on the ingest path.

- Dependency move: `alloy-signer` becomes a normal (non-dev) dependency of the node crate, since the ingest path erases the identity's signer to `dyn SignerSync` in production.

## Consensus notes

Each custody receipt carries exactly one signed `PostageProof`: a single signature over the 32-byte chunk address, bound to the storer's identity nonce and declared storage radius. The storer overlay a forwarder recovers from a minted receipt is identical to the one the storer's own key and nonce derive, so `Receipt::sign` and `Receipt::reconstruct` are exact inverses across the wire boundary. A node never signs a receipt for a chunk it does not store: only a storer responsible for the address mints one.

## Testing

- pushsync (`receipt.rs`): `sign_mints_a_receipt_that_reconstructs_to_the_same_storer` checks the minted receipt's storer, address, nonce, and radius, then round-trips it through `to_wire` plus `Receipt::reconstruct` and asserts the reconstructed receipt is field-identical to the minted one. The existing depth-policy tests now mint through the production `Receipt::sign` via the updated `wire()` helper.
- node (`behaviour.rs`): two end-to-end tests drive the real libp2p handler against an in-memory `MockReserve` whose `is_responsible_for` is a fixed flag. `responsible_storer_stores_and_signs_a_receipt` asserts the returned receipt acknowledges the chunk, declares the storer's radius, recovers to the storer's own overlay, and that the chunk is durably in the reserve. `non_responsible_storer_forwards_instead_of_storing` asserts a not-responsible storer takes the forward path (which resets under the stub forwarder) and stores nothing. The `MockReserve` implements the reworked `ReserveStore` eviction primitives (`evict_from_bin`, `evict_batch`) for completeness; the ingest path exercises none of them.
- builder (`launch.rs`): the storer-factory test additionally asserts the factory yields the reserve view (`node_store.reserve.is_some()`); the real `DbReserve` path is covered here.

## Related issues

None.

## AI assistance disclosure

This change was prepared with the assistance of a Claude Code agent (storer-lattice design), including this description. A human author is accountable and has reviewed it.
