### PR TITLE
feat(swarm-redistribution): consensus candidate-feed filters and exact-stamp witness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9339,6 +9339,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "vertex-swarm-api",
+ "vertex-swarm-postage",
 ]
 
 [[package]]

--- a/crates/swarm/redistribution/Cargo.toml
+++ b/crates/swarm/redistribution/Cargo.toml
@@ -14,6 +14,11 @@ workspace = true
 [dependencies]
 # vertex
 vertex-swarm-api.workspace = true
+# Canonical postage surface: the sampler filters and the inclusion-proof stamp
+# witness consume `Stamp`, `BatchId` and `PostageContext` from here, which
+# re-exports the nectar definitions verbatim, so there is one canonical copy of
+# each postage type across the workspace (never redefined).
+vertex-swarm-postage.workspace = true
 
 # swarm
 nectar-primitives.workspace = true

--- a/crates/swarm/redistribution/benches/redistribution.rs
+++ b/crates/swarm/redistribution/benches/redistribution.rs
@@ -38,6 +38,7 @@ use nectar_primitives::{
     SwarmAddress,
 };
 
+use vertex_swarm_postage::{BatchId, Stamp, StampIndex};
 use vertex_swarm_redistribution::{
     ClaimAnchor, CommittedDepth, SAMPLE_SIZE, SampleAnchor, SampleItem, canonical_neighbourhood,
     make_inclusion_proofs, reserve_sample,
@@ -126,14 +127,33 @@ fn soc_chunk(n: u64) -> DefaultAnyChunk {
         .expect("SOC chunk builds")
 }
 
+/// A deterministic synthetic stamp for pool item `n`.
+///
+/// `make_inclusion_proofs` requires every witnessed slot to carry the exact
+/// stamp it was won with, so the pool pins a distinct, deterministic stamp per
+/// item. The stamp does not feed the sample ordering (the transformed address is
+/// stamp independent) nor the RC/OG/TR BMT proofs, so attaching it leaves the
+/// `reserve_sample` benchmark's measured work unchanged while letting the
+/// `make_inclusion_proofs` benchmark build a proof at all. The batch id varies
+/// with `n` so distinct slots carry distinguishable stamps.
+fn fixture_stamp(n: u64) -> Stamp {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&n.wrapping_mul(0x9E37_79B9_7F4A_7C15).to_le_bytes());
+    let batch: BatchId = B256::from(bytes);
+    let index = StampIndex::new(n as u32, n as u32);
+    let sig = alloy_primitives::Signature::test_signature();
+    Stamp::with_index(batch, index, 1, sig)
+}
+
 /// A reserve-shaped pool of `count` sample items over distinct CAC bodies.
 ///
-/// Each item carries a real typed CAC and its transformed address, exactly the
-/// work `reserve_sample` orders by. Built outside the measured region.
+/// Each item carries a real typed CAC, its transformed address and a
+/// deterministic winning stamp, exactly the inputs `reserve_sample` orders by
+/// and `make_inclusion_proofs` witnesses. Built outside the measured region.
 fn sample_pool(count: usize) -> Vec<SampleItem> {
     let sample = sample_anchor();
     (0..count as u64)
-        .map(|n| SampleItem::new(sample, cac_chunk(n)))
+        .map(|n| SampleItem::with_stamp(sample, cac_chunk(n), fixture_stamp(n)))
         .collect()
 }
 

