### PR TITLE
feat(swarm): size-driven storage radius, committed depth and batch-expiry eviction

### DIFF
--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -14,7 +14,7 @@ pub use self::bandwidth::{
 pub use self::localstore::{SwarmLocalStore, SwarmLocalStoreConfig};
 pub use self::peers::SwarmPeerResolver;
 pub use self::pricing::{SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig};
-pub use self::reserve::{BinCursorStore, BinScanItem, ReserveStore};
+pub use self::reserve::{BinCursorStore, BinScanItem, ReserveStore, SettableRadius};
 pub use self::topology::{
     SwarmTopology, SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers,
     SwarmTopologyReporting, SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats,

--- a/crates/swarm/api/src/components/reserve.rs
+++ b/crates/swarm/api/src/components/reserve.rs
@@ -125,6 +125,36 @@ pub trait ReserveStore: SwarmLocalStore {
     fn evict_batch(&self, batch: BatchId, up_to_bin: Option<Bin>, max: u64) -> SwarmResult<u64>;
 }
 
+/// A [`ReserveStore`] whose storage radius can be committed at runtime.
+///
+/// The radius is the consensus-load-bearing output of the size-driven dynamics:
+/// it feeds the committed depth a redistribution round commits on chain, and it
+/// changes as the reserve fills or drains. [`ReserveStore::storage_radius`] is
+/// the *read* seam every consumer uses; this trait adds the matching *write*
+/// seam, kept separate so the read surface (which is used widely and behind
+/// `dyn`) carries no mutation capability and only the eviction-control loop
+/// depends on being able to move the radius.
+///
+/// The write is a single commit of an already-derived radius: deriving the value
+/// (from occupancy against capacity) and shedding the bins that fall out of
+/// responsibility are the control loop's job (the storer's radius controller);
+/// this method only publishes the result so subsequent
+/// [`storage_radius`](ReserveStore::storage_radius) /
+/// [`is_responsible_for`](ReserveStore::is_responsible_for) reads observe it. It
+/// is infallible and non-blocking: committing a radius moves no data.
+///
+/// Object-safe (`&self`, a `Copy` argument, no generics), so the controller can
+/// hold a `&dyn SettableRadius` as readily as a concrete reserve.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait SettableRadius: ReserveStore {
+    /// Commit a new storage-responsibility radius.
+    ///
+    /// After this returns, [`storage_radius`](ReserveStore::storage_radius)
+    /// reports `radius` and [`is_responsible_for`](ReserveStore::is_responsible_for)
+    /// is evaluated against it.
+    fn set_storage_radius(&self, radius: StorageRadius);
+}
+
 /// One entry yielded by a per-bin insertion-order scan.
 ///
 /// A flat, projected row of the reserve's append-only per-bin index: enough to

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -61,12 +61,12 @@ pub use self::accounting::{Au, AuConversionError};
 pub use self::components::{
     AccountingAction, BandwidthMode, BinCursorStore, BinScanItem, BootnodeComponents,
     ClientComponents, Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology,
-    ReserveStore, StorerComponents, SwarmAccountingConfig, SwarmBandwidthAccounting,
-    SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig, SwarmPeerBandwidth,
-    SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig,
-    SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins, SwarmTopologyCommands,
-    SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting, SwarmTopologyState,
-    SwarmTopologyStats, construct,
+    ReserveStore, SettableRadius, StorerComponents, SwarmAccountingConfig,
+    SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig,
+    SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder,
+    SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins,
+    SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting,
+    SwarmTopologyState, SwarmTopologyStats, construct,
 };
 pub use self::config::{
     DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN,

--- a/crates/swarm/redistribution/src/lib.rs
+++ b/crates/swarm/redistribution/src/lib.rs
@@ -49,7 +49,9 @@ pub const SAMPLE_SIZE: usize = 16;
 pub use anchor::{ClaimAnchor, SampleAnchor};
 pub use args::RedistributionArgs;
 pub use config::StorageConfig;
-pub use neighbourhood::{CommittedDepth, canonical_neighbourhood};
+pub use neighbourhood::{
+    CapacityDoubling, CapacityDoublingError, CommittedDepth, canonical_neighbourhood,
+};
 pub use proof::{ChunkInclusionProof, ChunkInclusionProofs, ProofError, make_inclusion_proofs};
 pub use sample::{SampleItem, reserve_commitment_content, reserve_sample};
 pub use witness::{WitnessIndices, witness_indices};

--- a/crates/swarm/redistribution/src/neighbourhood.rs
+++ b/crates/swarm/redistribution/src/neighbourhood.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 
 use nectar_primitives::{Bin, ChunkAddress, SwarmAddress};
+use vertex_swarm_api::StorageRadius;
 
 /// The committed neighbourhood depth for a redistribution round: the boundary
 /// at which a storer's reserve is sampled.
@@ -53,6 +54,119 @@ impl CommittedDepth {
     #[must_use]
     pub fn contains(self, bin: Bin) -> bool {
         bin >= self.0
+    }
+
+    /// Derive the consensus-committed depth from the reserve's
+    /// [`StorageRadius`] and the node's [`CapacityDoubling`] addend.
+    ///
+    /// This is the network-observable output the redistribution agent commits
+    /// on chain: `committedDepth = storage_radius + capacity_doubling`. The
+    /// storage radius is the reserve's own size-driven responsibility boundary
+    /// (see the storer's [radius controller][rc]); the capacity-doubling addend
+    /// lets an over-provisioned node sample a deeper neighbourhood than its bare
+    /// radius would imply, without changing what it stores.
+    ///
+    /// The addend is applied with a *saturating* `u8` add and then clamped to
+    /// the [`Bin`] range (`0..=MAX_PO`): the sum pins at [`Bin::MAX`] rather than
+    /// wrapping or panicking. With the addend bounded at
+    /// [`CapacityDoubling::MAX`] (`1`) the ceiling is reachable only from a radius
+    /// already at the deepest bin (`MAX_PO + 1`), so the clamp is defensive
+    /// belt-and-braces rather than a routine path, but it keeps the derivation
+    /// total (no fallible path), which is what callers on the commit hot-path
+    /// require. Because both inputs are byte-exact across nodes, so is the
+    /// output, which is the consensus property a redistribution round relies on.
+    ///
+    /// [rc]: https://docs.rs/vertex-swarm-storer (the `radius` module)
+    #[inline]
+    #[must_use]
+    pub fn from_radius(radius: StorageRadius, doubling: CapacityDoubling) -> Self {
+        let raw = radius.get().saturating_add(doubling.get());
+        // Clamp into the bin range; `Bin::try_from` only fails for `> MAX_PO`,
+        // in which case the deepest bin is the correct ceiling.
+        Self(Bin::try_from(raw).unwrap_or(Bin::MAX))
+    }
+}
+
+/// The capacity-doubling addend a node adds to its [`StorageRadius`] to obtain
+/// the [`CommittedDepth`] it samples and commits on chain.
+///
+/// A node with spare reserve capacity may commit to sampling a neighbourhood
+/// `capacity_doubling` bins deeper than its storage radius alone would define,
+/// effectively committing to hold the equivalent of `2^doubling` times the
+/// baseline reserve. It is a node-configured constant for a round (read from
+/// configuration, not derived from the reserve), distinct from the radius,
+/// which the reserve derives from its own occupancy.
+///
+/// Range is `0..=`[`MAX`](Self::MAX), where `MAX` is `1`: a zero addend means the
+/// committed depth equals the storage radius, and `1` is the deepest doubling the
+/// protocol admits (one bin deeper, twice the baseline reserve). The bound is the
+/// network's, not a representational one: a redistribution round will only ever
+/// observe a committed depth derived from a doubling in `0..=1`, so a larger
+/// addend is a configuration error that would put the node out of consensus with
+/// the rest of the network rather than merely saturating against the bin
+/// ceiling. The constructor rejects it so the misconfiguration surfaces at ingest
+/// rather than producing an out-of-consensus committed depth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct CapacityDoubling(u8);
+
+impl CapacityDoubling {
+    /// No doubling: the committed depth equals the storage radius.
+    pub const ZERO: Self = Self(0);
+
+    /// The maximum doubling the protocol admits.
+    ///
+    /// The network caps the per-node capacity doubling at one bin: a node may
+    /// commit to twice the baseline reserve, no more. A larger value is not a
+    /// representational overflow (it stays well within `u8` and the bin range)
+    /// but an out-of-consensus configuration the network would never produce, so
+    /// the ingress rejects it.
+    pub const MAX: Self = Self(1);
+
+    /// The raw addend. For edges only (config display, metrics, the wire).
+    #[inline]
+    #[must_use]
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+}
+
+/// The error a [`CapacityDoubling`] ingress raises for an addend above the
+/// protocol-permitted maximum ([`CapacityDoubling::MAX`]).
+///
+/// Distinct from a bin-range error: the value is a valid `u8` and a valid bin,
+/// it is the *consensus* bound it violates, so it carries the offending value
+/// and the permitted maximum for a configuration diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("capacity doubling {value} exceeds the maximum permitted doubling of {max}")]
+pub struct CapacityDoublingError {
+    /// The rejected addend.
+    pub value: u8,
+    /// The permitted maximum ([`CapacityDoubling::MAX`]).
+    pub max: u8,
+}
+
+/// The sole `u8` ingress for a capacity-doubling addend (typically the node's
+/// configuration). Fallible because the network caps the doubling at
+/// [`CapacityDoubling::MAX`]; an addend above it is a configuration error that
+/// would commit an out-of-consensus depth, not a value to silently clamp.
+impl TryFrom<u8> for CapacityDoubling {
+    type Error = CapacityDoublingError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        if value > Self::MAX.get() {
+            Err(CapacityDoublingError {
+                value,
+                max: Self::MAX.get(),
+            })
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+impl fmt::Display for CapacityDoubling {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "capacity_doubling={}", self.0)
     }
 }
 
@@ -122,6 +236,7 @@ pub fn canonical_neighbourhood(
 mod tests {
     use super::*;
     use alloy_primitives::B256;
+    use nectar_primitives::MAX_PO;
 
     fn addr(byte: u8) -> ChunkAddress {
         SwarmAddress::from(B256::repeat_byte(byte))
@@ -159,5 +274,71 @@ mod tests {
         assert_eq!(CommittedDepth::try_from(31).unwrap().get(), 31);
         assert!(CommittedDepth::try_from(32).is_err());
         assert_eq!(CommittedDepth::ZERO, CommittedDepth::try_from(0).unwrap());
+    }
+
+    fn radius(n: u8) -> StorageRadius {
+        StorageRadius::new(Bin::try_from(n).unwrap())
+    }
+
+    fn doubling(n: u8) -> CapacityDoubling {
+        CapacityDoubling::try_from(n).unwrap()
+    }
+
+    #[test]
+    fn committed_depth_is_radius_plus_doubling() {
+        // The network-observable consensus formula:
+        // committedDepth = storage_radius + capacity_doubling.
+        assert_eq!(
+            CommittedDepth::from_radius(radius(8), doubling(0)).get(),
+            8,
+            "zero doubling => committed depth equals storage radius"
+        );
+        assert_eq!(
+            CommittedDepth::from_radius(radius(8), doubling(1)).get(),
+            9,
+            "the maximum addend (1) is added to the radius"
+        );
+        assert_eq!(
+            CommittedDepth::from_radius(radius(0), doubling(1)).get(),
+            1,
+            "from a zero radius the depth is the addend alone"
+        );
+    }
+
+    #[test]
+    fn committed_depth_clamps_to_deepest_bin() {
+        // The only way to reach the ceiling now that the addend is capped at 1
+        // is a radius already at the deepest bin: radius MAX_PO + doubling 1
+        // would be MAX_PO + 1, which saturating-adds then clamps to the deepest
+        // bin rather than panicking or wrapping.
+        let d = CommittedDepth::from_radius(radius(MAX_PO), doubling(1));
+        assert_eq!(d.get(), MAX_PO, "saturating add then clamp to MAX_PO");
+        assert_eq!(d.bin(), Bin::MAX);
+
+        let edge = CommittedDepth::from_radius(radius(MAX_PO), doubling(0));
+        assert_eq!(edge.get(), MAX_PO, "radius at the ceiling stays at MAX_PO");
+    }
+
+    #[test]
+    fn capacity_doubling_rejects_above_maximum() {
+        // The network caps the doubling at one bin (parity with bee's
+        // maxAllowedDoubling = 1); 0 and 1 are admitted, 2 and above are
+        // rejected as out-of-consensus configuration even though they are valid
+        // bin indices.
+        assert_eq!(CapacityDoubling::try_from(0).unwrap().get(), 0);
+        assert_eq!(CapacityDoubling::try_from(1).unwrap().get(), 1);
+        assert_eq!(
+            CapacityDoubling::try_from(1).unwrap(),
+            CapacityDoubling::MAX
+        );
+        let err = CapacityDoubling::try_from(2).unwrap_err();
+        assert_eq!(err.value, 2);
+        assert_eq!(err.max, 1, "the diagnostic reports the permitted maximum");
+        assert!(
+            CapacityDoubling::try_from(MAX_PO).is_err(),
+            "even a valid bin index above the doubling maximum is rejected"
+        );
+        assert_eq!(CapacityDoubling::ZERO.get(), 0);
+        assert_eq!(CapacityDoubling::default(), CapacityDoubling::ZERO);
     }
 }

--- a/crates/swarm/storer/src/db_reserve/consensus_spec.rs
+++ b/crates/swarm/storer/src/db_reserve/consensus_spec.rs
@@ -21,7 +21,7 @@ use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage::{Batch, PostageContext, StampDigest, StampIndex};
-use nectar_primitives::{Chunk, DefaultContentChunk as ContentChunk};
+use nectar_primitives::{Bin, Chunk, DefaultContentChunk as ContentChunk};
 use std::sync::Arc;
 use vertex_storage_redb::RedbDatabase;
 use vertex_swarm_api::SwarmIdentity as _;
@@ -509,4 +509,239 @@ fn sample_collapses_duplicate_transformed_address() {
     // reserve's responsibility (a per-entry, chunk-typed Replay projection) is
     // covered by the bin-scan test; the at-most-once collapse over transformed
     // addresses belongs to the sampler that consumes that projection.
+}
+
+// --- radius dynamics (PR-E): expiry -> evict_batch end to end -----------
+
+#[test]
+fn batch_expiry_sweep_evicts_only_the_expired_batch() {
+    use crate::expiry::ExpirySweep;
+
+    // Two batches, each holding one stamped entry of a distinct content
+    // address (distinct addresses so neither eviction touches the other's
+    // refcounted payload).
+    let live_id = B256::repeat_byte(0x11);
+    let expiring_id = B256::repeat_byte(0x22);
+    let fx = Fixture::with_batches(&[live_id, expiring_id]);
+    let (chunk_a, addr_a) = content_chunk_in_bucket0(101);
+    let (chunk_b, addr_b) = content_chunk_in_bucket0(202);
+
+    fx.put(&chunk_a, &addr_a, live_id, 0, 100).unwrap();
+    fx.put(&chunk_b, &addr_b, expiring_id, 0, 100).unwrap();
+    assert_eq!(fx.reserve.count().unwrap(), 2, "two stamped entries");
+
+    // batch_for sets value = 1_000_000. Advance the chain's cumulative
+    // payout so it catches one batch's value but not the other: lower the
+    // expiring batch's value below total_amount, leave the live one above.
+    let mut expiring = fx.batches.get(&expiring_id).unwrap().unwrap();
+    expiring.set_value(500);
+    fx.batches.put(expiring).unwrap();
+    // total_amount = 1000 >= the expiring batch's value (500), but < the
+    // live batch's value (1_000_000).
+    fx.batches
+        .set_context(PostageContext::new(THRESHOLD + 1, 1000))
+        .unwrap();
+
+    // Run the sweep through the reserve's own batch-store handle (same DB).
+    let reserve_batches = DbBatchStore::new(Arc::clone(&fx.db)).unwrap();
+    let report = ExpirySweep::new(&reserve_batches, &fx.reserve)
+        .run()
+        .unwrap();
+
+    assert_eq!(
+        report.evicted_batches,
+        vec![expiring_id],
+        "only the expired batch is swept"
+    );
+    assert_eq!(report.evicted_entries, 1, "its single entry is removed");
+    assert_eq!(
+        fx.reserve.count().unwrap(),
+        1,
+        "the live batch's entry survives expiry of the other"
+    );
+    // The expired batch's payload is gone; the live one's remains.
+    assert_eq!(fx.payload_refcnt(&addr_b), None, "expired payload removed");
+    assert_eq!(
+        fx.payload_refcnt(&addr_a),
+        Some(1),
+        "live payload still refcounted"
+    );
+
+    // Idempotent: a second sweep at the same context evicts nothing.
+    let again = ExpirySweep::new(&reserve_batches, &fx.reserve)
+        .run()
+        .unwrap();
+    assert!(again.evicted_batches.is_empty(), "sweep is idempotent");
+    assert_eq!(fx.reserve.count().unwrap(), 1);
+}
+
+#[test]
+fn settable_radius_cell_round_trips_through_the_read_seam() {
+    // The settable radius cell (the SEAM the train was missing): a write via
+    // SettableRadius::set_storage_radius is observed by the ReserveStore read
+    // seam (storage_radius / is_responsible_for). Before this cell existed the
+    // derived radius had no write target and committedDepth could never change
+    // at runtime.
+    use vertex_swarm_api::SettableRadius;
+
+    let fx = Fixture::new();
+    assert_eq!(
+        fx.reserve.storage_radius(),
+        StorageRadius::ZERO,
+        "constructed at the configured radius"
+    );
+
+    let target = StorageRadius::new(Bin::try_from(5).unwrap());
+    // Drive the write through the trait object form to prove object safety.
+    let dyn_reserve: &dyn SettableRadius = &fx.reserve;
+    dyn_reserve.set_storage_radius(target);
+
+    assert_eq!(
+        fx.reserve.storage_radius(),
+        target,
+        "the read seam observes the committed radius"
+    );
+    // is_responsible_for now evaluates against the new radius: an address at
+    // proximity 5+ is in responsibility, a shallower one is not.
+    let (_chunk, addr) = content_chunk_in_bucket0(909);
+    let po = addr.proximity(&fx.overlay).get();
+    assert_eq!(
+        fx.reserve.is_responsible_for(&addr),
+        po >= 5,
+        "responsibility is evaluated against the committed radius"
+    );
+}
+
+#[test]
+fn radius_controller_apply_commits_a_shrink_through_the_seam() {
+    // The apply path (the wiring seam #391 consumes): from a radius above the
+    // floor, an under-filled, idle reserve shrinks one step, and apply commits
+    // the shallower radius through SettableRadius so the read seam sees it.
+    use crate::RadiusController;
+
+    let fx = Fixture::new();
+    // Start above the floor with no entries (within-radius 0 < threshold).
+    fx.reserve
+        .set_storage_radius(StorageRadius::new(Bin::try_from(5).unwrap()));
+
+    let controller = RadiusController::new(StorageRadius::ZERO);
+    let committed = controller
+        .apply(&fx.reserve, /* syncing_idle */ true)
+        .unwrap();
+
+    assert_eq!(
+        committed,
+        StorageRadius::new(Bin::try_from(4).unwrap()),
+        "an under-filled idle reserve shrinks one step"
+    );
+    assert_eq!(
+        fx.reserve.storage_radius(),
+        committed,
+        "apply commits the derived radius through the settable cell"
+    );
+}
+
+#[test]
+fn radius_controller_apply_holds_at_floor() {
+    // At the configured floor the shrink rule does not fire, so apply commits
+    // nothing and reports the unchanged radius.
+    use crate::RadiusController;
+
+    let fx = Fixture::new();
+    let controller = RadiusController::new(StorageRadius::ZERO);
+    let committed = controller.apply(&fx.reserve, true).unwrap();
+    assert_eq!(committed, StorageRadius::ZERO, "held at the floor");
+    assert_eq!(fx.reserve.storage_radius(), StorageRadius::ZERO);
+}
+
+#[test]
+fn nothing_evicted_when_no_batch_is_expired() {
+    use crate::expiry::ExpirySweep;
+
+    // Both batches retain ample value against a zero cumulative payout.
+    let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
+    let fx = Fixture::with_batches(&ids);
+    let (chunk, addr) = content_chunk_in_bucket0(303);
+    fx.put(&chunk, &addr, ids[0], 0, 100).unwrap();
+    fx.put(&chunk, &addr, ids[1], 0, 100).unwrap();
+    assert_eq!(fx.reserve.count().unwrap(), 2);
+
+    let reserve_batches = DbBatchStore::new(Arc::clone(&fx.db)).unwrap();
+    let report = ExpirySweep::new(&reserve_batches, &fx.reserve)
+        .run()
+        .unwrap();
+    assert!(report.evicted_batches.is_empty(), "no batch expired");
+    assert_eq!(report.evicted_entries, 0);
+    assert_eq!(fx.reserve.count().unwrap(), 2, "nothing evicted");
+}
+
+#[test]
+fn expired_event_evicts_reserve_before_store_removal() {
+    // The orphan-avoidance contract: on an `Expired` event the reserve
+    // entries must be shed BEFORE the batch leaves the store, otherwise the
+    // reconciliation sweep (which reads batch_ids) could never see them and
+    // they would be orphaned, inflating reserve size and the radius.
+    use crate::expiry::ExpirySweep;
+    use std::cell::Cell;
+
+    let expiring_id = B256::repeat_byte(0x33);
+    let fx = Fixture::with_batches(&[expiring_id]);
+    let (chunk, addr) = content_chunk_in_bucket0(404);
+    fx.put(&chunk, &addr, expiring_id, 0, 100).unwrap();
+    assert_eq!(fx.reserve.count().unwrap(), 1, "one stamped entry");
+
+    let reserve_batches = DbBatchStore::new(Arc::clone(&fx.db)).unwrap();
+    let sweep = ExpirySweep::new(&reserve_batches, &fx.reserve);
+
+    // The acknowledgement (store removal) asserts the reserve is already
+    // empty of the batch by the time it runs, proving the ordering.
+    let acked = Cell::new(false);
+    let removed = sweep
+        .on_expired_event::<_, std::io::Error>(expiring_id, || {
+            assert_eq!(
+                fx.reserve.count().unwrap(),
+                0,
+                "entries must be evicted before the store removal runs"
+            );
+            acked.set(true);
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(removed, 1, "the batch's single entry is evicted");
+    assert!(acked.get(), "the acknowledgement ran after eviction");
+    assert_eq!(fx.reserve.count().unwrap(), 0, "reserve drained");
+    assert_eq!(fx.payload_refcnt(&addr), None, "payload removed");
+}
+
+#[test]
+fn expired_event_does_not_acknowledge_when_eviction_fails_is_skipped() {
+    // Documents the short-circuit contract: a failing acknowledgement leaves
+    // the eviction done but surfaces the error so the caller can retry the
+    // removal. (Eviction failure itself is exercised by the reserve's own
+    // error tests; here we cover the acknowledge-error funnel.)
+    use crate::expiry::ExpirySweep;
+
+    let expiring_id = B256::repeat_byte(0x44);
+    let fx = Fixture::with_batches(&[expiring_id]);
+    let (chunk, addr) = content_chunk_in_bucket0(505);
+    fx.put(&chunk, &addr, expiring_id, 0, 100).unwrap();
+
+    let reserve_batches = DbBatchStore::new(Arc::clone(&fx.db)).unwrap();
+    let sweep = ExpirySweep::new(&reserve_batches, &fx.reserve);
+
+    let err = sweep
+        .on_expired_event::<_, std::io::Error>(expiring_id, || {
+            Err(std::io::Error::other("store removal failed"))
+        })
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("store removal failed"),
+        "acknowledge error is funnelled through SwarmError::storage"
+    );
+    // The eviction still happened (it precedes the acknowledge); the caller
+    // is responsible for retrying the store removal, which a later `run`
+    // backstop would also catch were the batch still present.
+    assert_eq!(fx.reserve.count().unwrap(), 0, "eviction already applied");
+    assert_eq!(fx.payload_refcnt(&addr), None);
 }

--- a/crates/swarm/storer/src/db_reserve/store.rs
+++ b/crates/swarm/storer/src/db_reserve/store.rs
@@ -3,13 +3,15 @@
 //! plus the lazy bin-scan iterator.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use alloy_primitives::B256;
 use nectar_primitives::{Bin, ChunkAddress, ProximityOrder};
 use tracing::debug;
 use vertex_storage::{Database, DatabaseError, DbCursorRO, DbTx, DbTxMut, Table};
 use vertex_swarm_api::{
-    BinCursorStore, BinScanItem, ReserveStore, SwarmError, SwarmLocalStore, SwarmResult,
+    BinCursorStore, BinScanItem, ReserveStore, SettableRadius, SwarmError, SwarmLocalStore,
+    SwarmResult,
 };
 use vertex_swarm_postage::{
     AdmissionValidator, Arbitration, BatchStore, IncomingStamp, PostageContext, StampIndexTable,
@@ -52,8 +54,19 @@ pub struct DbReserve<DB: Database, BS: BatchStore> {
     reserve: Reserve,
     /// Local overlay address, resolved once at construction.
     overlay: OverlayAddress,
-    /// Current storage-responsibility radius.
-    radius: StorageRadius,
+    /// Current storage-responsibility radius, behind a cheap lock-free cell.
+    ///
+    /// The radius is the consensus-load-bearing output of the size-driven
+    /// dynamics ([`crate::radius`]): the [`RadiusController`](crate::RadiusController)
+    /// applies a new value via [`set_storage_radius`](Self::set_storage_radius)
+    /// as the reserve fills or drains, and [`storage_radius`](ReserveStore::storage_radius)
+    /// reads it. A single byte (`0..=MAX_PO`) is all the radius ever is, so an
+    /// [`AtomicU8`] is both the cheapest write target and a lock-free read on the
+    /// hot `is_responsible_for` path; `Relaxed` ordering suffices because the
+    /// radius carries no happens-before relationship with other reserve state
+    /// (callers that need a consistent (radius, occupancy) pair re-derive the
+    /// radius from the occupancy themselves).
+    radius: AtomicU8,
 }
 
 impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
@@ -93,8 +106,40 @@ impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
             batches,
             reserve,
             overlay,
-            radius,
+            radius: AtomicU8::new(radius.get()),
         })
+    }
+
+    /// Read the current radius cell back into a [`StorageRadius`].
+    ///
+    /// The cell only ever holds a value written from a [`StorageRadius`] (a valid
+    /// `0..=MAX_PO` bin), so the `Bin::try_from` reconstruction never fails; the
+    /// `unwrap_or(StorageRadius::ZERO)` is a total fallback that keeps the read
+    /// infallible rather than panicking on a value the cell cannot hold.
+    fn load_radius(&self) -> StorageRadius {
+        let raw = self.radius.load(Ordering::Relaxed);
+        Bin::try_from(raw)
+            .map(StorageRadius::new)
+            .unwrap_or(StorageRadius::ZERO)
+    }
+
+    /// Apply a new storage-responsibility radius.
+    ///
+    /// This is the write seam the size-driven dynamics ([`crate::radius`]) feed:
+    /// the [`RadiusController`](crate::RadiusController) derives the radius from
+    /// the reserve's occupancy against its capacity and calls this to commit it,
+    /// after which [`storage_radius`](ReserveStore::storage_radius) and
+    /// [`is_responsible_for`](ReserveStore::is_responsible_for) observe the new
+    /// value. Committing the radius is a single relaxed atomic store; it does not
+    /// itself move any chunk (the controller sheds bins through the eviction
+    /// verbs before narrowing responsibility), so it never blocks or fails.
+    ///
+    /// Exposed both as this inherent method and through the
+    /// [`SettableRadius`](vertex_swarm_api::SettableRadius) extension trait so the
+    /// control loop can target it either concretely or generically over a
+    /// [`ReserveStore`].
+    pub fn set_storage_radius(&self, radius: StorageRadius) {
+        self.radius.store(radius.get(), Ordering::Relaxed);
     }
 
     /// The local overlay address.
@@ -431,11 +476,11 @@ where
     BS::Error: Send + Sync + 'static,
 {
     fn storage_radius(&self) -> StorageRadius {
-        self.radius
+        self.load_radius()
     }
 
     fn is_responsible_for(&self, address: &ChunkAddress) -> bool {
-        address.proximity(&self.overlay()).get() >= self.radius.get()
+        address.proximity(&self.overlay()).get() >= self.radius.load(Ordering::Relaxed)
     }
 
     fn count(&self) -> SwarmResult<u64> {
@@ -583,6 +628,17 @@ where
             }
         }
         self.evict_entries(&targets)
+    }
+}
+
+impl<DB: Database, BS: BatchStore + Send + Sync> SettableRadius for DbReserve<DB, BS>
+where
+    BS::Error: Send + Sync + 'static,
+{
+    fn set_storage_radius(&self, radius: StorageRadius) {
+        // Delegates to the inherent method (the same write the controller's apply
+        // path takes); the trait exposes that write generically over a reserve.
+        DbReserve::set_storage_radius(self, radius);
     }
 }
 

--- a/crates/swarm/storer/src/expiry.rs
+++ b/crates/swarm/storer/src/expiry.rs
@@ -1,0 +1,338 @@
+//! Batch-expiry driven eviction.
+//!
+//! A postage batch expires when the chain's cumulative payout per chunk catches
+//! up with the batch's per-chunk balance. Concretely, with
+//! [`PostageContext::total_amount`] the cumulative payout and [`Batch::value`]
+//! the batch's per-chunk balance, the batch is expired iff
+//! `value <= total_amount` ([`Batch::is_expired`]). As the chain advances,
+//! `total_amount` only ever increases, so expiry is monotone: once a batch is
+//! expired it stays expired.
+//!
+//! When a batch expires, every stamped entry the reserve holds under that batch
+//! is no longer paid for and must be unreserved. This module is the seam that
+//! turns the chain-side expiry signal into reserve evictions: it reads the live
+//! [`PostageContext`] and the batch set from the [`BatchStore`], decides which
+//! batches have become expired, and drives
+//! [`ReserveStore::evict_batch(batch, None, max)`](ReserveStore::evict_batch)
+//! over the reserve's `BatchGroup` index for each. `up_to_bin = None` evicts the
+//! *whole* batch, which is correct for expiry (an expired batch is paid for at
+//! no bin), as opposed to the radius-growth case which sheds only a batch's
+//! shallow, out-of-responsibility bins.
+//!
+//! # Where the signal comes from
+//!
+//! The chain indexer is out of scope (it is stubbed; see the postage crate). It
+//! reduces contract logs into [`BatchEvent`](nectar_postage::BatchEvent)s and
+//! advances the [`PostageContext`] (its `total_amount` rises as
+//! redistribution rounds pay out, and an `Expired` event removes the batch from
+//! the store).
+//!
+//! There are two paths into this module, and they have different guarantees:
+//!
+//! - **The event path (authoritative).** When the indexer delivers a
+//!   [`BatchEvent::Expired`](nectar_postage::BatchEvent::Expired) the reserve
+//!   must shed that batch's entries *before* the batch leaves the
+//!   [`BatchStore`]. [`ExpirySweep::on_expired_event`] enforces exactly this
+//!   ordering: it evicts the batch's reserve entries first and only then runs
+//!   the supplied acknowledgement (the store removal). This is the only
+//!   ordering that cannot orphan entries.
+//! - **The reconciliation path (backstop).** [`ExpirySweep::run`] samples the
+//!   *resulting state* (the batch store and its context) and evicts any batch
+//!   that is value-expired (`value <= total_amount`) but is still present in the
+//!   store. It is a backstop for value-threshold expiry the chain crossed
+//!   without (or before) an explicit `Expired` event, and for crash recovery. It
+//!   is idempotent and replay-safe: a second run at the same context evicts
+//!   nothing, because the batch's entries are already gone.
+//!
+//! # Eviction must precede removal (orphan-avoidance contract)
+//!
+//! [`run`](ExpirySweep::run) can only evict batches it can still *see* in the
+//! [`BatchStore`]: it infers the expired set from
+//! [`batch_ids`](BatchStore::batch_ids). If a batch is removed from the store
+//! before its reserve entries are evicted, those entries are orphaned - they
+//! never appear in any future `batch_ids` snapshot, so no later `run` will ever
+//! shed them. Orphaned entries inflate the reserve count, which drives the
+//! storage radius and therefore the consensus-committed depth, so this is a
+//! correctness hazard, not merely a leak.
+//!
+//! The contract is therefore: **evict before remove.** The live ingest wiring
+//! (#391/#392) must route an `Expired` event through
+//! [`on_expired_event`](ExpirySweep::on_expired_event) (evict, then acknowledge
+//! removal) rather than removing the batch from the store directly and relying on
+//! the next `run` to catch up. `run` remains correct for value-threshold expiry
+//! (where the batch is still present) and as a crash-recovery reconciliation, but
+//! it is not a substitute for the ordered event path.
+//!
+//! # Purity seam
+//!
+//! The decision - *which* of a set of batches are expired at a given
+//! `total_amount` - is the pure [`expired_batches`] function, tested in
+//! isolation. The driver [`ExpirySweep`] does the I/O (read the store, call
+//! `evict_batch`) around it.
+
+use nectar_postage::{Batch, BatchId, BatchStore, PostageContext};
+use vertex_swarm_api::{ReserveStore, SwarmError, SwarmResult};
+
+/// The maximum number of entries a single [`ExpirySweep::run`] will evict per
+/// batch in one call.
+///
+/// Eviction is one atomic transaction per `evict_batch` call; this bounds the
+/// transaction size so a pathologically large batch does not stall the control
+/// loop. The sweep re-runs on the next context advance, so a batch with more
+/// than `EVICT_BATCH_MAX` entries drains over successive sweeps rather than in
+/// one giant transaction.
+pub const EVICT_BATCH_MAX: u64 = 10_000;
+
+/// Decide which of the given batches are expired at `total_amount`.
+///
+/// Pure and total. `batches` yields `(BatchId, value)` pairs where `value` is
+/// the batch's per-chunk balance ([`Batch::value`]); a batch is expired iff
+/// `value <= total_amount`, matching [`Batch::is_expired`]. Returns the expired
+/// IDs in iteration order. Separated from the I/O so the rule is unit-tested
+/// without a store or a reserve.
+pub fn expired_batches<I>(batches: I, total_amount: u128) -> Vec<BatchId>
+where
+    I: IntoIterator<Item = (BatchId, u128)>,
+{
+    batches
+        .into_iter()
+        .filter(|&(_, value)| value <= total_amount)
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// The result of one expiry sweep: which batches were evicted and how many
+/// stamped entries went with them.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SweepReport {
+    /// The batches found expired and evicted this sweep.
+    pub evicted_batches: Vec<BatchId>,
+    /// The total stamped entries removed across all evicted batches.
+    pub evicted_entries: u64,
+}
+
+/// Drives batch-expiry eviction against a [`BatchStore`] and a [`ReserveStore`].
+///
+/// Borrows both for the duration of a sweep; holds no state of its own, so it is
+/// cheap to construct per sweep. See the [module docs](self) for the signal and
+/// the purity seam.
+#[derive(Debug, Clone, Copy)]
+pub struct ExpirySweep<'a, BS, R: ?Sized> {
+    batches: &'a BS,
+    reserve: &'a R,
+}
+
+impl<'a, BS, R> ExpirySweep<'a, BS, R>
+where
+    BS: BatchStore,
+    // The synchronous [`BatchStore`] returns its own typed error; funnelling it
+    // into [`SwarmError::storage`] (whose source is a boxed
+    // `Error + Send + Sync`) requires the store's error be thread-safe. This is
+    // the same bound `DbReserve` carries on its own batch-store reads.
+    BS::Error: Send + Sync + 'static,
+    R: ReserveStore + ?Sized,
+{
+    /// Construct a sweep over the given batch store and reserve.
+    #[must_use]
+    pub const fn new(batches: &'a BS, reserve: &'a R) -> Self {
+        Self { batches, reserve }
+    }
+
+    /// Run one reconciliation sweep: evict every batch that is value-expired at
+    /// the store's current [`PostageContext`] *and still present in the store*.
+    ///
+    /// Reads the live context and batch set, applies [`expired_batches`] to find
+    /// the expired IDs, then calls
+    /// [`evict_batch(id, None, EVICT_BATCH_MAX)`](ReserveStore::evict_batch) for
+    /// each. Idempotent: a second run at the same context evicts nothing and
+    /// reports no batches, since an expired batch's entries are already gone (a
+    /// batch is reported only when the call actually removed entries).
+    ///
+    /// This is the **backstop** path (see the [module docs](self)): it can only
+    /// shed batches it can still see in the [`BatchStore`]. A batch removed from
+    /// the store before its entries were evicted is invisible here and would be
+    /// orphaned, so the authoritative path for an `Expired` event is
+    /// [`on_expired_event`](Self::on_expired_event), which evicts before the
+    /// store removal. Use `run` for value-threshold expiry (the batch is still
+    /// present) and crash-recovery reconciliation.
+    ///
+    /// The [`BatchStore`] surface is synchronous (its production redb backing is
+    /// synchronous and its in-memory test backing is too), so a synchronous
+    /// control loop can call this directly without any executor bridge.
+    pub fn run(&self) -> SwarmResult<SweepReport> {
+        let context = self.context()?;
+        let total_amount = context.total_amount();
+
+        // Resolve the (id, value) pairs the rule consumes from the live store.
+        let ids = self.batch_ids()?;
+        let mut pairs: Vec<(BatchId, u128)> = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(batch) = self.batch(&id)? {
+                // Reuse Batch::is_expired's exact predicate via the value.
+                pairs.push((id, batch.value()));
+            }
+        }
+
+        let expired = expired_batches(pairs, total_amount);
+
+        let mut report = SweepReport::default();
+        for id in expired {
+            let removed = self.reserve.evict_batch(id, None, EVICT_BATCH_MAX)?;
+            // Only record a batch as swept when it actually had entries to shed.
+            // An expired batch may linger in the batch store until the indexer
+            // applies its `Expired` event, so a later sweep re-detects it as
+            // expired but finds nothing to evict; reporting it again would be
+            // misleading and would break idempotency of the report.
+            if removed > 0 {
+                report.evicted_entries = report.evicted_entries.saturating_add(removed);
+                report.evicted_batches.push(id);
+            }
+        }
+        Ok(report)
+    }
+
+    /// Handle an `Expired`
+    /// [`BatchEvent`](nectar_postage::BatchEvent::Expired) in the orphan-safe
+    /// order: evict the batch's reserve entries first, then run `acknowledge`
+    /// (the batch-store removal) only once eviction has succeeded.
+    ///
+    /// This is the **authoritative** event path (see the [module docs](self)).
+    /// Evicting before removal is what guarantees no entry is orphaned: once the
+    /// batch leaves the [`BatchStore`] the reconciliation [`run`](Self::run) can
+    /// no longer see it, so removal must never happen first. If eviction fails
+    /// the error short-circuits and `acknowledge` is *not* run, leaving the batch
+    /// in the store so the next attempt (event redelivery or a `run` backstop)
+    /// retries cleanly rather than stranding entries.
+    ///
+    /// `acknowledge` is the caller's store-removal step (typically the indexer's
+    /// [`BatchEventHandler`](nectar_postage::BatchEventHandler) applying the
+    /// `Expired` event). Returns the number of stamped entries evicted.
+    ///
+    /// Idempotent: replaying the same `Expired` event evicts nothing the second
+    /// time (the entries are gone) and still acknowledges, so a redelivered event
+    /// is safe.
+    pub fn on_expired_event<A, E>(&self, batch: BatchId, acknowledge: A) -> SwarmResult<u64>
+    where
+        A: FnOnce() -> Result<(), E>,
+        E: core::error::Error + Send + Sync + 'static,
+    {
+        // Evict first: while the batch is still in the store its entries are
+        // reachable by `run` as a fallback, so a failure here strands nothing.
+        let removed = self.evict_expired_batch(batch)?;
+        // Only now that the reserve no longer holds the batch is it safe to drop
+        // it from the store. The acknowledgement is the caller's store removal,
+        // not a batch-store read; its error is funnelled into
+        // `SwarmError::storage` directly.
+        acknowledge().map_err(SwarmError::storage)?;
+        Ok(removed)
+    }
+
+    /// Evict a single batch's whole footprint without touching the batch store,
+    /// the eviction primitive [`on_expired_event`](Self::on_expired_event) is
+    /// built on.
+    ///
+    /// Exposed for callers that own the store-removal ordering themselves; most
+    /// callers want [`on_expired_event`](Self::on_expired_event), which enforces
+    /// the evict-before-remove contract. Returns the number of stamped entries
+    /// removed.
+    pub fn evict_expired_batch(&self, batch: BatchId) -> SwarmResult<u64> {
+        self.reserve.evict_batch(batch, None, EVICT_BATCH_MAX)
+    }
+
+    /// The live [`PostageContext`], read straight from the synchronous
+    /// [`BatchStore`].
+    ///
+    /// The reserve (PR-D) and this sweep both read the [`BatchStore`] from
+    /// synchronous control paths. The store surface is itself synchronous, so the
+    /// read is a plain call whose typed error maps straight into
+    /// [`SwarmError::storage`]; there is no executor bridge.
+    fn context(&self) -> SwarmResult<PostageContext> {
+        self.batches.context().map_err(SwarmError::storage)
+    }
+
+    fn batch_ids(&self) -> SwarmResult<Vec<BatchId>> {
+        self.batches.batch_ids().map_err(SwarmError::storage)
+    }
+
+    fn batch(&self, id: &BatchId) -> SwarmResult<Option<Batch>> {
+        self.batches.get(id).map_err(SwarmError::storage)
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions over known-bounds inputs"
+)]
+mod tests {
+    use super::*;
+
+    fn id(byte: u8) -> BatchId {
+        BatchId::from([byte; 32])
+    }
+
+    #[test]
+    fn expired_iff_value_at_or_below_total_amount() {
+        // value <= total_amount expires; value > total_amount survives.
+        let batches = [(id(1), 100u128), (id(2), 200), (id(3), 300)];
+        // total_amount = 200: batches with value 100 and 200 expire, 300 lives.
+        let expired = expired_batches(batches, 200);
+        assert_eq!(expired, vec![id(1), id(2)]);
+    }
+
+    #[test]
+    fn boundary_equal_value_expires() {
+        // The predicate is `value <= total_amount`, so equality expires
+        // (matches Batch::is_expired), it does not survive.
+        assert_eq!(expired_batches([(id(1), 500u128)], 500), vec![id(1)]);
+        assert_eq!(
+            expired_batches([(id(1), 501u128)], 500),
+            Vec::<BatchId>::new()
+        );
+    }
+
+    #[test]
+    fn nothing_expires_below_all_values() {
+        let batches = [(id(1), 100u128), (id(2), 200)];
+        assert!(expired_batches(batches, 99).is_empty());
+    }
+
+    #[test]
+    fn monotone_in_total_amount() {
+        // As total_amount rises the expired set only grows (chain payout is
+        // monotone), so expiry never un-expires a batch.
+        let batches = [(id(1), 100u128), (id(2), 200), (id(3), 300)];
+        let lo = expired_batches(batches, 150);
+        let hi = expired_batches(batches, 250);
+        assert_eq!(lo, vec![id(1)]);
+        assert_eq!(hi, vec![id(1), id(2)]);
+        // Every batch expired at the lower threshold is still expired at the
+        // higher one.
+        for b in &lo {
+            assert!(hi.contains(b));
+        }
+    }
+
+    #[test]
+    fn agrees_with_batch_is_expired() {
+        // Cross-check the pure rule against nectar's own predicate so the two
+        // never drift. Construct a batch and compare for a sweep of amounts.
+        let batch = Batch::new(
+            id(7),
+            /* value */ 1_000u128,
+            /* start */ 0,
+            /* owner */ Default::default(),
+            /* depth */ 20,
+            /* bucket_depth */ 16,
+            /* immutable */ false,
+        );
+        for total in [0u128, 999, 1_000, 1_001, 5_000] {
+            let rule = expired_batches([(batch.id(), batch.value())], total);
+            if batch.is_expired(total) {
+                assert_eq!(rule, vec![batch.id()], "total={total}");
+            } else {
+                assert!(rule.is_empty(), "total={total}");
+            }
+        }
+    }
+}

