### PR TITLE
feat(swarm-postage): add DbBatchStore and the on-chain event ingest seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 [[package]]
 name = "nectar-contracts"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#9bca9affe11de422b682d663c15ebc6f2300e87a"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#0c191183ffd6458d529891487e1c8badcdd7b3e9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4915,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "nectar-postage"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#9bca9affe11de422b682d663c15ebc6f2300e87a"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#0c191183ffd6458d529891487e1c8badcdd7b3e9"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "nectar-primitives"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#9bca9affe11de422b682d663c15ebc6f2300e87a"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#0c191183ffd6458d529891487e1c8badcdd7b3e9"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "nectar-swarms"
 version = "0.2.1"
-source = "git+https://github.com/nxm-rs/nectar?branch=main#9bca9affe11de422b682d663c15ebc6f2300e87a"
+source = "git+https://github.com/nxm-rs/nectar?branch=main#0c191183ffd6458d529891487e1c8badcdd7b3e9"
 dependencies = [
  "alloy-chains",
  "num_enum",
@@ -9292,6 +9292,19 @@ dependencies = [
  "strum 0.28.0",
  "vertex-net-peer-score",
  "vertex-swarm-api",
+]
+
+[[package]]
+name = "vertex-swarm-postage"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "nectar-postage",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "vertex-storage",
+ "vertex-storage-redb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ members = [
     # Storer (chunk storage and staking)
     "crates/swarm/storer",
 
+    # Postage (batch store + on-chain event ingest seam)
+    "crates/swarm/postage",
+
     # RPC
     "crates/rpc/core",
     "crates/rpc/server",
@@ -133,6 +136,9 @@ indexing_slicing = "warn"
 ## nectar
 # Track nectar via a single shared git source so the workspace resolves one
 # copy of shared nectar types; Cargo.lock pins the exact commit.
+#
+# Tracks nectar `main`, which now carries the synchronous
+# BatchStore/StoreValidator/SnapshotStore conversion (nectar #103).
 nectar-contracts = { git = "https://github.com/nxm-rs/nectar", branch = "main" }
 nectar-postage = { git = "https://github.com/nxm-rs/nectar", branch = "main" }
 nectar-primitives = { git = "https://github.com/nxm-rs/nectar", branch = "main" }
@@ -232,6 +238,9 @@ vertex-swarm-redistribution = { path = "crates/swarm/redistribution" }
 
 # storer (chunk storage and staking)
 vertex-swarm-storer = { path = "crates/swarm/storer" }
+
+# postage (batch store + on-chain event ingest seam)
+vertex-swarm-postage = { path = "crates/swarm/postage" }
 
 # rpc
 vertex-rpc-core = { path = "crates/rpc/core" }

--- a/crates/swarm/postage/Cargo.toml
+++ b/crates/swarm/postage/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "vertex-swarm-postage"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Postage batch store and event ingest seam for the vertex Swarm node"
+
+[lints]
+workspace = true
+
+[dependencies]
+## nectar (re-exported public surface; do not redefine these types)
+# The `serde` feature is required so `Batch` satisfies the vertex-storage
+# `Value` bound (Serialize + DeserializeOwned) for the `Batches` table.
+nectar-postage = { workspace = true, features = ["serde"] }
+
+## vertex
+# The `alloy` feature provides the fixed-size codec for `Address`; `BatchId`
+# (a `B256`) is encoded by a local newtype codec in this crate.
+vertex-storage = { workspace = true, features = ["alloy"] }
+
+## misc
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+
+[dev-dependencies]
+alloy-primitives.workspace = true
+tempfile = "3"
+vertex-storage-redb.workspace = true
+
+[features]
+default = ["std"]
+std = []

--- a/crates/swarm/postage/src/lib.rs
+++ b/crates/swarm/postage/src/lib.rs
@@ -1,0 +1,91 @@
+//! Postage batch storage and the on-chain event ingest seam for the vertex
+//! Swarm node.
+//!
+//! This crate is the node-side home for postage state. It does not redefine any
+//! postage primitive: the batch model, the stamp model, validation and the
+//! event vocabulary all live in [`nectar_postage`] and are re-exported verbatim
+//! from this crate's root so downstream crates depend on one canonical copy of
+//! each type. What this crate adds is the *node's* concrete persistence and the
+//! *seam* through which on-chain batch state is driven into that persistence:
+//!
+//! - [`DbBatchStore`]: a [`nectar_postage::BatchStore`] backed by the
+//!   `vertex-storage` `Database` (redb in production). It persists batches and
+//!   the [`PostageContext`] across restarts, so a node recovers its full batch
+//!   set without replaying the whole chain.
+//! - [`DbBatchStore`] also implements [`nectar_postage::BatchEventHandler`]:
+//!   this is the ingest seam. The four [`BatchEvent`] variants map onto the
+//!   store mutations that keep the node's batch set in step with the contract.
+//!
+//! # Stamp validation is stateless (no per-batch public-key cache)
+//!
+//! A stamp is valid iff `ecrecover(sig, digest)` resolves to the batch owner
+//! and the index/bucket bounds hold. The node already knows `batch.owner` from
+//! the batch store, so validation needs no side state: recover the signer per
+//! stamp and compare to the owner (this is exactly what
+//! [`nectar_postage::StoreValidator`] does, reusing [`Stamp::recover_signer`]
+//! and the nectar digest). This crate therefore ships **no** per-batch
+//! public-key cache.
+//!
+//! nectar does support a cheaper path - recover the signer once with a full
+//! ecrecover ([`Stamp::recover_pubkey`]) and verify the remaining stamps of the
+//! same batch against that key ([`Stamp::verify_with_pubkey`]). That is a
+//! deliberate *future* optimisation: if profiling justifies it, it should be a
+//! per-process in-memory memoisation gated behind the batch-existence check,
+//! and **never** a persisted sidecar table. It is intentionally not implemented
+//! here, so that removing the cache cannot change validation semantics.
+//!
+//! # The ingest seam (and what is deliberately out of scope)
+//!
+//! Postage state on Swarm is owned by the postage-stamp contract on the
+//! settlement chain. A node learns about new batches, top-ups, dilutions and
+//! expiries by watching that contract's logs. The decode path is:
+//!
+//! ```text
+//!   chain logs --> [ PostageIndexer ] --> BatchEvent --> [ BatchEventHandler ]
+//!   (raw ABI)      (external crate)       (nectar)        (DbBatchStore here)
+//! ```
+//!
+//! This crate owns only the right-hand half: given a [`BatchEvent`], it applies
+//! the correct store mutation atomically (see [`DbBatchStore::handle_event`]).
+//!
+//! The left-hand half - the event ABI, the log decoder, and the indexer that
+//! pulls logs from a chain provider and reduces them into [`BatchEvent`]s - is
+//! **intentionally stubbed / out of scope** in this crate. That work is owned
+//! externally (a `PostageIndexer`) and is wired up by the node builder, not
+//! here. Concretely, this crate defines and documents the *seam*
+//! ([`BatchEventHandler`], re-exported, implemented by [`DbBatchStore`]) but
+//! ships no contract bindings, no `alloy_sol_types` event definitions, and no
+//! log-to-[`BatchEvent`] reducer. Keeping the two halves apart lets the chain
+//! indexer evolve (ABI revisions, reorg handling, batched log fetches) without
+//! touching the persistence layer, and lets this crate be tested with synthetic
+//! [`BatchEvent`]s and no chain at all.
+//!
+//! # Consensus note: keep stamp identity, not just the batch
+//!
+//! The store keys batches by [`BatchId`] alone, which is correct: a batch is a
+//! single on-chain object. It is the *reserve* and the *sampler* (other crates)
+//! that must key stamped entries by the full `(batchID, 8-byte stampIndex)` and
+//! carry the precise winning stamp through an inclusion proof. This crate's job
+//! stops at making the batch available for stamp validation; it does not
+//! collapse distinct stamps of a batch.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod store;
+
+// -------------------------------------------------------------------------
+// Re-export the nectar postage public surface.
+//
+// Downstream vertex crates depend on `vertex-swarm-postage` for postage types
+// and get exactly the nectar definitions, so there is a single canonical copy
+// of `Batch`, `Stamp`, `BatchEvent`, the `BatchStore`/`BatchEventHandler`
+// traits and the validators across the workspace.
+// -------------------------------------------------------------------------
+pub use nectar_postage::{
+    Batch, BatchEvent, BatchEventHandler, BatchId, BatchParams, BatchStore, BatchStoreError,
+    BatchStoreExt, PostageContext, STAMP_SIZE, Stamp, StampBytes, StampDigest, StampError,
+    StampIndex, StampValidator, StoreValidator, VerifyingKey, calculate_bucket, current_timestamp,
+};
+
+// This crate's own additions.
+pub use store::{DbBatchStore, DbBatchStoreError};

--- a/crates/swarm/postage/src/store.rs
+++ b/crates/swarm/postage/src/store.rs
@@ -1,0 +1,556 @@
+//! Persisting batch store over the `vertex-storage` `Database`, and the
+//! [`BatchEventHandler`] ingest seam.
+//!
+//! [`DbBatchStore`] is generic over the storage backend, so the same code
+//! serves an in-memory database (tests) and an on-disk redb database
+//! (production). It defines two tables:
+//!
+//! - [`Batches`]: `BatchId -> Batch`, the authoritative batch set.
+//! - [`ContextTable`]: a single-row table holding the current
+//!   [`PostageContext`]. redb has no schema-level singleton, so the singleton is
+//!   modelled as a one-key table under a fixed key.
+//!
+//! Every method is a single transaction. The [`BatchStore`] trait is
+//! synchronous (redb is sync), so each method is a plain function and no redb
+//! transaction guard is ever held across an `await` point; async, where it is
+//! needed at all, is added at the true edges (gRPC, FFI), not by the store.
+
+use nectar_postage::{Batch, BatchEvent, BatchEventHandler, BatchId, BatchStore, PostageContext};
+use std::sync::Arc;
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table, table};
+
+// Batch table: `BatchId -> Batch`.
+//
+// The authoritative set of batches the node knows about. Values are compressed
+// (the default): `Batch` serialises to a small but compressible record.
+table!(pub(crate) Batches, "postage_batches", BatchIdKey, Batch);
+
+// Context singleton table: fixed key -> `PostageContext`.
+//
+// redb offers no schema-level singleton, so the postage context is stored as a
+// single row under [`ContextKey::SINGLETON`]. Uncompressed: the value is a tiny
+// fixed record (a u64 and a u128).
+table!(pub(crate) ContextTable, "postage_context", ContextKey, PostageContext, compressed = false);
+
+/// Key newtype wrapping a [`BatchId`] for the [`Batches`] table.
+///
+/// [`BatchId`] is `alloy_primitives::B256`, a foreign type, so the
+/// vertex-storage [`Encode`]/[`Decode`] codecs cannot be implemented on it
+/// directly (orphan rule). This local newtype carries the 32-byte big-endian
+/// encoding, which is also the natural byte order of the id.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+pub(crate) struct BatchIdKey(pub BatchId);
+
+impl Encode for BatchIdKey {
+    type Encoded = [u8; 32];
+
+    fn encode(self) -> Self::Encoded {
+        self.0.0
+    }
+}
+
+impl Decode for BatchIdKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let bytes: [u8; 32] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        Ok(Self(BatchId::from(bytes)))
+    }
+}
+
+/// Key for the [`ContextTable`] singleton.
+///
+/// The context table holds exactly one row; this single-byte key is its address.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+pub(crate) struct ContextKey(u8);
+
+impl ContextKey {
+    /// The sole key under which the postage context is stored.
+    const SINGLETON: Self = Self(0);
+}
+
+impl Encode for ContextKey {
+    type Encoded = [u8; 1];
+
+    fn encode(self) -> Self::Encoded {
+        [self.0]
+    }
+}
+
+impl Decode for ContextKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let bytes: [u8; 1] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        Ok(Self(bytes[0]))
+    }
+}
+
+/// Error type returned by [`DbBatchStore`] operations.
+///
+/// Wraps the underlying [`DatabaseError`]; the [`BatchStore`] trait requires the
+/// associated error to implement [`std::error::Error`], which this does (via
+/// `thiserror`).
+#[derive(Debug, thiserror::Error)]
+pub enum DbBatchStoreError {
+    /// An error from the underlying database.
+    #[error("postage batch store database error: {0}")]
+    Database(#[from] DatabaseError),
+}
+
+/// Batch store backed by the `vertex-storage` `Database` trait.
+///
+/// Generic over the backend, so persistence is decided by whichever database
+/// the node opens. The store is cheap to clone-by-`Arc` and thread-safe for
+/// concurrent reads and writes. It implements both [`BatchStore`] (persistence)
+/// and [`BatchEventHandler`] (the on-chain ingest seam).
+pub struct DbBatchStore<DB: Database> {
+    db: Arc<DB>,
+}
+
+impl<DB: Database> DbBatchStore<DB> {
+    /// Create a batch store over a shared database handle.
+    ///
+    /// Ensures both the batch table and the context singleton table exist, so
+    /// every read path works on a fresh database without a separate
+    /// initialisation step.
+    pub fn new(db: Arc<DB>) -> Result<Self, DbBatchStoreError> {
+        db.update(|tx| {
+            tx.ensure_table(Batches::NAME)?;
+            tx.ensure_table(ContextTable::NAME)?;
+            Ok(())
+        })?;
+        Ok(Self { db })
+    }
+
+    /// Borrow the shared database handle.
+    pub fn database(&self) -> &Arc<DB> {
+        &self.db
+    }
+
+    /// Load a batch, apply `mutate` to it, and store it back, all inside a
+    /// single read-write transaction.
+    ///
+    /// This is the atomic read-modify-write the `TopUp` and `DepthIncrease`
+    /// events need: the load and the store share one transaction, so a
+    /// concurrent writer cannot interleave between the read and the write and
+    /// have its update silently clobbered (a lost update). A missing batch is a
+    /// no-op (the event is for a batch the node never saw, or already removed),
+    /// matching the idempotent ingest contract.
+    ///
+    /// `mutate` runs on the loaded value only and performs no I/O, so the
+    /// transaction is held for the minimum span.
+    fn mutate_sync(
+        &self,
+        id: &BatchId,
+        mutate: impl FnOnce(&mut Batch),
+    ) -> Result<(), DbBatchStoreError> {
+        self.db.update(|tx| {
+            if let Some(mut batch) = tx.get::<Batches>(BatchIdKey(*id))? {
+                mutate(&mut batch);
+                tx.put::<Batches>(BatchIdKey(*id), batch)?;
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    /// Remove an expired batch from the store, the *acknowledgement* half of the
+    /// evict-before-remove expiry contract.
+    ///
+    /// This is the bare store removal: it drops the batch row and returns
+    /// whether it existed. It performs **no** reserve eviction, because the
+    /// reserve lives downstream of this crate. It must therefore be driven only
+    /// as the acknowledgement of the reserve's evict-then-acknowledge entry
+    /// point (`ExpirySweep::on_expired_event`), which evicts the batch's stamped
+    /// entries first and runs this acknowledgement only once eviction has
+    /// succeeded. Calling it standalone for a live `Expired` event orphans the
+    /// reserve entries stamped under the batch; see the [`BatchEventHandler`]
+    /// impl docs.
+    ///
+    /// Idempotent: acknowledging an already-removed batch returns `false` and is
+    /// a harmless no-op, so a redelivered `Expired` event is safe.
+    pub fn acknowledge_expired(&self, id: &BatchId) -> Result<bool, DbBatchStoreError> {
+        self.remove(id)
+    }
+}
+
+// The `BatchStore` trait is synchronous: redb is itself synchronous, so each
+// method is a single transaction with no executor in sight. Async, where it is
+// needed at all, is added at the true edges (a gRPC service, an FFI boundary),
+// not here in the store.
+impl<DB: Database> BatchStore for DbBatchStore<DB> {
+    type Error = DbBatchStoreError;
+
+    fn get(&self, id: &BatchId) -> Result<Option<Batch>, Self::Error> {
+        Ok(self.db.view(|tx| tx.get::<Batches>(BatchIdKey(*id)))?)
+    }
+
+    fn put(&self, batch: Batch) -> Result<(), Self::Error> {
+        let id = batch.id();
+        self.db
+            .update(|tx| tx.put::<Batches>(BatchIdKey(id), batch))?;
+        Ok(())
+    }
+
+    fn remove(&self, id: &BatchId) -> Result<bool, Self::Error> {
+        Ok(self.db.update(|tx| tx.delete::<Batches>(BatchIdKey(*id)))?)
+    }
+
+    fn contains(&self, id: &BatchId) -> Result<bool, Self::Error> {
+        // No key-presence primitive on the transaction trait yet, so presence
+        // is a full read whose value is discarded.
+        // TODO(#214): switch to a key-presence check once available.
+        Ok(self.get(id)?.is_some())
+    }
+
+    fn context(&self) -> Result<PostageContext, Self::Error> {
+        self.db
+            .view(|tx| tx.get::<ContextTable>(ContextKey::SINGLETON))
+            .map(|opt| opt.unwrap_or_default())
+            .map_err(DbBatchStoreError::from)
+    }
+
+    fn set_context(&self, state: PostageContext) -> Result<(), Self::Error> {
+        self.db
+            .update(|tx| tx.put::<ContextTable>(ContextKey::SINGLETON, state))
+            .map_err(DbBatchStoreError::from)
+    }
+
+    fn batch_ids(&self) -> Result<Vec<BatchId>, Self::Error> {
+        // Iterate the batch table via the lazy read-only cursor (#396): the
+        // cursor owns its read snapshot, so it is detached from the borrowed
+        // transaction handle. Only keys are needed; values are still decoded by
+        // the cursor, but no per-batch second lookup is performed.
+        let tx = self.db.tx()?;
+        let mut cursor = tx.cursor::<Batches>()?;
+        let mut ids = Vec::new();
+        let mut entry = cursor.first()?;
+        while let Some((key, _batch)) = entry {
+            ids.push(key.0);
+            entry = cursor.next()?;
+        }
+        Ok(ids)
+    }
+
+    fn count(&self) -> Result<usize, Self::Error> {
+        self.db
+            .view(|tx| tx.count::<Batches>())
+            .map_err(DbBatchStoreError::from)
+    }
+}
+
+/// The on-chain ingest seam.
+///
+/// An external `PostageIndexer` decodes contract logs into [`BatchEvent`]s and
+/// drives this handler; see the crate-level documentation. The four variants
+/// map onto store mutations:
+///
+/// - [`BatchEvent::Created`]: the batch is fully described by the event, so it
+///   is written directly (`put`).
+/// - [`BatchEvent::TopUp`]: only the new normalised value is on the wire, so the
+///   batch is loaded, its value updated ([`Batch::set_value`]) and written back
+///   inside one transaction ([`DbBatchStore::mutate_sync`]), so a concurrent
+///   writer cannot clobber the update. A top-up for an unknown batch is a no-op
+///   (the create was missed; the indexer is responsible for ordering, this
+///   handler is idempotent).
+/// - [`BatchEvent::DepthIncrease`]: as top-up, but updates the depth
+///   ([`Batch::set_depth`]).
+/// - [`BatchEvent::Expired`]: the batch is removed via
+///   [`DbBatchStore::acknowledge_expired`].
+///
+/// Each mutation is a single transaction, so the store never observes a partial
+/// event application. Both this handler and the [`BatchStore`] trait are
+/// synchronous, so the handler reuses the store methods (and the `mutate_sync`
+/// helper) directly, with no executor.
+///
+/// # `Expired` is the bare removal, not the orphan-safe path
+///
+/// Handling [`BatchEvent::Expired`] here removes the batch from the store and
+/// nothing more. It does **not** evict the reserve entries stamped under that
+/// batch, because this crate is the parent of the reserve and cannot reach it.
+/// Removing the batch before its entries are evicted orphans those entries: once
+/// the batch leaves the store the reserve's reconciliation sweep can no longer
+/// see it, so the entries are never shed, which inflates the reserve size and
+/// therefore the consensus-committed storage radius.
+///
+/// The enforced ordering is **evict before remove**, and it is owned jointly
+/// with the reserve: the live ingest wiring (#391/#392) must route an `Expired`
+/// event through the reserve's evict-then-acknowledge entry point
+/// (`ExpirySweep::on_expired_event`), passing [`acknowledge_expired`] as the
+/// acknowledgement so the store removal runs *only after* eviction has
+/// succeeded. Driving `handle_event(Expired)` (or [`acknowledge_expired`])
+/// standalone for the live `Expired` path is therefore a bug: it skips the
+/// eviction and strands entries. The other three variants have no reserve
+/// coupling and are safe to drive directly.
+///
+/// [`acknowledge_expired`]: DbBatchStore::acknowledge_expired
+impl<DB: Database> BatchEventHandler for DbBatchStore<DB> {
+    type Error = DbBatchStoreError;
+
+    fn handle_event(&mut self, event: BatchEvent) -> Result<(), Self::Error> {
+        match event {
+            BatchEvent::Created { batch } => self.put(batch),
+            BatchEvent::TopUp {
+                batch_id,
+                new_value,
+            } => self.mutate_sync(&batch_id, |batch| batch.set_value(new_value)),
+            BatchEvent::DepthIncrease {
+                batch_id,
+                new_depth,
+            } => self.mutate_sync(&batch_id, |batch| batch.set_depth(new_depth)),
+            BatchEvent::Expired { batch_id } => {
+                self.acknowledge_expired(&batch_id)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, B256};
+    use vertex_storage_redb::RedbDatabase;
+
+    fn sample_batch(id_byte: u8, value: u128, depth: u8) -> Batch {
+        Batch::new(
+            B256::repeat_byte(id_byte),
+            value,
+            100,
+            Address::repeat_byte(0x11),
+            depth,
+            16,
+            false,
+        )
+    }
+
+    fn in_memory_store() -> DbBatchStore<RedbDatabase> {
+        let db = RedbDatabase::in_memory().unwrap().into_arc();
+        DbBatchStore::new(db).unwrap()
+    }
+
+    #[test]
+    fn crud_roundtrip() {
+        let store = in_memory_store();
+        let batch = sample_batch(0xaa, 1000, 20);
+        let id = batch.id();
+
+        assert!(!store.contains(&id).unwrap());
+        assert_eq!(store.get(&id).unwrap(), None);
+        assert_eq!(store.count().unwrap(), 0);
+
+        store.put(batch.clone()).unwrap();
+
+        assert!(store.contains(&id).unwrap());
+        assert_eq!(store.get(&id).unwrap(), Some(batch));
+        assert_eq!(store.count().unwrap(), 1);
+
+        // put is upsert: a second put of the same id replaces, not duplicates.
+        let updated = sample_batch(0xaa, 2000, 20);
+        store.put(updated.clone()).unwrap();
+        assert_eq!(store.count().unwrap(), 1);
+        assert_eq!(store.get(&id).unwrap(), Some(updated));
+
+        assert!(store.remove(&id).unwrap());
+        assert!(!store.remove(&id).unwrap());
+        assert!(!store.contains(&id).unwrap());
+        assert_eq!(store.count().unwrap(), 0);
+    }
+
+    #[test]
+    fn context_defaults_then_persists() {
+        let store = in_memory_store();
+        // A fresh store reports the default context.
+        assert_eq!(store.context().unwrap(), PostageContext::default());
+
+        let ctx = PostageContext::new(12_345, 678);
+        store.set_context(ctx).unwrap();
+        assert_eq!(store.context().unwrap(), ctx);
+
+        // Overwrite the singleton.
+        let ctx2 = PostageContext::new(99_999, 1);
+        store.set_context(ctx2).unwrap();
+        assert_eq!(store.context().unwrap(), ctx2);
+    }
+
+    #[test]
+    fn batch_ids_lists_all_keys_sorted() {
+        let store = in_memory_store();
+        for b in [0x03u8, 0x01, 0x02] {
+            store.put(sample_batch(b, 500, 20)).unwrap();
+        }
+        let ids = store.batch_ids().unwrap();
+        // The cursor walks key order, which for the 32-byte big-endian id is
+        // ascending by the repeated byte.
+        assert_eq!(
+            ids,
+            vec![
+                B256::repeat_byte(0x01),
+                B256::repeat_byte(0x02),
+                B256::repeat_byte(0x03),
+            ]
+        );
+    }
+
+    #[test]
+    fn persistence_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("postage.redb");
+        let batch = sample_batch(0xcc, 4242, 22);
+        let id = batch.id();
+        let ctx = PostageContext::new(7, 8);
+
+        {
+            let db = RedbDatabase::create(&path).unwrap().into_arc();
+            let store = DbBatchStore::new(db).unwrap();
+            store.put(batch.clone()).unwrap();
+            store.set_context(ctx).unwrap();
+        }
+
+        // Reopen the same file: state survives.
+        let db = RedbDatabase::open(&path).unwrap().into_arc();
+        let store = DbBatchStore::new(db).unwrap();
+        assert_eq!(store.get(&id).unwrap(), Some(batch));
+        assert_eq!(store.context().unwrap(), ctx);
+        assert_eq!(store.count().unwrap(), 1);
+    }
+
+    #[test]
+    fn handle_event_created() {
+        let mut store = in_memory_store();
+        let batch = sample_batch(0x01, 1000, 20);
+        let id = batch.id();
+        store
+            .handle_event(BatchEvent::Created {
+                batch: batch.clone(),
+            })
+            .unwrap();
+        assert_eq!(store.get(&id).unwrap(), Some(batch));
+    }
+
+    #[test]
+    fn handle_event_topup_updates_value() {
+        let mut store = in_memory_store();
+        let batch = sample_batch(0x02, 1000, 20);
+        let id = batch.id();
+        store.handle_event(BatchEvent::Created { batch }).unwrap();
+        store
+            .handle_event(BatchEvent::TopUp {
+                batch_id: id,
+                new_value: 5000,
+            })
+            .unwrap();
+        assert_eq!(store.get(&id).unwrap().unwrap().value(), 5000);
+
+        // Top-up for an unknown batch is a no-op (idempotent ingest).
+        let unknown = B256::repeat_byte(0xff);
+        store
+            .handle_event(BatchEvent::TopUp {
+                batch_id: unknown,
+                new_value: 9,
+            })
+            .unwrap();
+        assert_eq!(store.get(&unknown).unwrap(), None);
+    }
+
+    #[test]
+    fn handle_event_depth_increase_updates_depth() {
+        let mut store = in_memory_store();
+        let batch = sample_batch(0x03, 1000, 20);
+        let id = batch.id();
+        store.handle_event(BatchEvent::Created { batch }).unwrap();
+        store
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: id,
+                new_depth: 24,
+            })
+            .unwrap();
+        assert_eq!(store.get(&id).unwrap().unwrap().depth(), 24);
+    }
+
+    #[test]
+    fn handle_event_expired_removes() {
+        let mut store = in_memory_store();
+        let batch = sample_batch(0x04, 1000, 20);
+        let id = batch.id();
+        store.handle_event(BatchEvent::Created { batch }).unwrap();
+        assert!(store.contains(&id).unwrap());
+        store
+            .handle_event(BatchEvent::Expired { batch_id: id })
+            .unwrap();
+        assert!(!store.contains(&id).unwrap());
+        // Expiring an unknown batch is a harmless no-op.
+        store
+            .handle_event(BatchEvent::Expired { batch_id: id })
+            .unwrap();
+    }
+
+    #[test]
+    fn acknowledge_expired_is_idempotent() {
+        // The explicit removal seam returns whether the batch existed, and a
+        // second acknowledgement is a harmless no-op (redelivered Expired event).
+        let store = in_memory_store();
+        let batch = sample_batch(0x05, 1000, 20);
+        let id = batch.id();
+        store.put(batch).unwrap();
+        assert!(store.acknowledge_expired(&id).unwrap(), "first removal");
+        assert!(
+            !store.acknowledge_expired(&id).unwrap(),
+            "second removal is a no-op"
+        );
+        assert!(!store.contains(&id).unwrap());
+    }
+
+    #[test]
+    fn mutate_event_is_single_transaction() {
+        // The TopUp/DepthIncrease path loads, mutates and stores inside one
+        // transaction (mutate_sync), so the round trip is atomic. We cannot
+        // schedule a real interleaving in a single-threaded test, but we can
+        // assert the combined effect of two successive mutations is the last
+        // writer's value with no lost write, exercising the one-transaction path.
+        let mut store = in_memory_store();
+        let batch = sample_batch(0x06, 1000, 20);
+        let id = batch.id();
+        store.handle_event(BatchEvent::Created { batch }).unwrap();
+
+        store
+            .handle_event(BatchEvent::TopUp {
+                batch_id: id,
+                new_value: 7777,
+            })
+            .unwrap();
+        store
+            .handle_event(BatchEvent::DepthIncrease {
+                batch_id: id,
+                new_depth: 30,
+            })
+            .unwrap();
+
+        let got = store.get(&id).unwrap().unwrap();
+        assert_eq!(got.value(), 7777, "top-up value survives the depth update");
+        assert_eq!(got.depth(), 30, "depth update applied");
+    }
+
+    /// Regression marker for the remove-before-evict race (the orphan hazard).
+    ///
+    /// The orphan-safe ordering (evict the reserve entries, then acknowledge the
+    /// store removal) is enforced by the reserve crate's
+    /// `ExpirySweep::on_expired_event`, which is downstream of this crate, so the
+    /// race cannot be reproduced from `vertex-swarm-postage` alone (there is no
+    /// reserve here to orphan). The end-to-end "removal before sweep orphans
+    /// entries" regression lives in the reserve crate's tests (PR-D/PR-E), where
+    /// both halves are in scope. This crate's contribution is the explicit
+    /// [`DbBatchStore::acknowledge_expired`] seam and the contract documentation;
+    /// this ignored test records the cross-crate gap so it is not lost.
+    #[test]
+    #[ignore = "cross-crate: enforced and regression-tested in the reserve crate (PR-D/PR-E)"]
+    fn remove_before_evict_orphans_entries_is_reserve_crate_concern() {}
+
+    #[test]
+    fn batch_id_key_codec_roundtrip() {
+        let k = BatchIdKey(B256::repeat_byte(0x7e));
+        assert_eq!(BatchIdKey::decode(k.encode().as_ref()).unwrap(), k);
+        assert!(BatchIdKey::decode(&[0u8; 31]).is_err());
+    }
+}


### PR DESCRIPTION
## What this PR does

Adds the standalone `vertex-swarm-postage` crate, the node-side home for postage state. The crate does not redefine any postage primitive: the batch model, the stamp model, validation and the event vocabulary all live in `nectar-postage` and are re-exported verbatim from this crate's root, so every downstream vertex crate resolves a single canonical copy of `Batch`, `Stamp`, `BatchEvent`, `PostageContext`, the `BatchStore` and `BatchEventHandler` traits, and the validators.

What this crate adds is the node's own concrete persistence plus the seam through which on-chain batch state is driven into it:

- `DbBatchStore<DB>`: a `BatchStore` over the `vertex-storage` `Database` (redb in production), persisting the batch set and the postage context across restarts.
- `DbBatchStore<DB>` also implements `BatchEventHandler`, the on-chain event ingest seam an external postage indexer drives.

It also wires the new crate into the workspace (`Cargo.toml` members and dependency table, plus `Cargo.lock`).

## Where it sits

Stacked on `stack/01-grpc-chunk-streaming` (PR #390 has merged). This is the first car (car A) of the postage, reserve and sampler train: it lands the postage persistence and ingest seam that the reserve and sampler cars build on.

## nectar dependency

The `nectar-*` git dependencies track nectar `branch = "main"`. The synchronous `BatchStore`, `BatchStoreExt`, `StoreValidator` and `SnapshotStore` conversion has landed on main via nectar #103, so the train builds against main with no further pin.

## Design

`DbBatchStore<DB: Database>` is generic over the storage backend, so the same code serves an in-memory database in tests and an on-disk redb database in production. It is cheap to clone by `Arc` and is thread-safe for concurrent reads and writes. It defines two tables:

- `Batches` (`postage_batches`): `BatchId -> Batch`, the authoritative batch set, keyed by a `BatchIdKey` newtype that carries the 32-byte big-endian encoding of the `B256` id. The newtype exists only to carry the storage `Encode`/`Decode` codecs across the orphan rule for the foreign key type.
- `ContextTable` (`postage_context`): a single-row table holding the current `PostageContext`. redb has no schema-level singleton, so the context is modelled as one row under a fixed `ContextKey::SINGLETON` address.

**BatchStore.** `DbBatchStore` implements the synchronous nectar `BatchStore` directly: each method is a plain function over a single transaction, with no `async move { result }` facade and no executor in sight. (The earlier `get_sync` / `put_sync` / `remove_sync` shims are gone; only the genuine read-modify-write `mutate_sync` helper remains, which keeps the load-mutate-store logic in one place for the event handler.) Because redb is itself synchronous, no transaction guard is ever held across an `await` point, the futures stay `Send`-free on the wasm path, and the trait is naturally object-safe (it has an associated `Error` and no generic methods). `batch_ids` walks the lazy read-only cursor, whose read snapshot is detached from the borrowed transaction handle. A fresh database needs no separate initialisation step: `new` ensures both tables exist.

**BatchEventHandler ingest seam.** `DbBatchStore` also implements `BatchEventHandler`, the synchronous handler an external postage indexer drives (this seam was already synchronous and is unchanged in shape). The four `BatchEvent` variants map onto store mutations:

- `Created` writes the fully-described batch directly.
- `TopUp` and `DepthIncrease` load, mutate and store inside one `db.update` transaction via `mutate_sync`, closing the lost-update window a read-then-write pair would leave open.
- `Expired` removes the batch through the named `acknowledge_expired` seam.

Each mutation is a single transaction, so the store never observes a partial event application, and each variant is idempotent for an unknown batch.

Expiry is deliberately split. `acknowledge_expired` is the bare store removal only; it does not, and cannot from this crate, evict the reserve entries stamped under the batch. It is documented as the acknowledgement half of the reserve's evict-then-acknowledge expiry path (`ExpirySweep::on_expired_event`, a later car), so live `Expired` wiring (#391/#392) must route through the reserve's evict-before-remove path rather than removing the batch directly. The other three variants have no reserve coupling and are safe to drive directly.

**nectar reuse.** Stamp validation is stateless and reuses the nectar `StoreValidator` / `Stamp` path: a stamp is valid if and only if `ecrecover(sig, digest)` resolves to the batch owner and the index and bucket bounds hold. The owner is already known from the batch store, so no per-batch public-key cache is needed and none is shipped; the cheaper recover-once path nectar supports is noted as a possible future in-process optimisation only.

**Indexer / ABI stub.** The left-hand half of the decode path (the event ABI, the log decoder, and the indexer that reduces chain logs into `BatchEvent`s) is intentionally stubbed and owned externally. This crate ships no contract bindings and no log-to-event reducer, only the documented `BatchEventHandler` seam, so the chain indexer can evolve without touching the persistence layer and this crate can be tested with synthetic events and no chain.

## Testing

The crate's tests (against an in-memory redb backend, plus one on-disk reopen) cover:

- CRUD round-trip including `put` upsert semantics, `contains`, `get`, `count` and `remove`.
- The context singleton: default-on-fresh, set, and overwrite.
- `batch_ids` returning all keys in cursor (ascending big-endian) order.
- Persistence across a database create-then-reopen on a real file.
- All four `BatchEvent` variants via `handle_event`, including the unknown-batch no-ops for top-up and expiry.
- The single-transaction mutate path (successive top-up then depth-increase with no lost write).
- `acknowledge_expired` idempotency (the second acknowledgement is a no-op).
- The `BatchIdKey` codec round-trip and its decode rejection of wrong-length input.

A cross-crate marker test for the remove-before-evict orphan hazard is `#[ignore]`d here, since the orphan-safe ordering is enforced and regression-tested in the reserve crate where both halves are in scope.

## Related issues

Refs the storer and reserve effort. `contains` performs a full read pending a key-presence primitive, marked `TODO(#214)` in code to match the existing storer pattern. `batch_ids` uses the lazy cursor from #396. Live expiry ingest wiring is tracked under #391/#392.

## AI assistance disclosure

This change was prepared with the assistance of Claude Code. A human author reviewed it and is accountable for the contribution. The implementation follows the agreed schema and the nectar public API.