--- a/crates/swarm/redistribution/src/filter.rs
+++ b/crates/swarm/redistribution/src/filter.rs
@@ -1,0 +1,350 @@
+//! Consensus candidate-feed filters for the reserve sampler.
+//!
+//! Before a stamped reserve entry may enter the sample, it must pass a small
+//! set of filters that every honest node applies identically. Because the
+//! sample, the reserve-commitment chunk and the inclusion proofs are verified on
+//! chain, these filters are **consensus load bearing**: a node that admits a
+//! candidate the protocol would have excluded (or excludes one the protocol
+//! would have kept) computes a different sample and loses, or is slashed in, the
+//! round. They are therefore pure functions of their inputs, evaluated against a
+//! single round-consistent batch snapshot.
+//!
+//! The three filters below are independent exclusion gates: a candidate failing
+//! any one is dropped, so the final sample does not depend on the order they are
+//! evaluated in (bee splits them across its iterate/assemble phases; we evaluate
+//! them together). [`CandidateFilter::admit`] reports the first gate that fires
+//! so callers can meter each exclusion class. The gates are:
+//!
+//! 1. **Future-timestamp rejection.** The stamp's timestamp, decoded as a
+//!    big-endian `u64` of nanoseconds, must not exceed the round's
+//!    `consensusTime`. A stamp claiming to have been issued after the round was
+//!    fixed cannot have legitimately covered the chunk at sampling time, so it is
+//!    excluded.
+//! 2. **Below-minimum-balance exclusion.** A candidate whose batch's normalised
+//!    per-chunk balance is below the round's `minimumBalance` is excluded. The
+//!    set of such batches is computed once per round from the snapshot
+//!    ([`RoundBatches::is_below_minimum_balance`]) so the same batches are
+//!    excluded uniformly across every candidate.
+//! 3. **Rogue-chunk / valid-stamp rejection.** Only content-addressed (CAC) and
+//!    single-owner (SOC) chunks are admissible; any other shape is a *rogue*
+//!    chunk and is excluded. The stamp must also be admissible for the batch it
+//!    references in the snapshot (the batch exists and is neither expired nor
+//!    below balance). The expensive per-candidate `ecrecover` is deliberately
+//!    **not** repeated here: the reserve only ever admits entries whose stamps
+//!    were signature-validated on ingest, so re-recovering the signer for every
+//!    sampling candidate would be redundant work that changes no outcome. See
+//!    the design note on [`CandidateFilter`].
+//!
+//! A candidate that passes all three is mapped to a [`SampleItem`] carrying its
+//! exact winning stamp, ready for [`reserve_sample`](crate::reserve_sample).
+
+use nectar_primitives::AnyChunk;
+use vertex_swarm_postage::{BatchId, PostageContext, Stamp};
+
+use crate::anchor::SampleAnchor;
+use crate::sample::SampleItem;
+
+/// Why the candidate filter excluded a stamped reserve entry.
+///
+/// Kept as an explicit reason (rather than a bare `bool`) so callers can meter
+/// each exclusion class, exactly as the reference node's sampler statistics do
+/// (future stamps, below-balance, invalid/rogue), without re-deriving which gate
+/// fired.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FilterRejection {
+    /// The stamp's big-endian timestamp exceeded the round `consensusTime`.
+    FutureTimestamp,
+    /// The candidate's batch balance is below the round minimum.
+    BelowMinimumBalance,
+    /// The chunk is neither a CAC nor a SOC (a rogue chunk).
+    RogueChunk,
+    /// The stamp is not admissible for its batch in the round snapshot (the
+    /// batch is unknown or expired).
+    InvalidStamp,
+}
+
+/// A round-consistent view of postage batch state for the sampler.
+///
+/// The sampler reads batch facts for a single redistribution round through this
+/// trait so that every candidate in the round sees one frozen snapshot: the
+/// `consensusTime`, the `minimumBalance` and the per-batch balance facts must
+/// not move underneath the candidate feed mid-round, or two candidates could be
+/// judged against different state and the sample would no longer be a pure
+/// function of the round inputs.
+///
+/// It is intentionally minimal: the full
+/// [`BatchStore`](vertex_swarm_postage::BatchStore) is consulted once when the
+/// snapshot is taken, not per candidate. The node provides a concrete
+/// implementation (typically a frozen map of the batches in range); the
+/// consensus filters here depend only on this small surface, which keeps them
+/// pure and unit-testable with a synthetic snapshot and no chain.
+pub trait RoundBatches {
+    /// The round's `consensusTime`: the upper bound (inclusive) on a stamp's
+    /// big-endian timestamp, in the same nanosecond unit the stamp carries.
+    fn consensus_time(&self) -> u64;
+
+    /// Whether `batch` is below the round's minimum balance and must be
+    /// excluded. Computed once per round against the frozen snapshot so the
+    /// exclusion set is identical for every candidate.
+    fn is_below_minimum_balance(&self, batch: &BatchId) -> bool;
+
+    /// Whether `batch` is admissible at all in this round: present in the
+    /// snapshot and not expired under the round [`PostageContext`]. A stamp
+    /// referencing a batch that fails this is treated as an invalid stamp.
+    fn is_admissible(&self, batch: &BatchId) -> bool;
+}
+
+/// The consensus candidate-feed filter for one redistribution round.
+///
+/// Holds a borrow of the round snapshot and applies the three exclusion gates.
+/// It is the single place the sampler decides whether a stamped reserve entry
+/// may become a sample candidate. The gates are independent drop conditions, so
+/// their evaluation order does not affect the sample; [`admit`](Self::admit)
+/// returns the first that fires only so each exclusion class can be metered.
+///
+/// # Why no per-candidate `ecrecover`
+///
+/// The stamp digest and EIP-191 `ecrecover` are owned by nectar's stamp
+/// validation and are run when a stamp is admitted to the reserve (on ingest).
+/// By the time a stamped entry is a sampling candidate it has already been
+/// signature-validated, and the reserve never holds an entry whose stamp failed
+/// recovery. Re-recovering the signer for every candidate of every round would
+/// therefore be pure redundant work that cannot change any admission decision.
+/// The valid-stamp gate here is consequently structural: it checks that the
+/// stamp's batch is still admissible (known, unexpired, not below balance) in
+/// the round snapshot, and that the chunk is not a rogue shape. The cryptographic
+/// guarantee is upheld upstream, not re-litigated in the hot sampling loop.
+#[derive(Clone, Copy, Debug)]
+pub struct CandidateFilter<'a, R> {
+    batches: &'a R,
+    context: &'a PostageContext,
+}
+
+impl<'a, R: RoundBatches> CandidateFilter<'a, R> {
+    /// Build the filter for a round from its frozen batch snapshot and the
+    /// round's [`PostageContext`].
+    ///
+    /// The context is the frozen round context (block height and cumulative
+    /// payout) and is held so callers and the snapshot implementor can read it
+    /// back via [`context`](Self::context); it is *not* consulted inside
+    /// [`admit`](Self::admit). Expiry is the [`RoundBatches`] implementor's
+    /// responsibility: it must fold the same context into
+    /// [`RoundBatches::is_admissible`] (and the below-balance set) when it freezes
+    /// the snapshot, so every candidate in the round is judged against one
+    /// consistent expiry view.
+    #[must_use]
+    pub const fn new(batches: &'a R, context: &'a PostageContext) -> Self {
+        Self { batches, context }
+    }
+
+    /// The round's `consensusTime`, threaded from the snapshot.
+    #[must_use]
+    pub fn consensus_time(&self) -> u64 {
+        self.batches.consensus_time()
+    }
+
+    /// The round [`PostageContext`].
+    #[must_use]
+    pub const fn context(&self) -> &PostageContext {
+        self.context
+    }
+
+    /// Decide whether `(chunk, stamp)` is an admissible sample candidate.
+    ///
+    /// Applies the three exclusion gates and returns the first reason the
+    /// candidate is excluded, or `Ok(())` if it passes them all. The gates are
+    /// independent, so the reported reason is the first that fires, not a
+    /// protocol-mandated precedence. Pure: it reads only `stamp`, the chunk type,
+    /// and the frozen snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`FilterRejection`] for the first gate the candidate fails.
+    pub fn admit(&self, chunk: &AnyChunk, stamp: &Stamp) -> Result<(), FilterRejection> {
+        // (1) Future-timestamp: a stamp timestamped after the round was fixed
+        // could not have legitimately covered the chunk at sampling time.
+        if stamp.timestamp() > self.batches.consensus_time() {
+            return Err(FilterRejection::FutureTimestamp);
+        }
+
+        let batch = stamp.batch();
+
+        // (2) Below-minimum-balance: uniform per-round exclusion set.
+        if self.batches.is_below_minimum_balance(&batch) {
+            return Err(FilterRejection::BelowMinimumBalance);
+        }
+
+        // (3a) Rogue chunk: only CAC and SOC are admissible shapes.
+        if !(chunk.is_content() || chunk.is_single_owner()) {
+            return Err(FilterRejection::RogueChunk);
+        }
+
+        // (3b) Valid stamp (structural; no redundant ecrecover): the batch must
+        // still be admissible (known and unexpired) in the round snapshot.
+        if !self.batches.is_admissible(&batch) {
+            return Err(FilterRejection::InvalidStamp);
+        }
+
+        Ok(())
+    }
+
+    /// Build a sample candidate from `(chunk, stamp)` if it passes the filters.
+    ///
+    /// On admission the exact winning stamp travels with the item via
+    /// [`SampleItem::with_stamp`], so the eventual inclusion proof witnesses that
+    /// precise stamp. Returns `None` (with the reason discarded) when the
+    /// candidate is excluded; use [`Self::admit`] directly when the rejection
+    /// reason is needed (e.g. for metrics).
+    #[must_use]
+    pub fn candidate(
+        &self,
+        sample: SampleAnchor,
+        chunk: AnyChunk,
+        stamp: Stamp,
+    ) -> Option<SampleItem> {
+        match self.admit(&chunk, &stamp) {
+            Ok(()) => Some(SampleItem::with_stamp(sample, chunk, stamp)),
+            Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test assertions over known-bounds synthetic inputs"
+)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+    use nectar_primitives::{AnyChunk, DefaultContentChunk};
+    use std::collections::HashSet;
+    use vertex_swarm_postage::{Stamp, StampIndex};
+
+    /// A synthetic round snapshot: a fixed `consensusTime`, a below-balance set
+    /// and an admissible set, all frozen for the round.
+    struct TestRound {
+        consensus_time: u64,
+        below_balance: HashSet<BatchId>,
+        admissible: HashSet<BatchId>,
+    }
+
+    impl RoundBatches for TestRound {
+        fn consensus_time(&self) -> u64 {
+            self.consensus_time
+        }
+        fn is_below_minimum_balance(&self, batch: &BatchId) -> bool {
+            self.below_balance.contains(batch)
+        }
+        fn is_admissible(&self, batch: &BatchId) -> bool {
+            self.admissible.contains(batch)
+        }
+    }
+
+    fn cac(payload: &[u8]) -> AnyChunk {
+        DefaultContentChunk::new(payload.to_vec()).unwrap().into()
+    }
+
+    /// A stamp for `batch` at `timestamp`. The signature bytes are irrelevant to
+    /// these structural filters (no ecrecover is performed here), so a fixed
+    /// dummy signature keeps the test focused on the gates.
+    fn stamp_for(batch: BatchId, timestamp: u64) -> Stamp {
+        let index = StampIndex::new(0, 0);
+        let sig = alloy_primitives::Signature::test_signature();
+        Stamp::with_index(batch, index, timestamp, sig)
+    }
+
+    fn batch_id(byte: u8) -> BatchId {
+        B256::repeat_byte(byte)
+    }
+
+    fn anchor() -> SampleAnchor {
+        SampleAnchor::new(B256::repeat_byte(0xab))
+    }
+
+    fn round(consensus_time: u64) -> TestRound {
+        let good = batch_id(0x01);
+        TestRound {
+            consensus_time,
+            below_balance: HashSet::new(),
+            admissible: HashSet::from([good]),
+        }
+    }
+
+    fn ctx() -> PostageContext {
+        PostageContext::new(0, 0)
+    }
+
+    #[test]
+    fn admits_a_well_formed_candidate() {
+        let r = round(1_000);
+        let c = ctx();
+        let f = CandidateFilter::new(&r, &c);
+        let s = stamp_for(batch_id(0x01), 500);
+        assert_eq!(f.admit(&cac(b"hello"), &s), Ok(()));
+        assert!(f.candidate(anchor(), cac(b"hello"), s).is_some());
+    }
+
+    #[test]
+    fn rejects_future_timestamp() {
+        let r = round(1_000);
+        let c = ctx();
+        let f = CandidateFilter::new(&r, &c);
+        // Strictly greater than consensusTime is rejected; equal is allowed.
+        let future = stamp_for(batch_id(0x01), 1_001);
+        assert_eq!(
+            f.admit(&cac(b"x"), &future),
+            Err(FilterRejection::FutureTimestamp)
+        );
+        let boundary = stamp_for(batch_id(0x01), 1_000);
+        assert_eq!(f.admit(&cac(b"x"), &boundary), Ok(()));
+    }
+
+    #[test]
+    fn excludes_below_minimum_balance() {
+        let mut r = round(1_000);
+        let poor = batch_id(0x09);
+        r.admissible.insert(poor);
+        r.below_balance.insert(poor);
+        let c = ctx();
+        let f = CandidateFilter::new(&r, &c);
+        let s = stamp_for(poor, 500);
+        assert_eq!(
+            f.admit(&cac(b"x"), &s),
+            Err(FilterRejection::BelowMinimumBalance)
+        );
+        assert!(f.candidate(anchor(), cac(b"x"), s).is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_stamp_for_unknown_batch() {
+        let r = round(1_000);
+        let c = ctx();
+        let f = CandidateFilter::new(&r, &c);
+        // A batch absent from the admissible set is an invalid stamp.
+        let s = stamp_for(batch_id(0xee), 500);
+        assert_eq!(f.admit(&cac(b"x"), &s), Err(FilterRejection::InvalidStamp));
+    }
+
+    #[test]
+    fn future_timestamp_excluded_identically_to_below_balance() {
+        // The three exclusion classes all produce no candidate; the feed must
+        // drop them uniformly regardless of which gate fired.
+        let mut r = round(1_000);
+        let poor = batch_id(0x09);
+        r.admissible.insert(poor);
+        r.below_balance.insert(poor);
+        let c = ctx();
+        let f = CandidateFilter::new(&r, &c);
+
+        let future = stamp_for(batch_id(0x01), 5_000);
+        let below = stamp_for(poor, 100);
+        let unknown = stamp_for(batch_id(0xee), 100);
+
+        assert!(f.candidate(anchor(), cac(b"a"), future).is_none());
+        assert!(f.candidate(anchor(), cac(b"b"), below).is_none());
+        assert!(f.candidate(anchor(), cac(b"c"), unknown).is_none());
+    }
+}

--- a/crates/swarm/redistribution/src/lib.rs
+++ b/crates/swarm/redistribution/src/lib.rs
@@ -29,15 +29,21 @@
 //!   distinct types, so they cannot be transposed.
 //! - [`CommittedDepth`] / [`canonical_neighbourhood`]: the chunk addresses a
 //!   node is responsible for at a given depth.
+//! - [`CandidateFilter`] / [`RoundBatches`]: the consensus candidate-feed
+//!   filters (future timestamp, below-minimum-balance, rogue/invalid stamp)
+//!   applied against a round-consistent batch snapshot before sampling.
 //! - [`SampleItem`] / [`reserve_sample`]: the [`SAMPLE_SIZE`] chunks with the
-//!   smallest transformed addresses.
+//!   smallest transformed addresses. Each item carries the exact stamp its slot
+//!   was won with.
 //! - [`WitnessIndices`] / [`witness_indices`]: the sample slots a claim opens.
 //! - [`make_inclusion_proofs`] / [`ChunkInclusionProof`]: the proof of
-//!   entitlement submitted to the contract.
+//!   entitlement submitted to the contract, each witness carrying the precise
+//!   winning stamp as its single `PostageProof`.
 
 mod anchor;
 mod args;
 mod config;
+mod filter;
 mod neighbourhood;
 mod proof;
 mod sample;
@@ -49,6 +55,7 @@ pub const SAMPLE_SIZE: usize = 16;
 pub use anchor::{ClaimAnchor, SampleAnchor};
 pub use args::RedistributionArgs;
 pub use config::StorageConfig;
+pub use filter::{CandidateFilter, FilterRejection, RoundBatches};
 pub use neighbourhood::{
     CapacityDoubling, CapacityDoublingError, CommittedDepth, canonical_neighbourhood,
 };

--- a/crates/swarm/redistribution/src/proof.rs
+++ b/crates/swarm/redistribution/src/proof.rs
@@ -3,6 +3,7 @@
 use nectar_primitives::bmt::Prover;
 use nectar_primitives::error::PrimitivesError;
 use nectar_primitives::{AnyChunk, DefaultHasher, Proof};
+use vertex_swarm_postage::Stamp;
 
 use crate::SAMPLE_SIZE;
 use crate::anchor::{ClaimAnchor, SampleAnchor};
@@ -12,7 +13,8 @@ use crate::witness::witness_indices;
 /// A single chunk's inclusion proof within the proof of entitlement.
 ///
 /// This is the structure submitted to `Redistribution.sol`. It bundles three
-/// BMT proofs for one witnessed sample item:
+/// BMT proofs for one witnessed sample item plus the exact postage stamp the
+/// slot was won with:
 ///
 /// - [`Self::rc_proof`] (`proofSegments`/`proveSegment`): the item's slot in the
 ///   reserve-commitment chunk.
@@ -20,8 +22,14 @@ use crate::witness::witness_indices;
 ///   (original) BMT segment proof over the chunk's own body.
 /// - [`Self::tr_proof`] (`proofSegments3`): a sample-anchor-prefixed (transformed)
 ///   BMT segment proof over the same body.
-///
-/// Postage and SOC witness data are tracked separately.
+/// - [`Self::postage_proof`]: the single [`Stamp`] the slot was won with. The
+///   consensus rule is that each witness carries **exactly one** postage proof,
+///   and it is the precise stamp `(batchID, 8-byte index, timestamp,
+///   signature)` the candidate was selected under, taken straight off the
+///   winning [`SampleItem::stamp`]. It is never re-loaded by `batchID` alone: a
+///   batch holds many distinct stamps, so a batch-keyed reload could witness a
+///   different stamp than the one that actually won the slot, which the on-chain
+///   verifier would reject.
 #[derive(Clone, Debug)]
 pub struct ChunkInclusionProof {
     /// Reserve-commitment chunk inclusion proof (OG of the RC chunk).
@@ -32,6 +40,9 @@ pub struct ChunkInclusionProof {
     pub tr_proof: Proof,
     /// The little-endian `u64` span of the witnessed chunk body (`chunkSpan`).
     pub chunk_span: u64,
+    /// The exact postage stamp the witnessed slot was won with (the witness's
+    /// single `PostageProof`).
+    pub postage_proof: Stamp,
 }
 
 /// The three-witness proof of entitlement.
@@ -115,6 +126,17 @@ pub enum ProofError {
     /// The sample did not contain exactly [`SAMPLE_SIZE`] items.
     #[error("reserve sample must have {SAMPLE_SIZE} items, got {0}")]
     SampleSize(usize),
+    /// A witnessed slot had no stamp pinned to it.
+    ///
+    /// Each witness must carry exactly one `PostageProof`: the precise stamp the
+    /// slot was won with (see [`ChunkInclusionProof::postage_proof`]). A winning
+    /// candidate must therefore be built with [`SampleItem::with_stamp`]; a slot
+    /// reaching proof time with [`SampleItem::stamp`] unset is a construction
+    /// bug, refused here rather than papered over by re-loading a stamp by
+    /// `batchID` (which could witness a different stamp than the one that won).
+    /// Carries the offending sample slot index.
+    #[error("witnessed sample slot {0} has no stamp to prove")]
+    MissingStamp(usize),
     /// A BMT proof could not be generated.
     #[error(transparent)]
     #[strum(serialize = "bmt_error")]
@@ -141,12 +163,18 @@ pub enum ProofError {
 /// and [`AnyChunk::data`] already delegate to the inner BMT body for both CAC
 /// and SOC, so a SOC needs no `id`/`signature` header slicing.
 ///
+/// Each emitted witness also carries the exact stamp its slot was won with
+/// ([`ChunkInclusionProof::postage_proof`]), read from [`SampleItem::stamp`]: it
+/// is the single `PostageProof` the consensus rule requires, and it is never
+/// re-loaded by `batchID` alone.
+///
 /// # Errors
 ///
 /// Returns an error if `items` does not contain exactly [`SAMPLE_SIZE`]
-/// elements, or if any underlying BMT proof generation fails (e.g. an
-/// out-of-range segment index). The anchors are `bytes32` by construction, so
-/// the function never has to check for an unset salt.
+/// elements, if a witnessed slot has no stamp pinned to it
+/// ([`ProofError::MissingStamp`]), or if any underlying BMT proof generation
+/// fails (e.g. an out-of-range segment index). The anchors are `bytes32` by
+/// construction, so the function never has to check for an unset salt.
 pub fn make_inclusion_proofs(
     items: &[SampleItem],
     sample: SampleAnchor,
@@ -176,6 +204,12 @@ pub fn make_inclusion_proofs(
         debug_assert!(slot < items.len(), "witness slot out of sample bounds");
         let item = items.get(slot).ok_or(ProofError::SampleSize(items.len()))?;
 
+        // The single PostageProof for this witness: the exact stamp the slot was
+        // won with, taken straight off the winning item. Never re-loaded by
+        // batchID (a batch holds many stamps), so the witnessed stamp is byte-
+        // identical to the one the candidate was selected under.
+        let postage_proof = item.stamp.clone().ok_or(ProofError::MissingStamp(slot))?;
+
         // RC chunk inclusion proof at the even slot holding the chunk address.
         let rc_proof = rc_hash.generate_proof(&rc_content, slot * 2)?;
 
@@ -198,6 +232,7 @@ pub fn make_inclusion_proofs(
             og_proof,
             tr_proof,
             chunk_span: body.span,
+            postage_proof,
         })
     };
 

--- a/crates/swarm/redistribution/src/sample.rs
+++ b/crates/swarm/redistribution/src/sample.rs
@@ -1,6 +1,7 @@
 //! The reserve sample: selection and the reserve-commitment body.
 
 use nectar_primitives::{AnyChunk, ChunkAddress};
+use vertex_swarm_postage::Stamp;
 
 use crate::SAMPLE_SIZE;
 use crate::anchor::SampleAnchor;
@@ -15,26 +16,72 @@ use crate::anchor::SampleAnchor;
 /// inner BMT body for both, so SOC witness reads need no `id`/`signature`
 /// header slicing.
 ///
-/// The postage-stamp witness is intentionally absent: it is not built here.
-/// Reintroduce it via `nectar_postage::Stamp` only when that witness lands.
+/// # The winning stamp travels with the item
+///
+/// A chunk's content address is stamp independent, but the reserve admits one
+/// entry per distinct stamped entry `(batchID, 8-byte stampIndex, address)`, and
+/// the consensus rule is that each inclusion-proof witness must carry the
+/// **exact** stamp the sample slot was won with: the precise `(batchID,
+/// stampIndex, timestamp, signature)`, not a stamp re-loaded by `batchID` alone
+/// (a batch holds many distinct stamps; re-loading by batch could witness a
+/// different one). [`Self::stamp`] therefore pins that identity to the slot from
+/// the moment the candidate is selected, and [`make_inclusion_proofs`] reads it
+/// straight off the winning item.
+///
+/// [`make_inclusion_proofs`]: crate::make_inclusion_proofs
+///
+/// The stamp is an [`Option`] only because the consensus *ordering* primitives
+/// ([`reserve_sample`], [`reserve_commitment_content`]) and their byte-for-byte
+/// reference vectors are stamp independent: those fixtures exercise the
+/// transformed-address geometry and carry no stamp. A real candidate feed always
+/// builds items with [`Self::with_stamp`]; a `None` stamp surfaces as a
+/// [`ProofError::MissingStamp`](crate::ProofError::MissingStamp) the moment a
+/// proof of entitlement is built for that slot, so an unstamped item can never
+/// silently win a round.
+///
+/// [`reserve_commitment_content`]: crate::reserve_commitment_content
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SampleItem {
     /// The anchor-keyed transformed address the sample is ordered by.
     pub transformed_address: ChunkAddress,
     /// The typed chunk (content or single-owner) this item witnesses.
     pub chunk: AnyChunk,
+    /// The exact stamp this slot was won with: the precise `(batchID,
+    /// stampIndex, timestamp, signature)` carried straight into the inclusion
+    /// proof. `None` only for the stamp-independent ordering fixtures (see the
+    /// type-level note); a candidate feed always sets it.
+    pub stamp: Option<Stamp>,
 }
 
 impl SampleItem {
-    /// Build a sample item for `chunk` under the sample-time anchor.
+    /// Build a stamp-independent sample item for `chunk` under the sample-time
+    /// anchor.
     ///
     /// The transformed address is computed by nectar's
-    /// [`transformed_address`](AnyChunk::transformed_address).
+    /// [`transformed_address`](AnyChunk::transformed_address). This constructor
+    /// leaves [`Self::stamp`] unset and exists for the consensus *ordering*
+    /// vectors, which are stamp independent. Production candidate feeds use
+    /// [`Self::with_stamp`] so the winning stamp travels with the slot.
     #[must_use]
     pub fn new(sample: SampleAnchor, chunk: AnyChunk) -> Self {
         Self {
             transformed_address: chunk.transformed_address(sample.as_bytes()),
             chunk,
+            stamp: None,
+        }
+    }
+
+    /// Build a sample item carrying the exact `stamp` the slot was won with.
+    ///
+    /// This is the candidate-feed constructor: it pins the precise stamp
+    /// identity to the slot so the proof of entitlement witnesses that stamp and
+    /// no other (see the type-level note).
+    #[must_use]
+    pub fn with_stamp(sample: SampleAnchor, chunk: AnyChunk, stamp: Stamp) -> Self {
+        Self {
+            transformed_address: chunk.transformed_address(sample.as_bytes()),
+            chunk,
+            stamp: Some(stamp),
         }
     }
 
@@ -56,8 +103,42 @@ impl SampleItem {
 /// is *not* a valid SOC), so that the on-chain ordering check cannot be gamed by
 /// a single-owner chunk colliding with a CAC. We reproduce that exact tie-break.
 ///
-/// `candidates` may be supplied in any order; the output order depends only on
-/// the transformed addresses.
+/// # Determinism and the same-content multi-batch tie
+///
+/// `candidates` may be supplied in any order: the set of selected slots and the
+/// committed reserve-commitment bytes depend only on the transformed addresses,
+/// not on insertion order.
+///
+/// One subtlety is consensus relevant. The reserve admits one entry per distinct
+/// stamped entry `(batchID, stampIndex, address)`, so the *same content* may be
+/// presented under several batches. Those entries share a content address (it is
+/// stamp independent) and therefore a transformed address, so they tie, and "at
+/// most once" collapses them to a single slot. When two such CAC entries tie the
+/// equal-address branch keeps the **last** CAC seen, so *which batch's stamp*
+/// travels into [`SampleItem::stamp`] (and hence the witness's single
+/// `PostageProof`) is insertion-order dependent.
+///
+/// This matches bee, whose sampler assembles items off a concurrent worker pool
+/// and resolves the same tie by last-CAC-wins, so the kept stamp is likewise not
+/// order-defined there. It is consensus-safe because:
+///
+/// 1. The value committed on chain is the reserve-commitment hash over each
+///    slot's `chunk_address || transformed_address`
+///    ([`reserve_commitment_content`]). Both halves are identical for every tied
+///    entry (same content => same chunk address and, under one anchor, the same
+///    transformed address), so the commitment is byte-identical regardless of
+///    which batch wins the slot.
+/// 2. A witness's `PostageProof` is verified standalone by `Redistribution.sol`:
+///    the stamp signature must bind that chunk address and the batch must be a
+///    valid, funded batch. *Any* owning batch's stamp satisfies that check, so
+///    the contract accepts whichever tied stamp the slot carries.
+///
+/// The tie-break is therefore not extended to pick a canonical stamp: doing so
+/// would diverge from bee for no on-chain benefit, since the committed bytes are
+/// stable and the chain binds the stamp to the chunk, not to a canonical batch.
+/// (Two *different* contents colliding on a transformed address would commit
+/// different `chunk_address` bytes, but that is a 256-bit HMAC-keyed BMT
+/// collision, not a reachable consensus case; bee resolves it the same way.)
 #[must_use]
 pub fn reserve_sample(candidates: impl IntoIterator<Item = SampleItem>) -> Vec<SampleItem> {
     let mut sample: Vec<SampleItem> = Vec::with_capacity(SAMPLE_SIZE + 1);
@@ -91,7 +172,12 @@ fn insert_sample_item(sample: &mut Vec<SampleItem>, item: SampleItem) {
     match sample.get_mut(pos) {
         // Tie on the transformed address: the incumbent is replaced only when
         // the new chunk is a CAC (not a valid SOC), so a CAC always wins the
-        // slot. Either way no new slot is consumed.
+        // slot. Either way no new slot is consumed. For two CACs of the same
+        // content under different batches this keeps the last CAC seen, so the
+        // kept stamp is insertion-order dependent; the committed bytes are
+        // identical regardless and the chain binds the stamp to the chunk, so
+        // this is consensus-safe (see the function-level note, and it mirrors
+        // bee's concurrent last-CAC-wins assembly).
         Some(incumbent) if incumbent.transformed_address == key => {
             if item.chunk.is_content() {
                 *incumbent = item;

--- a/crates/swarm/redistribution/tests/conformance.rs
+++ b/crates/swarm/redistribution/tests/conformance.rs
@@ -37,6 +37,24 @@ use nectar_primitives::{
     SwarmAddress,
 };
 
+use vertex_swarm_postage::{BatchId, Stamp, StampIndex};
+
+/// A deterministic synthetic stamp for fixture item `slot`.
+///
+/// The reference inclusion-proof vectors are stamp independent (they pin the
+/// RC/OG/TR BMT geometry, which the stamp never feeds), but a proof of
+/// entitlement now requires each witnessed slot to carry the exact stamp it was
+/// won with. We therefore pin a distinct, deterministic stamp per slot so the
+/// byte-for-byte proof assertions remain unchanged while the proof can also be
+/// shown to witness *that precise* stamp (see the exact-stamp test). The batch
+/// id is the slot index so different slots carry distinguishable stamps.
+fn fixture_stamp(slot: usize) -> Stamp {
+    let batch: BatchId = B256::repeat_byte(0xc0 + slot as u8);
+    let index = StampIndex::new(slot as u32, slot as u32);
+    let sig = alloy_primitives::Signature::test_signature();
+    Stamp::with_index(batch, index, 1, sig)
+}
+
 // --- single-CAC transformed-address vector -----------------------------------
 
 const ANCHOR_CAC: &[u8] = b"swarm-test-anchor-deterministic!";
@@ -155,11 +173,18 @@ fn parse_chunk(it: &OracleItem) -> DefaultAnyChunk {
 /// Rebuild every sample item from the oracle (typed chunk + transformed address),
 /// asserting the parsed chunk address and the recomputed transformed address
 /// both match the reference.
+///
+/// Each item is pinned with a deterministic [`fixture_stamp`] so a proof of
+/// entitlement can be built (it requires the winning stamp on every witnessed
+/// slot). The stamp does not feed the RC/OG/TR BMT proofs, so attaching it
+/// leaves every byte-for-byte proof assertion unchanged; it does let the
+/// exact-stamp test confirm the proof witnesses *that* stamp.
 fn rebuild_items(oracle: &Oracle, sample: SampleAnchor) -> Vec<SampleItem> {
     oracle
         .items
         .iter()
-        .map(|it| {
+        .enumerate()
+        .map(|(slot, it)| {
             let chunk = parse_chunk(it);
             assert_eq!(
                 hex::encode(chunk.address().as_slice()),
@@ -167,7 +192,7 @@ fn rebuild_items(oracle: &Oracle, sample: SampleAnchor) -> Vec<SampleItem> {
                 "parsed chunk address must match the reference",
             );
 
-            let item = SampleItem::new(sample, chunk);
+            let item = SampleItem::with_stamp(sample, chunk, fixture_stamp(slot));
             assert_eq!(
                 hex::encode(item.transformed_address.as_slice()),
                 it.transformed_address.trim_start_matches("0x"),
@@ -259,6 +284,146 @@ fn inclusion_proofs_match_reference_byte_for_byte() {
         "proof2 (second challenged slot)",
     );
     assert_proof(&proofs.0[2], &oracle.proof_last, "proofLast (last slot)");
+}
+
+/// Each witness must carry the *exact* stamp the sample slot was won with: the
+/// `postage_proof` of witness *k* must be byte-identical to the stamp pinned to
+/// the slot that witness opens, never a stamp re-loaded by batch id alone.
+#[test]
+fn inclusion_proof_witnesses_the_exact_winning_stamp() {
+    let oracle = load_oracle();
+    let sample = sample_anchor(&oracle);
+    let claim = claim_anchor(&oracle);
+    let items = rebuild_items(&oracle, sample);
+
+    let idx = witness_indices(claim);
+    let proofs = make_inclusion_proofs(&items, sample, claim).expect("proofs build");
+
+    // Submission order is [challenged0, challenged1, last]; each carried stamp
+    // must equal the stamp pinned to the very slot it opened.
+    for (proof, slot) in [
+        (&proofs.0[0], idx.challenged[0]),
+        (&proofs.0[1], idx.challenged[1]),
+        (&proofs.0[2], idx.last),
+    ] {
+        let won_with = items[slot].stamp.clone().expect("slot stamp present");
+        assert_eq!(
+            proof.postage_proof, won_with,
+            "witness for slot {slot} must carry that slot's exact winning stamp",
+        );
+        // The precise identity the consensus rule pins: batch id and the full
+        // 8-byte stamp index, not merely the batch.
+        assert_eq!(proof.postage_proof.batch(), won_with.batch());
+        assert_eq!(
+            proof.postage_proof.stamp_index().to_be_bytes(),
+            won_with.stamp_index().to_be_bytes(),
+            "the full 8-byte stamp index must match",
+        );
+    }
+
+    // A distinct slot carries a distinct stamp, so a batch-keyed reload (which
+    // could not tell two stamps of one batch apart) would not satisfy this.
+    assert_ne!(
+        proofs.0[0].postage_proof, proofs.0[2].postage_proof,
+        "different witnessed slots must carry their own distinct stamps",
+    );
+}
+
+/// A sample slot that reaches proof time with no pinned stamp is refused, rather
+/// than papered over by re-loading a stamp by batch id.
+#[test]
+fn inclusion_proof_rejects_a_slot_without_a_stamp() {
+    use vertex_swarm_redistribution::ProofError;
+
+    let oracle = load_oracle();
+    let sample = sample_anchor(&oracle);
+    let claim = claim_anchor(&oracle);
+    let mut items = rebuild_items(&oracle, sample);
+
+    // Drop the stamp on the last slot (always witnessed).
+    let last = items.len() - 1;
+    items[last].stamp = None;
+
+    let err = make_inclusion_proofs(&items, sample, claim).expect_err("must reject");
+    assert!(
+        matches!(err, ProofError::MissingStamp(slot) if slot == last),
+        "expected MissingStamp({last}), got {err:?}",
+    );
+}
+
+/// The same content presented under two different batches is sampled **at most
+/// once**, and the committed reserve-commitment bytes are identical regardless
+/// of insertion order. Only *which batch's stamp* travels with the surviving
+/// slot is order dependent, which is consensus-safe: the chain commits the
+/// (order-invariant) `chunk_address || transformed_address` pair and binds the
+/// witnessed stamp to the chunk, not to a canonical batch. See the
+/// `reserve_sample` function note.
+#[test]
+fn same_content_multi_batch_ties_to_one_slot_with_stable_commitment() {
+    let anchor = SampleAnchor::new(B256::repeat_byte(0x5a));
+
+    // One content chunk, two distinct batches: same chunk address and (under one
+    // anchor) the same transformed address, so they tie.
+    let chunk: DefaultAnyChunk =
+        DefaultContentChunk::new(b"shared payload under two batches".to_vec())
+            .expect("cac builds")
+            .into();
+
+    let stamp_a = {
+        let batch: BatchId = B256::repeat_byte(0xa1);
+        Stamp::with_index(
+            batch,
+            StampIndex::new(1, 1),
+            1,
+            alloy_primitives::Signature::test_signature(),
+        )
+    };
+    let stamp_b = {
+        let batch: BatchId = B256::repeat_byte(0xb2);
+        Stamp::with_index(
+            batch,
+            StampIndex::new(2, 2),
+            2,
+            alloy_primitives::Signature::test_signature(),
+        )
+    };
+
+    let item_a = SampleItem::with_stamp(anchor, chunk.clone(), stamp_a.clone());
+    let item_b = SampleItem::with_stamp(anchor, chunk, stamp_b.clone());
+    assert_eq!(
+        item_a.transformed_address, item_b.transformed_address,
+        "same content under one anchor must share a transformed address",
+    );
+
+    let forward = reserve_sample(vec![item_a.clone(), item_b.clone()]);
+    let reverse = reserve_sample(vec![item_b.clone(), item_a.clone()]);
+
+    // At most once: a single slot in either order.
+    assert_eq!(forward.len(), 1, "tied content must collapse to one slot");
+    assert_eq!(reverse.len(), 1, "tied content must collapse to one slot");
+
+    // The committed bytes (chunk_address || transformed_address) are byte-
+    // identical across orders: nothing order dependent reaches the chain.
+    assert_eq!(
+        reserve_commitment_content(&forward),
+        reserve_commitment_content(&reverse),
+        "the reserve commitment must be insertion-order invariant",
+    );
+
+    // The only order-dependent quantity is which batch's stamp survives; both
+    // orders keep the last CAC seen (consensus-safe, documented as order-agnostic
+    // against bee). This pins the observed behaviour without asserting it is
+    // consensus-binding.
+    assert_eq!(
+        forward[0].stamp.as_ref().map(Stamp::batch),
+        Some(stamp_b.batch()),
+        "forward order keeps the last CAC's stamp",
+    );
+    assert_eq!(
+        reverse[0].stamp.as_ref().map(Stamp::batch),
+        Some(stamp_a.batch()),
+        "reverse order keeps the last CAC's stamp",
+    );
 }
 
 fn assert_proof(


### PR DESCRIPTION
Re-lands the redistribution consensus candidate-feed filters and exact-stamp witness.

The original PR #402 was recorded as merged, but its base was the `feat/reserve-radius-dynamics` branch, which was subsequently rewritten while untangling the #404 rebase. As a result the change did not reach `stack/01`, so this PR restores it on top of the current trunk (it now carries the merged #400, #401, #403 and #404). The content is unchanged from the original; only the base and commit hash differ.

Stacked on: stack/01-grpc-chunk-streaming.

This PR was prepared with AI assistance.