--- a/crates/swarm/storer/src/lib.rs
+++ b/crates/swarm/storer/src/lib.rs
@@ -29,6 +29,8 @@ mod cache;
 mod db_reserve;
 mod db_store;
 mod error;
+mod expiry;
+mod radius;
 mod reserve;
 mod traits;
 
@@ -36,6 +38,11 @@ pub use cache::ChunkCache;
 pub use db_reserve::DbReserve;
 pub use db_store::DbChunkStore;
 pub use error::StorerError;
+pub use expiry::{EVICT_BATCH_MAX, ExpirySweep, SweepReport, expired_batches};
+pub use radius::{
+    BIN_EVICT_MAX, RadiusController, RadiusDecision, RadiusOutcome, ReserveOccupancy,
+    derive_radius, grow_to_capacity, occupancy_of, shrink_threshold,
+};
 pub use reserve::{EvictionStrategy, Reserve};
 pub use traits::ChunkStore;
 

--- a/crates/swarm/storer/src/radius.rs
+++ b/crates/swarm/storer/src/radius.rs
@@ -1,0 +1,632 @@
+//! Size-driven storage-radius dynamics.
+//!
+//! The reserve's [`StorageRadius`] is not a static configuration value: it is
+//! derived from the reserve's own occupancy relative to its capacity, and that
+//! derived radius (plus a node-configured capacity-doubling addend) is the
+//! consensus-committed depth a redistribution round samples and commits on
+//! chain. This module is the clean-room, hand-derived specification of that
+//! derivation, expressed as a pure decision function so it can be unit-tested
+//! in isolation and reused by both the live eviction-control loop and the
+//! conformance tests.
+//!
+//! # Clean-room specification
+//!
+//! Derived from the Swarm reserve worker's intent (size-driven radius growth
+//! and shrink), encoded here from first principles rather than transcribed from
+//! the reference implementation. The rule, stated as a state machine over an
+//! occupancy snapshot:
+//!
+//! - **Within-capacity is the invariant.** The reserve must never sit above its
+//!   capacity once the control loop has converged: `total <= capacity`. The
+//!   grow rule restores this invariant whenever it is violated.
+//! - **Shrink threshold.** A reserve is considered comfortably under-filled when
+//!   its within-radius population sits below half its capacity. The `threshold`
+//!   is `capacity * 5 / 10` (equivalently `capacity / 2`). Below this the radius
+//!   may shrink; at or above it the radius holds.
+//! - **Shrink (radius decrease).** When the within-radius count is below the
+//!   threshold *and* the node is not actively syncing historical content
+//!   (`syncRate == 0`) *and* the radius is above its configured minimum, the
+//!   radius decreases by one. This widens responsibility (a shallower radius
+//!   admits more of the address space) so an under-utilised node pulls in more
+//!   chunks. The minimum-radius floor prevents a freshly started or sparsely
+//!   populated node from collapsing its radius to zero. Syncing must be idle
+//!   because an in-progress sync is still filling the reserve, so its momentary
+//!   low occupancy is not evidence of spare long-term capacity.
+//! - **Grow (radius increase).** When the reserve exceeds capacity, the node
+//!   sheds its furthest (shallowest-bin) chunks via unreserve/eviction and, if
+//!   shedding the current shallowest bin is not enough to get back within
+//!   capacity, increases the radius by one and repeats. A deeper radius narrows
+//!   responsibility (fewer addresses qualify), shedding load. The radius is
+//!   capped at the deepest bin ([`MAX_PO`]): a node that is still over capacity
+//!   at the maximum radius is genuinely over-provisioned and the control loop
+//!   surfaces [`RadiusOutcome::AtCeiling`].
+//!
+//! The derivation ([`derive_radius`]) is *pure*: it consumes occupancy counts
+//! and produces a [`RadiusDecision`]. Applying a decision (evicting a bin,
+//! committing the new radius) is [`RadiusController::apply`]'s job, which threads
+//! the eviction I/O and the [`SettableRadius`] write around the pure rule; see
+//! the [`RadiusController`] driver and the documented [reserve seam](#reserve-seam).
+//!
+//! # Differential oracle (planned)
+//!
+//! This module is the *hand-derived* specification: the rules above are encoded
+//! and tested against their own documented behaviour. A bee differential oracle
+//! (replaying a recorded sequence of `(occupancy, sync state)` snapshots through
+//! both this controller and the reference reserve worker, and asserting the
+//! radius trajectory matches step for step) is the planned follow-up conformance
+//! check. It is intentionally *not* part of this car: it needs a recorded oracle
+//! trace and a harness that are owned separately, and folding it in here would
+//! couple the pure policy to a fixture. The seam for it is the pure
+//! [`derive_radius`] function, which the oracle harness can drive directly. See
+//! the `radius_oracle_is_planned_followup` ignored test, which documents the
+//! exact comparison the oracle will perform.
+//!
+//! # Reserve seam
+//!
+//! The controller reads three quantities from the reserve and writes one back:
+//!
+//! - reserve population within the current radius
+//!   ([`ReserveOccupancy::within_radius`]),
+//! - total reserve population ([`ReserveOccupancy::total`]),
+//! - capacity ([`ReserveOccupancy::capacity`]),
+//! - and, on grow, the per-bin eviction primitive
+//!   ([`ReserveStore::evict_from_bin`]).
+//!
+//! The reads are exactly the existing [`ReserveStore`] surface
+//! (`count`/`count_in`/`capacity`/`storage_radius`/`evict_from_bin`); the write
+//! is the [`SettableRadius`] extension trait. [`DbReserve`](crate::DbReserve)
+//! implements both, so wiring the controller needs no new reserve verbs.
+//! [`occupancy_of`] builds the snapshot from any [`ReserveStore`], and
+//! [`RadiusController::apply`] reads it, applies the decision (shedding through
+//! [`evict_from_bin`](ReserveStore::evict_from_bin) on grow) and commits the
+//! derived radius through [`SettableRadius::set_storage_radius`]. #391 only wires
+//! the loop that calls `apply`; the runtime mutability already lives here.
+
+use nectar_primitives::{Bin, MAX_PO, ProximityOrder};
+use vertex_swarm_api::{ReserveStore, SettableRadius, StorageRadius, SwarmError, SwarmResult};
+
+/// A single radius-adjustment decision derived from reserve occupancy.
+///
+/// The output of the pure derivation. Holding is the common case; shrink/grow
+/// move the radius by exactly one step so the control loop converges
+/// monotonically rather than overshooting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RadiusDecision {
+    /// The radius is well-matched to occupancy; leave it unchanged.
+    Hold,
+    /// The reserve is under-filled and idle; widen responsibility by lowering
+    /// the radius one step (to the contained value).
+    Shrink(StorageRadius),
+    /// The reserve is over capacity; narrow responsibility by raising the
+    /// radius one step (to the contained value), after shedding the shallowest
+    /// bin.
+    Grow(StorageRadius),
+}
+
+/// The terminal outcome of running the grow loop to convergence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RadiusOutcome {
+    /// The reserve is within capacity at the (possibly increased) radius.
+    WithinCapacity(StorageRadius),
+    /// The reserve is still over capacity at the deepest bin; the node is
+    /// over-provisioned and cannot shed further by widening the radius.
+    AtCeiling(StorageRadius),
+}
+
+/// A snapshot of reserve occupancy the radius derivation consumes.
+///
+/// Counts are per *stamped entry* (distinct `(batchID, stampIndex, address)`),
+/// matching the consensus reserve-size definition, not per content address.
+/// The within-radius count is the population in bins at or deeper than the
+/// current radius; it is the quantity the shrink rule tests against the
+/// capacity threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReserveOccupancy {
+    /// Entries in bins at or deeper than the current radius.
+    pub within_radius: u64,
+    /// Total entries across all bins.
+    pub total: u64,
+    /// The reserve's capacity, in stamped entries.
+    pub capacity: u64,
+    /// The current storage radius.
+    pub radius: StorageRadius,
+}
+
+/// The capacity threshold below which the radius may shrink: `capacity * 5 / 10`.
+///
+/// The multiply-then-divide form mirrors the protocol's `capacity * 5 / 10`
+/// exactly (same truncation), and avoids the temptation to read `capacity / 2`
+/// as a different fraction if the proportion is ever retuned.
+#[inline]
+#[must_use]
+pub const fn shrink_threshold(capacity: u64) -> u64 {
+    // saturating_mul guards the (astronomically large) capacity that would
+    // overflow `* 5`; the reserve never approaches it, but the policy stays
+    // total rather than panicking in a debug build.
+    capacity.saturating_mul(5) / 10
+}
+
+/// Derive the next radius adjustment from a reserve-occupancy snapshot.
+///
+/// Pure and total. `minimum_radius` is the configured floor the shrink rule
+/// will not cross; `syncing_idle` is true when no historical sync is in flight
+/// (a sync in progress, `syncRate != 0`, suppresses shrinking, since low
+/// occupancy then reflects an unfinished fill rather than spare capacity).
+///
+/// Precedence: over-capacity (grow) is checked first because it is a hard
+/// constraint (the reserve must not exceed capacity); shrink is a soft
+/// optimisation considered only when within capacity.
+#[must_use]
+pub fn derive_radius(
+    occ: ReserveOccupancy,
+    minimum_radius: StorageRadius,
+    syncing_idle: bool,
+) -> RadiusDecision {
+    // Hard constraint first: shed load if over capacity by narrowing.
+    if occ.total > occ.capacity {
+        return match step_up(occ.radius) {
+            Some(next) => RadiusDecision::Grow(next),
+            None => RadiusDecision::Hold, // already at the ceiling
+        };
+    }
+
+    // Soft optimisation: widen responsibility when comfortably under-filled and
+    // not mid-sync, never below the configured floor.
+    if syncing_idle
+        && occ.within_radius < shrink_threshold(occ.capacity)
+        && occ.radius > minimum_radius
+        && let Some(next) = step_down(occ.radius)
+    {
+        return RadiusDecision::Shrink(next);
+    }
+
+    RadiusDecision::Hold
+}
+
+/// The radius one step deeper, or `None` if already at the deepest bin.
+#[inline]
+#[must_use]
+fn step_up(radius: StorageRadius) -> Option<StorageRadius> {
+    let raw = radius.get();
+    if raw >= MAX_PO {
+        return None;
+    }
+    Bin::try_from(raw + 1).ok().map(StorageRadius::new)
+}
+
+/// The radius one step shallower, or `None` if already at zero.
+#[inline]
+#[must_use]
+fn step_down(radius: StorageRadius) -> Option<StorageRadius> {
+    let raw = radius.get();
+    if raw == 0 {
+        return None;
+    }
+    Bin::try_from(raw - 1).ok().map(StorageRadius::new)
+}
+
+/// Build a [`ReserveOccupancy`] snapshot from a live [`ReserveStore`].
+///
+/// Reads the within-radius population (the sum of `count_in` over bins at or
+/// deeper than the current radius), the total population, the capacity and the
+/// radius. This is the read half of the [reserve seam](self#reserve-seam): the
+/// controller decides from the snapshot, the live loop applies the decision.
+///
+/// The within-radius sum walks at most `MAX_PO - radius + 1` bins, each an
+/// O(log n + matches) cursor count, so the snapshot is cheap relative to a full
+/// scan. A `total` already counted by the reserve is reused rather than
+/// re-summed.
+pub fn occupancy_of<R: ReserveStore + ?Sized>(reserve: &R) -> SwarmResult<ReserveOccupancy> {
+    let radius = reserve.storage_radius();
+    let total = reserve.count()?;
+    let mut within_radius = 0u64;
+    for po in radius.get()..=MAX_PO {
+        // `po` ranges over a valid bin index by construction (radius.get() and
+        // MAX_PO are both valid), so the conversion cannot fail; fall back to
+        // the deepest bin defensively rather than unwrapping.
+        let bin = ProximityOrder::new(po).unwrap_or(ProximityOrder::MAX);
+        within_radius = within_radius.saturating_add(reserve.count_in(bin)?);
+    }
+    Ok(ReserveOccupancy {
+        within_radius,
+        total,
+        capacity: reserve.capacity(),
+        radius,
+    })
+}
+
+/// Drives the grow loop to convergence over a pure shed function.
+///
+/// The live wiring passes a closure that sheds the shallowest in-radius bin via
+/// [`ReserveStore::evict_from_bin`] and reports the resulting total. This keeps
+/// the convergence logic (radius stepping, ceiling detection) pure and testable
+/// while leaving the I/O to the caller. The loop steps the radius up at most
+/// `MAX_PO - start` times, so it always terminates.
+///
+/// `shed` is invoked as `shed(radius)`: it should evict the bin at the current
+/// radius boundary (`bin == radius`), which is the shallowest bin that falls out
+/// of responsibility the moment the radius rises by one, and return the new
+/// total entry count. The loop stops as soon as the total is within capacity,
+/// returning the radius reached.
+///
+/// # Radius accounting
+///
+/// Responsibility is the set of bins *at or deeper than* the radius
+/// ([`ReserveStore::storage_radius`] semantics), so shedding bin `K` and raising
+/// the radius are one step: the node sheds bin `K` precisely because it is no
+/// longer responsible for it once the boundary moves to `K + 1`. The returned
+/// radius is therefore always one deeper than the deepest bin that was shed,
+/// matching the single-step [`derive_radius`] convention where
+/// [`RadiusDecision::Grow`] carries `radius + 1`. Equivalently: increment the
+/// radius, then evict the bins now shallower than it.
+pub fn grow_to_capacity<F>(
+    start: StorageRadius,
+    capacity: u64,
+    mut total: u64,
+    mut shed: F,
+) -> RadiusOutcome
+where
+    F: FnMut(StorageRadius) -> u64,
+{
+    let mut radius = start;
+    while total > capacity {
+        match step_up(radius) {
+            Some(next) => {
+                // Shed the bin at the current boundary; it falls out of
+                // responsibility as the radius rises to `next`. The new radius
+                // is `next` regardless of whether this shed sufficed, because
+                // bin `radius` is gone either way.
+                total = shed(radius);
+                radius = next;
+                if total <= capacity {
+                    return RadiusOutcome::WithinCapacity(radius);
+                }
+            }
+            None => return RadiusOutcome::AtCeiling(radius),
+        }
+    }
+    RadiusOutcome::WithinCapacity(radius)
+}
+
+/// A thin stateful driver around [`derive_radius`] for the live control loop.
+///
+/// Holds the configured floor; the radius itself lives in the reserve. The
+/// driver is deliberately tiny: it exists so the loop has one place to apply
+/// policy and so the policy is covered by tests independently of the
+/// redb-backed reserve.
+#[derive(Debug, Clone, Copy)]
+pub struct RadiusController {
+    /// The configured minimum radius the shrink rule will not cross.
+    minimum_radius: StorageRadius,
+}
+
+impl RadiusController {
+    /// Construct a controller with the given minimum-radius floor.
+    #[must_use]
+    pub const fn new(minimum_radius: StorageRadius) -> Self {
+        Self { minimum_radius }
+    }
+
+    /// The configured minimum radius.
+    #[must_use]
+    pub const fn minimum_radius(&self) -> StorageRadius {
+        self.minimum_radius
+    }
+
+    /// Decide the next radius adjustment for the given occupancy.
+    #[must_use]
+    pub fn decide(&self, occ: ReserveOccupancy, syncing_idle: bool) -> RadiusDecision {
+        derive_radius(occ, self.minimum_radius, syncing_idle)
+    }
+
+    /// Decide the next radius adjustment for a live reserve, reading its
+    /// occupancy through the [reserve seam](self#reserve-seam).
+    ///
+    /// A convenience over [`occupancy_of`] + [`Self::decide`] for the live loop;
+    /// the pure two-step form remains available for tests and the oracle.
+    pub fn decide_for<R: ReserveStore + ?Sized>(
+        &self,
+        reserve: &R,
+        syncing_idle: bool,
+    ) -> SwarmResult<RadiusDecision> {
+        Ok(self.decide(occupancy_of(reserve)?, syncing_idle))
+    }
+
+    /// Decide *and apply* one radius adjustment against a live reserve, returning
+    /// the radius now committed.
+    ///
+    /// This is the write half of the [reserve seam](self#reserve-seam) and the
+    /// single entry the live eviction-control loop (#391) calls: it reads the
+    /// occupancy, runs [`derive_radius`], performs the I/O the decision implies,
+    /// and commits the resulting radius through [`SettableRadius`] so subsequent
+    /// [`storage_radius`](ReserveStore::storage_radius) reads observe it. Before
+    /// this existed the dynamics were architecturally orphaned: there was no write
+    /// target for the derived radius, so it could never change at runtime.
+    ///
+    /// The decision maps to action as follows:
+    ///
+    /// - [`Hold`](RadiusDecision::Hold): commit nothing, return the current
+    ///   radius unchanged.
+    /// - [`Shrink`](RadiusDecision::Shrink): widening responsibility evicts
+    ///   nothing (the node simply admits more of the address space), so this
+    ///   commits the shallower radius directly.
+    /// - [`Grow`](RadiusDecision::Grow): the reserve is over capacity, so this
+    ///   runs [`grow_to_capacity`], shedding the boundary bin via
+    ///   [`evict_from_bin`](ReserveStore::evict_from_bin) and stepping the radius
+    ///   until the reserve is within capacity (or the ceiling is hit), then
+    ///   commits the converged radius. Eviction precedes the commit so the reserve
+    ///   never advertises a narrower radius than its contents justify.
+    ///
+    /// `syncing_idle` carries the same meaning as in [`derive_radius`]. Returns a
+    /// [`SwarmResult`] because the grow path performs reserve I/O.
+    pub fn apply<R: SettableRadius + ?Sized>(
+        &self,
+        reserve: &R,
+        syncing_idle: bool,
+    ) -> SwarmResult<StorageRadius> {
+        let occ = occupancy_of(reserve)?;
+        match self.decide(occ, syncing_idle) {
+            RadiusDecision::Hold => Ok(occ.radius),
+            RadiusDecision::Shrink(next) => {
+                reserve.set_storage_radius(next);
+                Ok(next)
+            }
+            RadiusDecision::Grow(_) => {
+                // The grow loop sheds the boundary bin and steps the radius until
+                // within capacity; thread its eviction through `evict_from_bin`.
+                // A reserve I/O error inside the closure is captured and surfaced
+                // after the loop rather than panicking through the pure driver.
+                let mut shed_err: Option<SwarmError> = None;
+                let outcome = grow_to_capacity(occ.radius, occ.capacity, occ.total, |radius| {
+                    if shed_err.is_some() {
+                        // A prior shed failed; stop shedding (report the count as
+                        // still over capacity so the loop makes no further claim).
+                        return occ.total;
+                    }
+                    match reserve.evict_from_bin(radius.bin(), BIN_EVICT_MAX) {
+                        Ok(_) => match reserve.count() {
+                            Ok(total) => total,
+                            Err(e) => {
+                                shed_err = Some(e);
+                                occ.total
+                            }
+                        },
+                        Err(e) => {
+                            shed_err = Some(e);
+                            occ.total
+                        }
+                    }
+                });
+                if let Some(e) = shed_err {
+                    return Err(e);
+                }
+                let next = match outcome {
+                    RadiusOutcome::WithinCapacity(r) | RadiusOutcome::AtCeiling(r) => r,
+                };
+                reserve.set_storage_radius(next);
+                Ok(next)
+            }
+        }
+    }
+}
+
+/// The maximum entries [`RadiusController::apply`] sheds from one bin in a single
+/// [`evict_from_bin`](ReserveStore::evict_from_bin) call.
+///
+/// Bounds the per-bin eviction transaction so a pathologically populated bin
+/// does not stall the control loop in one giant transaction; the loop re-runs on
+/// the next tick to drain any remainder. Matches the batch-eviction bound the
+/// expiry sweep uses.
+pub const BIN_EVICT_MAX: u64 = 10_000;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions over known-bounds inputs"
+)]
+mod tests {
+    use super::*;
+
+    fn r(n: u8) -> StorageRadius {
+        StorageRadius::new(Bin::try_from(n).unwrap())
+    }
+
+    fn occ(within: u64, total: u64, cap: u64, radius: u8) -> ReserveOccupancy {
+        ReserveOccupancy {
+            within_radius: within,
+            total,
+            capacity: cap,
+            radius: r(radius),
+        }
+    }
+
+    #[test]
+    fn threshold_is_five_tenths_of_capacity() {
+        assert_eq!(shrink_threshold(0), 0);
+        assert_eq!(shrink_threshold(1), 0);
+        assert_eq!(shrink_threshold(10), 5);
+        assert_eq!(shrink_threshold(11), 5);
+        // Matches the protocol's capacity * 5 / 10 for representative sizes.
+        for c in [0u64, 1, 2, 9, 10, 1000, 4_194_304] {
+            assert_eq!(shrink_threshold(c), c * 5 / 10);
+        }
+    }
+
+    // --- below-threshold decrease ------------------------------------------
+
+    #[test]
+    fn shrinks_when_underfilled_idle_and_above_floor() {
+        // within (4) < threshold (5), idle, radius 8 > floor 0 => shrink to 7.
+        let d = derive_radius(occ(4, 8, 10, 8), r(0), true);
+        assert_eq!(d, RadiusDecision::Shrink(r(7)));
+    }
+
+    #[test]
+    fn holds_when_at_or_above_threshold() {
+        // within (5) == threshold (5): not below, so hold.
+        assert_eq!(
+            derive_radius(occ(5, 8, 10, 8), r(0), true),
+            RadiusDecision::Hold
+        );
+        // within (6) > threshold: hold.
+        assert_eq!(
+            derive_radius(occ(6, 8, 10, 8), r(0), true),
+            RadiusDecision::Hold
+        );
+    }
+
+    #[test]
+    fn does_not_shrink_while_syncing() {
+        // Under-filled but a sync is in flight (syncRate != 0): low occupancy is
+        // not spare capacity, so hold.
+        assert_eq!(
+            derive_radius(occ(1, 8, 10, 8), r(0), false),
+            RadiusDecision::Hold
+        );
+    }
+
+    #[test]
+    fn does_not_shrink_below_floor() {
+        // Under-filled and idle, but radius already at the configured floor.
+        assert_eq!(
+            derive_radius(occ(1, 8, 10, 5), r(5), true),
+            RadiusDecision::Hold
+        );
+        // One above the floor: shrink down to the floor exactly.
+        assert_eq!(
+            derive_radius(occ(1, 8, 10, 6), r(5), true),
+            RadiusDecision::Shrink(r(5))
+        );
+    }
+
+    #[test]
+    fn does_not_shrink_at_zero_radius() {
+        // Floor at zero, radius at zero: step_down has nowhere to go.
+        assert_eq!(
+            derive_radius(occ(0, 0, 10, 0), r(0), true),
+            RadiusDecision::Hold
+        );
+    }
+
+    // --- over-capacity increase --------------------------------------------
+
+    #[test]
+    fn grows_when_over_capacity() {
+        // total (12) > capacity (10): grow one step regardless of sync state.
+        assert_eq!(
+            derive_radius(occ(12, 12, 10, 8), r(0), true),
+            RadiusDecision::Grow(r(9))
+        );
+        assert_eq!(
+            derive_radius(occ(12, 12, 10, 8), r(0), false),
+            RadiusDecision::Grow(r(9))
+        );
+    }
+
+    #[test]
+    fn over_capacity_takes_precedence_over_shrink() {
+        // Within-radius low (would shrink) but total over capacity: grow wins.
+        let d = derive_radius(occ(1, 12, 10, 8), r(0), true);
+        assert_eq!(d, RadiusDecision::Grow(r(9)));
+    }
+
+    #[test]
+    fn grow_holds_at_ceiling() {
+        // Over capacity but already at the deepest bin: cannot widen further.
+        assert_eq!(
+            derive_radius(occ(50, 50, 10, MAX_PO), r(0), true),
+            RadiusDecision::Hold
+        );
+    }
+
+    #[test]
+    fn within_capacity_at_boundary_holds() {
+        // total == capacity is within capacity; no grow.
+        assert_eq!(
+            derive_radius(occ(10, 10, 10, 8), r(0), true),
+            RadiusDecision::Hold
+        );
+    }
+
+    // --- grow loop convergence ---------------------------------------------
+
+    #[test]
+    fn grow_loop_converges_within_capacity() {
+        // Start over capacity; each shed removes 3 entries. capacity 10,
+        // total 16 -> 13 -> 10 (within at the second shed).
+        let mut remaining = 16u64;
+        let mut shed_at: Vec<u8> = Vec::new();
+        let out = grow_to_capacity(r(8), 10, 16, |radius| {
+            shed_at.push(radius.get());
+            remaining = remaining.saturating_sub(3);
+            remaining
+        });
+        // Shed bin 8 (radius -> 9), total 16 -> 13 still over; shed bin 9
+        // (radius -> 10), total 13 -> 10 within. Responsibility is bins >= radius
+        // and bins 8 and 9 are now evicted, so the converged radius is 10, one
+        // deeper than the deepest bin shed.
+        assert_eq!(shed_at, vec![8, 9], "sheds the boundary bin each step");
+        assert_eq!(out, RadiusOutcome::WithinCapacity(r(10)));
+        // The converged radius is the lowest bin still in responsibility:
+        // responsibility is bins >= radius, every shed bin is now below it, and
+        // the deepest shed bin (9) is exactly radius - 1. This is the consensus
+        // property: storage_radius feeds committedDepth, so an off-by-one here
+        // diverges on chain.
+        let radius = match out {
+            RadiusOutcome::WithinCapacity(rdx) | RadiusOutcome::AtCeiling(rdx) => rdx.get(),
+        };
+        assert_eq!(
+            radius,
+            *shed_at.last().unwrap() + 1,
+            "radius is one deeper than the deepest evicted bin"
+        );
+        for shed in &shed_at {
+            assert!(
+                *shed < radius,
+                "every shed bin {shed} is shallower than the radius {radius} (out of responsibility)"
+            );
+        }
+    }
+
+    #[test]
+    fn grow_loop_reports_ceiling_when_cannot_shed_enough() {
+        // Shedding never reduces below capacity: must hit the ceiling.
+        let out = grow_to_capacity(r(MAX_PO - 1), 10, 100, |_r| 100);
+        assert_eq!(out, RadiusOutcome::AtCeiling(r(MAX_PO)));
+    }
+
+    #[test]
+    fn grow_loop_no_op_when_already_within_capacity() {
+        let out = grow_to_capacity(r(8), 10, 5, |_r| unreachable!("should not shed"));
+        assert_eq!(out, RadiusOutcome::WithinCapacity(r(8)));
+    }
+
+    // --- controller --------------------------------------------------------
+
+    #[test]
+    fn controller_threads_floor() {
+        let c = RadiusController::new(r(4));
+        assert_eq!(c.minimum_radius(), r(4));
+        assert_eq!(c.decide(occ(1, 8, 10, 4), true), RadiusDecision::Hold);
+        assert_eq!(
+            c.decide(occ(1, 8, 10, 5), true),
+            RadiusDecision::Shrink(r(4))
+        );
+    }
+
+    /// The bee differential oracle is a planned follow-up: it will replay a
+    /// recorded `(occupancy, syncing_idle)` trace through both [`derive_radius`]
+    /// and bee's reserve worker and assert the radius trajectory matches step
+    /// for step. The fixture and harness are owned separately; this test
+    /// documents the comparison and the seam (drive [`derive_radius`] directly)
+    /// rather than asserting a green result that does not run.
+    #[test]
+    #[ignore = "bee differential oracle: needs a recorded reference trace (planned follow-up)"]
+    fn radius_oracle_is_planned_followup() {
+        // Placeholder shape of the oracle step:
+        //   for (snapshot, idle, expected) in recorded_trace() {
+        //       assert_eq!(derive_radius(snapshot, floor, idle), expected);
+        //   }
+        unimplemented!("differential oracle trace not yet recorded");
+    }
+}


### PR DESCRIPTION
## What this PR does

This is the fifth car (car E) of the postage, reserve and sampler train. It adds the reserve's size-driven storage-radius dynamics, the consensus-committed depth derived from that radius, and the batch-expiry eviction seam that unreserves a batch's entries once the chain has paid it out.

Everything here is a clean-room, hand-derived specification: the rules are encoded from first principles against their network-observable intent, not transcribed from any reference implementation. The pure decision functions are unit-tested in isolation and the seams are exercised end to end against the redb-backed reserve.

Concretely, the diff adds:

- A `SettableRadius: ReserveStore` trait (in `vertex-swarm-api`): the object-safe write half of the reserve radius, kept separate from the widely used read surface so only the eviction-control loop depends on mutation. `DbReserve` now holds its radius behind a lock-free `AtomicU8` and implements both the inherent setter and the trait.
- `CommittedDepth::from_radius` plus the `CapacityDoubling` newtype and `CapacityDoublingError` (in `vertex-swarm-redistribution`).
- A new `radius` module (in `vertex-swarm-storer`): the radius state machine, the pure `derive_radius` / `grow_to_capacity` / `shrink_threshold` / `occupancy_of` functions, and the `RadiusController` driver.
- A new `expiry` module (in `vertex-swarm-storer`): the `ExpirySweep` driver, the pure `expired_batches` rule, and the `SweepReport`.

## Where it sits

Stacked on `feat/reserve-per-entry` (#403), the per-stamped-entry six-table reserve rework. Read the diff against that parent branch rather than against the base storer branch. It consumes the parent's `ReserveStore` surface (`count` / `count_in` / `capacity` / `storage_radius` / `evict_from_bin` / `evict_batch`).

Because the nectar `BatchStore` is synchronous (nectar #103), the expiry control paths here read it directly (`batch_ids`, `get`, `context`) from a synchronous control path. There is no `block_on` shim and no `BatchStoreSync` bridge.

The live node control loop (#391) is not wired here: `RadiusController::apply` and `ExpirySweep` are the seams it will consume, and the runtime-mutable radius cell already exists, so that wiring only calls into these entry points.

## Design

### The radius state machine

The storage radius is derived from the reserve's own occupancy against its capacity, not configured statically. `derive_radius` is a pure, total function over a `ReserveOccupancy` snapshot (`within_radius`, `total`, `capacity`, `radius`) and a `syncing_idle` flag, returning a `RadiusDecision` of `Hold`, `Shrink(next)` or `Grow(next)`:

- **Increase (grow / unreserve).** Checked first, as a hard constraint: when `total > capacity` the reserve sheds its shallowest in-radius bin and raises the radius by one, narrowing responsibility (responsibility is the set of bins at or deeper than the radius). The radius is capped at the deepest bin (`MAX_PO`); a reserve still over capacity there is genuinely over-provisioned and the loop surfaces `RadiusOutcome::AtCeiling`.
- **Decrease (shrink).** A soft optimisation considered only when within capacity: when the within-radius count is below the threshold `capacity * 5 / 10` (`shrink_threshold`) AND syncing is idle (`syncRate == 0`) AND the radius is above its configured minimum, the radius decreases by one, widening responsibility so an under-filled node pulls in more chunks. The minimum-radius floor stops a fresh or sparse node collapsing to zero; the idle requirement stops a mid-sync node mistaking an unfinished fill for spare capacity.

`grow_to_capacity` drives the grow loop to convergence over a caller-supplied shed closure (the live wiring sheds via `evict_from_bin`), keeping radius stepping and ceiling detection pure. Responsibility being bins at or deeper than the radius, shedding bin `K` and raising the radius to `K + 1` are one step: the converged radius is always one deeper than the deepest bin shed, matching the single-step `Grow(radius + 1)` convention. `RadiusController::apply` ties it together end to end: read occupancy, derive the decision, perform the implied I/O (shed bins on grow, nothing on shrink), then commit the resulting radius through `SettableRadius::set_storage_radius`. Eviction precedes the commit, so the reserve never advertises a narrower radius than its contents justify. A reserve I/O error inside the shed closure is captured and surfaced after the loop rather than panicking through the pure driver.

### Committed depth and capacity doubling

`CommittedDepth::from_radius(radius, doubling)` implements the network-observable formula `committedDepth = storage_radius + capacity_doubling`. The addend is applied with a saturating `u8` add and then clamped into the bin range, so the value pins at the deepest bin rather than wrapping or panicking; the derivation is total, which the commit hot path requires. Both inputs are byte-exact across nodes, so the output is too.

`CapacityDoubling` is a node-configured addend bounded at `CapacityDoubling::MAX`, which is `1` (one bin deeper, twice the baseline reserve). The bound is the network's, not a representational one: `try_from` rejects any addend above it with a dedicated `CapacityDoublingError` carrying the offending value and the permitted maximum, so a misconfiguration surfaces at ingest rather than silently clamping or committing a depth the network would never produce.

### Batch-expiry eviction (evict before remove)

A batch expires when the chain's cumulative payout per chunk (`PostageContext::total_amount`) reaches the batch's per-chunk balance: expired if and only if `value <= total_amount`, matching `Batch::is_expired`. Expiry is monotone in `total_amount`. When a batch expires its stamped entries are no longer paid for and must be unreserved via `evict_batch(batch, None, max)` (the whole batch; `None` because an expired batch is paid for at no bin).

The decision of which batches are expired is the pure `expired_batches` function; the `ExpirySweep` driver does the I/O around it. There are two paths with distinct guarantees:

- **Event path (authoritative).** `ExpirySweep::on_expired_event` enforces evict-before-remove: it evicts the batch's reserve entries first and only then runs the caller's store-removal acknowledgement. If eviction fails it short-circuits and the acknowledgement does not run, leaving the batch discoverable for a retry. This is the only ordering that cannot orphan entries: the reconciliation sweep can only shed batches it can still see in the `BatchStore`, so a batch removed before its entries are evicted would orphan them, and orphaned entries inflate reserve size and therefore the committed depth, a correctness hazard rather than a mere leak.
- **Reconciliation path (backstop).** `ExpirySweep::run` reads the live context and batch set, applies `expired_batches`, and evicts any value-expired batch still present in the store. It is idempotent (a batch is reported only when the call actually removed entries) and serves value-threshold expiry the chain crossed without an explicit event, plus crash recovery.

Both paths read the synchronous `BatchStore` directly (no `block_on` shim, no `String` error wrapper).

## Consensus notes

`storage_radius` feeds `committedDepth`, which a redistribution round commits on chain, so the radius trajectory is consensus-load-bearing: an off-by-one in the grow loop or a divergent committed depth would put the node out of consensus. The grow-loop convergence test asserts the radius is exactly one deeper than the deepest evicted bin for that reason, and the capacity-doubling bound mirrors the network's permitted maximum (parity with bee's `maxAllowedDoubling`) so the committed depth is one the network would actually produce.

The radius rules here are a hand-derived specification. A bee differential oracle for the radius trajectory (replaying a recorded `(occupancy, syncing_idle)` trace through both `derive_radius` and the reference reserve worker and asserting the trajectory matches step for step) is a planned follow-up, not implemented in this car: it needs a separately owned recorded trace and harness. The seam for it is the pure `derive_radius` function; the ignored `radius_oracle_is_planned_followup` test documents the comparison it will perform.

## Testing

- **Over-capacity increase:** `derive_radius` grows by one step when `total > capacity` regardless of sync state, grow takes precedence over a would-be shrink, and grow holds at the `MAX_PO` ceiling; `total == capacity` is within capacity and holds.
- **Below-threshold decrease:** shrinks when under-filled, idle and above the floor; holds at or above the threshold; does not shrink while syncing, below the floor, or at a zero radius. The threshold is verified to equal `capacity * 5 / 10` across representative sizes.
- **Grow-loop convergence:** sheds the boundary bin each step, converges within capacity, asserts the radius is one deeper than the deepest evicted bin and that every shed bin is out of responsibility, reports the ceiling when it cannot shed enough, and is a no-op when already within capacity.
- **Committed depth:** `from_radius` equals `radius + doubling`, clamps to the deepest bin via saturating add, and the capacity-doubling bound admits `0` and `1`, rejects `2` and above (including otherwise-valid bin indices), with the diagnostic reporting the permitted maximum.
- **Settable radius and controller:** the radius cell round-trips through the read seam (including through a `&dyn SettableRadius` trait object); `apply` commits a shrink through the seam and holds at the floor.
- **Expiry eviction:** the pure `expired_batches` rule (boundary equality expires, monotone in `total_amount`, cross-checked against `Batch::is_expired`); an end-to-end sweep that evicts only the expired batch's entries while the live batch's refcounted payload survives, and is idempotent on a second run; nothing evicted when no batch is expired; and the evict-before-remove ordering on an `Expired` event, asserting the reserve is already drained when the acknowledgement runs and that an acknowledgement error is funnelled through while the eviction stays applied.

`cargo test`, `cargo clippy` (with `-D warnings`) and `cargo fmt --check` pass for the touched crates (`vertex-swarm-storer`, `vertex-swarm-redistribution`, `vertex-swarm-api`), and a workspace `cargo check` is green.

## Related issues

- Parent car: #403 (`feat/reserve-per-entry`).
- #391: the live node eviction-control loop that will call `RadiusController::apply` and `ExpirySweep` (not wired here; the seams and the runtime-mutable radius cell are provided for it).
- #392: the indexer wiring that will route `Expired` events through `on_expired_event`.

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent. A human author reviewed the specification, the rules and the tests, and is responsible for the contribution.
