### PR TITLE
docs: deflate over-verbose rustdoc from the #350 stack

### DIFF
--- a/crates/ffi/src/api/client.rs
+++ b/crates/ffi/src/api/client.rs
@@ -1,10 +1,8 @@
 //! The embedded client handle and its upload/download surface.
 //!
-//! [`VertexClient`] owns a native tokio runtime, the running client node task,
-//! and the chunk provider that drives uploads and downloads. The host builds one
-//! with [`VertexClient::build`], then calls [`VertexClient::upload_chunk`] and
-//! [`VertexClient::download_chunk`]. Dropping the handle fires graceful shutdown
-//! and tears the node down.
+//! [`VertexClient`] owns a native tokio runtime, the running node task, and the
+//! chunk provider for uploads and downloads. Dropping the handle fires graceful
+//! shutdown.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -43,44 +41,31 @@ use crate::error::{FfiError, FfiResult};
 /// How long [`VertexClient`] waits for in-flight tasks during shutdown.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Network chunk provider wrapped with config-gated download verification, the
-/// concrete provider the client builder produces for a client node.
+/// The concrete chunk provider the client builder produces for a client node.
 type ClientChunks = VerifyingChunkProvider<NetworkChunkProvider<Arc<Identity>>>;
 
-/// A running embedded Swarm client.
-///
-/// Opaque to the host: it is constructed and used only through the methods in
-/// this module. It owns the runtime that drives the node so the host does not
-/// have to manage one.
+/// A running embedded Swarm client. Opaque to the host; owns the runtime that
+/// drives the node.
 #[frb(opaque)]
 pub struct VertexClient {
     chunks: ClientChunks,
     runtime: Runtime,
-    // Held so the global executor and the node task stay alive for the lifetime
-    // of the client. Taken on drop to fire graceful shutdown.
+    // Keeps the global executor and node task alive; taken on drop to shut down.
     task_manager: Option<TaskManager>,
 }
 
 impl VertexClient {
-    /// Build and start an embedded client for `config`.
+    /// Build and start an embedded client for `config`, returning once the node
+    /// is running and discovering peers.
     ///
-    /// Spins up a native multi-thread runtime, constructs the client node on it,
-    /// and spawns the node's event loop as a background task. Returns once the
-    /// node is built and running; the client begins discovering peers
-    /// immediately.
-    ///
-    /// One client per process. The node internals resolve their task executor
-    /// from a process-global slot that the first built client populates, so a
-    /// second concurrent client would spawn its node tasks onto the first
-    /// client's runtime. Build a single client, hold it for the process
-    /// lifetime, and drop it to shut the node down.
+    /// One client per process: node internals resolve their executor from a
+    /// process-global slot the first client populates, so a second concurrent
+    /// client would spawn onto the first client's runtime.
     pub fn build(config: VertexClientConfig) -> Result<VertexClient, FfiError> {
         let runtime = Runtime::new().map_err(|e| FfiError::Build {
             reason: format!("runtime: {e}"),
         })?;
 
-        // The task manager registers the global executor against the runtime
-        // handle and owns the shutdown signal the node task observes.
         let task_manager = TaskManager::new(runtime.handle().clone());
         let executor = task_manager.executor();
 
@@ -117,17 +102,12 @@ impl VertexClient {
         })
     }
 
-    /// Upload a pre-stamped chunk to the storers closest to its address.
-    ///
-    /// The chunk, its address, and its postage stamp are reconstructed into a
-    /// strong [`StampedChunk`] before any network call. Returns the first
-    /// storer's receipt.
+    /// Upload a pre-stamped chunk to the storers closest to its address,
+    /// returning the first storer's receipt.
     pub fn upload_chunk(&self, chunk: VertexChunkUpload) -> Result<VertexPushReceipt, FfiError> {
         let validate = chunk.validate;
         let stamped = reconstruct_upload(chunk)?;
 
-        // `put` selects the stamp-signature check from the flag, collapsing the
-        // former validate? branch onto the chunk core.
         let receipt = self.runtime.block_on(self.chunks.put(stamped, validate));
 
         receipt.map(receipt_into_ffi).map_err(|e| FfiError::Upload {
@@ -135,11 +115,10 @@ impl VertexClient {
         })
     }
 
-    /// Download the chunk at `address` from the network.
+    /// Download the chunk at the 32-byte `address`.
     ///
-    /// `address` is the chunk's 32-byte address. `verify_stamp` opts into postage
-    /// stamp signer recovery; chunk content integrity is always enforced by the
-    /// retrieval path.
+    /// `verify_stamp` opts into postage stamp signer recovery; chunk content
+    /// integrity is always enforced by the retrieval path.
     pub fn download_chunk(
         &self,
         address: Vec<u8>,
@@ -156,9 +135,7 @@ impl VertexClient {
 
         let served_by = result.served_by.to_string();
 
-        // A storer may omit the stamp from a delivery; the chunk is still
-        // address-validated. Verify only a present stamp, and emit an empty
-        // stamp field when absent.
+        // A delivery may omit the stamp; the chunk is still address-validated.
         if verify_stamp && let Some(stamp) = &result.stamp {
             stamp
                 .recover_signer(&address)
@@ -181,23 +158,15 @@ impl VertexClient {
 
     /// Open a memory-bounded streaming download over a list of chunk addresses.
     ///
-    /// Returns a pull-based [`VertexDownloadStream`] handle, not a pushed sink.
-    /// The host drives it by awaiting [`VertexDownloadStream::next`] once per
-    /// item; the core retrieval pipeline advances only when the host pulls, so a
-    /// host that stops awaiting transitively pauses the network reads and nothing
-    /// is buffered on the host's behalf. At most `config.max_concurrency` chunks
-    /// are in flight. Items arrive in completion order, each carrying its
-    /// address. A per-address failure (a miss, wrong bytes, or no candidate
-    /// peer) arrives as an item carrying `error`, never as a torn-down stream.
-    /// The returned [`FfiError`] only covers up-front input rejection (a
-    /// malformed address); retrieval failures surface as items.
+    /// At most `config.max_concurrency` chunks are in flight, arriving in
+    /// completion order. A per-address failure surfaces as an item carrying
+    /// `error`, not a torn-down stream; the returned [`FfiError`] only covers a
+    /// malformed address rejected up front.
     pub fn download_stream(
         &self,
         addresses: Vec<Vec<u8>>,
         config: VertexStreamConfig,
     ) -> Result<VertexDownloadStream, FfiError> {
-        // Reject malformed input up front so the host learns immediately rather
-        // than mid-stream.
         let parsed: Vec<ChunkAddress> = addresses
             .iter()
             .map(|bytes| parse_address(bytes))
@@ -212,33 +181,24 @@ impl VertexClient {
 
     /// Open a memory-bounded streaming upload over a list of pre-stamped chunks.
     ///
-    /// Returns a pull-based [`VertexUploadStream`] handle. The host drives it by
-    /// awaiting [`VertexUploadStream::next`] once per chunk; the core push
-    /// pipeline admits a new push only when the host pulls, up to
-    /// `config.max_concurrency` at once, so a host that stops awaiting acks
-    /// transitively pauses the network pushes. Each chunk is reconstructed into a
-    /// strong [`StampedChunk`] lazily, as the pipeline admits it.
-    ///
-    /// A chunk whose bytes do not match its address fails at admission and
-    /// surfaces as the ack item for that chunk carrying `error`; the stream then
-    /// continues with the rest. Per-chunk push failures (no storer, rejection)
-    /// surface the same way.
+    /// Up to `config.max_concurrency` pushes are in flight; each chunk is
+    /// reconstructed lazily as admitted. A per-chunk failure (address mismatch,
+    /// no storer, rejection) surfaces as that chunk's ack carrying `error`; the
+    /// stream continues.
     pub fn upload_stream(
         &self,
         chunks: Vec<VertexChunkUpload>,
         config: VertexStreamConfig,
     ) -> Result<VertexUploadStream, FfiError> {
         let cfg = stream_config(config);
-        // Parse each chunk's address up front so a malformed address fails before
-        // any push starts, and so the feed can pair each chunk with its address.
+        // Parse all addresses before any push, so a malformed one fails up front.
         let addresses: Vec<ChunkAddress> = chunks
             .iter()
             .map(|chunk| parse_address(&chunk.address))
             .collect::<FfiResult<_>>()?;
 
         let sender = self.chunks.clone();
-        // Reconstruct each chunk only as the pipeline pulls it. A reconstruction
-        // failure surfaces as that address's error ack rather than aborting.
+        // Lazy per-chunk reconstruction: a failure becomes an error ack, not an abort.
         let feed = addresses.into_iter().zip(chunks).map(|(address, chunk)| {
             let built = reconstruct_upload(chunk).map_err(|e| SwarmError::InvalidChunk {
                 address: Some(address),
@@ -253,38 +213,26 @@ impl VertexClient {
     }
 }
 
-/// Mutable state of a [`VertexDownloadStream`]: the core stream and the next
-/// item index. The address comes from each stream item, not by position.
 struct DownloadState {
     inner: GetStream<ClientChunks>,
     index: u64,
 }
 
-/// A pull-based streaming download handle.
-///
-/// Opaque to the host: it holds the bounded core [`GetStream`] pipeline and is
-/// driven one item at a time through [`Self::next`]. Because the core advances
-/// only when polled, a host that awaits slowly paces the network reads and the
-/// in-flight byte window is never exceeded; nothing accumulates on the host's
-/// behalf. Dropping the handle drops the core stream and cancels its in-flight
+/// A pull-based streaming download handle, opaque to the host and driven one
+/// item at a time through [`Self::next`]. Dropping it cancels in-flight
 /// retrievals.
 ///
-/// The core stream's in-flight futures are `Send` but not `Sync`, while the
-/// bridge requires the opaque handle to be `Sync`; the `tokio::sync::Mutex`
-/// supplies that (`Mutex<T>: Sync` for `T: Send`) and is held across the single
-/// `next` poll. The host drives one stream serially, so the lock is uncontended.
+/// The `tokio::sync::Mutex` makes the handle `Sync` for the bridge (the core
+/// stream's in-flight futures are `Send` but not `Sync`); held only across the
+/// single `next` poll, uncontended since the host drives serially.
 #[frb(opaque)]
 pub struct VertexDownloadStream {
     state: tokio::sync::Mutex<DownloadState>,
 }
 
 impl VertexDownloadStream {
-    /// Pull the next downloaded chunk, or `None` once every address has produced
-    /// an item.
-    ///
-    /// Polls the core stream once. Items arrive in completion order, each
-    /// carrying its address. Awaiting this is the backpressure: until the host
-    /// calls it, the core issues no further retrievals.
+    /// Pull the next downloaded chunk in completion order, or `None` once every
+    /// address has produced an item. Awaiting this is the backpressure.
     pub async fn next(&self) -> Option<VertexChunkData> {
         let mut state = self.state.lock().await;
         let (address, result) = state.inner.next().await?;
@@ -294,13 +242,10 @@ impl VertexDownloadStream {
         Some(match result {
             Ok(verified) => {
                 let (chunk, stamp) = verified.into_parts();
-                // A storer may omit the stamp from a delivery; emit an empty
-                // stamp field when absent.
                 let stamp = stamp.map(|s| s.to_bytes().to_vec()).unwrap_or_default();
                 VertexChunkData {
                     index,
                     address,
-                    // One copy at the boundary; the chunk stayed `Bytes` until here.
                     data: chunk.into_bytes().to_vec(),
                     stamp,
                     error: None,
@@ -317,23 +262,17 @@ impl VertexDownloadStream {
     }
 }
 
-/// Mutable state of a [`VertexUploadStream`]: the core stream and the next ack
-/// index. The address comes from each stream item, not by position.
 struct UploadState {
     inner: PutStream<ClientChunks>,
     index: u64,
 }
 
-/// A pull-based streaming upload handle.
-///
-/// Opaque to the host: it holds the bounded core [`PutStream`] pipeline and is
-/// driven one ack at a time through [`Self::next`]. The core admits a push only
-/// as the host pulls, so a host that stops awaiting acks pauses the pushes.
-/// Dropping the handle drops the core stream and cancels its in-flight pushes.
+/// A pull-based streaming upload handle, opaque to the host and driven one ack
+/// at a time through [`Self::next`]. Dropping it cancels in-flight pushes.
 ///
 /// The `tokio::sync::Mutex` makes the handle `Sync` for the bridge (the core
-/// stream is `Send` but not `Sync`); it is held only across the single `next`
-/// poll and is uncontended because the host drives one stream serially.
+/// stream is `Send` but not `Sync`); held only across the single `next` poll,
+/// uncontended since the host drives serially.
 #[frb(opaque)]
 pub struct VertexUploadStream {
     state: tokio::sync::Mutex<UploadState>,
@@ -374,10 +313,8 @@ impl Drop for VertexClient {
 
 /// Minimal infrastructure context for building the client outside the CLI.
 ///
-/// The launch path needs an executor and a data directory. The FFI client runs
-/// fully in-memory: `db_path()` stays `None`, so no database is opened and no
-/// peer snapshots are persisted. The data directory is a temporary path derived
-/// from the system temp dir and is never written to by the launch path.
+/// The FFI client runs fully in-memory: no database is opened and no peer
+/// snapshots are persisted, so `data_dir` is an unused temp path.
 struct LaunchContext {
     executor: TaskExecutor,
     data_dir: std::path::PathBuf,
@@ -404,15 +341,13 @@ impl InfrastructureContext for LaunchContext {
 
 /// Map the boundary stream config to the core [`StreamConfig`].
 ///
-/// Limiting is by chunk count: only `max_concurrency` is used. The host's
-/// `window_bytes` is retained for ABI stability but ignored (byte/bandwidth
-/// limiting belongs at the connection layer). The core clamps to at least one,
-/// so a zero degrades to one-at-a-time streaming rather than a deadlock.
+/// Limiting is by chunk count; `window_bytes` is retained for ABI stability but
+/// ignored. The core clamps to at least one, so a zero degrades to
+/// one-at-a-time rather than deadlocking.
 fn stream_config(config: VertexStreamConfig) -> StreamConfig {
     StreamConfig::new(usize::try_from(config.max_concurrency).unwrap_or(usize::MAX))
 }
 
-/// Resolve the spec for the requested network.
 fn network_spec(network: VertexNetwork) -> Arc<Spec> {
     match network {
         VertexNetwork::Mainnet => init_mainnet(),
@@ -421,10 +356,8 @@ fn network_spec(network: VertexNetwork) -> Arc<Spec> {
     }
 }
 
-/// Build a client identity from an optional private key.
-///
-/// A present key must be exactly 32 bytes. An absent key yields a random
-/// ephemeral identity.
+/// Build a client identity. A present key must be exactly 32 bytes; an absent
+/// key yields a random ephemeral identity.
 fn build_identity(spec: &Arc<Spec>, private_key: Option<&[u8]>) -> FfiResult<Arc<Identity>> {
     let Some(key) = private_key else {
         return Ok(Arc::new(Identity::random(
@@ -467,16 +400,11 @@ fn build_network(bootnodes: Vec<String>) -> NetworkConfig {
 
 /// Reconstruct a strong [`StampedChunk`] from the raw upload payload.
 ///
-/// Consumes the upload so the host-supplied `data` `Vec` moves straight into
-/// `Bytes` (a zero-copy `Vec -> Bytes` conversion). This is the only payload
-/// materialization on the upload-in direction: the bridge copies the host bytes
-/// once into this `Vec`, and the conversion reuses that allocation, so no second
-/// copy is made.
+/// Consumes the upload so `data` moves into `Bytes` without a second copy.
 fn reconstruct_upload(chunk: VertexChunkUpload) -> FfiResult<StampedChunk> {
     let address = parse_address(&chunk.address)?;
     let stamp = parse_stamp(&chunk.stamp)?;
-    // The bytes self-validate against the address (a mismatch is rejected), which
-    // also pins the chunk variant.
+    // Bytes self-validate against the address (mismatch rejected), pinning the variant.
     StampedChunk::reconstruct(address, chunk.data.into(), stamp).map_err(|e| {
         FfiError::ChunkMismatch {
             reason: e.to_string(),
@@ -484,21 +412,18 @@ fn reconstruct_upload(chunk: VertexChunkUpload) -> FfiResult<StampedChunk> {
     })
 }
 
-/// Parse a 32-byte chunk address, mapping the core [`ParseAddressError`] onto the
-/// FFI boundary's [`FfiError::InvalidAddress`].
+/// Parse a 32-byte chunk address.
 fn parse_address(bytes: &[u8]) -> FfiResult<ChunkAddress> {
     core_parse_address(bytes)
         .map_err(|ParseAddressError { got }| FfiError::InvalidAddress { len: got })
 }
 
-/// Parse a wire-encoded postage stamp.
 fn parse_stamp(bytes: &[u8]) -> FfiResult<Stamp> {
     Stamp::try_from_slice(bytes).map_err(|e| FfiError::InvalidStamp {
         reason: e.to_string(),
     })
 }
 
-/// Map a [`PushReceipt`] to the flat boundary shape.
 fn receipt_into_ffi(receipt: PushReceipt) -> VertexPushReceipt {
     let PushReceipt {
         storer,
@@ -514,7 +439,6 @@ fn receipt_into_ffi(receipt: PushReceipt) -> VertexPushReceipt {
     }
 }
 
-/// Extract the chunk provider from the built client's components.
 fn chunks_from(components: impl HasChunkClient<ChunkClient = ClientChunks>) -> ClientChunks {
     components.chunk_client().clone()
 }
@@ -526,8 +450,7 @@ mod tests {
 
     use super::*;
 
-    /// Build a content chunk from raw data and return its wire encoding alongside
-    /// its address, matching the upload payload the boundary expects.
+    /// Build a content chunk and return its wire encoding alongside its address.
     fn content_wire(data: &[u8]) -> (Vec<u8>, Vec<u8>) {
         let chunk: ContentChunk = ContentChunk::new(data.to_vec()).unwrap();
         let address = chunk.address().as_bytes().to_vec();

--- a/crates/node/builder/src/builder.rs
+++ b/crates/node/builder/src/builder.rs
@@ -11,7 +11,7 @@ use vertex_tasks::TaskExecutor;
 
 use crate::{InfrastructureError, LaunchError, NodeHandle};
 
-/// Context for launching a node with executor, directories, and API config.
+/// Executor, directories, and API config needed to launch a node.
 #[derive(Clone)]
 pub struct LaunchContext<A = ()> {
     pub executor: TaskExecutor,
@@ -21,7 +21,7 @@ pub struct LaunchContext<A = ()> {
 }
 
 impl<A> LaunchContext<A> {
-    /// Create a new launch context with an in-memory database configuration.
+    /// Defaults to an in-memory database configuration.
     pub fn new(executor: TaskExecutor, dirs: DataDirs, api: A) -> Self {
         Self {
             executor,
@@ -31,14 +31,13 @@ impl<A> LaunchContext<A> {
         }
     }
 
-    /// Set the resolved database configuration.
     #[must_use]
     pub fn with_database_config(mut self, database: DatabaseConfig) -> Self {
         self.database = database;
         self
     }
 
-    /// Get the data directory root.
+    /// Data directory root.
     pub fn data_dir(&self) -> &std::path::PathBuf {
         &self.dirs.root
     }
@@ -59,7 +58,7 @@ impl<A: Send + Sync> InfrastructureContext for LaunchContext<A> {
 }
 
 impl<A: NodeRpcConfig> LaunchContext<A> {
-    /// Get the gRPC socket address from configuration.
+    /// gRPC socket address; falls back to localhost if the configured address is unparseable.
     pub fn grpc_addr(&self) -> SocketAddr {
         let ip: IpAddr = self.api.grpc_addr().parse().unwrap_or_else(|_| {
             tracing::warn!(
@@ -76,13 +75,11 @@ impl<A: NodeRpcConfig> LaunchContext<A> {
 pub struct NodeBuilder;
 
 impl NodeBuilder {
-    /// Create a new node builder.
     #[must_use]
     pub fn new() -> Self {
         Self
     }
 
-    /// Add launch context (executor, data directories, and API config).
     #[must_use]
     pub fn with_launch_context<A>(
         self,
@@ -108,29 +105,25 @@ pub struct WithLaunchContext<A> {
 }
 
 impl<A> WithLaunchContext<A> {
-    /// Get a reference to the launch context.
     pub fn context(&self) -> &LaunchContext<A> {
         &self.ctx
     }
 
-    /// Set the resolved database configuration on the launch context.
     #[must_use]
     pub fn with_database_config(mut self, database: DatabaseConfig) -> Self {
         self.ctx = self.ctx.with_database_config(database);
         self
     }
 
-    /// Get the data directories.
     pub fn dirs(&self) -> &DataDirs {
         &self.ctx.dirs
     }
 
-    /// Get the task executor.
     pub fn executor(&self) -> &TaskExecutor {
         &self.ctx.executor
     }
 
-    /// Provide the protocol configuration (protocol type inferred from config).
+    /// Protocol type is inferred from the config.
     #[must_use]
     pub fn with_protocol<C: NodeBuildsProtocol>(self, config: C) -> WithProtocol<C::Protocol, A> {
         tracing::info!("Protocol: {}", config.protocol_name());
@@ -151,14 +144,11 @@ impl<P: NodeProtocol, A: NodeRpcConfig + Send + Sync> WithProtocol<P, A>
 where
     P::Config: NodeBuildsProtocol,
 {
-    /// Get a reference to the launch context.
     pub fn context(&self) -> &LaunchContext<A> {
         &self.ctx
     }
 
-    /// Launch the node, serving its components with the chosen transport.
-    ///
-    /// The transport is selected by the caller; this path names no transport.
+    /// Launch the node, serving its components with the caller-selected transport.
     pub async fn launch_with<Tr: Transport>(
         self,
     ) -> Result<NodeHandle<P::Components>, LaunchError<P::BuildError>>
@@ -167,22 +157,18 @@ where
     {
         use tracing::info;
 
-        // Infrastructure configuration
         info!("Data directory: {}", self.ctx.dirs.root.display());
         info!("RPC address: {}", self.ctx.grpc_addr());
 
         let addr = self.ctx.grpc_addr();
 
-        // Launch the protocol (builds components and spawns services)
         let components = P::launch(self.config, &self.ctx)
             .await
             .map_err(LaunchError::Protocol)?;
 
-        // Populate the transport registry from the components.
         let mut registry = Tr::Registry::default();
         components.register(&mut registry);
 
-        // Bind the server and spawn it as a critical task.
         let server = Tr::into_server(registry, addr)
             .map_err(|e| InfrastructureError::Transport(e.into()))?;
 
@@ -203,7 +189,7 @@ where
         ))
     }
 
-    /// Launch the node with the gRPC transport (back-compat alias).
+    /// Launch with the gRPC transport.
     pub async fn launch(self) -> Result<NodeHandle<P::Components>, LaunchError<P::BuildError>>
     where
         P::Components: ServeWith<GrpcTransport>,
@@ -216,19 +202,15 @@ impl<P: NodeProtocol> WithProtocol<P, ()>
 where
     P::Config: NodeBuildsProtocol,
 {
-    /// Launch the node without gRPC server.
-    ///
-    /// Use this when you don't need the gRPC API.
+    /// Launch without a gRPC server.
     pub async fn launch_without_grpc(
         self,
     ) -> Result<NodeHandle<P::Components>, LaunchError<P::BuildError>> {
         use tracing::info;
 
-        // Infrastructure configuration
         info!("Data directory: {}", self.ctx.dirs.root.display());
         info!("gRPC: disabled");
 
-        // Launch the protocol (builds components and spawns services)
         let components = P::launch(self.config, &self.ctx)
             .await
             .map_err(LaunchError::Protocol)?;

--- a/crates/rpc/server/src/registry.rs
+++ b/crates/rpc/server/src/registry.rs
@@ -1,15 +1,11 @@
-//! gRPC service registry for dynamic service composition.
-//!
-//! The [`GrpcRegistry`] allows protocols to register their gRPC services
-//! during the build phase, eliminating the need for a separate "providers"
-//! extraction step.
+//! gRPC service registry: protocols register their services during the build
+//! phase, then the registry composes them into a tonic server.
 
 use std::net::SocketAddr;
 use tonic::service::Routes;
 
-/// Registry for gRPC services that protocols register during build.
-///
-/// Collects services and file descriptors, then builds into a tonic server.
+/// Collects gRPC services and reflection file descriptors, then builds a tonic
+/// server.
 ///
 /// # Example
 ///
@@ -17,13 +13,9 @@ use tonic::service::Routes;
 /// use vertex_rpc_server::GrpcRegistry;
 ///
 /// let mut registry = GrpcRegistry::new();
-///
-/// // Protocol registers its services during build
 /// registry.add_service(MyServiceServer::new(my_service));
 /// registry.add_descriptor(MY_FILE_DESCRIPTOR_SET);
-///
-/// // Launcher builds the server from the registry
-/// let server = registry.into_router();
+/// let server = registry.into_server(addr)?;
 /// ```
 #[derive(Default)]
 pub struct GrpcRegistry {
@@ -32,14 +24,10 @@ pub struct GrpcRegistry {
 }
 
 impl GrpcRegistry {
-    /// Create a new empty registry.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Add a gRPC service to the registry.
-    ///
-    /// Services are accumulated and will be composed into a single router.
     pub fn add_service<S>(&mut self, service: S)
     where
         S: tonic::codegen::Service<
@@ -58,38 +46,29 @@ impl GrpcRegistry {
         });
     }
 
-    /// Add file descriptors for gRPC reflection.
-    ///
-    /// Descriptors are used by tools like `grpcurl` for service discovery.
+    /// Add file descriptors for gRPC reflection (used by tools like `grpcurl`).
     pub fn add_descriptor(&mut self, descriptor: &'static [u8]) {
         self.descriptors.push(descriptor);
     }
 
-    /// Check if any services have been registered.
     pub fn is_empty(&self) -> bool {
         self.routes.is_none()
     }
 
-    /// Get the registered file descriptors.
     pub fn descriptors(&self) -> &[&'static [u8]] {
         &self.descriptors
     }
 
-    /// Consume the registry and return the composed routes.
-    ///
-    /// Returns `None` if no services were registered.
     pub fn into_routes(self) -> Option<Routes> {
         self.routes
     }
 
-    /// Build a gRPC server from this registry.
-    ///
-    /// Includes reflection service if descriptors were registered.
+    /// Build a gRPC server, registering a reflection service if any descriptors
+    /// were added.
     pub fn into_server(
         mut self,
         addr: SocketAddr,
     ) -> Result<GrpcServerHandle, tonic_reflection::server::Error> {
-        // Build reflection service if we have descriptors
         if !self.descriptors.is_empty() {
             let mut reflection_builder = tonic_reflection::server::Builder::configure();
             for desc in &self.descriptors {
@@ -122,14 +101,10 @@ pub struct GrpcServerHandle {
 }
 
 impl GrpcServerHandle {
-    /// Get the address the server will bind to.
     pub fn addr(&self) -> SocketAddr {
         self.addr
     }
 
-    /// Serve the gRPC server.
-    ///
-    /// Returns when the server shuts down.
     pub async fn serve(self) -> Result<(), tonic::transport::Error> {
         if let Some(routes) = self.routes {
             configure_server(tonic::transport::Server::builder())
@@ -137,7 +112,6 @@ impl GrpcServerHandle {
                 .serve(self.addr)
                 .await
         } else {
-            // No services registered, just return
             Ok(())
         }
     }
@@ -153,24 +127,20 @@ impl GrpcServerHandle {
                 .serve_with_shutdown(self.addr, signal)
                 .await
         } else {
-            // No services registered, wait for shutdown signal
             signal.await;
             Ok(())
         }
     }
 }
 
-/// Max simultaneous HTTP/2 streams a single connection may open. Each streaming
-/// RPC (chunk upload/download/has) is one stream, so this bounds how many an
-/// untrusted client can run at once.
+/// Max simultaneous HTTP/2 streams per connection. Each streaming chunk RPC is
+/// one stream, bounding how many an untrusted client can run at once.
 const MAX_CONCURRENT_STREAMS: u32 = 256;
 /// Max in-flight requests served concurrently per connection.
 const MAX_CONNECTION_CONCURRENCY: usize = 256;
 
-/// Apply connection-level limits that bound the gRPC amplification surface (the
-/// streaming chunk RPCs are reachable by untrusted clients). Per-stream memory
-/// is already bounded by each handler's concurrency; these cap how many streams
-/// and requests one connection can run.
+/// Connection-level limits bounding the gRPC amplification surface; streaming
+/// chunk RPCs are reachable by untrusted clients.
 fn configure_server(builder: tonic::transport::Server) -> tonic::transport::Server {
     builder
         .concurrency_limit_per_connection(MAX_CONNECTION_CONCURRENCY)

--- a/crates/rpc/server/src/transport.rs
+++ b/crates/rpc/server/src/transport.rs
@@ -39,7 +39,6 @@ pub trait TransportServer: Send + 'static {
 
 /// Components that can register themselves into a [`Transport`]'s registry.
 pub trait ServeWith<Tr: Transport>: Send + Sync {
-    /// Register services into the transport's registry.
     fn register(&self, reg: &mut Tr::Registry);
 }
 
@@ -67,7 +66,7 @@ impl TransportServer for GrpcServerHandle {
     }
 }
 
-/// Bridge existing gRPC registrants into the generic seam with zero churn.
+/// Any gRPC registrant serves over [`GrpcTransport`].
 impl<C: RegistersGrpcServices> ServeWith<GrpcTransport> for C {
     fn register(&self, reg: &mut GrpcRegistry) {
         self.register_grpc_services(reg);

--- a/crates/storage/redb/src/cursor.rs
+++ b/crates/storage/redb/src/cursor.rs
@@ -1,37 +1,17 @@
 //! Lazy, streaming read-only cursor over a redb table.
 //!
 //! [`RedbCursorRO`] implements [`DbCursorRO`] without materialising the table.
-//! It is reachable from a caller-held read transaction (see
-//! [`RedbReadTx::cursor`](crate::RedbReadTx::cursor)), so a cursor-backed
-//! iterator can outlive the call that created it (unlike `Database::view`,
-//! whose borrowed transaction is dropped at the closure boundary).
+//! It owns the [`redb::ReadOnlyTable`], which `Arc`-pins the read snapshot via
+//! its transaction guard, so the cursor (and any `Range` it builds) can outlive
+//! the [`RedbReadTx::cursor`](crate::RedbReadTx::cursor) call that created it.
 //!
-//! # Lifetime approach
-//!
-//! redb 2.6.3's `ReadOnlyTable<K, V>` has no lifetime parameter: it owns an
-//! `Arc<TransactionGuard>` plus an `Arc`-backed B-tree, so it is fully detached
-//! from the `&ReadTransaction` used to open it. The guard's `Drop` is what ends
-//! the read snapshot, so while the table (and any `Range` it produces, each of
-//! which clones the guard) is alive the snapshot stays pinned even after the
-//! originating `ReadTransaction` is dropped. Its inherent `range()` returns a
-//! `Range<'static, K, V>` whose `'static` lifetime is genuine. The cursor
-//! therefore simply owns the [`redb::ReadOnlyTable`] with no borrow
-//! relationship to any transaction; no `self_cell`, `ouroboros`, or hand-rolled
-//! unsafe is required.
-//!
-//! # Direction model
-//!
-//! A single redb `Range` is one iterator that consumes from both ends of a
-//! fixed range; its forward (`next`) and backward (`next_back`) frontiers do
-//! not share a single movable position. A faithful bidirectional cursor cannot
-//! be backed by one persistent `Range`. Instead we keep a live forward range
-//! for `next()` (amortised O(1) B-tree traversal) and, for any backward or
-//! seeking move, rebuild a fresh range from the cached current key (O(log n)).
-//! The current position is cached as raw encoded key/value bytes so that
-//! `current()` needs no `Clone` bound on `T::Value`.
+//! redb's `Range` is a single iterator consuming from both ends of a fixed
+//! range, so it cannot back a movable bidirectional cursor. We keep a live
+//! forward range for `next()` (amortised O(1)) and rebuild a fresh range from
+//! the cached current key for any backward or seeking move (O(log n)). The
+//! current position is cached as raw key/value bytes so `current()` needs no
+//! `Clone` bound on `T::Value`.
 
-// The cursor's helpers return `Result<Option<(T::Key, T::Value)>, _>`, matching
-// the `DbCursorRO` trait signatures (which carry the same allow in traits.rs).
 #![allow(clippy::type_complexity)]
 
 use std::marker::PhantomData;
@@ -49,23 +29,17 @@ struct Position {
 
 /// A lazy read-only cursor over a single redb table.
 ///
-/// Owns the opened [`ReadOnlyTable`] (which Arc-pins the read snapshot via its
-/// transaction guard), so it is self-contained and may be held across calls and
-/// returned from a function, outliving the transaction it was opened from.
+/// Owns its [`ReadOnlyTable`] (which `Arc`-pins the read snapshot), so it may be
+/// held across calls and returned from a function, outliving the originating tx.
 pub struct RedbCursorRO<T: Table> {
-    /// Owned, `'static`-detached table handle used to build ranges on demand.
-    /// Keeps the read snapshot alive through its `Arc<TransactionGuard>`.
     table: ReadOnlyTable<&'static [u8], &'static [u8]>,
     /// Live forward range driving `next()`; rebuilt by seeking/backward moves.
     forward: Option<Range<'static, &'static [u8], &'static [u8]>>,
-    /// The current entry, if the cursor points at a real row. `None` after a
-    /// seek miss or once iteration has run off either end.
     current: Option<Position>,
-    /// The raw key the cursor logically sits at, used as the exclusive upper
-    /// bound for `prev()`. On a hit this equals `current.key`; on a seek miss it
-    /// is the (absent) seek key, so `prev()` still steps back into the table.
-    /// This is what makes the `seek(hi)` then `prev()` range-tail pattern work
-    /// even when `hi` lies beyond every stored key.
+    /// Raw key the cursor logically sits at, used as the exclusive upper bound
+    /// for `prev()`. On a seek miss it holds the absent seek key, so the
+    /// `seek(hi)` then `prev()` range-tail pattern works even when `hi` lies
+    /// beyond every stored key.
     anchor: Option<Vec<u8>>,
     _marker: PhantomData<fn() -> T>,
 }
@@ -76,12 +50,6 @@ fn read_err(context: &str, err: redb::StorageError) -> DatabaseError {
 }
 
 impl<T: Table> RedbCursorRO<T> {
-    /// Open a cursor over table `T` from a held read transaction.
-    ///
-    /// The table must already exist (it is created during database
-    /// initialisation); opening a never-created table yields
-    /// [`DatabaseError::InitCursor`]. An empty but existent table opens
-    /// successfully and yields no entries.
     pub(crate) fn new(table: ReadOnlyTable<&'static [u8], &'static [u8]>) -> Self {
         Self {
             table,
@@ -92,17 +60,13 @@ impl<T: Table> RedbCursorRO<T> {
         }
     }
 
-    /// Decode a raw key/value pair into owned `(T::Key, T::Value)`.
-    ///
-    /// Values borrowed from a redb `AccessGuard` must be decoded before the
-    /// guard is dropped, so callers extract the raw bytes first and decode here.
     fn decode_pair(key: &[u8], value: &[u8]) -> Result<(T::Key, T::Value), DatabaseError> {
         let k = T::Key::decode(key)?;
         let v = decode_value::<T>(value)?;
         Ok((k, v))
     }
 
-    /// Cache the entry (as both `current` and `anchor`) and return the decoded pair.
+    /// Cache the entry as both `current` and `anchor`, returning the decoded pair.
     fn record(
         &mut self,
         key: Vec<u8>,
@@ -114,8 +78,8 @@ impl<T: Table> RedbCursorRO<T> {
         Ok(pair)
     }
 
-    /// Build a full-table forward range. The explicit byte-slice bound avoids
-    /// the `RangeFull` type-inference ambiguity on the generic `range()` method.
+    /// Full-table forward range. The explicit byte-slice bound avoids the
+    /// `RangeFull` type-inference ambiguity on the generic `range()` method.
     fn full_range(&self) -> Result<Range<'static, &'static [u8], &'static [u8]>, DatabaseError> {
         let empty: &[u8] = &[];
         self.table
@@ -123,7 +87,7 @@ impl<T: Table> RedbCursorRO<T> {
             .map_err(|e| read_err(&format!("cursor range {}", T::NAME), e))
     }
 
-    /// Build a forward range starting at (and including) `from`.
+    /// Forward range starting at and including `from`.
     fn range_from(
         &self,
         from: &[u8],
@@ -141,15 +105,14 @@ impl<T: Table> RedbCursorRO<T> {
         match range.next() {
             Some(entry) => {
                 let (k, v) = entry.map_err(|e| read_err(&format!("cursor next {}", T::NAME), e))?;
-                // Decode the borrowed slices into owned bytes before the guards drop.
+                // Own the bytes before the access guards drop.
                 let key = k.value().to_vec();
                 let value = v.value().to_vec();
                 drop((k, v));
                 Ok(Some(self.record(key, value)?))
             }
             None => {
-                // Exhausted: clear the live range and the current entry, but keep
-                // the anchor so a subsequent prev() can still step back from the
+                // Keep the anchor so a subsequent prev() can step back from the
                 // last visited key.
                 self.forward = None;
                 self.current = None;
@@ -173,8 +136,7 @@ impl<T: Table> DbCursorRO<T> for RedbCursorRO<T> {
                 let key = k.value().to_vec();
                 let value = v.value().to_vec();
                 drop((k, v));
-                // No live forward range after positioning at the tail; prev()
-                // will rebuild from the cached key.
+                // No forward range at the tail; prev() rebuilds from the cached key.
                 self.forward = None;
                 Ok(Some(self.record(key, value)?))
             }
@@ -193,9 +155,8 @@ impl<T: Table> DbCursorRO<T> for RedbCursorRO<T> {
         self.forward = Some(self.range_from(key_bytes)?);
         let found = self.advance_forward()?;
         if found.is_none() {
-            // No key at or after the seek key: cache it as the anchor so the
-            // range-tail pattern (seek(hi) then prev()) can step back to the
-            // greatest key strictly below `hi`.
+            // No key at or after `key`: anchor on it so a following prev() steps
+            // back to the greatest key strictly below it.
             self.anchor = Some(key_bytes.to_vec());
         }
         Ok(found)
@@ -213,10 +174,9 @@ impl<T: Table> DbCursorRO<T> for RedbCursorRO<T> {
                 let value = guard.value().to_vec();
                 drop(guard);
                 let key_vec = key_bytes.to_vec();
-                // Anchor a forward range at the found key so next() continues from here.
                 self.forward = Some(self.range_from(key_bytes)?);
-                // Consume the just-found element off the forward range so a
-                // following next() yields the *successor*, matching seek().
+                // Drop the just-found element so a following next() yields the
+                // successor, matching seek().
                 if let Some(range) = self.forward.as_mut() {
                     let _ = range.next();
                 }
@@ -227,13 +187,11 @@ impl<T: Table> DbCursorRO<T> for RedbCursorRO<T> {
     }
 
     fn next(&mut self) -> Result<Option<(T::Key, T::Value)>, DatabaseError> {
-        // If a live forward range exists (e.g. mid-scan after seek()/next()),
-        // just advance it. Otherwise (after last()/prev()/a fresh cursor)
-        // rebuild it as the strict successor of the anchor, or from the start.
+        // Mid-scan: advance the live range. Otherwise rebuild it as the strict
+        // successor of the anchor, or from the start when there is no anchor.
         if self.forward.is_none() {
             match &self.anchor {
                 Some(anchor) => {
-                    // Strict successor: range starts at the anchor, skip it.
                     let mut range = self.range_from(anchor)?;
                     let _ = range.next();
                     self.forward = Some(range);
@@ -245,10 +203,7 @@ impl<T: Table> DbCursorRO<T> for RedbCursorRO<T> {
     }
 
     fn prev(&mut self) -> Result<Option<(T::Key, T::Value)>, DatabaseError> {
-        // Previous element relative to the current position: the greatest key
-        // strictly less than the anchor key. With no anchor (fresh cursor or
-        // after running off the front) there is nothing before the start, so
-        // return None.
+        // Greatest key strictly less than the anchor; nothing before the start.
         let Some(upper) = self.anchor.clone() else {
             return Ok(None);
         };
@@ -263,14 +218,12 @@ impl<T: Table> DbCursorRO<T> for RedbCursorRO<T> {
                 let key = k.value().to_vec();
                 let value = v.value().to_vec();
                 drop((k, v));
-                // Direction changed; drop any forward range so the next next()
-                // rebuilds from this new position.
+                // Direction changed; force next() to rebuild from this position.
                 self.forward = None;
                 Ok(Some(self.record(key, value)?))
             }
             None => {
-                // Ran off the front: no entry below the anchor. Clear position so
-                // current() reports None and a further prev() stays None.
+                // Off the front: clear position so current() and further prev() report None.
                 self.forward = None;
                 self.current = None;
                 self.anchor = None;
@@ -298,7 +251,7 @@ mod tests {
 
     use crate::RedbDatabase;
 
-    // -- A simple u64 -> u64 byte-ordered table --
+    // A simple u64 -> u64 byte-ordered table.
 
     #[derive(
         Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
@@ -320,7 +273,7 @@ mod tests {
 
     table!(NumTable, "nums", K, u64);
 
-    // -- A composite (Bin, u64) -> [u8; 4] table modelling the storer BinSeqIndex --
+    // A composite (Bin, u64) -> [u8; 4] table, big-endian so byte order is logical order.
 
     #[derive(
         Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
@@ -328,7 +281,6 @@ mod tests {
     struct BinSeq(u8, u64);
 
     impl Encode for BinSeq {
-        // Big-endian, bin most-significant, so byte order == logical order.
         type Encoded = [u8; 9];
         fn encode(self) -> Self::Encoded {
             let mut out = [0u8; 9];
@@ -452,9 +404,8 @@ mod tests {
         fill_nums(&db, &[10, 20, 30, 100, 110]);
         let tx = db.tx().unwrap();
         let mut c = tx.cursor::<NumTable>().unwrap();
-        // Last entry strictly below the range upper bound 40 is 30 -- and crucially
-        // NOT the global table maximum (110). This proves the range-tail comes from
-        // seek(hi) + prev(), never a global last().
+        // Last entry strictly below upper bound 40 is 30, not the global max 110:
+        // proves the range-tail comes from seek(hi) + prev(), not a global last().
         assert_eq!(c.seek(K(40)).unwrap(), Some((K(100), 1000)));
         assert_eq!(c.prev().unwrap(), Some((K(30), 300)));
         assert_ne!(c.current().unwrap(), Some((K(110), 1100)));
@@ -540,15 +491,12 @@ mod tests {
 
     #[test]
     fn cursor_outlives_originating_call() {
-        // The cursor owns its table handle, which Arc-pins the read snapshot, so
-        // it can be returned from a function and iterated after that function
-        // (and the RedbReadTx it was opened from) has returned.
+        // The cursor Arc-pins the snapshot, so it survives `tx` being dropped here.
         fn make_cursor(db: &RedbDatabase) -> crate::RedbCursorRO<NumTable> {
             let tx = db.tx().unwrap();
             let mut c = tx.cursor::<NumTable>().unwrap();
             c.seek(K(10)).unwrap();
             c
-            // `tx` is dropped here, at the end of this function.
         }
 
         let db = setup();
@@ -566,7 +514,7 @@ mod tests {
         assert_ss::<crate::RedbCursorRO<NumTable>>();
     }
 
-    // -- Storer-shaped BinSeqIndex pattern --
+    // Composite-key bin scan and per-bin topmost-seq pattern.
 
     #[test]
     fn bin_scan_and_topmost_seq() {
@@ -616,10 +564,8 @@ mod tests {
         assert!(matches!(below, Some((BinSeq(b, _), _)) if b != 9));
     }
 
-    // -- Streaming / no-materialise confirmation --
-
-    // A value type that counts how many times it is deserialised, so a test can
-    // assert the cursor decodes only what it consumes (lazy), not the whole table.
+    // A value type that counts deserialisations, so a test can assert the cursor
+    // decodes only what it consumes, not the whole table.
     static DECODE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
     #[derive(Debug, PartialEq, serde::Serialize)]

--- a/crates/storage/redb/src/tx.rs
+++ b/crates/storage/redb/src/tx.rs
@@ -13,20 +13,13 @@ use vertex_util_runtime::time::Instant;
 
 use crate::metrics::{mode, operation};
 
-/// Dynamically create a redb TableDefinition from a table name.
-///
-/// All tables use `&[u8]` for both keys and values — the vertex-storage
-/// Encode/Decode traits handle keys; postcard+zstd handles values.
+/// All tables use `&[u8]` keys and values; Encode/Decode handle keys, postcard+zstd handle values.
 fn table_def(name: &str) -> TableDefinition<'_, &[u8], &[u8]> {
     TableDefinition::new(name)
 }
 
-/// Intern a table name string to get a `&'static str`.
-///
-/// redb's `TableDefinition::new` requires `&'static str` for table creation.
-/// This function leaks the string on first use per unique name, then returns
-/// the cached reference on subsequent calls. Safe because table names are a
-/// small finite set initialized once at startup.
+/// Leak a table name once to satisfy redb's `&'static str` requirement, caching by name; bounded
+/// since table names are a small finite set fixed at startup.
 fn intern_table_name(name: &str) -> &'static str {
     static INTERNED: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
     let set = INTERNED.get_or_init(|| Mutex::new(HashSet::new()));
@@ -39,7 +32,7 @@ fn intern_table_name(name: &str) -> &'static str {
     leaked
 }
 
-/// Deserialize a value from raw bytes, decompressing first if the table uses compression.
+/// Decode a stored value, zstd-decompressing first when the table compresses.
 pub(crate) fn decode_value<T: Table>(raw: &[u8]) -> Result<T::Value, DatabaseError> {
     if T::COMPRESS_VALUES {
         let bytes = zstd::decode_all(raw).map_err(|e| {
@@ -60,7 +53,6 @@ pub(crate) fn decode_value<T: Table>(raw: &[u8]) -> Result<T::Value, DatabaseErr
     })
 }
 
-/// Record a completed DB operation's metrics.
 fn record_op(table: &'static str, op: &'static str, outcome: &'static str, elapsed: f64) {
     counter!("db_operations_total", "table" => table, "operation" => op, "outcome" => outcome)
         .increment(1);
@@ -68,10 +60,8 @@ fn record_op(table: &'static str, op: &'static str, outcome: &'static str, elaps
         .record(elapsed);
 }
 
-/// Shared read operations for both read-only and read-write transactions.
-///
-/// Both `RedbReadTx` and `RedbWriteTx` have an `inner` field whose
-/// `open_table` returns a type implementing `ReadableTable + ReadableTableMetadata`.
+/// Shared `DbTx` read methods for both transaction kinds. Requires an `inner` field whose
+/// `open_table` yields a `ReadableTable + ReadableTableMetadata`.
 macro_rules! impl_db_tx_reads {
     () => {
         fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError> {
@@ -234,15 +224,9 @@ impl RedbReadTx {
         }
     }
 
-    /// Open a lazy, streaming read-only cursor over table `T`.
-    ///
-    /// The returned [`RedbCursorRO`] owns its table handle (which Arc-pins this
-    /// transaction's read snapshot), so it may be held and iterated after this
-    /// `RedbReadTx` is dropped. This is the held-transaction cursor path that
-    /// `Database::view` cannot provide, since `view` drops its borrowed
-    /// transaction at the closure boundary.
-    ///
-    /// Errors with [`DatabaseError::InitCursor`] if the table does not exist.
+    /// Open a streaming read cursor over table `T`. The cursor owns its table handle, which
+    /// Arc-pins the read snapshot, so it outlives this `RedbReadTx`. Errors
+    /// [`DatabaseError::InitCursor`] if the table does not exist.
     pub fn cursor<T: Table>(&self) -> Result<crate::cursor::RedbCursorRO<T>, DatabaseError> {
         let def = table_def(T::NAME);
         let table = self.inner.open_table(def).map_err(|e| {
@@ -258,11 +242,8 @@ impl RedbReadTx {
 impl DbTx for RedbReadTx {
     impl_db_tx_reads!();
 
-    /// Open a held read cursor over table `T`.
-    ///
-    /// Delegates to the inherent [`RedbReadTx::cursor`] and erases the concrete
-    /// [`RedbCursorRO`] behind the trait's boxed [`DbCursorRO`]. The cursor owns
-    /// its read snapshot, so the box is `Send` and outlives this transaction.
+    /// Boxes the inherent [`RedbReadTx::cursor`] behind the trait's [`DbCursorRO`]; the cursor
+    /// owns its snapshot, so the box is `Send` and outlives this transaction.
     fn cursor<T: Table>(
         &self,
     ) -> Result<Box<dyn vertex_storage::DbCursorRO<T> + Send>, DatabaseError> {
@@ -279,8 +260,8 @@ impl Drop for RedbReadTx {
 
 /// Read-write transaction wrapping `redb::WriteTransaction`.
 ///
-/// Uses `ManuallyDrop` so `commit()` can move out the inner transaction
-/// while still recording tx duration on drop.
+/// `ManuallyDrop` lets `commit()` move out the inner transaction while `Drop` still records
+/// tx duration.
 pub struct RedbWriteTx {
     inner: ManuallyDrop<redb::WriteTransaction>,
     start: Instant,
@@ -306,8 +287,8 @@ impl Drop for RedbWriteTx {
         histogram!("db_tx_duration_seconds", "mode" => mode::WRITE)
             .record(self.start.elapsed().as_secs_f64());
         if !self.committed {
-            // SAFETY: Only dropped once, and `commit()` sets committed=true
-            // before this runs, so we only drop here if commit wasn't called.
+            // SAFETY: `committed` is false, so `commit()` never took `inner`; this is the
+            // single drop of it.
             unsafe { ManuallyDrop::drop(&mut self.inner) };
         }
     }
@@ -318,7 +299,7 @@ impl DbTxMut for RedbWriteTx {
         let start = Instant::now();
         let _span = tracing::trace_span!("db_commit").entered();
 
-        // SAFETY: We set committed=true so Drop won't double-drop.
+        // SAFETY: setting `committed` first stops `Drop` from also taking `inner`.
         self.committed = true;
         let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
         let result = inner.commit().map_err(DatabaseError::commit_err);

--- a/crates/storage/src/traits.rs
+++ b/crates/storage/src/traits.rs
@@ -110,13 +110,11 @@ pub trait DbTx: Send + Sync {
     /// Count the number of entries in a table.
     fn count<T: Table>(&self) -> Result<usize, DatabaseError>;
 
-    /// Open a lazy, streaming read-only [`DbCursorRO`] over table `T`.
+    /// Open a streaming read-only [`DbCursorRO`] over table `T`.
     ///
-    /// The cursor owns its own read snapshot, so the returned boxed iterator may
-    /// outlive this transaction handle. Backends that cannot provide a held
-    /// cursor (e.g. a read cursor over an uncommitted write transaction) return
-    /// [`DatabaseError::InitCursor`]; the default implementation does so, and a
-    /// backing read transaction overrides it with a real cursor.
+    /// The cursor owns its own read snapshot, so the boxed iterator may outlive
+    /// this handle. Backends that cannot hold a cursor (e.g. over an uncommitted
+    /// write transaction) return [`DatabaseError::InitCursor`], as does this default.
     fn cursor<T: Table>(&self) -> Result<Box<dyn DbCursorRO<T> + Send>, DatabaseError> {
         Err(DatabaseError::InitCursor(DatabaseErrorInfo::msg(
             "this transaction does not support read cursors",
@@ -168,18 +166,10 @@ pub trait DbCursorRO<T: Table>: Send + Sync {
 
 /// Read-write cursor for modifying entries during iteration.
 ///
-/// # Status
-///
-/// This trait is declared but intentionally has no backend implementation yet
-/// (see issue #214). The read-only [`DbCursorRO`] path is implemented over redb
-/// without any self-referential lifetime, because redb's `ReadOnlyTable` owns
-/// its transaction guard and is detached from the read transaction. A write
-/// cursor is materially harder: redb's write-side `Table` borrows the
-/// `WriteTransaction` with a real lifetime, so a held write cursor reintroduces
-/// a self-referential borrow. The current consumer (the storer's reserve and
-/// `BinSeqIndex` maintenance) writes via direct keyed `put`/`delete` inside a
-/// write transaction, which gives no positional advantage over a write cursor
-/// on a B-tree, so the read-write cursor is deferred until a consumer needs it.
+/// Declared but not yet backed by an implementation (issue #214): a held write
+/// cursor over redb would reintroduce a self-referential borrow of the write
+/// transaction, and current consumers write via direct keyed `put`/`delete`
+/// with no positional advantage on a B-tree. Deferred until a consumer needs it.
 pub trait DbCursorRW<T: Table>: DbCursorRO<T> {
     /// Insert or update the entry at the current cursor position.
     fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
@@ -215,10 +205,8 @@ impl<T: DbTx + ?Sized> IndexedRead for T {
 
 /// Write with automatic secondary index maintenance (blanket-implemented for all `DbTxMut`).
 pub trait IndexedWrite: DbTxMut {
-    /// Insert or update a primary entry, maintaining the secondary index.
-    ///
-    /// Handles three cases: fresh insert, update with unchanged index key,
-    /// and update with changed index key (stale index entry is removed).
+    /// Insert or update a primary entry, maintaining the secondary index
+    /// (removing the stale index entry when the index key changes).
     fn put_indexed<I: SecondaryIndex>(
         &self,
         pk: <I::Primary as Table>::Key,
@@ -243,7 +231,6 @@ impl<T: DbTxMut + ?Sized> IndexedWrite for T {
     ) -> Result<(), DatabaseError> {
         let new_idx = I::extract(&value);
 
-        // If an existing entry has a different index key, remove the stale index entry.
         if let Some(old_value) = self.get::<I::Primary>(pk.clone())? {
             let old_idx = I::extract(&old_value);
             if old_idx != new_idx {
@@ -251,7 +238,6 @@ impl<T: DbTxMut + ?Sized> IndexedWrite for T {
             }
         }
 
-        // Always write both entries to keep index self-healing.
         self.put::<I::Primary>(pk.clone(), value)?;
         self.put::<I>(new_idx, pk)?;
         Ok(())

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -32,10 +32,7 @@ pub trait HasTopology: Send + Sync {
     fn topology(&self) -> &Self::Topology;
 }
 
-/// Chunk client access (client/storer levels).
-///
-/// Exposes the components' chunk client so the gRPC chunk service and embedders
-/// (FFI) can drive uploads and downloads. Mirrors [`HasTopology`].
+/// Chunk client access (client/storer levels), driving uploads and downloads.
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait HasChunkClient: Send + Sync {
     /// The chunk client type.
@@ -66,18 +63,12 @@ pub trait HasStore: Send + Sync {
 
 /// Reserve access (storer level).
 ///
-/// Narrows [`HasStore`] to the storer reserve: the proximity-ordered,
-/// always-stamped [`ReserveStore`]. A storer that runs a reserve exposes it here
-/// so the redistribution and sync subsystems can query radius, capacity, and
-/// per-bin insertion order without depending on the concrete store type.
+/// Narrows [`HasStore`] to the proximity-ordered, always-stamped reserve so the
+/// redistribution and sync subsystems can query radius, capacity, and per-bin
+/// insertion order without naming the concrete store type.
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait HasReserve: HasStore {
     /// The reserve type.
-    ///
-    /// Bounded by [`BinCursorStore`] (which refines [`ReserveStore`]) so the
-    /// wired handle exposes both the proximity axis and the per-bin
-    /// insertion-order axis the redistribution sampler and sync need; without it
-    /// the cursor surface would be unreachable behind the erased handle.
     type Reserve: BinCursorStore;
 
     /// Get the reserve.
@@ -93,8 +84,6 @@ pub struct BootnodeComponents<T> {
 }
 
 impl<T> BootnodeComponents<T> {
-    /// Wire bootnode components. Crate-visible: only the builder constructs
-    /// components, via the [`construct`] seam.
     pub(crate) fn new(topology: T) -> Self {
         Self { topology }
     }
@@ -110,14 +99,8 @@ impl<T: Send + Sync> HasTopology for BootnodeComponents<T> {
 
 /// Client components (topology + chunk client).
 ///
-/// The transport-facing read surface a built client/storer exposes: topology
-/// for the node service, chunk client for the chunk service.
-///
-/// Accounting is deliberately not a component. It is a builder-wired internal of
-/// the network chunk client — the network chunk provider settles through a
-/// shared accounting `Arc` plumbed in at launch — so it never surfaces as a
-/// served capability. Local (non-network) providers do not account at all, and
-/// bootnodes run only a listen-only pricing handler (no accounting state).
+/// Accounting is intentionally absent: it is a builder-wired internal of the
+/// network chunk client, not a served capability.
 ///
 /// Construction is builder-exclusive; see [`construct`].
 #[derive(Debug, Clone)]
@@ -127,8 +110,6 @@ pub struct ClientComponents<T, C> {
 }
 
 impl<T, C> ClientComponents<T, C> {
-    /// Wire client components. Crate-visible: only the builder constructs
-    /// components, via the [`construct`] seam.
     pub(crate) fn new(topology: T, chunk_client: C) -> Self {
         Self {
             topology,
@@ -163,8 +144,6 @@ pub struct StorerComponents<T, C, S> {
 }
 
 impl<T, C, S> StorerComponents<T, C, S> {
-    /// Wire storer components. Crate-visible: only the builder constructs
-    /// components, via the [`construct`] seam.
     pub(crate) fn new(topology: T, chunk_client: C, store: S) -> Self {
         Self {
             client: ClientComponents::new(topology, chunk_client),
@@ -199,26 +178,22 @@ impl<T: Send + Sync, C: Send + Sync, S: Send + Sync> HasStore for StorerComponen
 
 /// Builder-only construction seam for the component containers.
 ///
-/// Components are a builder-wired provider DAG over shared `Arc`s (the chunk
-/// provider already embeds the topology handle); only the builder wires those
-/// `Arc`s correctly, so the public containers expose no constructors. The
-/// builder and the in-process node reach construction through these
-/// `#[doc(hidden)]` free functions instead. Not part of the stable API.
+/// Containers wire shared `Arc`s that only the builder assembles correctly, so
+/// they expose no public constructors; the builder and in-process node reach
+/// construction through these `#[doc(hidden)]` functions. Not part of the stable
+/// API.
 #[doc(hidden)]
 pub mod construct {
     use super::{BootnodeComponents, ClientComponents, StorerComponents};
 
-    /// Wire [`BootnodeComponents`].
     pub fn bootnode<T>(topology: T) -> BootnodeComponents<T> {
         BootnodeComponents::new(topology)
     }
 
-    /// Wire [`ClientComponents`].
     pub fn client<T, C>(topology: T, chunk_client: C) -> ClientComponents<T, C> {
         ClientComponents::new(topology, chunk_client)
     }
 
-    /// Wire [`StorerComponents`].
     pub fn storer<T, C, S>(topology: T, chunk_client: C, store: S) -> StorerComponents<T, C, S> {
         StorerComponents::new(topology, chunk_client, store)
     }

--- a/crates/swarm/api/src/components/reserve.rs
+++ b/crates/swarm/api/src/components/reserve.rs
@@ -1,19 +1,11 @@
-//! The storer reserve: proximity-ordered local chunk storage.
+//! The storer reserve: proximity-ordered, always-stamped local chunk storage.
 //!
-//! The reserve is the storer's authoritative, *stamped* chunk store. It refines
-//! [`SwarmLocalStore`]'s point access with the proximity axis the protocol needs:
-//! a [`StorageRadius`] of responsibility, a population [`count`](ReserveStore::count)
-//! against a [`capacity`](ReserveStore::capacity), per-proximity-order accounting,
-//! and furthest-first eviction.
-//!
-//! Two traits stack on top of [`SwarmLocalStore`]:
-//!
-//! - [`ReserveStore`] — the proximity axis (radius, responsibility, capacity,
-//!   eviction). Every chunk in the reserve is stamped; a stampless put is
-//!   invalid.
-//! - [`BinCursorStore`] — adds the insertion-order axis, an append-only
-//!   per-bin sequence used by redistribution and sync to replay what landed in
-//!   a bin since a given cursor.
+//! Refines [`SwarmLocalStore`] point access with a proximity axis: a
+//! [`StorageRadius`] of responsibility, [`count`](ReserveStore::count) against
+//! [`capacity`](ReserveStore::capacity), per-proximity-order accounting, and
+//! furthest-first eviction. Every chunk in the reserve is stamped; a stampless
+//! put is invalid. [`BinCursorStore`] adds an append-only per-bin insertion
+//! sequence used by redistribution and sync.
 
 use alloy_primitives::B256;
 use nectar_primitives::{Bin, ChunkAddress, ProximityOrder};
@@ -25,180 +17,98 @@ use super::SwarmLocalStore;
 
 /// The storer reserve: proximity-ordered, always-stamped local chunk storage.
 ///
-/// Refines [`SwarmLocalStore`] (point access) with the proximity axis a storer
-/// reserve needs. Unlike a client cache, the reserve is authoritative and
-/// always stamped — a chunk admitted to the reserve carries the stamp that
-/// authorises its storage, so a stampless put is invalid.
-///
-/// The reserve has a fixed [`capacity`](Self::capacity); when [`count`](Self::count)
-/// would exceed it the reserve sheds load by [`evict_furthest`](Self::evict_furthest),
-/// dropping the chunk furthest (lowest proximity) from the local overlay first.
-/// The [`storage_radius`](Self::storage_radius) is the responsibility boundary the
-/// reserve advertises: chunks at or within it are ones the node is responsible
-/// for ([`is_responsible_for`](Self::is_responsible_for)).
-///
-/// # Bin and proximity order in the reserve
-///
-/// [`Bin`] (a routing-table slot) and [`ProximityOrder`] (a metric distance) are
-/// distinct nectar types. In *this* trait they coincide deliberately: the reserve
-/// measures everything relative to the *local overlay*, so a chunk's reserve bin
-/// is exactly its proximity order to the overlay, and the two share the
-/// `0..=MAX_PO` range. The bin-scoped verbs ([`evict_from_bin`](Self::evict_from_bin),
-/// the `up_to_bin` bound of [`evict_batch`](Self::evict_batch)) therefore name a
-/// [`Bin`] but address the proximity index keyed by proximity order; an
-/// implementation crosses the boundary explicitly via [`From<ProximityOrder>`](Bin)
-/// / [`Bin::get`] rather than treating the two as an unchecked `u8` pun.
+/// Proximity is measured against the local overlay, so a chunk's reserve bin
+/// equals its proximity order to the overlay. Bin-scoped verbs name a [`Bin`]
+/// but key the proximity index by proximity order; cross via
+/// [`From<ProximityOrder>`](Bin) / [`Bin::get`], never an unchecked `u8` pun.
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait ReserveStore: SwarmLocalStore {
-    /// The reserve's current storage-responsibility radius.
-    ///
-    /// Chunks whose proximity to the local overlay is at or beyond this radius
-    /// are within the node's area of responsibility. The radius widens or
-    /// narrows as the reserve fills or drains relative to its capacity.
+    /// The reserve's current storage-responsibility radius. Chunks at or beyond
+    /// it are within the node's area of responsibility; it widens or narrows as
+    /// the reserve fills or drains relative to capacity.
     #[must_use]
     fn storage_radius(&self) -> StorageRadius;
 
-    /// Whether the given address falls within the reserve's current
-    /// responsibility radius (i.e. the node is responsible for storing it).
+    /// Whether `address` falls within the current storage radius.
     #[must_use]
     fn is_responsible_for(&self, address: &ChunkAddress) -> bool;
 
-    /// The number of chunks currently held in the reserve.
+    /// Total chunks currently held in the reserve.
     fn count(&self) -> SwarmResult<u64>;
 
-    /// The maximum number of chunks the reserve will hold.
-    ///
-    /// Capacity is enforced by the caller (the eviction-control loop) via the
-    /// scoped eviction primitives below, not by [`put`](SwarmLocalStore::put),
-    /// which always admits a stamped chunk.
+    /// The maximum number of chunks the reserve will hold. Enforced by the
+    /// eviction-control loop, not by [`put`](SwarmLocalStore::put).
     #[must_use]
     fn capacity(&self) -> u64;
 
-    /// The number of chunks held at the given [`ProximityOrder`] relative to the
-    /// local overlay.
-    ///
-    /// Used to compute where the [`storage_radius`](Self::storage_radius) must
-    /// sit to keep the population within capacity. Backed by an O(log n + matches)
-    /// cursor walk of the proximity index, not a full table scan.
+    /// Chunks held at `po` relative to the local overlay. Backed by an
+    /// O(log n + matches) cursor walk, not a full table scan.
     fn count_in(&self, po: ProximityOrder) -> SwarmResult<u64>;
 
     /// Evict the single chunk furthest (lowest proximity) from the local
-    /// overlay, returning its address, or `None` if the reserve is empty.
-    ///
-    /// The point shedding primitive, backed by an O(log n) cursor read of the
-    /// proximity index. For bulk shedding under capacity pressure or batch
-    /// expiry, prefer [`evict_from_bin`](Self::evict_from_bin) /
-    /// [`evict_batch`](Self::evict_batch), which delete a whole group in one
-    /// atomic transaction.
+    /// overlay, or `None` if empty. For bulk shedding prefer the group-atomic
+    /// [`evict_from_bin`](Self::evict_from_bin) / [`evict_batch`](Self::evict_batch).
     fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>>;
 
-    /// Evict up to `max` chunks whose proximity bin equals `bin`, returning the
-    /// number evicted.
-    ///
-    /// The bin-atomic shedding primitive the capacity-control loop uses when the
-    /// storage radius grows: a shallow bin is shed as a unit. The targeted rows
-    /// are collected up front and deleted (chunk value plus every secondary index
-    /// entry) in a single atomic transaction, so the reserve never observes a
-    /// partially-evicted bin.
+    /// Evict up to `max` chunks in `bin`, returning the count. Targets are
+    /// deleted (chunk value plus every secondary index entry) in one atomic
+    /// transaction, so the reserve never observes a partially-evicted bin.
     fn evict_from_bin(&self, bin: Bin, max: u64) -> SwarmResult<u64>;
 
-    /// Evict up to `max` chunks belonging to postage batch `batch`, returning the
-    /// number evicted.
+    /// Evict up to `max` chunks of batch `batch`, returning the count.
+    /// `up_to_bin = Some(b)` evicts only bins strictly shallower than `b` (shed
+    /// out-of-responsibility chunks as the radius grows); `None` evicts the whole
+    /// batch (expired or invalidated). Atomic per the same rule as
+    /// [`evict_from_bin`](Self::evict_from_bin).
     ///
-    /// With `up_to_bin = Some(b)` only chunks in bins strictly shallower than `b`
-    /// are evicted (shed a batch's out-of-responsibility chunks as the radius
-    /// grows); with `up_to_bin = None` the whole batch is evicted (an expired or
-    /// invalidated batch). Deletes the chunk value and every secondary index entry
-    /// for each target in a single atomic transaction.
-    ///
-    /// # Expiry ordering seam
-    ///
-    /// This is the entry point an expiry handler must call to drain an expired
-    /// batch's entries *before* the batch is removed from the postage
-    /// [`BatchStore`](vertex_swarm_postage::BatchStore). The reserve size counts
-    /// per stamped entry and drives the consensus radius, so the invariant is
-    /// evict-then-remove: if a batch were removed from the batch store first, its
-    /// entries would be orphaned in the reserve (no batch to discover them),
-    /// inflating size and the committed radius. Removing the batch first is a bug;
-    /// route an expiry through `evict_batch(batch, None, ..)` until it returns `0`
-    /// and only then remove the batch.
+    /// Expiry ordering is evict-then-remove: drain a batch through
+    /// `evict_batch(batch, None, ..)` until it returns `0` before removing it
+    /// from the [`BatchStore`](vertex_swarm_postage::BatchStore). Removing the
+    /// batch first orphans its entries in the reserve (no batch to discover
+    /// them), inflating the per-stamped-entry size and the committed radius.
     fn evict_batch(&self, batch: BatchId, up_to_bin: Option<Bin>, max: u64) -> SwarmResult<u64>;
 }
 
 /// A [`ReserveStore`] whose storage radius can be committed at runtime.
 ///
-/// The radius is the consensus-load-bearing output of the size-driven dynamics:
-/// it feeds the committed depth a redistribution round commits on chain, and it
-/// changes as the reserve fills or drains. [`ReserveStore::storage_radius`] is
-/// the *read* seam every consumer uses; this trait adds the matching *write*
-/// seam, kept separate so the read surface (which is used widely and behind
-/// `dyn`) carries no mutation capability and only the eviction-control loop
-/// depends on being able to move the radius.
-///
-/// The write is a single commit of an already-derived radius: deriving the value
-/// (from occupancy against capacity) and shedding the bins that fall out of
-/// responsibility are the control loop's job (the storer's radius controller);
-/// this method only publishes the result so subsequent
-/// [`storage_radius`](ReserveStore::storage_radius) /
-/// [`is_responsible_for`](ReserveStore::is_responsible_for) reads observe it. It
-/// is infallible and non-blocking: committing a radius moves no data.
-///
-/// Object-safe (`&self`, a `Copy` argument, no generics), so the controller can
-/// hold a `&dyn SettableRadius` as readily as a concrete reserve.
+/// The write seam matching the [`storage_radius`](ReserveStore::storage_radius)
+/// read seam, kept separate so the widely-used read surface carries no mutation
+/// capability. The control loop derives the radius and sheds out-of-responsibility
+/// bins; this only publishes an already-derived value and moves no data.
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait SettableRadius: ReserveStore {
-    /// Commit a new storage-responsibility radius.
-    ///
-    /// After this returns, [`storage_radius`](ReserveStore::storage_radius)
-    /// reports `radius` and [`is_responsible_for`](ReserveStore::is_responsible_for)
-    /// is evaluated against it.
+    /// Publish an already-derived storage radius.
     fn set_storage_radius(&self, radius: StorageRadius);
 }
 
-/// One entry yielded by a per-bin insertion-order scan.
-///
-/// A flat, projected row of the reserve's append-only per-bin index: enough to
-/// drive redistribution and sync (which chunk, under which batch, at what
-/// insertion sequence) without rehydrating the chunk body. The `stamp_hash`
-/// identifies the exact stamp version that admitted the chunk, so a consumer can
-/// detect a re-stamp without fetching the value.
+/// A projected row of the reserve's per-bin index: enough to drive
+/// redistribution and sync (which chunk, batch, insertion sequence) without
+/// rehydrating the chunk body. `stamp_hash` identifies the exact stamp version,
+/// so a consumer can detect a re-stamp without fetching the value.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinScanItem {
-    /// The chunk's monotonically increasing insertion sequence within its bin.
+    /// Monotonically increasing insertion sequence within the bin.
     pub seq: u64,
-    /// The chunk's address.
+    /// Address of the stored chunk.
     pub address: ChunkAddress,
-    /// The postage batch under which the chunk was stamped.
+    /// Postage batch the entry was stamped under.
     pub batch_id: BatchId,
-    /// A hash identifying the exact stamp version that admitted the chunk.
+    /// Hash of the exact stamp version, to detect a re-stamp without a fetch.
     pub stamp_hash: B256,
 }
 
-/// A reserve that also exposes its append-only, per-bin insertion order.
-///
-/// Adds the insertion-order axis to [`ReserveStore`]: each bin keeps a
-/// monotonically increasing cursor, and chunks can be replayed in insertion
-/// order from an arbitrary starting sequence. Redistribution and sync use this
-/// to stream "what landed in this bin since cursor C" without scanning the whole
-/// reserve.
-///
-/// Object-safe by construction: [`scan_bin_from`](Self::scan_bin_from) returns a
-/// boxed iterator rather than an RPITIT, so the trait can be used behind `dyn`.
+/// Adds an append-only per-bin insertion-order axis to [`ReserveStore`]. Each
+/// bin keeps a monotonic cursor; entries can be replayed from an arbitrary
+/// sequence, so redistribution and sync stream "what landed since cursor C"
+/// without scanning the whole reserve.
 pub trait BinCursorStore: ReserveStore {
-    /// The current insertion cursor for `bin`: the highest sequence assigned in
-    /// that bin so far (`0` if the bin is empty).
+    /// Highest sequence assigned in `bin` so far (`0` if empty).
     fn bin_cursor(&self, bin: Bin) -> SwarmResult<u64>;
 
-    /// Replay `bin`'s entries in insertion order starting at `start_seq`,
-    /// inclusive.
-    ///
-    /// The iterator yields a fallible [`BinScanItem`] per entry. It is `Send` so
-    /// a redistribution/sync task can move it across an await point.
-    ///
-    /// Backed by a lazy read-only cursor that owns its snapshot, so the iterator
-    /// outlives the call that opened it. The scan compacts on eviction, so it
-    /// yields only entries whose chunk is still present; a consumer that needs the
-    /// body still resolves it through [`get`](SwarmLocalStore::get).
+    /// Replay `bin`'s entries in insertion order from `start_seq`, inclusive.
+    /// The iterator is `Send` (movable across an await point) and owns its
+    /// snapshot. It compacts on eviction, yielding only entries whose chunk is
+    /// still present; resolve the body via [`get`](SwarmLocalStore::get).
     fn scan_bin_from<'a>(
         &'a self,
         bin: Bin,

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -1,44 +1,22 @@
-//! Swarm API - core abstractions for Ethereum Swarm.
+//! Swarm API - libp2p-agnostic trait surface for an Ethereum Swarm node. The
+//! libp2p boundary lives in `vertex-swarm-node`.
 //!
-//! This crate defines *what* the Swarm protocol does without prescribing *how*.
-//! All traits are libp2p-agnostic; the libp2p boundary lives in `vertex-swarm-node`.
+//! Node capabilities form a trait chain, each level adding associated types:
+//! [`SwarmPrimitives`] (`Spec` + `Identity`), [`SwarmNetworkTypes`] (+ topology),
+//! [`SwarmClientTypes`] (+ accounting), [`SwarmStorerTypes`] (+ store).
 //!
-//! # Type Hierarchy
+//! Runtime containers mirror the chain: [`BootnodeComponents`] (topology),
+//! [`ClientComponents`] (+ chunk client), [`StorerComponents`] (+ store), accessed
+//! through [`HasTopology`], [`HasChunkClient`], [`HasStore`], [`HasIdentity`].
+//! Accounting is not a component: it is wired into the network chunk client and
+//! shared through an `Arc` at launch; bootnodes run a listen-only pricing handler.
 //!
-//! Node capabilities are modelled as a trait chain where each level adds
-//! associated types for additional services:
+//! [`SwarmProtocol`] implements [`vertex_node_api::NodeProtocol`].
 //!
-//! - [`SwarmPrimitives`] - `Spec` + `Identity` (pure data, no services)
-//! - [`SwarmNetworkTypes`] - adds `Topology` (peer discovery)
-//! - [`SwarmClientTypes`] - adds `Accounting` (bandwidth + pricing)
-//! - [`SwarmStorerTypes`] - adds `Store` (local chunk persistence)
-//!
-//! # Component Containers
-//!
-//! Each capability level has a runtime container:
-//!
-//! - [`BootnodeComponents`] - topology only
-//! - [`ClientComponents`] - topology + chunk client (transport read surface)
-//! - [`StorerComponents`] - topology + chunk client + store
-//!
-//! Access is abstracted via [`HasTopology`], [`HasChunkClient`], [`HasStore`],
-//! and [`HasIdentity`] traits. Accounting is not a component: it is a
-//! builder-wired internal of the network chunk client (settled through a shared
-//! `Arc` at launch), and bootnodes run only a listen-only pricing handler.
-//!
-//! # Protocol Integration
-//!
-//! [`SwarmProtocol`] implements [`vertex_node_api::NodeProtocol`], bridging the
-//! Swarm domain with the generic node infrastructure.
-//!
-//! # Peer Reporting
-//!
-//! [`PeerReporter`] is the single sanctioned path for subsystems to affect a
-//! peer's score, with [`SwarmScoringEvent`] as the shared event vocabulary.
-//! [`PeerAffordability`] lets protocol handlers ask bandwidth accounting
-//! whether a peer can pay for a request, and [`PeerLifecycleEvent`] carries
-//! the resulting lifecycle decisions (warnings, disconnects, bans) to
-//! subscribers such as topology.
+//! [`PeerReporter`] is the only path for subsystems to affect a peer's score
+//! ([`SwarmScoringEvent`] is the event vocabulary). [`PeerAffordability`] asks
+//! accounting whether a peer can pay; [`PeerLifecycleEvent`] carries the resulting
+//! decisions (warnings, disconnects, bans) to subscribers such as topology.
 
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -98,7 +76,6 @@ pub use self::types::{
     SwarmNetworkTypes, SwarmNodeType, SwarmPrimitives, SwarmStorerTypes, TopologyOf,
 };
 
-// Re-export primitives for convenience
 pub use nectar_primitives::{
     AnyChunk, Bin, Chunk, ChunkAddress, ChunkType, ChunkTypeId, ChunkTypeSet, ContentChunk,
     ProximityOrder, SingleOwnerChunk, StandardChunkSet,

--- a/crates/swarm/builder/src/handle.rs
+++ b/crates/swarm/builder/src/handle.rs
@@ -12,15 +12,11 @@ use vertex_tasks::{GracefulShutdown, NodeTask, NodeTaskFn};
 use crate::providers::NetworkChunkProvider;
 use crate::verify::VerifyingChunkProvider;
 
-/// Network chunk provider wrapped with config-gated download verification.
 type VerifiedChunkProvider = VerifyingChunkProvider<NetworkChunkProvider<Arc<Identity>>>;
 
-/// Build output from launching a Swarm node.
-///
-/// Contains the node's main event loop task function and the api component
-/// container. The component type `P` determines the node's capabilities; all
-/// containers implement `HasTopology` for topology access. The transport (gRPC
-/// today) is wired at `bin/vertex`, not here.
+/// Build output from launching a Swarm node: the event-loop task function plus
+/// the component container `P`, which determines the node's capabilities. All
+/// containers implement `HasTopology`. The transport is wired at `bin/vertex`.
 pub struct BuiltNode<P> {
     task_fn: NodeTaskFn,
     providers: P,
@@ -31,7 +27,7 @@ impl<P> BuiltNode<P> {
         Self { task_fn, providers }
     }
 
-    /// Consume and create the main event loop task with graceful shutdown.
+    /// Build the event-loop task wired to the shutdown signal.
     pub fn into_task(self, shutdown: GracefulShutdown) -> NodeTask {
         (self.task_fn)(shutdown)
     }
@@ -48,14 +44,12 @@ impl<P> BuiltNode<P> {
         self.providers
     }
 
-    /// Decompose into task function and providers.
     pub fn into_parts(self) -> (NodeTaskFn, P) {
         (self.task_fn, self.providers)
     }
 }
 
 impl<P: HasTopology> BuiltNode<P> {
-    /// Access the topology handle.
     pub fn topology(&self) -> &P::Topology {
         self.providers.topology()
     }
@@ -68,10 +62,9 @@ pub type BuiltBootnode = BuiltNode<BootnodeComponents<TopologyHandle<Arc<Identit
 pub type BuiltClient =
     BuiltNode<ClientComponents<TopologyHandle<Arc<Identity>>, VerifiedChunkProvider>>;
 
-/// Built storer node (topology + chunks + the persisting reserve as the local
-/// store). The store is erased to `Arc<dyn SwarmLocalStore>`: the launch path
-/// keeps the concrete reserve and shares one trait handle with the node so
-/// serving-on-retrieval reads the reserve.
+/// Built storer node (topology + chunks + persisting reserve as the local
+/// store). The store is erased to `Arc<dyn SwarmLocalStore>` so one handle is
+/// shared for serve-on-retrieval while the launch path keeps the concrete reserve.
 pub type BuiltStorer = BuiltNode<
     StorerComponents<
         TopologyHandle<Arc<Identity>>,

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -66,11 +66,9 @@ where
 
 /// Open the shared database when persistence is configured.
 ///
-/// `ctx.db_path()` is the single source of truth for the storage mode: `None`
-/// means the node runs fully in-memory and no database is opened, `Some(path)`
-/// opens (or creates) the database file there and spawns the periodic metrics
-/// task. An open failure on a configured path degrades to in-memory operation
-/// instead of aborting the node; the warning spells out what is lost.
+/// `ctx.db_path()` selects the storage mode: `None` runs fully in-memory,
+/// `Some(path)` opens (or creates) the file and spawns the metrics task. An open
+/// failure on a configured path degrades to in-memory rather than aborting.
 fn open_shared_database(ctx: &dyn InfrastructureContext) -> Option<Arc<RedbDatabase>> {
     let Some(path) = ctx.db_path() else {
         info!("Node storage: in-memory (opt into persistence with --db.persist or --db.path)");
@@ -115,22 +113,12 @@ fn spawn_db_metrics_task(ctx: &dyn InfrastructureContext, db: Arc<RedbDatabase>)
         });
 }
 
-/// Construct, validate, and log the shared chain provider for a chain-needing
-/// node.
+/// Build and validate the shared chain provider for a chain-needing node.
 ///
-/// Selects the network address book from the spec, then builds and validates a
-/// wallet-filled alloy provider over the configured RPC URL signed by the node's
-/// Ethereum identity. The chain is a shared provider, not a long-lived service,
-/// so there is nothing to spawn: the returned [`SharedChainProvider`] is a
-/// cloneable handle that future chain consumers (the SWAP settlement service in
-/// a later PR) borrow to build their clients (for example a
-/// `ChequebookContract`).
-///
-/// Returns:
-/// - `Ok(Some(provider))` when the chain is connected and validated.
-/// - `Ok(None)` when the chain is deliberately skipped (no RPC URL configured,
-///   or a development network with no canonical deployment).
-/// - `Err` only when a configured connection fails to connect or validate.
+/// Returns `Ok(None)` when the chain is deliberately skipped (no RPC URL, or a
+/// network with no canonical deployment), `Err` only when a configured
+/// connection fails. The returned [`SharedChainProvider`] is a cloneable handle,
+/// not a spawned service.
 #[cfg(feature = "chain")]
 async fn build_node_chain_provider(
     spec: &Arc<Spec>,
@@ -206,44 +194,34 @@ macro_rules! define_launch_types {
 }
 
 define_launch_types!(
-    /// Associated type set for the bootnode launch path: spec, identity, and
-    /// topology only, with no bandwidth accounting.
+    /// Bootnode launch types: spec, identity, topology, no accounting.
     BootnodeLaunchTypes
 );
 define_launch_types!(
-    /// Associated type set for the client launch path: the bootnode types plus
-    /// the default bandwidth accounting stack.
+    /// Client launch types: bootnode types plus the default accounting stack.
     ClientLaunchTypes,
     with_client
 );
 define_launch_types!(
-    /// Associated type set for the storer launch path: the bootnode types plus
-    /// the default bandwidth accounting stack.
+    /// Storer launch types: bootnode types plus the default accounting stack.
     StorerLaunchTypes,
     with_client
 );
 
-/// Factory that turns the opened shared database (if any) into the node's
-/// `SwarmLocalStore`.
+/// Turns the opened shared database (if any) into the node's `SwarmLocalStore`.
 ///
-/// The store is the single surface the retrieval handler consults before going
-/// to the network, so each node type wires its own: the client builds a
-/// byte-bounded in-memory cache (the database handle is ignored), while the
-/// storer builds the persisting reserve over the same database the peer store
-/// backs onto. The factory receives the opened database so the storer reserve
-/// and the peer store share one handle rather than opening the file twice.
+/// Each node type wires its own: the client ignores the handle and builds an
+/// in-memory cache, the storer builds the persisting reserve over the same
+/// database the peer store backs onto (one handle, not two opens).
 type StoreFactory<'a> =
     Box<dyn FnOnce(Option<Arc<RedbDatabase>>) -> Result<NodeStore, SwarmNodeError> + Send + 'a>;
 
-/// The node's local store, plus the storer reserve view when the node is a
-/// storer.
+/// The node's local store, plus the storer reserve view when the node is a storer.
 ///
-/// A storer's local store *is* its reserve, but the two trait objects are
-/// distinct (`Arc<dyn ReserveStore>` does not upcast to `Arc<dyn SwarmLocalStore>`),
-/// so both views of the one `DbReserve` are carried here: `local` is what the
-/// retrieval handler and the components share, and `reserve` is the proximity-axis
-/// view the pushsync ingest path needs (`is_responsible_for`, `put`,
-/// `storage_radius`). A client leaves `reserve` `None`.
+/// A storer's local store *is* its reserve, but `Arc<dyn ReserveStore>` does not
+/// upcast to `Arc<dyn SwarmLocalStore>`, so both views of the one `DbReserve` are
+/// carried: `local` for retrieval and components, `reserve` for pushsync ingest.
+/// A client leaves `reserve` `None`.
 struct NodeStore {
     local: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
     reserve: Option<Arc<dyn vertex_swarm_api::ReserveStore>>,
@@ -266,28 +244,22 @@ struct ClientNodeParams<'a> {
     swap: &'a SwapConfig,
 }
 
-/// Outputs of [`build_client_backed_node`]: the long-running node task plus the
-/// handles the node-type-specific RPC providers wrap.
+/// Outputs of [`build_client_backed_node`]: the node task plus the handles the
+/// node-type-specific RPC providers wrap.
 struct ClientNodeParts {
     task: NodeTaskFn,
     topology: TopologyHandle<Arc<Identity>>,
     chunks: VerifiedChunkProvider,
-    /// The node's local store, erased to the trait. The node holds its own
-    /// clone; the storer wires this one as its components' store so the
-    /// retrieval-serving reserve and the served store are the same instance.
+    /// The node's local store, erased to the trait; the storer wires this same
+    /// instance into its components so retrieval and storage share one store.
     store: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
 }
 
-/// Shared launch path for the node types backed by a client node (client and
-/// storer).
+/// Shared launch path for the client- and storer-backed node types.
 ///
-/// Builds the node, then the bandwidth accounting (reporting violations to the
-/// peer manager, with SWAP settlement embedded when enabled) and the verified
-/// chunk provider with score- and affordability-aware candidate selection,
-/// spawns the client service and the SWAP settlement service, connects the
-/// chain provider when the node type requires one, and wraps the node run loop
-/// in a task that owns the accounting and chain handles for the node's
-/// lifetime.
+/// Wires accounting (violations to the peer manager, SWAP settlement when
+/// enabled) and the selection-aware verified chunk provider, then spawns the run
+/// loop in a task owning the accounting and chain handles for the node's lifetime.
 async fn build_client_backed_node(
     ctx: &dyn InfrastructureContext,
     params: ClientNodeParams<'_>,
@@ -298,22 +270,14 @@ async fn build_client_backed_node(
     let db = open_shared_database(ctx);
     let peer_store = create_peer_store(&db);
 
-    // Build the node's local store from the opened database. The client ignores
-    // the handle and runs an in-memory cache; the storer builds the persisting
-    // reserve over the same `db` so the reserve and the peer store share one
-    // handle. The same store serves inbound retrievals and holds local
-    // deliveries: the retrieval handler consults `SwarmLocalStore::get` before
-    // the network, so a storer serves from its reserve.
     let NodeStore {
         local: store,
         reserve,
     } = (params.make_store)(db.clone())?;
-    // The node consumes its own clone; the returned handle is the same instance
-    // the storer surfaces as its components' store.
     let node_store = Arc::clone(&store);
 
-    // Prepare SWAP settlement first: the provider must be embedded in the
-    // accounting, and the swap event sink must be routed at node build time.
+    // SWAP settlement is prepared first: the provider embeds in the accounting
+    // and the swap event sink routes at node build time.
     #[cfg(feature = "swap")]
     let (swap_provider, swap_wiring) = crate::swap::SwapWiring::prepare(
         params.spec,
@@ -341,9 +305,8 @@ async fn build_client_backed_node(
         ctx.executor(),
     );
 
-    // The peer manager behind the topology handle is the reporting authority:
-    // accounting and the settlement services report violations through it so
-    // misbehaving peers are scored down.
+    // The peer manager is the reporting authority: accounting and the settlement
+    // services report violations through it so misbehaving peers are scored down.
     let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
 
     let accounting_builder = AccountingBuilder::new(params.bandwidth.clone())
@@ -358,31 +321,26 @@ async fn build_client_backed_node(
     };
     #[cfg(not(feature = "swap"))]
     let accounting = accounting_builder.build(params.identity);
-    // Share one accounting instance across the selector, the two-leg forwarder,
+    // One accounting instance is shared by the selector, the two-leg forwarder,
     // and the node task that keeps it alive.
     let accounting = Arc::new(accounting);
 
-    // Enable multi-hop forwarding: a retrieval cache miss relays to a
-    // strictly-closer peer and an inbound pushsync relays toward the chunk's
-    // neighbourhood, accounting both legs over the same accounting instance the
-    // origin path uses. Installed before the event loop accepts connections.
+    // Multi-hop forwarding: a retrieval cache miss relays to a strictly-closer
+    // peer and an inbound pushsync relays toward the chunk's neighbourhood,
+    // accounting both legs over the same instance. Must precede the event loop.
     node.enable_forwarding(
         Arc::new(topology.clone()),
         Arc::clone(&accounting),
         client_handle.clone(),
     );
 
-    // Storer ingest: when the node is a storer, give the inbound pushsync path
-    // its reserve so a delivery the node is responsible for is stored and
-    // acknowledged with a signed receipt instead of being relayed. Installed
-    // before the event loop accepts connections, alongside forwarding. A client
-    // has no reserve and keeps the verbatim-relay path.
+    // Storer ingest: the inbound pushsync path gets the reserve so a delivery the
+    // node is responsible for is stored and acknowledged with a signed receipt
+    // instead of relayed. A client has no reserve and keeps the verbatim relay.
     if let Some(reserve) = reserve {
         node.enable_storage(reserve);
     }
 
-    // Retrieval and pushsync candidate selection consults peer scores and
-    // affordability on top of proximity order.
     let selector = Arc::new(PeerSelector::new(
         Arc::new(topology.clone()),
         accounting.bandwidth().clone(),
@@ -390,17 +348,9 @@ async fn build_client_backed_node(
         Arc::new(AccountingSettlement::new(accounting.bandwidth().clone())),
     ));
 
-    // Outbound self-throttle: pace our retrieval and pushsync requests under
-    // each peer's pseudosettle allowance so a burst never crosses the remote's
-    // settlement trigger. The allowance signal is the same `PeerAffordability`
-    // the selector consults, built once in accounting. One bucket token is one
-    // AU: the bucket refills at the pseudosettle per-second forgiveness rate
-    // (`refresh_rate` AU/sec) and each request costs the exact per-chunk
-    // proximity price the remote meters, taken from the same pricer the
-    // accounting layer debits through, so a neighborhood chunk paces at the full
-    // forgiveness rate while a distant one costs proportionally more. The bucket
-    // is sized to a configurable percent of the headroom toward the payment
-    // threshold, keeping a burst below the swap trigger with a margin to spare.
+    // Outbound self-throttle: pace our retrieval and pushsync requests under each
+    // peer's pseudosettle allowance so a burst never crosses the settlement
+    // trigger. See `SelfThrottle` for the token/price/sizing model.
     let throttle = Arc::new(SelfThrottle::new(&accounting, params.bandwidth));
     let throttled_handle = client_handle.clone().with_throttle(Arc::clone(&throttle));
 
@@ -408,11 +358,8 @@ async fn build_client_backed_node(
         NetworkChunkProvider::new(throttled_handle, topology.clone()).with_selector(selector);
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
-    // Spawn client service as independent task with graceful shutdown. The
-    // client service reports retrieval and pushsync outcomes (success,
-    // failure, and malformed-chunk invalid data) through the same peer manager
-    // authority that accounting uses.
-    // The service shares the same throttle instance the handle paces against, so
+    // The client service reports retrieval and pushsync outcomes through the same
+    // peer manager authority accounting uses, and shares the handle's throttle so
     // a peer disconnect clears that peer's bucket.
     let client_service = client_service
         .with_reporter(Arc::clone(&reporter))
@@ -435,9 +382,9 @@ async fn build_client_backed_node(
         .await?
     };
 
-    // Spawn the SWAP settlement service over the shared accounting instance,
-    // forwarding its cheque commands to the node and cashing received cheques
-    // on chain when a provider is present.
+    // SWAP settlement service over the shared accounting: forwards cheque
+    // commands to the node and cashes received cheques on chain when a provider
+    // is present.
     #[cfg(feature = "swap")]
     if let Some(wiring) = swap_wiring {
         wiring.spawn(
@@ -450,8 +397,8 @@ async fn build_client_backed_node(
         );
     }
 
-    // Return node task - accounting is moved into the closure to keep it
-    // alive. The chain provider is held alive the same way.
+    // Accounting and the chain provider are moved into the task to keep them
+    // alive for the node's lifetime.
     let task = single_task(move |shutdown| async move {
         let _accounting = accounting;
         #[cfg(feature = "chain")]
@@ -526,16 +473,14 @@ impl SwarmLaunchConfig for ClientConfig {
                 network: self.network(),
                 bandwidth: self.bandwidth(),
                 verify: self.verify(),
-                // The cache-only client builds its chunk cache over a
-                // byte-bounded LRU; no reserve, signer, radius, or redb is
-                // wired, so the opened database handle is ignored.
+                // Cache-only client: a byte-bounded LRU, no reserve, so the
+                // opened database handle is ignored and every pushsync relays.
                 make_store: Box::new(|_db| {
                     Ok(NodeStore {
                         local: Arc::new(vertex_swarm_localstore::ChunkStore::with_budget(
                             vertex_swarm_localstore::DEFAULT_CACHE_BUDGET_BYTES as usize,
                             vertex_swarm_localstore::DEFAULT_SOC_CACHE_TTL_NS,
                         )),
-                        // A client has no reserve: every inbound pushsync relays.
                         reserve: None,
                     })
                 }),
@@ -565,33 +510,14 @@ impl SwarmLaunchConfig for StorerConfig {
         self,
         ctx: &dyn InfrastructureContext,
     ) -> Result<(NodeTaskFn, Self::Providers), Self::Error> {
-        // The storer's local store is the persisting reserve. Its capacity is a
-        // consensus quantity, not a function of local disk: the Swarm spec fixes
-        // the reserve at a power-of-two number of chunks
-        // (`DEFAULT_RESERVE_CAPACITY = 2^22`), and the redistribution game derives
-        // the storage radius, and thence the committed depth it samples and
-        // commits on chain, from occupancy relative to exactly that figure. Two
-        // nodes covering the same neighbourhood must therefore agree on the
-        // capacity regardless of how much disk each has provisioned, so the
-        // capacity is read from the spec, never estimated from a byte budget (the
-        // byte budget governs only the client cache and disk provisioning). Start
-        // at radius 0 (responsible for everything until the radius manager raises
-        // it); furthest-from-neighbourhood eviction sheds under pressure.
-        // `redistribution_enabled` is read here so the storage config is no longer
-        // discarded; the redistribution subsystem (which consumes it) is not part
-        // of this train.
+        // Reserve capacity is a consensus quantity read from the spec, not local
+        // disk: a fixed power-of-two chunk count from which the redistribution game
+        // derives storage radius and committed depth, so nodes covering one
+        // neighbourhood must agree on it regardless of disk.
         let _redistribution_enabled = self.storage().redistribution_enabled();
         let capacity = self.spec().reserve_capacity;
         let identity = self.identity().clone();
 
-        // The storer's local store is the persisting reserve, built over the
-        // database the launch path opens. The launch path returns the same
-        // erased handle the node holds (`Arc<dyn ReserveStore>` does not upcast
-        // to `Arc<dyn SwarmLocalStore>`, so the concrete `Arc<DbReserve>` is
-        // kept and the launch path erases the one `SwarmLocalStore` handle the
-        // node and the components share). Serving-on-retrieval reads it because
-        // the retrieval handler consults `SwarmLocalStore::get` before the
-        // network.
         let parts = build_client_backed_node(
             ctx,
             ClientNodeParams {
@@ -615,42 +541,21 @@ impl SwarmLaunchConfig for StorerConfig {
     }
 }
 
-/// Block confirmations a batch must accrue before the reserve will admit chunks
-/// stamped under it.
-///
-/// Matches the intent's `blockThreshold` (`10`): a batch's creation must be
-/// sufficiently confirmed on chain before it is usable, so a reorg cannot
-/// retroactively invalidate admitted chunks. The chain-driven ingest (#391/#392)
-/// will make this configurable once the postage indexer feeds a live
-/// `PostageContext`; until then the reserve runs with no batches and admits
-/// nothing, so the threshold is the admission policy that takes effect the moment
-/// the batch store is populated.
+/// Block confirmations a batch must accrue before the reserve admits chunks
+/// stamped under it, so a reorg cannot retroactively invalidate admitted chunks.
 const RESERVE_CONFIRMATION_THRESHOLD: u64 = 10;
 
 /// Build the storer reserve over the shared database, erased to the local-store
 /// trait.
 ///
-/// Reuses the opened shared database when present so the reserve, its batch
-/// store and the peer store share one handle; falls back to an in-memory redb
-/// when the node runs without persistence, keeping the storer servable (the
-/// reserve just does not survive a restart, matching the in-memory degradation
-/// elsewhere). Both the in-memory open and the reserve's table creation are
-/// surfaced as a build error rather than panicking.
+/// Reuses the opened database when present so the reserve, its batch store and
+/// the peer store share one handle; falls back to in-memory redb without
+/// persistence. Open and table-creation failures surface as a build error.
 ///
-/// The reserve now admits only stamped chunks, so it is built over two further
-/// collaborators sharing the same database:
-///
-/// - a [`DbBatchStore`](vertex_swarm_postage::DbBatchStore), the authoritative
-///   postage batch set and live [`PostageContext`] the admission policy reads;
-/// - an [`AdmissionValidator`](vertex_swarm_postage::AdmissionValidator)
-///   enforcing [`RESERVE_CONFIRMATION_THRESHOLD`] block confirmations plus the
-///   structural and signature checks before a stamped chunk enters the reserve.
-///
-/// The batch store starts empty: until the postage indexer (#391/#392) feeds
-/// `Created`/`TopUp`/`DepthIncrease`/`Expired` events the reserve admits nothing,
-/// which is the correct conservative behaviour for a storer with no known
-/// batches. The wiring is in place so populating the batch store is all that is
-/// left to make the storer admit live traffic.
+/// Admits only stamped chunks, gated by a `DbBatchStore` (the batch set) and an
+/// `AdmissionValidator` enforcing [`RESERVE_CONFIRMATION_THRESHOLD`] confirmations
+/// plus structural and signature checks. The batch store starts empty, so the
+/// reserve admits nothing until the postage indexer populates it.
 fn build_storer_reserve(
     db: Option<Arc<RedbDatabase>>,
     identity: &Arc<Identity>,
@@ -669,8 +574,8 @@ fn build_storer_reserve(
                 .into_arc()
         }
     };
-    // The batch store and the reserve share one database handle, so the postage
-    // ingest seam and the reserve see a single consistent view.
+    // Batch store and reserve share one handle so the postage ingest seam and the
+    // reserve see a single consistent view.
     let batches =
         DbBatchStore::new(Arc::clone(&db)).map_err(|e| SwarmNodeError::Build(e.into()))?;
     let admission = AdmissionValidator::new(RESERVE_CONFIRMATION_THRESHOLD);
@@ -686,8 +591,8 @@ fn build_storer_reserve(
         )
         .map_err(|e| SwarmNodeError::Build(e.into()))?,
     );
-    // One `DbReserve`, two trait-object views: the local-store view the node and
-    // components share, and the reserve view the pushsync ingest path uses.
+    // One `DbReserve`, two trait-object views: local-store (node and components)
+    // and reserve (pushsync ingest).
     Ok(NodeStore {
         local: Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
         reserve: Some(reserve as Arc<dyn vertex_swarm_api::ReserveStore>),
@@ -845,9 +750,8 @@ mod tests {
         );
     }
 
-    /// The launch path hands the peer manager to the accounting builder as the
-    /// peer reporter. Verify that composition end to end: an accounting
-    /// violation must reach the peer manager and lower the peer's score.
+    /// An accounting violation must reach the peer manager wired as reporter and
+    /// lower the peer's score.
     #[test]
     fn accounting_violation_reaches_peer_manager() {
         let identity = test_identity_arc();
@@ -878,20 +782,9 @@ mod tests {
         assert!(after < baseline, "violation must lower the score");
     }
 
-    /// The storer store factory builds the persisting reserve (not the
-    /// cache-only client store) and falls back to an in-memory database when
-    /// persistence is not configured.
-    ///
-    /// The reworked reserve admits only stamped chunks whose batch is known and
-    /// whose stamp passes the admission validator the factory wires. This test
-    /// owns the *wiring* contract: that the factory yields a working
-    /// `SwarmLocalStore` handle, that it is the admission-gated reserve (a put
-    /// for an unknown batch is rejected, proving admission is wired and not
-    /// bypassed), and that the handle serves back what the reserve holds. The
-    /// full admissible-put path (batch registration, signature recovery, owner
-    /// match) is exercised exhaustively by the reserve crate's own tests, which
-    /// can reach the batch store the factory deliberately erases; reproducing it
-    /// here would only re-test the reserve through a narrower seam.
+    /// The storer factory builds the admission-gated reserve, not the cache-only
+    /// client store: a put for an unknown batch is rejected, proving admission is
+    /// wired. The full admissible-put path is covered by the reserve crate.
     #[test]
     fn storer_reserve_factory_builds_admission_gated_store() {
         use alloy_primitives::{B256, Signature};
@@ -900,14 +793,11 @@ mod tests {
         use vertex_swarm_primitives::CachedChunk;
 
         let identity = test_identity_arc();
-        // The reserve capacity is a consensus power-of-two chunk count (the spec
-        // fixes the default at 2^22); a small power of two keeps the test cheap
-        // while matching that shape.
+        // A small power of two matches the consensus chunk-count shape cheaply.
         let capacity: u64 = 1 << 12;
 
         // db = None exercises the in-memory fallback.
         let node_store = build_storer_reserve(None, &identity, capacity).expect("reserve builds");
-        // A storer always exposes the reserve view the pushsync ingest path needs.
         assert!(
             node_store.reserve.is_some(),
             "the storer factory yields the reserve view"
@@ -928,10 +818,9 @@ mod tests {
             "an empty reserve serves nothing"
         );
 
-        // A stamped put whose batch is unknown to the (empty) batch store is
-        // rejected by the wired admission validator. This is the load-bearing
-        // assertion: it proves the factory built the admission-gated reserve and
-        // did not fall back to a store that accepts arbitrary chunks.
+        // A stamped put for a batch unknown to the empty batch store is rejected
+        // by the wired admission validator, proving the factory did not fall back
+        // to a store that accepts arbitrary chunks.
         let chunk: AnyChunk = ContentChunk::new(b"unadmissible".to_vec())
             .expect("valid content chunk")
             .into();

--- a/crates/swarm/net/pushsync/src/error.rs
+++ b/crates/swarm/net/pushsync/src/error.rs
@@ -17,10 +17,8 @@ vertex_net_codec::protocol_error! {
 
         /// Chunk bytes did not match the delivery's address.
         ///
-        /// Carries the message string rather than the source error: chunk
-        /// reconstruction now returns nectar's `StampError`, which `InvalidStamp`
-        /// already claims via `#[from]`, so this variant cannot also derive a
-        /// `From<StampError>`. The call site maps the error to its string.
+        /// Carries a string rather than a source error because the underlying
+        /// `StampError` is already claimed by `InvalidStamp` via `#[from]`.
         #[error("invalid chunk: {0}")]
         InvalidChunk(String),
 
@@ -36,22 +34,18 @@ vertex_net_codec::protocol_error! {
         #[error("invalid storage radius: {0}")]
         InvalidStorageRadius(u32),
 
-        /// A custody receipt's signature did not recover to a signer overlay.
-        /// An all-zero (structural failure) signature, or any signature that
-        /// fails public-key recovery, lands here. Such a receipt is rejected at
-        /// the decode boundary and never reaches a domain consumer.
+        /// Custody receipt signature failed public-key recovery (including the
+        /// all-zero structural-failure signature). Rejected at the decode boundary.
         #[error("custody receipt signature did not recover to a signer overlay")]
         MalformedReceiptSignature,
     }
 }
 
 impl PushsyncError {
-    /// True when the error is a malformed-chunk signal: the delivered bytes
-    /// failed address or stamp reconstruction, or the address itself was
-    /// unparseable. These are attributable to the sending peer and warrant an
-    /// adverse score, distinct from a transport or negotiation failure. Receipt
-    /// decoding errors are excluded since they describe a storer's reply, not a
-    /// chunk a peer pushed at us.
+    /// True for malformed-chunk signals attributable to the sending peer
+    /// (address or stamp reconstruction failed). Excludes receipt-decode errors,
+    /// which describe a storer's reply rather than a chunk pushed at us, and so
+    /// must not feed an adverse score.
     #[must_use]
     pub fn is_invalid_chunk(&self) -> bool {
         matches!(
@@ -75,8 +69,6 @@ mod tests {
 
     #[test]
     fn receipt_decode_errors_are_not_invalid_chunk() {
-        // A bad nonce length describes a storer reply, not a chunk a peer
-        // pushed at us, so it must not be scored as invalid data.
         assert!(!PushsyncError::InvalidNonceLength(3).is_invalid_chunk());
         assert!(!PushsyncError::ConnectionClosed.is_invalid_chunk());
     }

--- a/crates/swarm/net/pushsync/src/receipt.rs
+++ b/crates/swarm/net/pushsync/src/receipt.rs
@@ -1,48 +1,20 @@
-//! The custody receipt: reconstructed and verified at the decode boundary.
+//! The custody receipt, reconstructed and verified at the decode boundary.
 //!
-//! [`Receipt`] is the only receipt representation that exists past the pushsync
-//! decode boundary. An unsigned receipt is not representable: the sole
-//! constructor [`Receipt::reconstruct`] recovers the storer overlay from the
-//! signature, so a receipt whose storer cannot be recovered is rejected at decode
-//! (as [`PushsyncError::MalformedReceiptSignature`]) and never becomes a
-//! [`Receipt`]. Domain code therefore deals only in receipts whose `storer` is a
-//! real, recovered overlay.
+//! [`Receipt`] is the only receipt representation past the decode boundary. Its
+//! sole constructor [`Receipt::reconstruct`] recovers the storer overlay from the
+//! signature, so a receipt whose storer cannot be recovered never becomes a
+//! [`Receipt`]; consumers always see a real, recovered `storer`.
 //!
-//! # Why the storer is recovered, not read
+//! The storer is recovered, not read: it is not on the wire, and on a multi-hop
+//! relay the delivering peer is several hops from the real storer. The storer
+//! signs over the 32-byte chunk address only; the nonce binds the overlay, not
+//! the signature.
 //!
-//! A receipt's storer is not on the wire. The storer signs over the 32-byte chunk
-//! address only; the nonce is a separate field that binds the storer's overlay,
-//! not the signature. On a multi-hop relay the immediate peer that hands a
-//! receipt back is several hops from the real storer, so the storer is recovered
-//! from the signature, never read from whoever delivered the receipt.
-//!
-//! # Depth policy
-//!
-//! [`Receipt::verify_depth`] is the custody-depth check: a receipt is trusted
-//! only when its storer is deep enough for the chunk, with the bar derived from
-//! the locally observed neighbourhood depth and trust-but-verified against the
-//! receipt's own declared radius. The recovery and the check both live next to
-//! the type so consumers call
-//! `receipt.verify_depth(local_depth, neighbourhood_credible)` directly.
-//!
-//! The check is gated on a credible neighbourhood view. The local depth is an
-//! atomic that begins at zero on a fresh, sparse, or just-restarted node, and
-//! the receipt's declared radius is unsigned wire data the responder controls.
-//! With a low local floor the radius would become the sole bar, which a
-//! responder can set to zero, so a shallow receipt would be wrongly accepted. A
-//! caller therefore passes whether its neighbourhood view is credible (its
-//! topology has saturated, so the observed depth reflects a real boundary); when
-//! it is not, the check returns [`DepthVerdict::Unverifiable`] rather than
-//! leaning on an attacker-controlled field it cannot anchor.
-//!
-//! # Future wire format
-//!
-//! When the wire format is later refined to carry a self-authenticating storer
-//! (tracked under a separate fork-gated proposal), only [`Receipt::reconstruct`]
-//! changes: the [`Receipt`] type and every consumer stay put. The recovery has no
-//! topology or database dependency (only the signature, the network id, and
-//! `compute_overlay`); a separate issue tracks lifting it into nectar as a
-//! reusable primitive.
+//! [`Receipt::verify_depth`] checks the storer is deep enough for the chunk. The
+//! bar is `max(local_depth - tolerance, declared_radius)`, gated on a credible
+//! neighbourhood view: an attacker controls the unsigned radius, so without a
+//! credible local floor it returns [`DepthVerdict::Unverifiable`] rather than
+//! trusting the radius alone.
 
 use alloy_signer::SignerSync;
 use nectar_primitives::ChunkAddress;
@@ -55,94 +27,64 @@ use crate::error::PushsyncError;
 
 /// A node identity that can mint its own custody receipt.
 ///
-/// [`Receipt::sign`] needs three things from the minting node, and they are not
-/// three independent parameters: they are all facets of the node's single
-/// identity. The signing key proves custody, and the `network_id` and `nonce`
-/// are the two inputs that, together with the recovered signing address, derive
-/// the storer overlay via [`compute_overlay`] (the same derivation a forwarder
-/// replays in [`Receipt::reconstruct`]). Threading them as loose arguments
-/// duplicated state the identity already owns, so they are bundled behind this
-/// one handle: the caller passes its identity and the receipt path reads the
-/// signer and the overlay-derivation inputs from it.
-///
-/// This trait is deliberately minimal and lives in the pushsync layer rather
-/// than referencing the node's full identity type: pushsync sits below the node
-/// and cannot depend on it. A node-layer identity implements this trait (or a
-/// node-owned capability bundle does), so the richer identity remains the single
-/// source of truth without leaking node concerns into this crate.
+/// Bundles the three facets of the node identity that [`Receipt::sign`] needs:
+/// the signing key, plus the `network_id` and `nonce` that derive the storer
+/// overlay via [`compute_overlay`]. Lives in the pushsync layer because pushsync
+/// sits below the node and cannot depend on the node's full identity type; a
+/// node-layer identity implements this trait.
 pub trait ReceiptSigner {
     /// The synchronous signing key. Erased trait objects
     /// (`dyn SignerSync + Send + Sync`) satisfy this via `alloy-signer`'s blanket
-    /// impls, so a node can plug in its key without this crate being generic over
-    /// the concrete signer.
+    /// impls, so this crate need not be generic over the concrete signer.
     type Signer: alloy_signer::SignerSync + ?Sized;
 
-    /// The receipt signing key, signing over the 32-byte chunk address.
     fn signer(&self) -> &Self::Signer;
 
-    /// The network id, one of the two overlay-derivation inputs.
     fn network_id(&self) -> NetworkId;
 
-    /// The node's identity nonce, the other overlay-derivation input. It binds
-    /// the storer overlay but is not part of the signed message.
+    /// The identity nonce. Binds the storer overlay but is not part of the
+    /// signed message.
     fn nonce(&self) -> Nonce;
 }
 
 /// Length in bytes of a well-formed recoverable signature.
 const SIGNATURE_LEN: usize = 65;
 
-/// Slack subtracted from the locally observed depth before it becomes the floor.
-///
-/// Topology views drift: a peer at the genuine edge of the responsible
-/// neighbourhood can sit one bin shallower than our own observed depth without
-/// being a free-rider. Subtracting a small fixed tolerance from the local floor
-/// avoids false-rejecting such an honest, marginally-shallow receipt while still
-/// rejecting receipts that are meaningfully outside the neighbourhood. The
-/// declared radius can only raise the bar above this floor, never lower it.
+/// Slack subtracted from the local depth before it becomes the floor, so an
+/// honest peer one bin shallower than our observed depth (topology drift) is not
+/// false-rejected.
 pub const SHALLOW_RECEIPT_TOLERANCE: u8 = 1;
 
-/// The storer of a custody receipt is too shallow for the chunk:
-/// `PO(storer, chunk) < required`. The chunk never reached the responsible
-/// neighbourhood, so the custody claim is fraudulent (or, at best, useless for
-/// retrievability) and must be rejected.
+/// The storer is too shallow for the chunk: `PO(storer, chunk) < required`, so
+/// the chunk never reached the responsible neighbourhood.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("shallow receipt: storer proximity {observed} below required depth {required}")]
 pub struct ShallowReceipt {
-    /// The required depth the storer had to reach.
     pub required: u8,
-    /// The storer's actual proximity order to the chunk address.
+    /// The storer's proximity order to the chunk address.
     pub observed: u8,
 }
 
 impl From<&ShallowReceipt> for &'static str {
-    /// The metric label for a shallow-receipt rejection. A static label paired
-    /// with the typed `required`/`observed` fields gives metrics a clean
-    /// `reason` value without leaking the dynamic depths into the label space.
+    /// Static metric label; the dynamic depths stay out of the label space.
     fn from(_: &ShallowReceipt) -> Self {
         "shallow_receipt"
     }
 }
 
-/// The outcome of [`Receipt::verify_depth`].
-///
-/// The check is three-valued because there are two distinct failure modes that
-/// must not be conflated. A [`Shallow`](Self::Shallow) verdict is a positive
-/// finding of misbehaviour: against a credible local view the storer is provably
-/// too shallow, so the responder is penalised. An
-/// [`Unverifiable`](Self::Unverifiable) verdict is the absence of a finding: the
-/// local view is not credible enough to judge custody depth (a fresh, sparse, or
-/// just-restarted node before its neighbourhood saturates), so the receipt is
-/// neither trusted nor blamed.
+/// The outcome of [`Receipt::verify_depth`]. Three-valued to keep two failure
+/// modes distinct: a [`Shallow`](Self::Shallow) verdict is a positive finding of
+/// misbehaviour (penalise the responder); an
+/// [`Unverifiable`](Self::Unverifiable) verdict is the absence of a finding (do
+/// not penalise).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DepthVerdict {
-    /// The storer is deep enough for the chunk against a credible local view.
+    /// Deep enough against a credible local view.
     Verified,
-    /// The storer is provably too shallow against a credible local view; the
-    /// responder must be penalised.
+    /// Provably too shallow against a credible local view; penalise the responder.
     Shallow(ShallowReceipt),
-    /// The local neighbourhood view is not credible, so custody depth cannot be
-    /// judged. The receipt is treated as unconfirmed, not as misbehaviour: the
-    /// responder is not penalised.
+    /// Local view is not credible; custody depth cannot be judged. Treated as
+    /// unconfirmed, not misbehaviour.
     Unverifiable,
 }
 
@@ -150,20 +92,18 @@ pub enum DepthVerdict {
 ///
 /// Constructed only by [`Receipt::reconstruct`], so [`storer`](Self::storer) is
 /// always a real overlay recovered from the signature. The signature and nonce
-/// are retained so a forwarder can relay the receipt verbatim (it never re-signs
-/// or mints a receipt); the recovered storer is what the depth policy consumes.
+/// are retained so a forwarder can relay the receipt verbatim.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Receipt {
-    /// The address of the chunk the receipt acknowledges custody of.
+    /// The chunk this receipt acknowledges custody of.
     pub address: ChunkAddress,
-    /// The overlay recovered from the signature: the real storer, regardless of
-    /// which peer relayed the receipt.
+    /// The real storer recovered from the signature, regardless of relayer.
     pub storer: OverlayAddress,
     /// The storer's signature over the 32-byte chunk address.
     pub signature: alloy_primitives::Signature,
     /// The nonce the storer used to derive its overlay.
     pub nonce: Nonce,
-    /// The storer's declared storage radius at the time of acceptance.
+    /// The storer's declared storage radius at acceptance time.
     pub storage_radius: StorageRadius,
 }
 
@@ -171,20 +111,17 @@ impl Receipt {
     /// Reconstruct and verify the storer of a wire receipt at the decode
     /// boundary.
     ///
-    /// The signed message is the 32-byte chunk address only; the nonce binds the
-    /// overlay, not the signature. The storer overlay is derived from the
-    /// recovered Ethereum address with the canonical
-    /// [`compute_overlay`](vertex_swarm_primitives::compute_overlay) formula
+    /// The storer overlay is derived from the recovered Ethereum address via
+    /// [`compute_overlay`](vertex_swarm_primitives::compute_overlay)
     /// (`keccak256(eth || network_id_le || nonce)`).
     ///
-    /// Returns [`PushsyncError::MalformedReceiptSignature`] for an all-zero
-    /// (structural failure) signature or any signature that fails recovery. This
-    /// is the only way to build a [`Receipt`], so a receipt that reaches a
-    /// consumer is always storer-verified.
+    /// # Errors
+    ///
+    /// [`PushsyncError::MalformedReceiptSignature`] for an all-zero signature
+    /// (the structural-failure signal) or any signature that fails recovery.
     pub fn reconstruct(wire: WireReceipt, network_id: NetworkId) -> Result<Self, PushsyncError> {
-        // The structural failure signal is an all-zero signature; never recover
-        // it. (The codec already rejects a wrong-length signature as a failure
-        // response, so a `WireReceipt` here is full-length.)
+        // The all-zero signature is the structural-failure signal; never recover
+        // it.
         if wire.signature.as_bytes() == [0u8; SIGNATURE_LEN] {
             return Err(PushsyncError::MalformedReceiptSignature);
         }
@@ -206,29 +143,19 @@ impl Receipt {
 
     /// Verify the storer is deep enough for the chunk.
     ///
-    /// The required depth is dynamic: hard-coding it would reject legitimately
-    /// shallow receipts in a small, young, or sparse neighbourhood, failing valid
-    /// uploads. The locally observed neighbourhood depth is the trusted authority
-    /// (the only input an attacker cannot influence), so it sets the floor (minus
-    /// a small [`SHALLOW_RECEIPT_TOLERANCE`] for honest topology drift). The
-    /// receipt's declared `storage_radius` is attacker-controlled and is trusted
-    /// only to raise the bar, never to lower it: a storer that declares a deeper
-    /// radius binds itself to a stricter custody claim, while a shallower (or
-    /// zero) radius cannot weaken the local floor. Hence
-    /// `required = max(local_depth - tolerance, storage_radius)`.
+    /// `required = max(local_depth - tolerance, storage_radius)`. The local depth
+    /// is the trusted authority (the one input an attacker cannot influence) and
+    /// sets the floor, minus [`SHALLOW_RECEIPT_TOLERANCE`] for topology drift.
+    /// The attacker-controlled declared `storage_radius` can only raise the bar,
+    /// never lower it.
     ///
-    /// The floor is only meaningful when `neighbourhood_credible` is true. The
-    /// local depth is an atomic that begins at zero before the neighbourhood
-    /// saturates, and the declared radius is unsigned wire data the responder
-    /// controls. With a non-credible view the floor would collapse to the
-    /// attacker-controlled radius (which the responder can set to zero), so there
-    /// is no bar to anchor: the check returns [`DepthVerdict::Unverifiable`]
-    /// WITHOUT reading the radius. The caller treats that as unconfirmed custody,
-    /// not as misbehaviour.
+    /// When `neighbourhood_credible` is false the floor is meaningless (a fresh
+    /// node's depth begins at zero), so the bar would collapse to the
+    /// attacker-controlled radius; the check returns
+    /// [`DepthVerdict::Unverifiable`] without reading the radius.
     ///
-    /// The depth check is a cheap first filter, not a cryptographic guarantee;
-    /// stake-binding and retrievability auditing (storage incentives, tracked in
-    /// #75) are the layer that makes forgery unprofitable.
+    /// This is a cheap first filter, not a cryptographic guarantee; storage
+    /// incentives (#75) make forgery unprofitable.
     pub fn verify_depth(
         &self,
         local_depth: NeighborhoodDepth,
@@ -248,29 +175,15 @@ impl Receipt {
 
     /// Mint a custody receipt for a chunk this node has taken into its reserve.
     ///
-    /// This is the storer-side counterpart to [`reconstruct`](Self::reconstruct):
-    /// where reconstruct recovers a relayed receipt's storer from the signature,
-    /// `sign` produces a fresh receipt that a forwarder will later reconstruct.
-    /// Everything the minting node contributes comes from its [`ReceiptSigner`]
-    /// identity: it signs over the 32-byte chunk address only (matching what
-    /// `reconstruct` recovers from), and its `network_id` and `nonce` are the two
-    /// overlay-derivation inputs. The `nonce` binds the storer overlay but is not
-    /// part of the signed message. `storage_radius` is the only per-receipt input
-    /// the identity does not own (it tracks the reserve), so it stays an explicit
-    /// argument.
+    /// Storer-side counterpart to [`reconstruct`](Self::reconstruct): produces a
+    /// fresh receipt a forwarder will later reconstruct. The signer, `network_id`
+    /// and `nonce` come from the [`ReceiptSigner`] identity; `storage_radius`
+    /// tracks the reserve and stays an explicit argument.
     ///
-    /// Taking the identity as one handle, rather than the signer plus loose
-    /// `network_id`/`nonce` parameters, keeps the overlay-derivation inputs with
-    /// the key that owns them: the storer overlay is a property of the identity,
-    /// so the three are never passed inconsistently.
-    ///
-    /// The receipt round-trips through [`reconstruct`](Self::reconstruct): the
-    /// `storer` is derived by recovering the signer's Ethereum address from the
-    /// freshly minted signature and applying [`compute_overlay`] with the
-    /// identity's nonce, exactly as the read side does. Deriving it from the
-    /// recovered address (rather than asking the signer for its address)
-    /// guarantees the minted receipt is self-consistent under recovery, so the
-    /// returned [`Receipt`] is fully verified by construction.
+    /// The `storer` is derived by recovering the Ethereum address from the freshly
+    /// minted signature and applying [`compute_overlay`], exactly as the read side
+    /// does, so the receipt is self-consistent under recovery and verified by
+    /// construction.
     pub fn sign(
         identity: &impl ReceiptSigner,
         address: ChunkAddress,
@@ -281,10 +194,8 @@ impl Receipt {
             .signer()
             .sign_message_sync(address.as_bytes())
             .map_err(|_| PushsyncError::MalformedReceiptSignature)?;
-        // Derive the storer overlay the same way `reconstruct` does on the read
-        // side: recover the Ethereum address from the signature over the chunk
-        // address, then combine it with the identity's network id and nonce. A
-        // forwarder reconstructing this receipt recovers exactly this overlay.
+        // Derive the overlay the same way `reconstruct` does, so a forwarder
+        // recovers exactly this overlay.
         let eth = signature
             .recover_address_from_msg(address.as_bytes())
             .map_err(|_| PushsyncError::MalformedReceiptSignature)?;
@@ -300,9 +211,8 @@ impl Receipt {
 
     /// Reproduce the wire receipt for verbatim relay.
     ///
-    /// A forwarder relays the storer's receipt unchanged; it never re-signs. The
-    /// recovered `storer` is not on the wire, so this reproduces only the bytes
-    /// the storer signed (the signature, nonce, and radius for the chunk).
+    /// The recovered `storer` is not on the wire, so this emits only the bytes the
+    /// storer signed.
     #[must_use]
     pub fn to_wire(&self) -> WireReceipt {
         WireReceipt::new(
@@ -323,9 +233,7 @@ mod tests {
 
     const NET: NetworkId = NetworkId::MAINNET;
 
-    /// A test-only [`ReceiptSigner`]: a real signing key plus the identity nonce
-    /// and network id, bundled exactly as a node identity bundles them. Lets the
-    /// receipt tests mint through the production [`Receipt::sign`] path.
+    /// Test-only [`ReceiptSigner`] so the tests mint through [`Receipt::sign`].
     struct TestIdentity {
         signer: PrivateKeySigner,
         nonce: Nonce,
@@ -367,13 +275,9 @@ mod tests {
         StorageRadius::new(Bin::new(n).unwrap())
     }
 
-    /// Grind the node's identity nonce until the storer overlay sits at least
-    /// `min_depth` bits deep relative to `address`, then mint the receipt with the
-    /// production [`Receipt::sign`] path and reduce it to its wire form.
-    ///
-    /// A real node has a fixed identity nonce; the grind here only constructs a
-    /// *test* storer at a chosen depth so the depth-policy tests have a known
-    /// proximity. The receipt itself is minted exactly as production does.
+    /// Grind the nonce until the storer overlay sits at least `min_depth` bits
+    /// deep relative to `address`, then mint via [`Receipt::sign`] and reduce to
+    /// wire form. The grind only constructs a test storer at a known proximity.
     fn wire(
         signer: &PrivateKeySigner,
         address: &ChunkAddress,
@@ -399,9 +303,7 @@ mod tests {
 
     #[test]
     fn sign_mints_a_receipt_that_reconstructs_to_the_same_storer() {
-        // The storer-side mint and the forwarder-side recovery are inverses: a
-        // receipt signed with the node's identity nonce reconstructs to the
-        // overlay that nonce plus the signing key derive.
+        // Mint and recovery are inverses.
         let signer = PrivateKeySigner::random();
         let address = chunk_address(0x42);
         let nonce = Nonce::from([3u8; 32]);
@@ -414,8 +316,7 @@ mod tests {
         assert_eq!(minted.nonce, nonce);
         assert_eq!(minted.storage_radius, radius(7));
 
-        // Round-trip through the wire and the forwarder-side decode boundary: the
-        // reconstructed receipt is byte- and field-identical to the minted one.
+        // Round-trip through the decode boundary is field-identical.
         let reconstructed =
             Receipt::reconstruct(minted.to_wire(), NET).expect("reconstructs the minted receipt");
         assert_eq!(reconstructed, minted);
@@ -471,9 +372,8 @@ mod tests {
     fn shallow_receipt_is_rejected_and_radius_zero_cannot_lower_the_bar() {
         let signer = PrivateKeySigner::random();
         let address = chunk_address(0xff);
-        // The storer is shallow (grind only to depth 0) and declares radius 0 to
-        // try to bypass the check; against a credible local view the local floor
-        // (depth 12) rejects it anyway.
+        // Shallow storer (depth 0) declaring radius 0 cannot bypass the local
+        // floor under a credible view.
         let (raw, storer) = wire(&signer, &address, 0, radius(0));
         let observed = address.proximity(&storer).get();
         let local = observed + SHALLOW_RECEIPT_TOLERANCE + 1;
@@ -487,10 +387,9 @@ mod tests {
 
     #[test]
     fn non_credible_view_returns_unverifiable_even_when_the_floor_collapses() {
-        // Regression for #316: with a non-credible neighbourhood view the local
-        // floor is meaningless and the unsigned radius must not become the sole
-        // bar. Even at the worst case (local_depth == 0, storage_radius == 0, a
-        // storer ground to depth 0) the verdict is Unverifiable, never Verified.
+        // Regression for #316: under a non-credible view the worst case
+        // (local_depth 0, radius 0, storer at depth 0) is Unverifiable, not
+        // Verified.
         let signer = PrivateKeySigner::random();
         let address = chunk_address(0xff);
         let (raw, _) = wire(&signer, &address, 0, radius(0));
@@ -506,8 +405,8 @@ mod tests {
     fn declared_radius_can_only_raise_the_bar() {
         let signer = PrivateKeySigner::random();
         let address = chunk_address(0xff);
-        // A storer ~4 bits deep declaring radius 12 binds itself to a stricter
-        // claim; it is rejected even where the local floor alone would accept it.
+        // A ~4-bit-deep storer declaring radius 12 binds a stricter claim and is
+        // rejected even where the local floor alone would accept it.
         let (raw, storer) = wire(&signer, &address, 4, radius(12));
         let observed = address.proximity(&storer).get();
         assert!(

--- a/crates/swarm/net/retrieval/src/error.rs
+++ b/crates/swarm/net/retrieval/src/error.rs
@@ -17,21 +17,17 @@ vertex_net_codec::protocol_error! {
 
         /// Chunk bytes did not match the requested address.
         ///
-        /// Carries the message string rather than the source error: chunk
-        /// reconstruction now goes through nectar's `AnyChunk::from_wire_bytes`,
-        /// which returns `PrimitivesError` — already claimed by `InvalidAddress`
-        /// via `#[from]` — so this variant cannot also derive a
-        /// `From<PrimitivesError>`. The call site maps the error to its string.
+        /// Carries a string, not the source `PrimitivesError`, because that type
+        /// is already claimed by `InvalidAddress` via `#[from]`.
         #[error("invalid chunk: {0}")]
         InvalidChunk(String),
     }
 }
 
 impl RetrievalError {
-    /// True when the error is a malformed-chunk signal: the delivered bytes
-    /// failed address or stamp reconstruction, or the address itself was
-    /// unparseable. These are attributable to the sending peer and warrant an
-    /// adverse score, distinct from a transport or negotiation failure.
+    /// True for malformed-chunk signals attributable to the sending peer
+    /// (bad bytes, stamp, or address), which warrant an adverse score; false
+    /// for transport or negotiation failures.
     #[must_use]
     pub fn is_invalid_chunk(&self) -> bool {
         matches!(

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -1,8 +1,6 @@
-//! Client service for managing network interactions.
+//! Client service bridging business logic and the network layer.
 //!
-//! The `ClientService` bridges the business logic layer with the network layer.
-//! It owns channels to communicate with `ClientBehaviour` and processes
-//! incoming events.
+//! Owns channels to `ClientBehaviour` and processes incoming events.
 
 use std::sync::Arc;
 
@@ -18,9 +16,7 @@ use vertex_tasks::{GracefulShutdown, SpawnableTask};
 use crate::protocol::{ClientCommand, ClientEvent, FailureKind};
 use crate::throttle::{ProtocolKind, SelfThrottle};
 
-/// Report source label for retrieval-protocol peer scoring.
 const RETRIEVAL_SOURCE: ReportSource = ReportSource::Protocol("retrieval");
-/// Report source label for pushsync-protocol peer scoring.
 const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
 
 pub(crate) const DEFAULT_CHANNEL_CAPACITY: usize = 256;
@@ -28,35 +24,25 @@ pub(crate) const DEFAULT_CHANNEL_CAPACITY: usize = 256;
 /// Handle for sending commands to the network layer.
 ///
 /// Request methods ([`Self::retrieve_chunk`], [`Self::push_chunk`]) thread a
-/// response channel through the command into the per-connection handler, so
-/// each outbound request is a self-contained future: the substream that
-/// carries the request is the correlation, and no shared rendezvous state
-/// exists. Concurrent requests for the same chunk address never collide, so
-/// callers may freely race the same address across peers.
-/// Outbound self-throttle shared by both chunk-transfer protocols.
-///
-/// When set, [`ClientHandle::retrieve_chunk`] and [`ClientHandle::push_chunk`]
-/// pace themselves under the remote peer's pseudosettle allowance before the
-/// request is dispatched. Without it, requests dispatch immediately, exactly as
-/// before the throttle existed (and as the unit tests rely on).
+/// response channel through the command into the per-connection handler, so each
+/// outbound request is a self-contained future correlated by its substream with
+/// no shared rendezvous state. Concurrent requests for the same chunk address
+/// never collide, so callers may race the same address across peers.
 #[derive(Clone)]
 pub struct ClientHandle {
     command_tx: mpsc::Sender<ClientCommand>,
+    /// When set, requests pace themselves under the peer's pseudosettle
+    /// allowance before dispatch.
     throttle: Option<Arc<SelfThrottle>>,
 }
 
 /// Result of a chunk retrieval.
 ///
-/// The chunk is address-validated at decode (BMT hash for content, owner plus
-/// signature for single-owner), so it answers the request regardless of the
-/// stamp. The stamp is optional: a storer answers a retrieval with the chunk
-/// bytes and may omit the stamp from the delivery, which is never re-read on
-/// this path. A stampless chunk is served to the caller; a stampless content
-/// chunk is also cached by address (content is immutable), while a retrieved
-/// single-owner chunk is never cached (it has no version signal).
+/// The chunk is address-validated at decode, so it answers the request
+/// regardless of the stamp. The stamp is optional: a storer may omit it from the
+/// delivery, and it is never re-read on this path.
 #[derive(Debug)]
 pub struct RetrievalResult {
-    /// The retrieved chunk.
     pub chunk: AnyChunk,
     /// The postage stamp the responder attached, if any.
     pub stamp: Option<Stamp>,
@@ -66,43 +52,32 @@ pub struct RetrievalResult {
 
 /// Outcome error shared by both chunk transfer operations.
 ///
-/// Both [`ClientHandle::retrieve_chunk`] (get) and
-/// [`ClientHandle::push_chunk`] (put) resolve through this single type. Most
-/// variants are operation-agnostic and can surface from either path; the two
-/// operation-specific variants are called out below.
+/// Both [`ClientHandle::retrieve_chunk`] and [`ClientHandle::push_chunk`]
+/// resolve through this type; most variants surface from either path.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ChunkTransferError {
-    // Shared variants: either a get or a put can produce these.
-    /// Channel closed.
     #[error("Network channel closed")]
     ChannelClosed,
-    /// The target peer has no active connection.
     #[error("Peer not connected")]
     NotConnected,
-    /// Request cancelled.
     #[error("Request cancelled")]
     Cancelled,
-    /// The request was dispatched but the peer did not complete it within the
-    /// per-protocol deadline (`retrieval_timeout` for a get, `pushsync_timeout`
-    /// for a put). This is the liveness boundary against a withholding peer: the
-    /// outbound substream's upgrade timeout fires and the attempt resolves here
-    /// rather than hanging. It is retryable (see [`Self::is_retryable`]): another
-    /// candidate may answer promptly.
+    /// The peer did not complete the request within the per-protocol deadline
+    /// (`retrieval_timeout` / `pushsync_timeout`). The liveness boundary against
+    /// a withholding peer; retryable against another candidate.
     #[error("Request timed out")]
     TimedOut,
-    /// Local protocol failure (dial, stream, or an inactive handler). Failures
-    /// reported by the remote peer are carried by [`Self::Remote`] instead.
+    /// Local protocol failure (dial, stream, or inactive handler). Remote-side
+    /// failures are carried by [`Self::Remote`].
     #[error("Protocol error: {0}")]
     Protocol(String),
-    /// The remote peer reported a failure (a retrieval error delivery or a
-    /// non-success pushsync receipt). The reason is intentionally not carried:
-    /// the remote's error string is adversarial input we never read.
+    /// The remote reported a failure. The reason is not carried: the remote's
+    /// error string is adversarial input we never read.
     #[error("Remote peer reported a failure")]
     Remote,
 
-    // Retrieval-specific: only a get produces this.
-    /// Chunk not found.
+    /// Retrieval only.
     #[error("Chunk not found: {0}")]
     NotFound(ChunkAddress),
 }
@@ -110,15 +85,10 @@ pub enum ChunkTransferError {
 impl ChunkTransferError {
     /// Whether retrying the request against another candidate may succeed.
     ///
-    /// A timeout, a remote-reported failure, or a transient local protocol
-    /// error are all worth retrying on a fresh peer: a different candidate may
-    /// hold the chunk and answer within the deadline. A cancelled or
+    /// Timeout, remote failure, transient protocol error, and not-found are
+    /// retryable (another candidate may hold the chunk); a cancelled or
     /// channel-closed request reflects a local teardown that another attempt
-    /// cannot fix, and a not-found is the chunk's own absence at the queried
-    /// peer (still potentially elsewhere, so the get path races other
-    /// candidates regardless). The classification exists so callers route a
-    /// withholding peer's `TimedOut` to the next candidate rather than treating
-    /// it as terminal.
+    /// cannot fix.
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::TimedOut | Self::Remote | Self::Protocol(_) | Self::NotFound(_) => true,
@@ -128,7 +98,7 @@ impl ChunkTransferError {
 }
 
 impl ClientHandle {
-    /// Create a new client handle without outbound self-throttling.
+    /// Create a handle without outbound self-throttling.
     pub fn new(command_tx: mpsc::Sender<ClientCommand>) -> Self {
         Self {
             command_tx,
@@ -144,9 +114,10 @@ impl ClientHandle {
         self
     }
 
-    /// Send a command to the network layer (non-blocking).
+    /// Send a command to the network layer.
     ///
-    /// Uses `try_send` because callers (e.g. the libp2p event loop) must not block.
+    /// Non-blocking `try_send`: callers such as the libp2p event loop must not
+    /// block.
     pub fn send_command(&self, command: ClientCommand) -> Result<(), ChunkTransferError> {
         self.command_tx.try_send(command).map_err(|e| match e {
             mpsc::error::TrySendError::Full(_) => {
@@ -160,17 +131,13 @@ impl ClientHandle {
 
     /// Retrieve a chunk from a specific peer.
     ///
-    /// Sends a retrieval command carrying the response channel and waits for
-    /// the outcome. The request is self-contained: any failure on the path
-    /// (peer not connected, queue overflow, substream error, disconnect)
-    /// resolves or drops the channel, so this future never hangs.
+    /// Any failure on the path resolves or drops the response channel, so this
+    /// future never hangs.
     pub async fn retrieve_chunk(
         &self,
         peer: OverlayAddress,
         address: ChunkAddress,
     ) -> Result<RetrievalResult, ChunkTransferError> {
-        // Pace ourselves under the peer's pseudosettle allowance before issuing
-        // the request, so a burst does not trip the remote's refuse threshold.
         if let Some(throttle) = &self.throttle {
             throttle
                 .acquire(peer, address, ProtocolKind::Retrieval)
@@ -190,11 +157,9 @@ impl ClientHandle {
 
     /// Push a stamped chunk to a specific peer.
     ///
-    /// Sends a push command carrying the response channel and waits for the
-    /// storer's [`Receipt`]. Same failure semantics as [`Self::retrieve_chunk`]:
-    /// the future never hangs. The receipt is already storer-verified (the decode
-    /// boundary rejects an unrecoverable receipt), so an `Ok` here always carries
-    /// a recovered storer.
+    /// Same failure semantics as [`Self::retrieve_chunk`]. The returned
+    /// [`Receipt`] is storer-verified at the decode boundary, so an `Ok` here
+    /// always carries a recovered storer.
     pub async fn push_chunk(
         &self,
         peer: OverlayAddress,
@@ -202,8 +167,6 @@ impl ClientHandle {
     ) -> Result<Receipt, ChunkTransferError> {
         let address = *chunk.address();
 
-        // Pace ourselves under the peer's pseudosettle allowance before issuing
-        // the push, so a burst does not trip the remote's refuse threshold.
         if let Some(throttle) = &self.throttle {
             throttle
                 .acquire(peer, address, ProtocolKind::Pushsync)
@@ -223,34 +186,24 @@ impl ClientHandle {
     }
 }
 
-/// Client service that processes network events.
-///
-/// This is the business logic layer that handles `ClientEvent` from the network.
+/// Business-logic layer that processes `ClientEvent`s from the network.
 pub struct ClientService {
-    /// Handle for sending commands.
     handle: ClientHandle,
-    /// Event receiver from the network.
     event_rx: mpsc::Receiver<ClientEvent>,
-    /// Optional peer scoring authority. Retrieval and pushsync outcomes feed
-    /// it so honest peers climb and misbehaving peers are scored down.
-    /// Best-effort: without a reporter, outcomes only surface as logs.
+    /// Peer scoring authority fed by retrieval and pushsync outcomes.
+    /// Best-effort: without it, outcomes only surface as logs.
     reporter: Option<Arc<dyn PeerReporter>>,
-    /// Optional client cache. The service caches the client's own successful
-    /// retrieval of a content chunk here (immutable, served indefinitely, with or
-    /// without a stamp), so a later request can serve it from the cache. A
-    /// retrieved single-owner chunk is never cached: it has no version signal and
-    /// could serve a stale revision.
+    /// Client cache for the node's own retrieval deliveries. Content chunks are
+    /// cached; single-owner chunks are not (no version signal).
     store: Option<Arc<dyn SwarmLocalStore>>,
-    /// Optional outbound self-throttle, shared with the client handle. On
-    /// disconnect the service clears the peer's bucket so memory does not grow
-    /// with the count of distinct peers seen and a reconnect starts fresh.
+    /// Outbound self-throttle shared with the handle; cleared per peer on
+    /// disconnect so memory does not grow with distinct peers seen.
     throttle: Option<Arc<SelfThrottle>>,
 }
 
 impl ClientService {
-    /// Create a new client service with default channel capacity.
-    ///
-    /// Returns the service and a sender for events (to be used by the network layer).
+    /// Create a service with default channel capacity, returning the service, an
+    /// event sender for the network layer, and a command handle.
     pub fn new() -> (Self, mpsc::Sender<ClientEvent>, ClientHandle) {
         let (command_tx, _command_rx) = mpsc::channel(DEFAULT_CHANNEL_CAPACITY);
         let (event_tx, event_rx) = mpsc::channel(DEFAULT_CHANNEL_CAPACITY);
@@ -268,9 +221,8 @@ impl ClientService {
         (service, event_tx, handle)
     }
 
-    /// Create with explicit channels.
-    ///
-    /// Use this when the network layer creates the command channel.
+    /// Create with explicit channels, for when the network layer owns the
+    /// command channel.
     pub fn with_channels(
         command_tx: mpsc::Sender<ClientCommand>,
         event_rx: mpsc::Receiver<ClientEvent>,
@@ -289,9 +241,6 @@ impl ClientService {
     }
 
     /// Attach a peer reporter so retrieval and pushsync outcomes feed scoring.
-    ///
-    /// Reporting is best-effort and non-blocking. Without a reporter, outcomes
-    /// only surface as logs, exactly as before.
     #[must_use]
     pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
         self.reporter = Some(reporter);
@@ -301,23 +250,20 @@ impl ClientService {
     /// Attach the client cache so the service caches its own retrieval
     /// deliveries.
     ///
-    /// A content chunk resolved from one of our own outbound retrievals is cached
-    /// here (immutable, served indefinitely, with or without a stamp). A
-    /// single-owner chunk is never cached from retrieval, since a stampless SOC
-    /// has no version signal and could serve a stale revision. Without a store,
-    /// deliveries are not cached and a repeat request always hits the network.
+    /// Content chunks are cached by address (immutable); single-owner chunks are
+    /// not, since a stampless SOC has no version signal and could serve a stale
+    /// revision.
     #[must_use]
     pub fn with_store(mut self, store: Arc<dyn SwarmLocalStore>) -> Self {
         self.store = Some(store);
         self
     }
 
-    /// Attach the outbound self-throttle so the service clears a peer's bucket
-    /// on disconnect.
+    /// Attach the outbound self-throttle so the service clears a peer's bucket on
+    /// disconnect.
     ///
-    /// This must be the same [`SelfThrottle`] instance attached to the
-    /// [`ClientHandle`] via [`ClientHandle::with_throttle`], so the bucket the
-    /// outbound API paces against is the one cleared here.
+    /// Must be the same [`SelfThrottle`] instance attached to the
+    /// [`ClientHandle`] via [`ClientHandle::with_throttle`].
     #[must_use]
     pub fn with_throttle(mut self, throttle: Arc<SelfThrottle>) -> Self {
         self.throttle = Some(throttle);
@@ -329,7 +275,6 @@ impl ClientService {
         self.handle.clone()
     }
 
-    /// Report a scoring event for a peer if a reporter is configured.
     fn report(&self, peer: &OverlayAddress, event: SwarmScoringEvent, source: ReportSource) {
         if let Some(reporter) = &self.reporter {
             reporter.report_peer(peer, event, source);
@@ -390,15 +335,9 @@ impl ClientService {
                 stamp,
                 latency,
             } => {
-                // The requester is resolved directly by the handler; this
-                // event exists for accounting, peer scoring, and caching. The
-                // chunk was already verified against the requested address at
-                // decode, so an honest delivery raises the peer's score. A
-                // retrieved content chunk (CAC) is immutable, so it is cached by
-                // address (with or without a stamp, exactly as delivered) and a
-                // later request serves it locally. A retrieved SOC is never
-                // cached: it arrives without a version signal and could serve a
-                // stale revision, so it is delivered to the caller only.
+                // The requester is resolved by the handler; this event exists for
+                // accounting, scoring, and caching. Content chunks are cached by
+                // address (immutable); SOCs are not (no version signal).
                 debug!(%peer, %address, ?latency, "Chunk received");
                 if let Some(store) = &self.store
                     && chunk.is_content()
@@ -447,8 +386,8 @@ impl ClientService {
                 address,
                 latency,
             } => {
-                // The pusher is resolved directly by the handler; this event
-                // exists for accounting and peer scoring.
+                // The pusher is resolved by the handler; this event exists for
+                // accounting and scoring.
                 debug!(%peer, %address, ?latency, "Receipt received");
                 self.report(
                     &peer,
@@ -459,9 +398,6 @@ impl ClientService {
 
             ClientEvent::PeerDisconnected { peer_id, overlay } => {
                 debug!(%peer_id, %overlay, "Peer disconnected");
-                // Drop the peer's throttle bucket so memory does not grow with
-                // the count of distinct peers seen and a reconnect starts from a
-                // fresh allowance rather than stale credit.
                 if let Some(throttle) = &self.throttle {
                     throttle.clear(&overlay);
                 }
@@ -489,24 +425,12 @@ impl ClientService {
                 error,
                 kind,
             } => {
-                // The requester is resolved directly by the handler; this
-                // event exists for peer scoring.
-                //
-                // A malformed chunk is invalid data (weight -10): the peer
-                // handed back bytes that failed address/stamp reconstruction,
-                // which is genuine misbehaviour and is scored adversely.
-                //
-                // A plain `Protocol` failure (the remote reported "I don't have
-                // it" / could not forward, a timeout, or a transport error) is
-                // NOT scored: a peer not holding or not forwarding a requested
-                // chunk is the expected, blameless outcome for the vast majority
-                // of peers on any given retrieval, and on a bulk download the
-                // flood of such misses would otherwise decay scores past the
-                // disconnect threshold and prune the peer set (erode Kademlia
-                // depth). The staggered race already steers around an unhelpful
-                // candidate within a request; bee likewise uses a temporary
-                // per-chunk skiplist here, never a connection-killing score
-                // penalty. Only misbehaviour touches the persistent score.
+                // Scoring policy: a malformed chunk is misbehaviour and scored
+                // adversely. A plain `Protocol` failure (miss, timeout, or
+                // transport error) is blameless and not scored, so a bulk
+                // download's flood of misses cannot decay the peer set past the
+                // disconnect threshold; the staggered race steers around an
+                // unhelpful candidate within a request instead.
                 warn!(%peer, %address, %error, ?kind, "Retrieval failed");
                 match kind {
                     FailureKind::InvalidChunk => {
@@ -518,8 +442,7 @@ impl ClientService {
                         self.report(&peer, SwarmScoringEvent::InvalidData, RETRIEVAL_SOURCE);
                     }
                     FailureKind::Protocol => {
-                        // Blameless miss/timeout: count it for visibility but do
-                        // not penalise the peer's score.
+                        // Blameless miss: counted but not scored.
                         metrics::counter!(
                             "swarm.client.retrieval_miss",
                             "protocol" => "retrieval",
@@ -535,12 +458,8 @@ impl ClientService {
                 error,
                 kind,
             } => {
-                // The pusher is resolved directly by the handler; this event
-                // exists for peer scoring. Same classification as retrieval: a
-                // malformed receipt is invalid data (scored), while a plain
-                // `Protocol` failure (the peer could not store/forward, a
-                // timeout, or a transport error) is a blameless outcome that
-                // must not drive the peer toward disconnection.
+                // Same scoring policy as retrieval: a malformed receipt is
+                // scored, a plain `Protocol` failure is blameless.
                 warn!(%peer, %address, %error, ?kind, "Push failed");
                 match kind {
                     FailureKind::InvalidChunk => {
@@ -562,9 +481,8 @@ impl ClientService {
             }
 
             ClientEvent::InboundInvalidData { peer, protocol } => {
-                // A peer pushed us a malformed chunk or sent a malformed
-                // retrieval request: the decode rejected it and it was never
-                // relayed. Score the sender adversely for invalid data.
+                // Decode rejected a malformed inbound chunk or request before
+                // relay; score the sender adversely.
                 warn!(%peer, %protocol, "Inbound malformed data rejected");
                 metrics::counter!(
                     "swarm.client.invalid_chunk",
@@ -595,7 +513,6 @@ impl ClientService {
                 // TODO: Credit peer's balance in accounting system:
                 //   accounting.for_peer(peer).credit(amount.as_u64() as i64);
 
-                // Send ack with current timestamp
                 let ack = PaymentAck::now(amount);
 
                 if let Err(e) = self.handle.send_command(ClientCommand::AckPseudosettle {
@@ -671,14 +588,12 @@ mod tests {
     }
 
     impl RecordingReporter {
-        /// Return the single recorded report, asserting exactly one exists.
         fn single(&self) -> (OverlayAddress, SwarmScoringEvent, ReportSource) {
             let reports = self.reports.lock().unwrap();
             assert_eq!(reports.len(), 1, "expected exactly one report");
             *reports.first().expect("one report")
         }
 
-        /// Assert that no scoring report was recorded.
         fn assert_none(&self) {
             let reports = self.reports.lock().unwrap();
             assert!(reports.is_empty(), "expected no report, got {reports:?}");
@@ -713,10 +628,7 @@ mod tests {
 
     #[test]
     fn plain_retrieval_failure_does_not_penalise_peer() {
-        // A blameless miss/timeout (`FailureKind::Protocol`) is the expected
-        // outcome for a peer that simply does not hold or cannot forward the
-        // chunk. It must not touch the peer's persistent score, so a bulk
-        // download cannot decay the peer set past the disconnect threshold.
+        // `FailureKind::Protocol` is a blameless miss and must not be scored.
         let (service, reporter) = service_with_reporter();
         service.process_event(ClientEvent::RetrievalFailed {
             peer: peer(2),
@@ -743,9 +655,8 @@ mod tests {
 
     #[test]
     fn plain_push_failure_does_not_penalise_peer() {
-        // Mirror of the retrieval case: a peer that could not store/forward a
-        // pushed chunk (timeout, transport error, remote-reported failure) is
-        // not misbehaving and must not be scored toward disconnection.
+        // Mirror of the retrieval case: a `FailureKind::Protocol` push failure
+        // must not be scored.
         let (service, reporter) = service_with_reporter();
         service.process_event(ClientEvent::PushFailed {
             peer: peer(4),
@@ -787,7 +698,7 @@ mod tests {
         assert_eq!(source, ReportSource::Protocol("pushsync"));
     }
 
-    // Throttle wiring at the outbound-API boundary.
+    // Throttle wiring at the outbound API boundary.
     use crate::throttle::SelfThrottle;
     use vertex_swarm_api::{
         Au, BandwidthMode, PeerAffordability, SwarmBandwidthAccounting, SwarmClientAccounting,
@@ -799,10 +710,7 @@ mod tests {
     use vertex_swarm_test_utils::MockIdentity;
 
     /// A fixed per-peer allowance, in AU, for the throttle's allowance signal.
-    ///
-    /// Also stands in as the [`SwarmBandwidthAccounting`] half of the client
-    /// accounting mock: the throttle reads only affordability and pricing off the
-    /// accounting object, so the accounting surface is a no-op.
+    /// Also serves as a no-op [`SwarmBandwidthAccounting`] half of the mock.
     #[derive(Clone)]
     struct FixedAllowance(u64);
     impl PeerAffordability for FixedAllowance {
@@ -847,8 +755,8 @@ mod tests {
         }
     }
 
-    /// A pricer that meters every chunk at one AU, so the throttle's bucket holds
-    /// exactly `tokens` requests.
+    /// Meters every chunk at one AU, so the bucket holds exactly `tokens`
+    /// requests.
     #[derive(Clone)]
     struct OneAuPricer;
     impl SwarmPricing for OneAuPricer {
@@ -860,8 +768,7 @@ mod tests {
         }
     }
 
-    /// Minimal [`SwarmClientAccounting`] bundling a fixed allowance and the
-    /// one-AU pricer so [`SelfThrottle::new`] can extract both.
+    /// Bundles the fixed allowance and one-AU pricer for [`SelfThrottle::new`].
     #[derive(Clone)]
     struct MockClientAccounting {
         bandwidth: FixedAllowance,
@@ -879,9 +786,8 @@ mod tests {
         }
     }
 
-    /// Build a handle whose throttle gives each peer a bucket of `tokens`
-    /// one-AU requests (refresh rate and per-request chunk price are both 1 AU,
-    /// so the bucket holds exactly `tokens` requests and refills one per second).
+    /// Build a handle whose throttle gives each peer a bucket of `tokens` one-AU
+    /// requests, refilling one per second.
     fn throttled_handle(tokens: u64) -> (ClientHandle, mpsc::Receiver<ClientCommand>) {
         let (tx, rx) = mpsc::channel::<ClientCommand>(16);
         let accounting = MockClientAccounting {
@@ -889,7 +795,7 @@ mod tests {
             pricing: OneAuPricer,
         };
         // Only refresh_rate (1 AU/sec) and throttle_allowance_percent (100) are
-        // read off the config; the rest are placeholders the throttle ignores.
+        // read; the rest are placeholders.
         let config = DefaultBandwidthConfig::new(
             BandwidthMode::Pseudosettle,
             0,
@@ -973,7 +879,7 @@ mod tests {
 
     #[tokio::test]
     async fn unthrottled_handle_dispatches_immediately() {
-        // Without a throttle the handle behaves exactly as before: no pacing.
+        // Without a throttle there is no pacing.
         let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
         let handle = ClientHandle::new(tx);
         let address = test_address();

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -1,9 +1,5 @@
-//! ClientNode - Swarm node with client protocols for chunk retrieval and upload.
-//!
-//! A [`ClientNode`] extends the base topology protocols with client protocols:
-//! pricing, retrieval, pushsync, and settlement (pseudosettle/swap).
-//!
-//! Use this for nodes that need to read from and write to the Swarm network.
+//! [`ClientNode`]: base topology protocols plus client protocols (pricing,
+//! retrieval, pushsync, settlement) for reading from and writing to the network.
 
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -39,14 +35,12 @@ use crate::{ClientHandle, ClientService};
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "ClientNodeEvent")]
 pub(crate) struct ClientNodeBehaviour<I: SwarmIdentity + Clone> {
-    /// Transport-level connection caps (total, per-peer, pending). Listed
-    /// first so a denied connection is rejected before the other behaviours
-    /// allocate per-connection state.
+    /// Connection caps (total, per-peer, pending). First so a denied connection
+    /// is rejected before other behaviours allocate per-connection state.
     pub(crate) connection_limits: connection_limits::Behaviour,
     pub(crate) identify: identify::Behaviour,
-    /// NAT traversal (AutoNAT v2, UPnP) and LAN discovery (mDNS), composed as
-    /// one platform sub-behaviour. The browser sibling is a no-op: a wasm
-    /// client dials over websockets and never listens.
+    /// NAT traversal and LAN discovery as one platform sub-behaviour; a no-op in
+    /// the browser, where a wasm client dials over websockets and never listens.
     pub(crate) nat: NatBehaviour,
     pub(crate) topology: TopologyBehaviour<I>,
     pub(crate) client: ClientBehaviour,
@@ -63,20 +57,18 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
         let agent_versions = topology.agent_versions();
         Self {
             connection_limits,
-            // Identify advertises addresses scoped to each peer (see
+            // Identify advertises addresses scoped per peer (see
             // `addresses_for_remote`), so a public peer never receives our
-            // private or loopback addresses. A NAT'd node with no public address
-            // sends an empty listen set to public peers; peers tolerate this
-            // (they fall back to the connection's remote multiaddr).
+            // private or loopback addresses.
             identify: identify::Behaviour::new(
                 identify::Config::new(local_public_key),
                 agent_versions,
             ),
             nat,
             topology,
-            // The cache-only client never relays: the forwarder is stubbed so a
-            // cache miss and every inbound pushsync reset the substream. The real
-            // multi-hop relay is filled in separately.
+            // Cache-only client never relays: the stub forwarder resets the
+            // substream on cache miss and every inbound pushsync. The real relay
+            // is installed by `enable_forwarding`.
             client: ClientBehaviour::new(
                 ClientBehaviourConfig::default(),
                 store,
@@ -86,9 +78,8 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
     }
 }
 
-/// Assemble the client base node, wiring the platform NAT sub-behaviour
-/// (AutoNAT v2, UPnP, and mDNS natively; a no-op in the browser) into the
-/// composite.
+/// Assemble the client base node, wiring the platform NAT sub-behaviour into
+/// the composite.
 async fn build_client_base<I, C>(
     infra: BuiltInfrastructure<I>,
     network_config: &C,
@@ -146,10 +137,8 @@ impl From<ClientEvent> for ClientNodeEvent {
     }
 }
 
-/// A Swarm client node with pricing, retrieval, and pushsync protocols.
-///
-/// Unlike [`BootNode`](super::BootNode), this includes client protocols for
-/// reading from and writing to the Swarm network.
+/// A Swarm client node with pricing, retrieval, and pushsync protocols. Unlike
+/// [`BootNode`](super::BootNode), it can read from and write to the network.
 pub struct ClientNode<I: SwarmIdentity + Clone> {
     base: BaseNode<I, ClientNodeBehaviour<I>>,
     client_event_tx: mpsc::Sender<ClientEvent>,
@@ -173,21 +162,12 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
         self.base.topology_handle()
     }
 
-    /// Enable multi-hop forwarding (relay) for this node.
-    ///
-    /// Installs the real network forwarder in place of the default stub, so a
+    /// Enable multi-hop forwarding (relay), replacing the default stub so a
     /// retrieval cache miss forwards to a strictly-closer peer and an inbound
     /// pushsync relays toward the chunk's neighbourhood, accounting both legs.
-    /// Must be called during node assembly, before the event loop accepts
-    /// connections: a handler created earlier would capture the stub.
     ///
-    /// `topology` selects strictly-closer relay candidates, provides the locally
-    /// observed neighbourhood depth that bounds the receipt depth check, yields
-    /// the network id (via its identity spec) the decode boundary uses to recover
-    /// a receipt signer, and yields the peer reporter that is the single scoring
-    /// path a shallow relayed receipt is reported through; `accounting` drives the
-    /// two-leg prepare/apply. The topology and accounting handles are typically
-    /// the same ones the origin path uses.
+    /// Must be called during node assembly, before the event loop accepts
+    /// connections: a handler created earlier captures the stub.
     pub fn enable_forwarding<T, A>(
         &mut self,
         topology: Arc<T>,
@@ -207,9 +187,8 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
         let local = self.overlay_address();
         let network_id = topology.identity().spec().network_id();
         let reporter = topology.reporter();
-        // The decode boundary needs the network id to recover an inbound custody
-        // receipt's signer; set it on the behaviour config before any handler is
-        // created (handlers clone the config at connection establishment).
+        // Network id recovers an inbound receipt's signer; set it before any
+        // handler is created (handlers clone the config at connection setup).
         self.base
             .swarm
             .behaviour_mut()
@@ -225,29 +204,22 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
             .set_forwarder(forwarder);
     }
 
-    /// Install the storer ingest capability on the client behaviour.
-    ///
-    /// Turns the inbound pushsync path from forward-only into store-and-sign for
-    /// chunks this node is responsible for: a responsible delivery is put into
-    /// `reserve` and acknowledged with a receipt signed by the node's identity
-    /// key, bound to the node's identity nonce. Deliveries the node is not
-    /// responsible for still forward (see [`enable_forwarding`](Self::enable_forwarding)).
+    /// Install the storer ingest capability, turning the inbound pushsync path
+    /// from forward-only into store-and-sign for chunks this node is responsible
+    /// for: a responsible delivery is put into `reserve` and acknowledged with a
+    /// receipt signed by the identity key, bound to its nonce. Non-responsible
+    /// deliveries still forward (see
+    /// [`enable_forwarding`](Self::enable_forwarding)).
     ///
     /// Must be called during node assembly, before the event loop accepts
-    /// connections: a handler created earlier would not capture the capability.
-    /// Only the storer launch path calls this; a client never does.
+    /// connections: a handler created earlier does not capture the capability.
     pub fn enable_storage(&mut self, reserve: Arc<dyn vertex_swarm_api::ReserveStore>) {
         use vertex_swarm_api::SwarmSpec;
 
         let identity = self.base.identity();
         let nonce = identity.nonce();
-        // The storer overlay a minted receipt binds is derived from the same
-        // identity that signs it, so the capability carries the identity's
-        // network id and nonce alongside the signer rather than re-deriving them
-        // elsewhere.
         let network_id = identity.spec().network_id();
-        // The identity's concrete signer is erased to the synchronous signer
-        // trait; `I::Signer: Signer + SignerSync`, so the coercion is sound.
+        // `I::Signer: Signer + SignerSync`, so erasing to SignerSync is sound.
         let signer: Arc<dyn alloy_signer::SignerSync + Send + Sync> = identity.signer();
         let capability = crate::protocol::StorerCapability::new(reserve, signer, network_id, nonce);
         self.base
@@ -294,9 +266,6 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
     }
 
     /// Run the event loop with graceful shutdown support.
-    ///
-    /// When the shutdown signal fires, the node will complete its current work
-    /// and exit gracefully.
     pub async fn run(mut self, shutdown: GracefulShutdown) -> Result<()> {
         info!("Starting client node event loop");
 
@@ -439,11 +408,8 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
         self
     }
 
-    /// Inject the client chunk cache.
-    ///
-    /// The behaviour serves inbound retrievals from it and the client service
-    /// caches its own deliveries into it. When unset, the build creates a
-    /// default in-memory cache with the standard budget and SOC TTL.
+    /// Inject the client chunk cache (served for inbound retrievals and used for
+    /// the client's own deliveries). Defaults to an in-memory cache when unset.
     pub fn with_store(mut self, store: Arc<dyn SwarmLocalStore>) -> Self {
         self.store = Some(store);
         self
@@ -462,11 +428,8 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
         self
     }
 
-    /// Route swap wire events to the SWAP settlement service.
-    ///
-    /// When set, swap cheque events are forwarded to this channel so the
-    /// settlement service can validate and credit received cheques and complete
-    /// outbound settlements.
+    /// Route swap cheque events to the SWAP settlement service for validation,
+    /// crediting, and outbound settlement.
     #[cfg(feature = "swap")]
     pub fn with_swap_events(
         mut self,
@@ -503,9 +466,6 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
             }
         };
 
-        // Default to an in-memory cache sized by the standard budget and SOC
-        // TTL; an embedder or the native builder injects its own via
-        // `with_store`.
         let store: Arc<dyn SwarmLocalStore> = self.store.unwrap_or_else(|| {
             Arc::new(vertex_swarm_localstore::ChunkStore::with_budget(
                 vertex_swarm_localstore::DEFAULT_CACHE_BUDGET_BYTES as usize,
@@ -515,7 +475,6 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
 
         let mut base = build_client_base(infra, network_config, Arc::clone(&store)).await?;
 
-        // Register the local PeerId for address advertisement in handshakes
         base.swarm
             .behaviour()
             .topology
@@ -546,8 +505,6 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
         let (event_tx, event_rx) = mpsc::channel(crate::client_service::DEFAULT_CHANNEL_CAPACITY);
 
         let (client_service, client_handle) = ClientService::with_channels(command_tx, event_rx);
-        // The service caches the client's own retrieval deliveries into the same
-        // cache the behaviour serves inbound requests from.
         let client_service = client_service.with_store(store);
 
         let node = ClientNode {

--- a/crates/swarm/node/src/protocol/behaviour.rs
+++ b/crates/swarm/node/src/protocol/behaviour.rs
@@ -1,8 +1,6 @@
-//! ClientBehaviour for managing client-side protocols.
-//!
-//! This behaviour manages multiple client protocols (pricing, retrieval, pushsync)
-//! using a per-connection handler pattern. Handlers start in dormant state and are
-//! activated after handshake completion.
+//! `ClientBehaviour`: the client-side protocols (pricing, retrieval, pushsync)
+//! driven through a per-connection [`ClientHandler`]. Handlers are created
+//! dormant and activated after handshake completion.
 
 use std::{
     collections::{HashMap, VecDeque},
@@ -34,12 +32,10 @@ use super::{
 
 const DEFAULT_MAX_PENDING_EVENTS: usize = 4096;
 
-/// Configuration for the client behaviour.
 #[derive(Debug, Clone)]
 pub(crate) struct Config {
-    /// Handler configuration.
     pub(crate) handler: HandlerConfig,
-    /// Maximum pending events before dropping new ones.
+    /// Pending-event queue cap; events past it are dropped.
     pub(crate) max_pending_events: usize,
 }
 
@@ -53,9 +49,8 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Build a config for the given local node role. The handler's inbound
-    /// protocol set is narrowed by role: bootnodes advertise pricing only,
-    /// clients and storers advertise the full client protocol set.
+    /// The handler's inbound protocol set is narrowed by role: bootnodes
+    /// advertise pricing only, clients and storers the full set.
     pub(crate) fn for_role(local_role: vertex_swarm_primitives::SwarmNodeType) -> Self {
         let mut cfg = Self::default();
         cfg.handler.local_role = local_role;
@@ -63,46 +58,31 @@ impl Config {
     }
 }
 
-/// The ClientBehaviour manages client-side protocols.
-///
-/// It creates handlers in dormant state for each connection, and activates
-/// them after receiving `ActivatePeer` commands (typically sent after
-/// handshake completion).
-///
-/// # Event Routing
-///
-/// Settlement events can be routed directly to settlement services via optional
-/// event senders. Use [`route_pseudosettle_events`](Self::route_pseudosettle_events)
-/// to configure routing. Events are still emitted as [`ClientEvent`] for other consumers.
+/// Creates dormant handlers per connection and activates them on an
+/// `ActivatePeer` command (sent after handshake completion). Settlement events
+/// can additionally be routed to dedicated sinks via the `route_*` setters;
+/// they are still emitted as [`ClientEvent`].
 pub(crate) struct ClientBehaviour {
     config: Config,
-    /// The client cache, cloned into each handler at connection establishment so
-    /// inbound retrievals can serve from it.
+    /// Cloned into each handler at connection establishment so inbound
+    /// retrievals can serve from it.
     store: Arc<dyn SwarmLocalStore>,
-    /// The forwarder seam, cloned into each handler so a cache miss or a
-    /// pushsync can relay to a closer peer.
+    /// Cloned into each handler so a cache miss or pushsync can relay to a
+    /// closer peer.
     forward: Arc<dyn Forwarder>,
-    /// The storer ingest capability, present only on a storer node and cloned
-    /// into each handler. When absent (a client) every inbound pushsync takes the
-    /// verbatim-relay path; when set, deliveries the node is responsible for are
-    /// stored and acknowledged with a signed receipt.
+    /// Present only on a storer. When set, deliveries the node is responsible
+    /// for are stored and acknowledged with a signed receipt; when absent every
+    /// inbound pushsync takes the verbatim-relay path.
     storer: Option<StorerCapability>,
-    /// Map of peer_id -> overlay for activated peers.
     peer_overlays: HashMap<PeerId, OverlayAddress>,
-    /// Map of overlay -> peer_id for reverse lookup.
     overlay_peers: HashMap<OverlayAddress, PeerId>,
-    /// Pending events to emit.
     pending_events: VecDeque<ToSwarm<ClientEvent, HandlerCommand>>,
-    /// Optional sender for pseudosettle events.
     pseudosettle_event_tx: Option<mpsc::UnboundedSender<PseudosettleEvent>>,
-    /// Optional sender for swap events.
     #[cfg(feature = "swap")]
     swap_event_tx: Option<mpsc::UnboundedSender<SwapEvent>>,
 }
 
 impl ClientBehaviour {
-    /// Create a new client behaviour with the given configuration, cache, and
-    /// forwarder.
     pub(crate) fn new(
         config: Config,
         store: Arc<dyn SwarmLocalStore>,
@@ -123,40 +103,30 @@ impl ClientBehaviour {
     }
 
     /// Install the storer ingest capability, turning inbound pushsync into a
-    /// store-and-sign path for chunks this node is responsible for.
+    /// store-and-sign path for chunks this node is responsible for. Only a
+    /// storer installs this; a client keeps the verbatim-relay path.
     ///
-    /// Must be called before any peer connects, for the same reason as
-    /// [`set_forwarder`](Self::set_forwarder): handlers clone the capability at
-    /// connection establishment, so a handler created earlier would not see it.
-    /// Only a storer node installs this; a client never does and keeps the
-    /// verbatim-relay path.
+    /// Must run before any peer connects: handlers clone it at connection setup.
     pub(crate) fn set_storer(&mut self, storer: StorerCapability) {
         self.storer = Some(storer);
     }
 
     /// Install the multi-hop relay forwarder, replacing the default stub.
     ///
-    /// Must be called before any peer connects: handlers clone the forwarder at
-    /// connection establishment, so a handler created before this call captures
-    /// the stub. The node builder installs the real forwarder during assembly,
-    /// well before the event loop accepts connections.
+    /// Must run before any peer connects: handlers clone it at connection setup.
     pub(crate) fn set_forwarder(&mut self, forward: Arc<dyn Forwarder>) {
         self.forward = forward;
     }
 
-    /// Set the network id used to recover an inbound custody receipt's signer at
-    /// the decode boundary.
+    /// Network id used to recover an inbound custody receipt's signer at the
+    /// decode boundary.
     ///
-    /// Must be called before any peer connects, for the same reason as
-    /// [`set_forwarder`](Self::set_forwarder): handlers clone the config at
-    /// connection establishment, so a handler created earlier captures the
-    /// default. The node builder sets it during assembly.
+    /// Must run before any peer connects: handlers clone the config at connection
+    /// setup.
     pub(crate) fn set_network_id(&mut self, network_id: nectar_primitives::NetworkId) {
         self.config.handler.network_id = network_id;
     }
 
-    /// Build a dormant handler for a new connection, sharing the cache and
-    /// forwarder into it.
     fn new_handler(&self) -> ClientHandler {
         ClientHandler::new(
             self.config.handler.clone(),
@@ -166,10 +136,7 @@ impl ClientBehaviour {
         )
     }
 
-    /// Route pseudosettle events to the given sink.
-    ///
-    /// Once routed, pseudosettle-related events will be sent to this channel
-    /// in addition to being emitted as [`ClientEvent`].
+    /// Also send pseudosettle events to `tx` (still emitted as [`ClientEvent`]).
     pub(crate) fn route_pseudosettle_events(
         &mut self,
         tx: mpsc::UnboundedSender<PseudosettleEvent>,
@@ -177,11 +144,7 @@ impl ClientBehaviour {
         self.pseudosettle_event_tx = Some(tx);
     }
 
-    /// Route swap events to the given sink.
-    ///
-    /// Once routed, swap-related events will be sent to this channel in addition
-    /// to being emitted as [`ClientEvent`]. The node wires this up when a swap
-    /// settlement service is present.
+    /// Also send swap events to `tx` (still emitted as [`ClientEvent`]).
     #[cfg(feature = "swap")]
     // Wired by the node builder when the swap settlement service is present.
     #[allow(dead_code)]
@@ -189,7 +152,6 @@ impl ClientBehaviour {
         self.swap_event_tx = Some(tx);
     }
 
-    /// Push an event if the queue isn't full, otherwise drop with a metric.
     fn push_event(&mut self, event: ToSwarm<ClientEvent, HandlerCommand>) {
         if self.pending_events.len() >= self.config.max_pending_events {
             warn!("Behaviour event queue full, dropping event");
@@ -199,7 +161,6 @@ impl ClientBehaviour {
         self.pending_events.push_back(event);
     }
 
-    /// Handle a command from the application layer.
     pub(crate) fn on_command(&mut self, command: ClientCommand) {
         match command {
             ClientCommand::ActivatePeer {
@@ -316,12 +277,10 @@ impl ClientBehaviour {
         }
     }
 
-    /// Handle an event from a handler.
     fn on_handler_event(&mut self, peer_id: PeerId, event: HandlerEvent) {
         match event {
             HandlerEvent::Activated { overlay } => {
                 debug!(%peer_id, %overlay, "Handler activated");
-                // Already tracked in on_command, just emit event
                 self.pending_events
                     .push_back(ToSwarm::GenerateEvent(ClientEvent::PeerActivated {
                         peer_id,
@@ -450,7 +409,6 @@ impl ClientBehaviour {
                 amount,
                 request_id,
             } => {
-                // Route to pseudosettle service if configured
                 if let Some(tx) = &self.pseudosettle_event_tx
                     && tx
                         .send(PseudosettleEvent::Received {
@@ -470,7 +428,6 @@ impl ClientBehaviour {
                 }));
             }
             HandlerEvent::PseudosettleSent { overlay, ack } => {
-                // Route to pseudosettle service if configured
                 if let Some(tx) = &self.pseudosettle_event_tx
                     && tx
                         .send(PseudosettleEvent::Sent {
@@ -493,7 +450,6 @@ impl ClientBehaviour {
                 cheque,
                 peer_rate,
             } => {
-                // Route to swap service if configured
                 if let Some(tx) = &self.swap_event_tx
                     && tx
                         .send(SwapEvent::ChequeReceived {
@@ -514,7 +470,6 @@ impl ClientBehaviour {
             }
             #[cfg(feature = "swap")]
             HandlerEvent::SwapChequeSent { overlay, peer_rate } => {
-                // Route to swap service if configured
                 if let Some(tx) = &self.swap_event_tx
                     && tx
                         .send(SwapEvent::ChequeSent {
@@ -546,7 +501,6 @@ impl NetworkBehaviour for ClientBehaviour {
         _local_addr: &Multiaddr,
         _remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        // Create a dormant handler - will be activated after handshake
         Ok(self.new_handler())
     }
 
@@ -558,7 +512,6 @@ impl NetworkBehaviour for ClientBehaviour {
         _role_override: Endpoint,
         _port_use: libp2p::core::transport::PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        // Create a dormant handler - will be activated after handshake
         Ok(self.new_handler())
     }
 
@@ -567,7 +520,6 @@ impl NetworkBehaviour for ClientBehaviour {
             && info.remaining_established == 0
             && let Some(overlay) = self.peer_overlays.remove(&info.peer_id)
         {
-            // Clean up peer tracking if last connection
             self.overlay_peers.remove(&overlay);
             debug!(peer_id = %info.peer_id, %overlay, "Peer disconnected");
             self.pending_events
@@ -619,7 +571,7 @@ mod tests {
     use crate::client_service::RetrievalResult;
     use crate::protocol::StubForwarder;
 
-    /// A clock fixed at a single instant, for SOC freshness tests.
+    /// Fixed-instant clock for SOC freshness tests.
     struct FixedClock(i64);
 
     impl Clock for FixedClock {
@@ -651,7 +603,6 @@ mod tests {
         OverlayAddress::from([n; 32])
     }
 
-    /// Build a swarm whose `ClientBehaviour` serves from `store`.
     fn swarm_with_store(store: Arc<dyn SwarmLocalStore>) -> Swarm<ClientBehaviour> {
         Swarm::new_ephemeral_tokio(move |_| {
             ClientBehaviour::new(
@@ -662,8 +613,8 @@ mod tests {
         })
     }
 
-    /// Connect two client swarms and activate both handlers with the given
-    /// overlays so the request/serve path is live.
+    /// Connect two client swarms and activate both handlers so the
+    /// request/serve path is live.
     async fn connect_and_activate(
         client: &mut Swarm<ClientBehaviour>,
         server: &mut Swarm<ClientBehaviour>,
@@ -676,7 +627,6 @@ mod tests {
         server.listen().with_memory_addr_external().await;
         client.connect(server).await;
 
-        // Activate each side's handler for the other peer.
         client
             .behaviour_mut()
             .on_command(ClientCommand::ActivatePeer {
@@ -693,7 +643,6 @@ mod tests {
             });
     }
 
-    /// Drive both swarms until the retrieval response channel resolves.
     async fn drive_until_retrieved(
         client: &mut Swarm<ClientBehaviour>,
         server: &mut Swarm<ClientBehaviour>,
@@ -745,8 +694,7 @@ mod tests {
 
     #[tokio::test]
     async fn serves_a_fresh_soc_from_the_cache() {
-        // A single-owner chunk stamped at 900ns, served at 1000ns under a 500ns
-        // TTL: still fresh, so it serves from cache.
+        // SOC stamped at 900ns, served at 1000ns under a 500ns TTL: still fresh.
         let chunk = soc_chunk(b"feed v1", 900);
         let address = *chunk.address();
 
@@ -780,9 +728,9 @@ mod tests {
 
     #[tokio::test]
     async fn expired_soc_is_not_served_and_resets() {
-        // The same SOC stamped at 900ns but served at 2000ns under a 500ns TTL is
-        // expired: the cache reads it as a miss and, with the stub forwarder, the
-        // inbound retrieval resets instead of serving a stale revision.
+        // SOC stamped at 900ns, served at 2000ns under a 500ns TTL: expired, so
+        // the cache misses and the inbound retrieval resets rather than serving a
+        // stale revision.
         let chunk = soc_chunk(b"feed v1", 900);
         let address = *chunk.address();
 
@@ -817,9 +765,8 @@ mod tests {
 
     #[tokio::test]
     async fn cache_miss_resets_with_stub_forwarder() {
-        // The server's cache is empty and its forwarder is the stub, so the
-        // inbound retrieval cannot be served or forwarded: the substream resets
-        // and the requester sees a remote failure.
+        // Empty cache plus stub forwarder: the inbound retrieval can neither
+        // serve nor forward, so the substream resets and the requester fails.
         let address = *content_chunk(b"never cached").address();
 
         let mut client = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
@@ -846,9 +793,8 @@ mod tests {
 
     #[tokio::test]
     async fn inbound_pushsync_resets_with_stub_forwarder() {
-        // The cache-only client never takes custody: an inbound pushsync forwards,
-        // and with the stub forwarder the forward fails, so the substream resets
-        // and the pusher sees a failure. No receipt is ever signed.
+        // A cache-only client never takes custody: inbound pushsync forwards, the
+        // stub forward fails, the substream resets, and no receipt is signed.
         let chunk = content_chunk(b"pushed chunk");
 
         let mut client = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
@@ -885,20 +831,15 @@ mod tests {
 
     // --- Storer ingest (store + sign) integration tests ---
     //
-    // A storer holds a `StorerCapability`: an inbound pushsync delivery the node
-    // is responsible for is stored in the reserve and acknowledged with the
-    // node's own signed receipt, instead of being relayed. A delivery the node is
-    // NOT responsible for still forwards (the verbatim-relay path), which with the
-    // stub forwarder resets — exactly as a client does. Both branches are driven
-    // here through the real libp2p handler.
+    // A storer holds a `StorerCapability`: a responsible delivery is stored and
+    // acknowledged with a signed receipt; a non-responsible delivery forwards
+    // (verbatim-relay), which resets under the stub forwarder. Both branches run
+    // through the real libp2p handler.
 
-    /// A minimal in-memory `ReserveStore` for the ingest tests.
-    ///
-    /// Backs the point-access surface with a map and answers `is_responsible_for`
-    /// from a fixed flag, so a test can put the handler on either branch
-    /// deterministically. The proximity-axis accounting methods are trivial: the
-    /// ingest path only exercises `is_responsible_for`, `put`, and
-    /// `storage_radius`.
+    /// In-memory `ReserveStore` for the ingest tests. `is_responsible_for` is a
+    /// fixed flag so a test can pin either branch; the proximity-axis accounting
+    /// methods are stubs since the ingest path only uses `is_responsible_for`,
+    /// `put`, and `storage_radius`.
     struct MockReserve {
         chunks: std::sync::Mutex<
             std::collections::HashMap<
@@ -987,9 +928,8 @@ mod tests {
         }
     }
 
-    /// Build a server swarm that holds the storer ingest capability: the inbound
-    /// pushsync path stores responsible deliveries and signs receipts. Returns the
-    /// swarm, the shared reserve (to assert what was stored), and the signer (to
+    /// Server swarm holding the storer ingest capability. Returns the swarm, the
+    /// shared reserve (to assert what was stored), the signer and nonce (to
     /// assert the receipt recovers to the storer's overlay).
     fn storer_swarm(
         responsible: bool,
@@ -1018,7 +958,6 @@ mod tests {
                 store,
                 Arc::new(StubForwarder),
             );
-            // The receipt is signed/recovered against this network id.
             behaviour.set_network_id(NetworkId::MAINNET);
             let capability = crate::protocol::StorerCapability::new(
                 Arc::clone(&reserve_for_swarm) as Arc<dyn vertex_swarm_api::ReserveStore>,
@@ -1071,8 +1010,8 @@ mod tests {
             .expect("push resolved within timeout");
 
         let receipt = result.expect("the responsible storer signs and returns a receipt");
-        // The receipt acknowledges this chunk, declares the storer's radius, and
-        // recovers to the storer's own overlay (its identity key + nonce).
+        // The receipt acknowledges the chunk, declares the storer's radius, and
+        // recovers to the storer's own overlay.
         assert_eq!(receipt.address, address);
         assert_eq!(receipt.storage_radius, radius);
         let expected_storer = compute_overlay(&signer.address(), NetworkId::MAINNET, &nonce);
@@ -1080,7 +1019,6 @@ mod tests {
             receipt.storer, expected_storer,
             "the receipt recovers to the storer that signed it"
         );
-        // The chunk is durably in the reserve before the receipt was sent.
         assert!(
             reserve.contains(&address),
             "the responsible storer took custody of the chunk"
@@ -1092,9 +1030,9 @@ mod tests {
         use vertex_swarm_api::StorageRadius;
         use vertex_swarm_primitives::Bin;
 
-        // The storer holds the ingest capability but is NOT responsible for this
-        // chunk, so it takes the forward path. With the stub forwarder the forward
-        // fails and the substream resets; nothing is stored and no receipt signed.
+        // The storer holds the ingest capability but is NOT responsible, so it
+        // forwards; the stub forward fails, the substream resets, nothing is
+        // stored, and no receipt is signed.
         let chunk = content_chunk(b"not my responsibility");
         let address = *chunk.address();
         let radius = StorageRadius::new(Bin::new(4).unwrap());
@@ -1139,10 +1077,10 @@ mod tests {
     // --- Three-node relay (forwarding) integration tests ---
     //
     // These drive the real `NetworkForwarder` through the libp2p harness: node B
-    // sits between requester A and storer C, its forwarder's outbound
-    // `ClientHandle` feeding back into B's own behaviour so the upstream leg is a
-    // genuine A->B->C path. The relay verifies, accounts both legs, caches the
-    // forwarded chunk, and relays the storer's receipt verbatim.
+    // relays between requester A and storer C, its outbound `ClientHandle`
+    // feeding back into B's own behaviour for a genuine A->B->C path. The relay
+    // verifies, accounts both legs, caches the forwarded chunk, and relays the
+    // storer's receipt verbatim.
 
     use nectar_primitives::NetworkId;
     use vertex_swarm_api::{
@@ -1159,8 +1097,8 @@ mod tests {
     use crate::ClientHandle;
     use crate::protocol::NetworkForwarder;
 
-    /// A reporter that drops every report; the relay harness only cares about
-    /// the forward outcome, not the scoring side effect, for the happy path.
+    /// Drops every report; the relay harness asserts on forward outcome, not the
+    /// scoring side effect.
     struct NoopReporter;
 
     impl PeerReporter for NoopReporter {
@@ -1185,7 +1123,7 @@ mod tests {
         Arc::new(ClientAccounting::new(bandwidth, pricer))
     }
 
-    /// An overlay sharing `leading_bits` leading bits with `address`.
+    /// An overlay sharing exactly `leading_bits` leading bits with `address`.
     fn overlay_at_proximity(
         address: &nectar_primitives::ChunkAddress,
         leading_bits: usize,
@@ -1199,9 +1137,9 @@ mod tests {
         OverlayAddress::from(bytes)
     }
 
-    /// Build node B: an empty-cache client whose forwarder relays to `storer`
-    /// (returned by the mock topology) over a `ClientHandle` wired back into B.
-    /// Returns B and the receiver carrying B's own outbound relay commands.
+    /// Node B: a client whose forwarder relays to `storer` (via the mock
+    /// topology) over a `ClientHandle` wired back into B. Returns B and the
+    /// receiver carrying B's outbound relay commands.
     fn relay_node(
         store: Arc<dyn SwarmLocalStore>,
         local: OverlayAddress,
@@ -1220,8 +1158,8 @@ mod tests {
                 store,
                 Arc::new(StubForwarder),
             );
-            // The decode boundary recovers an inbound receipt's signer with this
-            // network id; the storer test receipts are ground against it too.
+            // Inbound receipts are recovered against this network id; the storer
+            // test receipts are ground against it too.
             behaviour.set_network_id(NetworkId::MAINNET);
             let forwarder = Arc::new(NetworkForwarder::new(
                 local,
@@ -1251,8 +1189,6 @@ mod tests {
         let provide_price = accounting.pricing().peer_price(&a_overlay, &address);
         let receive_price = accounting.pricing().peer_price(&c_overlay, &address);
 
-        // C serves the chunk from its cache; B caches the forwarded delivery; A
-        // holds no store of its own.
         let c_store: Arc<dyn SwarmLocalStore> =
             Arc::new(ChunkStore::with_budget(1 << 20, 1_000_000_000));
         c_store.put(chunk.clone().into()).unwrap();
@@ -1267,7 +1203,6 @@ mod tests {
         );
         let mut c = swarm_with_store(c_store);
 
-        // A <-> B and B <-> C, activated with the chosen overlays.
         connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
         connect_and_activate(&mut b, &mut c, b_overlay, c_overlay).await;
 
@@ -1278,7 +1213,7 @@ mod tests {
             response: tx,
         });
 
-        // Drive all three swarms; B's forwarder commands are pumped back into B.
+        // B's forwarder commands are pumped back into B.
         let result = {
             let drive = async {
                 loop {
@@ -1320,8 +1255,8 @@ mod tests {
             "B is debited for the chunk C served it"
         );
 
-        // B cached the forwarded content chunk by address even though the serve
-        // path stripped the stamp: a later get from its store hits, stampless.
+        // The forwarded content chunk is cached stampless (the serve path strips
+        // the stamp), so a later get hits.
         let cached = b_store
             .get(&address)
             .unwrap()
@@ -1334,10 +1269,9 @@ mod tests {
 
     #[tokio::test]
     async fn relay_does_not_cache_a_forwarded_soc() {
-        // The same three-node relay, but the chunk is a single-owner chunk. A
-        // retrieved SOC arrives stampless (the serve path ships data only) and so
-        // carries no version signal, so the relay must forward it without caching:
-        // caching a stampless SOC could later serve a stale revision.
+        // A retrieved SOC arrives stampless, so it carries no version signal: the
+        // relay forwards it without caching (a cached stampless SOC could later
+        // serve a stale revision).
         let chunk = soc_chunk(b"feed revision", 900);
         let address = *chunk.address();
 
@@ -1347,8 +1281,7 @@ mod tests {
 
         let accounting = relay_accounting();
 
-        // C serves the SOC from its cache (a generous TTL keeps it fresh); B is
-        // the relay whose store we assert stays empty; A holds no store.
+        // A generous TTL keeps C's cached SOC fresh.
         let c_store: Arc<dyn SwarmLocalStore> =
             Arc::new(ChunkStore::with_budget(1 << 20, u64::MAX));
         c_store.put(chunk.clone().into()).unwrap();
@@ -1398,7 +1331,6 @@ mod tests {
             "the SOC arrives intact at A"
         );
 
-        // B forwarded the SOC but did not cache it: a get from its store misses.
         assert!(
             b_store.get(&address).unwrap().is_none(),
             "a forwarded SOC must not be cached"
@@ -1407,10 +1339,9 @@ mod tests {
 
     #[tokio::test]
     async fn relay_without_strictly_closer_peer_resets_rather_than_looping() {
-        // B's only routing candidate is no closer to the chunk than the
-        // requester A, so the loop bound rejects it: B cannot forward sideways or
-        // backwards, the inbound retrieval resets, and A sees a remote failure.
-        // No accounting reservation is taken.
+        // B's only candidate is no closer to the chunk than requester A, so the
+        // loop bound rejects it: B cannot forward sideways or backwards, the
+        // inbound retrieval resets, and no accounting reservation is taken.
         let chunk = content_chunk(b"nowhere closer to relay to");
         let address = *chunk.address();
 
@@ -1480,19 +1411,16 @@ mod tests {
         let chunk = content_chunk(b"pushed through B to C");
         let address = *chunk.address();
 
-        // A (pusher) is far; B relays to the strictly-closer C; C is the storer
-        // of record. C's forwarder ClientHandle is answered by the test with a
-        // signed receipt, modelling C taking custody and signing. B and C must
-        // relay that receipt VERBATIM (the cache-only client never signs), so A
-        // sees C's exact signature, nonce, and radius. The relay seams verify the
-        // receipt depth before relaying, so the receipt must be genuinely deep:
-        // signed over the 32-byte chunk address by a key whose overlay (via the
-        // nonce) reaches at least the storer's declared radius for the chunk.
+        // A (pusher) is far; B relays to the strictly-closer C, the storer of
+        // record. The test answers C's outbound push with a signed receipt. B and
+        // C relay that receipt verbatim (a cache-only client never signs), so A
+        // sees C's exact signature, nonce, and radius. The relay seams verify
+        // receipt depth, so the receipt must be genuinely deep: the signer's
+        // overlay (via the nonce) must reach the declared radius for the chunk.
         let a_overlay = overlay_at_proximity(&address, 2);
         let b_overlay = overlay_at_proximity(&address, 3);
         let c_overlay = overlay_at_proximity(&address, 18);
 
-        // The storer's signed receipt, produced once at C and never re-signed.
         // The relay forwarders derive overlays with NetworkId::MAINNET, so grind
         // the nonce against that network id.
         let storer_radius = StorageRadius::new(Bin::new(7).unwrap());
@@ -1509,9 +1437,6 @@ mod tests {
             }
             counter += 1;
         };
-        // C's wire receipt, produced once and never re-signed. The decode
-        // boundary at each hop recovers its storer; the test answers C's outbound
-        // push command with the recovered `Receipt`.
         let storer_receipt = WireReceipt::new(address, signature, nonce, storer_radius);
         let receipt_for_c =
             Receipt::reconstruct(storer_receipt.clone(), NetworkId::MAINNET).expect("reconstructs");
@@ -1559,10 +1484,9 @@ mod tests {
                         _ = a.select_next_some() => {}
                         _ = b.select_next_some() => {}
                         _ = c.select_next_some() => {}
-                        // B's relay leg flows through B's own behaviour.
                         Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
                         // C is the storer: answer its outbound push with the
-                        // signed receipt instead of forwarding it on.
+                        // signed receipt instead of forwarding on.
                         Some(cmd) = c_commands.recv() => {
                             if let ClientCommand::PushChunk { response, .. } = cmd {
                                 let _ = response.send(Ok(receipt_for_c.clone()));
@@ -1578,9 +1502,8 @@ mod tests {
         };
 
         let relayed = result.expect("A receives the storer's receipt through B");
-        // The receipt is relayed verbatim across both hops: A sees C's exact
-        // signature, nonce, and radius, never a re-signed value, and the recovered
-        // storer matches C's storer at every hop.
+        // Verbatim across both hops: A sees C's exact wire receipt and storer,
+        // never a re-signed value.
         assert_eq!(relayed.to_wire(), storer_receipt);
         assert_eq!(relayed.storer, receipt_for_c.storer);
 

--- a/crates/swarm/node/src/protocol/events.rs
+++ b/crates/swarm/node/src/protocol/events.rs
@@ -1,19 +1,8 @@
 //! Events and commands for the client behaviour.
 //!
-//! The client behaviour emits [`ClientEvent`]s and accepts [`ClientCommand`]s.
-//!
-//! # Design
-//!
-//! The client behaviour handles:
-//! - Protocol negotiation and stream management
-//! - Message encoding/decoding
-//! - Per-peer connection state
-//!
-//! # Settlement Events
-//!
-//! Settlement-specific events ([`PseudosettleEvent`]) are defined here
-//! for routing to the respective settlement services. The behaviour routes these
-//! events based on optional senders configured at construction time.
+//! The behaviour emits [`ClientEvent`]s and accepts [`ClientCommand`]s. Settlement
+//! events ([`PseudosettleEvent`], [`SwapEvent`]) are routed to their services via
+//! optional senders configured at construction time.
 
 use alloy_primitives::U256;
 use libp2p::PeerId;
@@ -29,24 +18,17 @@ use crate::client_service::{ChunkTransferError, RetrievalResult};
 
 /// Channel on which an outbound retrieval request resolves.
 ///
-/// The sender travels with the request from the caller through the behaviour
-/// and handler into the outbound substream state, so the response (or any
-/// failure along the way) resolves the caller directly. Dropping the sender
+/// The sender travels with the request to the outbound substream; dropping it
 /// anywhere on that path surfaces as [`ChunkTransferError::Cancelled`].
 pub type RetrievalResponseTx = oneshot::Sender<Result<RetrievalResult, ChunkTransferError>>;
 
 /// Channel on which an outbound chunk push resolves.
 ///
-/// Same lifecycle as [`RetrievalResponseTx`]: the storer's verified receipt or
-/// the failure that prevented it resolves the caller directly. The receipt is a
-/// [`Receipt`]: a receipt whose storer could not be recovered is rejected at the
-/// decode boundary and surfaces here as an error, never as a value.
+/// A receipt whose storer cannot be recovered is rejected at decode and surfaces
+/// here as an error, never as a value.
 pub type PushResponseTx = oneshot::Sender<Result<Receipt, ChunkTransferError>>;
 
 /// Why a retrieval or pushsync request failed, classified for peer scoring.
-///
-/// Derived from the typed codec error at the point the failure is observed, so
-/// the client service never parses error strings to decide how to score a peer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FailureKind {
     /// The peer delivered or pushed a chunk that failed address or stamp
@@ -58,16 +40,10 @@ pub enum FailureKind {
 }
 
 /// Events emitted by the client behaviour.
-///
-/// `ChunkReceived` carries a whole chunk, so it dwarfs the other variants; the
-/// size difference is accepted rather than boxing a value that is emitted once
-/// per delivery and consumed immediately.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum ClientEvent {
     /// Received a payment threshold from a peer.
-    ///
-    /// Validate this threshold and decide whether to continue or disconnect.
     PricingReceived {
         /// The peer's overlay address.
         peer: OverlayAddress,
@@ -83,10 +59,7 @@ pub enum ClientEvent {
         peer: OverlayAddress,
     },
 
-    /// We served an inbound retrieval request from our cache.
-    ///
-    /// The chunk has already gone down the wire; this event is for scoring and
-    /// metrics only.
+    /// We served an inbound retrieval request from our cache (scoring/metrics only).
     InboundServed {
         /// The peer we served.
         peer: OverlayAddress,
@@ -112,11 +85,9 @@ pub enum ClientEvent {
         peer: OverlayAddress,
     },
 
-    /// We took custody of an inbound pushsync delivery: stored it in the reserve
-    /// and acknowledged it with our own signed receipt.
-    ///
-    /// Reached only on a storer responsible for the chunk; this event is for
-    /// scoring and metrics only.
+    /// We stored an inbound pushsync delivery in the reserve and acknowledged it
+    /// with our own signed receipt. Reached only on a storer responsible for the
+    /// chunk (scoring/metrics only).
     InboundStored {
         /// The peer that pushed.
         peer: OverlayAddress,
@@ -132,8 +103,6 @@ pub enum ClientEvent {
     },
 
     /// Received a chunk from a peer (response to our request).
-    ///
-    /// Record the bandwidth usage for accounting.
     ChunkReceived {
         /// The peer that sent the chunk.
         peer: OverlayAddress,
@@ -181,10 +150,8 @@ pub enum ClientEvent {
         kind: FailureKind,
     },
 
-    /// A peer sent us malformed data on an inbound substream.
-    ///
-    /// The chunk or request failed reconstruction at decode and was rejected;
-    /// the sender is scored adversely for invalid data.
+    /// A peer sent malformed data on an inbound substream; rejected at decode and
+    /// scored adversely for invalid data.
     InboundInvalidData {
         /// The peer that sent the malformed data.
         peer: OverlayAddress,
@@ -192,10 +159,7 @@ pub enum ClientEvent {
         protocol: &'static str,
     },
 
-    /// A settlement is needed with a peer.
-    ///
-    /// Emitted when the balance crosses the payment threshold. Initiate
-    /// swap or pseudosettle accordingly.
+    /// The balance crossed the payment threshold; settle via swap or pseudosettle.
     SettlementNeeded {
         /// The peer to settle with.
         peer: OverlayAddress,
@@ -249,9 +213,7 @@ pub enum ClientEvent {
         peer_rate: U256,
     },
 
-    /// A peer's handler has been activated.
-    ///
-    /// This is emitted after the ActivatePeer command is processed.
+    /// A peer's handler has been activated (after [`ClientCommand::ActivatePeer`]).
     PeerActivated {
         /// The libp2p peer ID.
         peer_id: PeerId,
@@ -282,20 +244,13 @@ pub enum ClientEvent {
 
 /// Commands accepted by the client behaviour.
 ///
-/// Request commands ([`Self::RetrieveChunk`], [`Self::PushChunk`]) carry the
-/// response channel for their outcome, so the enum is intentionally not
-/// `Clone`.
-///
-/// `PushChunk` carries a whole [`StampedChunk`], so it dwarfs the other
-/// variants; the size difference is accepted rather than boxing a value that is
-/// constructed once per upload and moved straight onto the wire.
+/// Request commands ([`Self::RetrieveChunk`], [`Self::PushChunk`]) carry their
+/// response channel, so the enum is intentionally not `Clone`.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ClientCommand {
-    /// Activate the handler for a peer after handshake completes.
-    ///
-    /// This is sent by the node when TopologyEvent::PeerAuthenticated is received.
-    /// The handler transitions from dormant to active state.
+    /// Activate the handler for a peer after handshake completes, transitioning it
+    /// from dormant to active.
     ActivatePeer {
         /// The libp2p peer ID.
         peer_id: PeerId,
@@ -306,9 +261,6 @@ pub enum ClientCommand {
     },
 
     /// Announce our payment threshold to a peer.
-    ///
-    /// The threshold value depends on the peer's node type (Storer vs Client)
-    /// and configuration.
     AnnouncePricing {
         /// The peer to announce to.
         peer: OverlayAddress,
@@ -376,10 +328,7 @@ pub enum ClientCommand {
     },
 }
 
-/// Events routed to the pseudosettle service.
-///
-/// These events are extracted from [`ClientEvent`] and sent to the
-/// pseudosettle service via a dedicated channel for type-safe handling.
+/// Events extracted from [`ClientEvent`] and routed to the pseudosettle service.
 #[derive(Debug, Clone)]
 pub enum PseudosettleEvent {
     /// We sent a pseudosettle and received an ack.
@@ -400,12 +349,7 @@ pub enum PseudosettleEvent {
     },
 }
 
-/// Events routed to the swap settlement service.
-///
-/// These events are extracted from [`ClientEvent`] and sent to the swap
-/// service via a dedicated channel for type-safe handling. They carry strong
-/// types ([`SignedCheque`], typed peer, typed rate) so the service never sees
-/// raw wire bytes.
+/// Events extracted from [`ClientEvent`] and routed to the swap settlement service.
 #[cfg(feature = "swap")]
 #[derive(Debug, Clone)]
 pub enum SwapEvent {

--- a/crates/swarm/node/src/protocol/handler.rs
+++ b/crates/swarm/node/src/protocol/handler.rs
@@ -1,31 +1,15 @@
-//! Connection handler for client protocols.
+//! Connection handler for client protocols (pricing, retrieval, pushsync,
+//! pseudosettle, and swap when enabled) on a single peer connection.
 //!
-//! The `ClientHandler` manages multiple protocols on a single connection:
-//! - Pricing: Payment threshold exchange
-//! - Retrieval: Chunk request/response
-//! - PushSync: Chunk push with receipt
-//! - Pseudosettle: Bandwidth accounting payments
+//! The handler is `Dormant` until an `Activate` command (sent after handshake)
+//! transitions it to `Active`, after which it processes protocol messages.
 //!
-//! # Lifecycle
-//!
-//! 1. Handler starts in `Dormant` state when connection established
-//! 2. After handshake, `Activate` command transitions to `Active` state
-//! 3. In `Active` state, handler processes protocol messages
-//!
-//! # Inbound serving
-//!
-//! Retrieval and pushsync inbound requests are served by **self-contained
-//! futures**: each request becomes one future pushed into [`ClientHandler`]'s
-//! `inbound` set, with the substream's responder as the correlation. A retrieval
-//! serves from the cache (content chunks indefinitely, single-owner chunks while
-//! fresh) or forwards to a closer peer; a pushsync forwards and relays the
-//! storer's receipt verbatim, never signing. The future resolves to an
-//! [`InboundOutcome`] that the handler turns into a scoring or metrics event;
-//! the response itself never travels back as a command.
-//!
-//! Pseudosettle inbound still uses the request-id responder map below, because
-//! the pseudosettle service gates the accepted amount against a time-based
-//! allowance before acking, so its ack cannot be folded inline.
+//! Retrieval and pushsync inbound requests are served by self-contained futures
+//! in the `inbound` set, each resolving to an [`InboundOutcome`] the handler
+//! turns into a scoring or metrics event; the response is sent inside the future,
+//! never routed back as a command. Pseudosettle inbound uses the request-id
+//! responder map instead, because its ack is gated on a time-based allowance and
+//! cannot be folded inline.
 
 use std::{
     collections::{HashMap, VecDeque},
@@ -77,36 +61,31 @@ const RESPONSE_SEND_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_CONCURRENT_RESPONSE_SENDS: usize = 8;
 /// Responders older than this are dropped as stale.
 const RESPONDER_STALE_TIMEOUT: Duration = Duration::from_secs(60);
-/// Maximum concurrent inbound serving futures per connection.
-///
-/// Caps how many retrieval and pushsync requests a single peer can have in
-/// flight against us at once; once full, `listen_protocol` stops advertising
-/// inbound serving so the muxer back-pressures the peer.
+/// Maximum concurrent inbound serving futures per connection. Once full,
+/// `listen_protocol` stops advertising inbound serving so the muxer
+/// back-pressures the peer.
 const MAX_INBOUND_SERVING: usize = 32;
 
-/// The outcome of serving one inbound retrieval or pushsync request.
-///
-/// Returned by the self-contained inbound future and turned into a scoring or
-/// metrics event by the handler. It never carries a response: the response was
-/// already sent (or the substream reset) inside the future.
+/// Outcome of serving one inbound retrieval or pushsync request. The response is
+/// already sent (or the substream reset) inside the future; this carries only the
+/// scoring/metrics signal.
 #[derive(Debug)]
 pub(crate) enum InboundOutcome {
-    /// A retrieval was answered from our cache.
+    /// Retrieval answered from cache.
     Served { overlay: OverlayAddress },
-    /// A retrieval was answered by forwarding to a closer peer.
+    /// Retrieval answered by forwarding to a closer peer.
     Forwarded { overlay: OverlayAddress },
-    /// A retrieval could not be served or forwarded; the substream was reset.
+    /// Retrieval could not be served or forwarded; substream reset.
     Missed {
         overlay: OverlayAddress,
         address: ChunkAddress,
     },
-    /// A pushsync was forwarded and the storer's receipt relayed verbatim.
+    /// Pushsync forwarded and the storer's receipt relayed verbatim.
     Relayed { overlay: OverlayAddress },
-    /// An inbound pushsync the node is responsible for was stored into the
-    /// reserve and acknowledged with a freshly signed custody receipt.
+    /// Pushsync the node is responsible for: stored into the reserve and
+    /// acknowledged with a freshly signed custody receipt.
     Stored { overlay: OverlayAddress },
-    /// A pushsync could not be forwarded (or, on the storer ingest path, could
-    /// not be stored or acknowledged); the substream was reset.
+    /// Pushsync could not be forwarded, stored, or acknowledged; substream reset.
     PushFailed {
         overlay: OverlayAddress,
         address: ChunkAddress,
@@ -115,64 +94,30 @@ pub(crate) enum InboundOutcome {
 
 /// Configuration for the client handler.
 ///
-/// # Deadlines are split deliberately
-///
-/// Three deadlines coexist here, and the split is intentional. `timeout` is the
-/// shared deadline for pricing, pseudosettle, and swap, where no per-caller
-/// liveness guarantee is owed. `retrieval_timeout` and `pushsync_timeout` are
-/// the named, per-protocol deadlines for the two chunk-transfer operations, each
-/// threaded into its own outbound [`SubstreamProtocol`].
-///
-/// They default to the same 30s value but are separate fields on purpose: the
-/// retrieval and pushsync liveness invariant (below) is bounded by these two and
-/// nothing else, so tuning one must not silently move pricing, pseudosettle, or
-/// swap. Do not collapse the three back into one field assuming they are equal;
-/// a future change may shorten `retrieval_timeout` for a faster candidate-race
-/// without touching settlement.
-///
-/// # Retrieval and pushsync liveness invariant
-///
-/// A peer that negotiates the chunk-transfer substream and its headers but then
-/// withholds the response frame (a delivery for retrieval, a receipt for
-/// pushsync) cannot stall the caller indefinitely. The outbound
-/// [`SubstreamProtocol`] is dispatched `.with_timeout(retrieval_timeout)` (or
-/// `pushsync_timeout`), so the upgrade future, including the blocked read of the
-/// response frame, is bounded by that deadline. When it elapses the attempt
-/// resolves with [`ChunkTransferError::TimedOut`] and the caller is free to race
-/// the next candidate. This is the only liveness boundary against a withholding
-/// peer, so the deadline lives on a named field rather than an incidental shared
-/// value.
+/// The three deadlines are separate fields on purpose: `retrieval_timeout` and
+/// `pushsync_timeout` bound each chunk-transfer substream upgrade, including the
+/// blocked read of the response frame, so a peer that negotiates the substream
+/// then withholds the response resolves with [`ChunkTransferError::TimedOut`]
+/// rather than stalling the caller. This is the only liveness boundary against a
+/// withholding peer. Do not collapse them into the shared `timeout` (used by
+/// pricing, pseudosettle, and swap); tuning one must not move settlement.
 #[derive(Debug, Clone)]
 pub(crate) struct Config {
-    /// Shared deadline for the protocols with no per-caller liveness guarantee:
-    /// pricing, pseudosettle, and swap. Retrieval and pushsync use their own
-    /// named deadlines below; see the type-level note on the deliberate split.
+    /// Shared deadline for pricing, pseudosettle, and swap.
     pub(crate) timeout: Duration,
-    /// Deadline for an outbound retrieval. Bounds the substream upgrade,
-    /// including the blocked read of the delivery frame, so a withholding peer
-    /// resolves the attempt with [`ChunkTransferError::TimedOut`] rather than
-    /// hanging. Deliberately distinct from `timeout` (see the type-level note).
+    /// Outbound retrieval deadline; see the type-level note.
     pub(crate) retrieval_timeout: Duration,
-    /// Deadline for an outbound pushsync. Bounds the substream upgrade,
-    /// including the blocked read of the receipt frame, so a withholding peer
-    /// resolves the attempt with [`ChunkTransferError::TimedOut`] rather than
-    /// hanging. Deliberately distinct from `timeout` (see the type-level note).
+    /// Outbound pushsync deadline; see the type-level note.
     pub(crate) pushsync_timeout: Duration,
-    /// Maximum pending commands before dropping new ones.
     pub(crate) max_pending_commands: usize,
-    /// Maximum pending events before dropping new ones.
     pub(crate) max_pending_events: usize,
-    /// Local node's role. Controls which protocols are advertised on
-    /// inbound substream upgrades and which outbound commands are honoured.
-    /// Bootnodes only speak pricing (listen-only) so the rest of the
-    /// client surface is inert.
+    /// Controls which protocols are advertised on inbound upgrades and which
+    /// outbound commands are honoured. Bootnodes only speak pricing.
     pub(crate) local_role: SwarmNodeType,
-    /// Network id, used to recover the signer overlay of an inbound custody
-    /// receipt at the decode boundary (`compute_overlay(eth, network_id, nonce)`).
+    /// Used to recover the signer overlay of an inbound custody receipt at decode
+    /// (`compute_overlay(eth, network_id, nonce)`).
     pub(crate) network_id: NetworkId,
-    /// Our advertised swap exchange rate, sent in the swap headers exchange.
-    /// Rate negotiation is owned by the settlement service; the handler only
-    /// carries the value onto the wire.
+    /// Advertised swap exchange rate sent in the swap headers exchange.
     #[cfg(feature = "swap")]
     pub(crate) swap_exchange_rate: U256,
 }
@@ -194,222 +139,133 @@ impl Default for Config {
 }
 
 /// Commands sent from the behaviour to the handler.
-///
-/// `PushChunk` carries a whole [`StampedChunk`] and dwarfs the other variants;
-/// the size difference is accepted rather than boxing a one-shot upload value.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum HandlerCommand {
     /// Activate the handler after handshake completion.
     Activate {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The peer's node type.
         node_type: SwarmNodeType,
     },
     /// Announce our payment threshold to the peer.
-    AnnouncePricing {
-        /// The threshold to announce.
-        threshold: U256,
-    },
+    AnnouncePricing { threshold: U256 },
     /// Request a chunk from the peer.
     RetrieveChunk {
-        /// The address of the chunk to retrieve.
         address: ChunkAddress,
-        /// Resolves with the retrieved chunk or the failure.
         response: RetrievalResponseTx,
     },
     /// Push a chunk to the peer for storage.
     PushChunk {
-        /// The chunk and its postage stamp.
         chunk: StampedChunk,
-        /// Resolves with the storer's receipt or the failure.
         response: PushResponseTx,
     },
     /// Send a pseudosettle payment to the peer.
-    SendPseudosettle {
-        /// The amount to send.
-        amount: U256,
-    },
+    SendPseudosettle { amount: U256 },
     /// Acknowledge a pseudosettle payment.
-    AckPseudosettle {
-        /// Request ID to match the responder.
-        request_id: u64,
-        /// The ack to send.
-        ack: PaymentAck,
-    },
+    AckPseudosettle { request_id: u64, ack: PaymentAck },
     /// Send a swap cheque to the peer.
     #[cfg(feature = "swap")]
-    SendCheque {
-        /// The signed cheque to send.
-        cheque: SignedCheque,
-    },
+    SendCheque { cheque: SignedCheque },
 }
 
 /// Events emitted by the handler to the behaviour.
-///
-/// `ChunkReceived` carries a whole chunk and dwarfs the other variants; the size
-/// difference is accepted rather than boxing a delivery that flows straight to
-/// the cache and the requester.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum HandlerEvent {
     /// Handler has been activated.
-    Activated {
-        /// The peer's overlay address.
-        overlay: OverlayAddress,
-    },
+    Activated { overlay: OverlayAddress },
     /// Received pricing threshold from peer.
     PricingReceived {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The payment threshold.
         threshold: U256,
     },
     /// Successfully sent our pricing threshold.
-    PricingSent {
-        /// The peer's overlay address.
-        overlay: OverlayAddress,
-    },
-    /// We served an inbound retrieval request from our cache.
-    ///
-    /// Scoring and metrics only: the chunk has already gone down the wire.
-    InboundServed {
-        /// The peer we served.
-        overlay: OverlayAddress,
-    },
-    /// We answered an inbound retrieval by forwarding to a closer peer.
-    InboundForwarded {
-        /// The peer we served.
-        overlay: OverlayAddress,
-    },
-    /// We could not serve or forward an inbound retrieval; the substream reset.
+    PricingSent { overlay: OverlayAddress },
+    /// Served an inbound retrieval from cache (scoring/metrics only).
+    InboundServed { overlay: OverlayAddress },
+    /// Answered an inbound retrieval by forwarding to a closer peer.
+    InboundForwarded { overlay: OverlayAddress },
+    /// Could not serve or forward an inbound retrieval; substream reset.
     InboundMissed {
-        /// The peer that asked.
         overlay: OverlayAddress,
-        /// The requested chunk address.
         address: ChunkAddress,
     },
-    /// We relayed a storer's receipt for an inbound pushsync.
-    InboundRelayed {
-        /// The peer that pushed.
-        overlay: OverlayAddress,
-    },
-    /// We took custody of an inbound pushsync delivery: stored it in the reserve
-    /// and acknowledged it with our own signed receipt.
-    InboundStored {
-        /// The peer that pushed.
-        overlay: OverlayAddress,
-    },
-    /// We could not forward an inbound pushsync; the substream reset.
+    /// Relayed a storer's receipt for an inbound pushsync.
+    InboundRelayed { overlay: OverlayAddress },
+    /// Took custody of an inbound pushsync: stored and acknowledged with our own
+    /// signed receipt.
+    InboundStored { overlay: OverlayAddress },
+    /// Could not forward an inbound pushsync; substream reset.
     InboundPushFailed {
-        /// The peer that pushed.
         overlay: OverlayAddress,
-        /// The chunk address.
         address: ChunkAddress,
     },
-    /// Received a chunk from peer.
+    /// Received a chunk from peer. `latency` is request-to-delivery, for scoring.
     ChunkReceived {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The chunk address.
         address: ChunkAddress,
-        /// The received chunk.
         chunk: AnyChunk,
-        /// The postage stamp the responder attached, if any.
         stamp: Option<Stamp>,
-        /// Time from outbound request to delivery, for latency scoring.
         latency: Duration,
     },
-    /// Received a receipt from peer.
+    /// Received a receipt from peer. `latency` is request-to-receipt, for scoring.
     ReceiptReceived {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The chunk address.
         address: ChunkAddress,
-        /// Time from outbound request to receipt, for latency scoring.
         latency: Duration,
     },
-    /// An outbound retrieval request failed.
-    ///
-    /// The requester has already been resolved through its response channel;
-    /// this event feeds peer scoring and metrics.
+    /// An outbound retrieval failed. The requester is already resolved through
+    /// its response channel; this feeds scoring and metrics. `kind` distinguishes
+    /// a malformed chunk from a plain failure.
     RetrievalFailed {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The requested chunk address.
         address: ChunkAddress,
-        /// Error description.
         error: String,
-        /// Whether the failure was a malformed chunk (vs a plain failure).
         kind: FailureKind,
     },
-    /// An outbound chunk push failed.
-    ///
-    /// The pusher has already been resolved through its response channel;
-    /// this event feeds peer scoring and metrics.
+    /// An outbound push failed. The pusher is already resolved through its
+    /// response channel; this feeds scoring and metrics.
     PushFailed {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The chunk address.
         address: ChunkAddress,
-        /// Error description.
         error: String,
-        /// Whether the failure was a malformed chunk (vs a plain failure).
         kind: FailureKind,
     },
-    /// A peer sent us malformed data on an inbound substream.
-    ///
-    /// Raised when an inbound pushsync delivery or retrieval request fails
-    /// chunk or stamp reconstruction at decode. Attributed to the sender so
-    /// the offending peer is scored adversely and the chunk is never relayed.
+    /// A peer sent malformed data on an inbound substream (chunk or stamp
+    /// reconstruction failed at decode). Attributed to the sender; the chunk is
+    /// never relayed.
     InboundInvalidData {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The protocol that rejected the data.
         protocol: &'static str,
     },
     /// Protocol error occurred.
     Error {
-        /// The peer's overlay address (if known).
         overlay: Option<OverlayAddress>,
-        /// The protocol that errored.
         protocol: &'static str,
-        /// Error description.
         error: String,
     },
     /// Received pseudosettle payment from peer.
     PseudosettleReceived {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The payment amount.
         amount: U256,
-        /// Request ID for matching ack.
         request_id: u64,
     },
     /// Successfully sent pseudosettle payment.
     PseudosettleSent {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The ack received.
         ack: PaymentAck,
     },
-    /// Received a swap cheque from peer.
+    /// Received a swap cheque from peer. `peer_rate` is from the headers exchange.
     #[cfg(feature = "swap")]
     SwapChequeReceived {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The signed cheque received.
         cheque: SignedCheque,
-        /// The peer's advertised exchange rate, from the headers exchange.
         peer_rate: U256,
     },
-    /// Successfully sent a swap cheque.
+    /// Successfully sent a swap cheque. `peer_rate` is from the headers exchange.
     #[cfg(feature = "swap")]
     SwapChequeSent {
-        /// The peer's overlay address.
         overlay: OverlayAddress,
-        /// The peer's advertised exchange rate, from the headers exchange.
         peer_rate: U256,
     },
 }
@@ -423,46 +279,37 @@ enum State {
     Active { overlay: OverlayAddress },
 }
 
-/// A pending inbound pseudosettle response waiting for the application layer to
-/// gate the amount and provide an ack.
+/// A pending inbound pseudosettle response awaiting the application's ack.
 struct StoredResponse {
     response: vertex_swarm_net_pseudosettle::PseudosettleInboundResult,
     stored_at: Instant,
 }
 
-/// Swarm client connection handler.
-///
-/// Manages multiple client protocols on a single peer connection.
+/// Swarm client connection handler managing multiple client protocols on a
+/// single peer connection.
 pub(crate) struct ClientHandler {
     config: Config,
     state: State,
-    /// The client cache, shared from the behaviour. Inbound retrievals serve
-    /// from it; forwarded retrieval deliveries are cached into it.
+    /// Client cache: inbound retrievals serve from it, forwarded deliveries cache
+    /// into it.
     store: Arc<dyn SwarmLocalStore>,
-    /// The forwarder seam, shared from the behaviour. A cache miss forwards a
-    /// retrieval; a pushsync this node is not responsible for forwards. Stubbed
-    /// in the cache-only client.
+    /// Forwards a retrieval cache miss or a pushsync this node is not responsible
+    /// for. Stubbed in the cache-only client.
     forward: Arc<dyn Forwarder>,
-    /// The storer ingest capability, present only on a storer node. When set,
-    /// an inbound pushsync delivery the node is responsible for is stored into
-    /// the reserve and acknowledged with a freshly signed custody receipt; when
-    /// absent (a client), every delivery takes the verbatim-relay path.
+    /// Present only on a storer node. When set, an inbound pushsync the node is
+    /// responsible for is stored and acknowledged with a signed custody receipt;
+    /// when absent, every delivery takes the verbatim-relay path.
     storer: Option<StorerCapability>,
-    /// Counter for pseudosettle request IDs.
     next_request_id: u64,
-    /// Pending commands to process.
     pending_commands: VecDeque<HandlerCommand>,
-    /// Pending events to emit.
     pending_events: VecDeque<HandlerEvent>,
-    /// Whether pricing has been sent.
     pricing_sent: bool,
-    /// Whether pricing outbound is pending.
     pricing_outbound_pending: bool,
     /// Self-contained inbound serving futures (retrieval and pushsync).
     inbound: FuturesUnordered<BoxFuture<'static, InboundOutcome>>,
-    /// Stored pseudosettle responders waiting for the service's ack, keyed by
-    /// request_id. Retrieval and pushsync no longer use this map; only
-    /// pseudosettle does, because its ack is gated on a time-based allowance.
+    /// Pseudosettle responders awaiting the service's ack, keyed by request_id.
+    /// Only pseudosettle uses this, because its ack is gated on a time-based
+    /// allowance.
     pending_responses: HashMap<u64, StoredResponse>,
     /// Bounded set for async pseudosettle ack sends (prevents blocking poll).
     response_sends: futures_bounded::FuturesSet<Result<(), String>>,
@@ -479,10 +326,8 @@ impl ClientHandler {
         self.pending_events.push_back(event);
     }
 
-    /// Create a new handler in dormant state.
-    ///
-    /// `storer` is `Some` only on a storer node; a client passes `None` and runs
-    /// the verbatim-relay pushsync path unchanged.
+    /// Create a new handler in dormant state. `storer` is `Some` only on a storer
+    /// node; a client passes `None` and runs the verbatim-relay pushsync path.
     pub(crate) fn new(
         config: Config,
         store: Arc<dyn SwarmLocalStore>,
@@ -509,7 +354,6 @@ impl ClientHandler {
         }
     }
 
-    /// Get the overlay address if active.
     fn overlay(&self) -> Option<OverlayAddress> {
         match &self.state {
             State::Active { overlay, .. } => Some(*overlay),
@@ -517,15 +361,14 @@ impl ClientHandler {
         }
     }
 
-    /// Generate the next request ID (pseudosettle only).
     fn next_request_id(&mut self) -> u64 {
         let id = self.next_request_id;
         self.next_request_id = self.next_request_id.wrapping_add(1);
         id
     }
 
-    /// Store a pending pseudosettle response, evicting stale entries if at
-    /// capacity.
+    /// Store a pending pseudosettle response, evicting stale entries (then the
+    /// oldest) when at capacity.
     fn store_response(
         &mut self,
         request_id: u64,
@@ -555,13 +398,11 @@ impl ClientHandler {
         );
     }
 
-    /// Remove responders older than the stale timeout.
     fn evict_stale_responses(&mut self) {
         let cutoff = Instant::now() - RESPONDER_STALE_TIMEOUT;
         self.pending_responses.retain(|_, v| v.stored_at > cutoff);
     }
 
-    /// Take a pending pseudosettle response by request ID.
     fn take_response(
         &mut self,
         request_id: u64,
@@ -571,7 +412,6 @@ impl ClientHandler {
             .map(|s| s.response)
     }
 
-    /// Process activation command.
     fn activate(&mut self, overlay: OverlayAddress, node_type: SwarmNodeType) {
         match &self.state {
             State::Dormant => {
@@ -606,9 +446,8 @@ impl ClientHandler {
         }
     }
 
-    /// Handle an inbound retrieval request by pushing a self-contained serving
-    /// future: serve from cache (content indefinitely, single-owner while
-    /// fresh), else forward to a closer peer, caching a forwarded delivery.
+    /// Serve an inbound retrieval from a self-contained future: cache hit (content
+    /// indefinitely, single-owner while fresh), else forward to a closer peer.
     fn on_retrieval_request(
         &mut self,
         request: vertex_swarm_net_retrieval::Request,
@@ -627,10 +466,8 @@ impl ClientHandler {
         let store = Arc::clone(&self.store);
         let forward = Arc::clone(&self.forward);
         self.inbound.push(Box::pin(async move {
-            // Cache hit: content chunks serve indefinitely, single-owner chunks
-            // only while fresh (the store applies the TTL on `get`). A cached
-            // content chunk is stampless, a cached SOC carries its stamp; serve
-            // whichever stamp the cache held (matching how it was delivered).
+            // Cache hit: the store applies the single-owner TTL on `get`. Serve
+            // whichever stamp the cache held.
             if let Ok(Some(cached)) = store.get(&address)
                 && *cached.address() == address
             {
@@ -644,19 +481,14 @@ impl ClientHandler {
                 }
             }
 
-            // Miss: forward to a closer peer, excluding the requester. The
-            // forwarder already validated the chunk against the address; the
-            // address equality re-check here is the serve-time guard. A retrieved
-            // content chunk (CAC) is immutable, so it is cached by address even
-            // when stampless (exactly as a storer answers). A retrieved SOC is
-            // never cached: it arrives without a version signal and could serve a
-            // stale revision, so it is only relayed onward, never stored.
+            // Miss: forward to a closer peer, excluding the requester. Only
+            // content chunks are cached (immutable, address-keyed); a retrieved
+            // SOC has no version signal so it is relayed but never stored.
             match forward.retrieve(address, overlay).await {
                 Ok(forwarded) => {
                     if *forwarded.chunk.address() != address {
-                        // A forwarder that returns a chunk for the wrong address
-                        // is a bug in the relay, not the requester's fault; reset.
-                        // Drop the credit unapplied (nothing was delivered).
+                        // Wrong address means a relay bug, not the requester's
+                        // fault; reset and drop the credit unapplied.
                         drop(forwarded.provide);
                         responder.send_error();
                         return InboundOutcome::Missed { overlay, address };
@@ -669,16 +501,13 @@ impl ClientHandler {
                     }
                     match responder.send_chunk(forwarded.chunk, forwarded.stamp).await {
                         Ok(()) => {
-                            // The chunk is on the wire: commit the upstream
-                            // credit now (the requester actually received the
-                            // delivery we are billing for).
+                            // Delivered: commit the upstream credit.
                             forwarded.provide.apply_boxed();
                             InboundOutcome::Forwarded { overlay }
                         }
                         Err(e) => {
-                            // The requester never received the chunk: drop the
-                            // un-applied credit, releasing the reservation, so
-                            // we never bill for a delivery that did not land.
+                            // Not delivered: drop the unapplied credit so we never
+                            // bill for a delivery that did not land.
                             debug!(%overlay, %address, error = %e, "Forward serve send failed");
                             drop(forwarded.provide);
                             InboundOutcome::Missed { overlay, address }
@@ -695,11 +524,9 @@ impl ClientHandler {
 
     /// Handle an inbound pushsync delivery.
     ///
-    /// A storer that is responsible for the chunk takes custody: it stores the
-    /// delivery in its reserve and acknowledges it with its own freshly signed
-    /// custody receipt. Otherwise (a client, or a storer not responsible for the
-    /// address) the delivery is forwarded to a closer peer and the storer's
-    /// receipt relayed verbatim — this node never signs for a chunk it does not
+    /// A storer responsible for the chunk takes custody (store and sign).
+    /// Otherwise the delivery is forwarded to a closer peer and the storer's
+    /// receipt relayed verbatim; this node never signs for a chunk it does not
     /// store. A store or forward failure resets the substream.
     fn on_pushsync_delivery(
         &mut self,
@@ -717,9 +544,8 @@ impl ClientHandler {
         let address = *chunk.address();
         debug!(%overlay, %address, "Received pushsync delivery");
 
-        // Storer ingest: if this node holds a reserve and is responsible for the
-        // chunk, take custody locally instead of relaying. The capability is
-        // absent on a client, so the client path below is unchanged.
+        // Storer ingest: if responsible for the chunk, take custody locally
+        // instead of relaying. Absent on a client.
         if let Some(storer) = &self.storer
             && storer.reserve.is_responsible_for(&address)
         {
@@ -735,20 +561,16 @@ impl ClientHandler {
             match forward.push(chunk, overlay).await {
                 Ok(forwarded) => {
                     // Relay the storer's receipt verbatim: we never sign. The
-                    // signer was recovered and verified at decode, so the wire
-                    // bytes reproduce the storer's own signature, nonce, and
-                    // radius unchanged.
+                    // signer was verified at decode, so the wire bytes reproduce
+                    // the storer's signature, nonce, and radius unchanged.
                     let relay = forwarded.receipt.to_wire();
                     match responder.send_receipt(relay).await {
                         Ok(()) => {
-                            // The receipt reached the pusher: commit the upstream
-                            // credit now.
                             forwarded.provide.apply_boxed();
                             InboundOutcome::Relayed { overlay }
                         }
                         Err(e) => {
-                            // The pusher never received the receipt: drop the
-                            // un-applied credit, releasing the reservation.
+                            // Receipt not delivered: drop the unapplied credit.
                             debug!(%overlay, %address, error = %e, "Receipt relay send failed");
                             drop(forwarded.provide);
                             InboundOutcome::PushFailed { overlay, address }
@@ -763,14 +585,11 @@ impl ClientHandler {
         }));
     }
 
-    /// Take custody of a delivery: store it into the reserve and acknowledge it
-    /// with a freshly signed custody receipt.
-    ///
-    /// Reached only when the node holds a [`StorerCapability`] and is responsible
-    /// for `address`. The chunk arrives as an always-stamped [`StampedChunk`], so
-    /// it goes into the reserve as a stamped [`CachedChunk`]. A reserve put
-    /// failure (a capacity error, or a backend error) or a sign failure resets the
-    /// substream rather than acknowledging a chunk we did not durably take.
+    /// Take custody of a delivery: store it into the reserve and acknowledge with
+    /// a freshly signed custody receipt. Reached only when the node holds a
+    /// [`StorerCapability`] and is responsible for `address`. A reserve put or
+    /// sign failure resets the substream rather than acknowledging a chunk we did
+    /// not durably take.
     async fn store_and_sign(
         storer: StorerCapability,
         chunk: StampedChunk,
@@ -778,27 +597,24 @@ impl ClientHandler {
         overlay: OverlayAddress,
         responder: vertex_swarm_net_pushsync::PushsyncResponder,
     ) -> InboundOutcome {
-        // Persist the delivery before acknowledging it: a receipt must never
-        // claim custody of a chunk that is not durably in the reserve. The
-        // reserve is always stamped; the pushsync delivery is always stamped, so
-        // the conversion preserves the stamp.
+        // Persist before acknowledging: a receipt must never claim custody of a
+        // chunk that is not durably in the reserve.
         if let Err(e) = storer.reserve.put(CachedChunk::from(chunk)) {
             debug!(%overlay, %address, error = %e, "Reserve put failed; not acknowledging");
             responder.send_error();
             return InboundOutcome::PushFailed { overlay, address };
         }
 
-        // Mint our own custody receipt over the chunk address, declaring our
-        // current storage radius. The capability is the node's identity, so it
-        // supplies the signing key and the overlay-derivation inputs (network id
-        // and nonce); a forwarder upstream recovers our overlay from the
-        // signature exactly as it would a relayed receipt.
+        // Sign our own custody receipt over the address, declaring our current
+        // storage radius. The capability supplies the signing key and
+        // overlay-derivation inputs; an upstream forwarder recovers our overlay
+        // from the signature.
         let storage_radius = storer.reserve.storage_radius();
         let receipt = match Receipt::sign(&storer, address, storage_radius) {
             Ok(receipt) => receipt,
             Err(e) => {
-                // The chunk is stored, but we cannot prove custody. Reset rather
-                // than send an unsigned acknowledgement; the pusher retries.
+                // Stored, but cannot prove custody. Reset rather than send an
+                // unsigned ack; the pusher retries.
                 debug!(%overlay, %address, error = %e, "Receipt sign failed; not acknowledging");
                 responder.send_error();
                 return InboundOutcome::PushFailed { overlay, address };
@@ -808,17 +624,16 @@ impl ClientHandler {
         match responder.send_receipt(receipt.to_wire()).await {
             Ok(()) => InboundOutcome::Stored { overlay },
             Err(e) => {
-                // The chunk is stored; only the acknowledgement failed to reach
-                // the pusher. The pusher treats the reset as a failed push and
-                // retries, which is idempotent: the reserve put is
-                // content-addressed, so a re-delivery is a no-op.
+                // Stored; only the ack failed to reach the pusher. The pusher
+                // retries, which is idempotent (the reserve put is
+                // content-addressed, so a re-delivery is a no-op).
                 debug!(%overlay, %address, error = %e, "Receipt send failed after store");
                 InboundOutcome::PushFailed { overlay, address }
             }
         }
     }
 
-    /// Turn a resolved inbound outcome into a scoring or metrics event.
+    /// Turn a resolved inbound outcome into a scoring/metrics event.
     fn on_inbound_outcome(&mut self, outcome: InboundOutcome) {
         let event = match outcome {
             InboundOutcome::Served { overlay } => HandlerEvent::InboundServed { overlay },
@@ -846,11 +661,9 @@ impl ClientHandler {
         let overlay = self.overlay();
         match delivery {
             vertex_swarm_net_retrieval::Delivery::Error => {
-                // The remote reported a failure (signalled by empty data). The
-                // reason is adversarial input we never read; it is a plain
-                // protocol failure, not malformed data. Malformed chunks never
-                // reach this arm: they fail reconstruction at decode and surface
-                // as a dial upgrade error.
+                // Remote reported a failure (empty data): a plain protocol
+                // failure. Malformed chunks never reach this arm; they fail
+                // reconstruction at decode and surface as a dial upgrade error.
                 debug!(?overlay, %address, "Retrieval failed");
                 if let Some(overlay) = overlay {
                     self.push_event(HandlerEvent::RetrievalFailed {
@@ -898,9 +711,7 @@ impl ClientHandler {
         let overlay = self.overlay();
         match response_msg {
             vertex_swarm_net_pushsync::ReceiptResponse::Failed => {
-                // The remote reported a rejection (signalled by an empty
-                // signature; the reference does not sign its failures). The
-                // reason is adversarial input we never read.
+                // Remote reported a rejection (empty signature).
                 debug!(?overlay, %address, "Pushsync failed");
                 if let Some(overlay) = overlay {
                     self.push_event(HandlerEvent::PushFailed {
@@ -920,11 +731,9 @@ impl ClientHandler {
                     return;
                 };
                 let receipt_address = receipt.address;
-                // The decode boundary: reconstruct and verify the receipt storer
-                // before any domain consumer sees it. A receipt whose storer
-                // cannot be recovered (an all-zero or unrecoverable signature) is
-                // rejected here as invalid data and never becomes a domain
-                // receipt; the peer that handed it back is scored.
+                // Decode boundary: reconstruct and verify the receipt storer
+                // before any consumer sees it. An unrecoverable signature is
+                // rejected here as invalid data and the peer is scored.
                 match Receipt::reconstruct(receipt, self.config.network_id) {
                     Ok(receipt) => {
                         debug!(%overlay, address = %receipt_address, "Received receipt");
@@ -956,7 +765,6 @@ impl ClientHandler {
     }
 }
 
-/// Multi-protocol ConnectionHandler implementation.
 #[allow(deprecated)]
 impl ConnectionHandler for ClientHandler {
     type FromBehaviour = HandlerCommand;
@@ -969,7 +777,7 @@ impl ConnectionHandler for ClientHandler {
     fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
         // Back-pressure: once the inbound serving set is full, advertise the
         // dormant (empty) protocol set so the muxer stops accepting new inbound
-        // retrieval and pushsync substreams from this peer until we drain.
+        // substreams until we drain.
         let upgrade = match &self.state {
             State::Active { .. } if self.inbound.len() < MAX_INBOUND_SERVING => {
                 let upgrade = ClientInboundUpgrade::active_for(self.config.local_role);
@@ -988,7 +796,6 @@ impl ConnectionHandler for ClientHandler {
     ) -> Poll<
         ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
     > {
-        // Emit pending events first
         if let Some(event) = self.pending_events.pop_front() {
             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
         }
@@ -1001,7 +808,7 @@ impl ConnectionHandler for ClientHandler {
             }
         }
 
-        // Drain completed pseudosettle ack sends
+        // Drain completed pseudosettle ack sends.
         while let Poll::Ready(result) = self.response_sends.poll_unpin(cx) {
             match result {
                 Ok(Ok(())) => {
@@ -1029,7 +836,6 @@ impl ConnectionHandler for ClientHandler {
             }
         }
 
-        // Process pending commands
         while let Some(cmd) = self.pending_commands.pop_front() {
             match cmd {
                 HandlerCommand::Activate { overlay, node_type } => {
@@ -1160,22 +966,17 @@ impl ConnectionHandler for ClientHandler {
             }
 
             ConnectionEvent::DialUpgradeError(e) => {
-                // Classify from the typed upgrade error while it is still
-                // concrete: a malformed chunk delivered on the outbound
-                // substream fails reconstruction at decode and arrives here as
-                // an `Apply` error we can downcast, not a string we parse.
+                // Classify from the typed error while concrete: a malformed chunk
+                // arrives as an `Apply` error we downcast, not a parsed string.
                 let apply_error = match &e.error {
                     libp2p::swarm::StreamUpgradeError::Apply(err) => Some(err),
                     _ => None,
                 };
-                // The per-protocol upgrade deadline fired: the substream
-                // negotiated but the response frame never arrived within
-                // `retrieval_timeout`/`pushsync_timeout`. This is the liveness
-                // boundary against a withholding peer. The chunk-transfer arms
-                // resolve the caller with the typed `ChunkTransferError::TimedOut`
-                // rather than flattening it into a `Protocol(String)`, but still
-                // emit `FailureKind::Protocol` for scoring so the existing
-                // retrieval/push failure path (-2.0) is unchanged.
+                // Timeout means the per-protocol deadline fired: the substream
+                // negotiated but the response frame never arrived. The
+                // chunk-transfer arms resolve the caller with the typed
+                // `ChunkTransferError::TimedOut` while still scoring as
+                // `FailureKind::Protocol`.
                 let timed_out = matches!(&e.error, libp2p::swarm::StreamUpgradeError::Timeout);
                 let error = e.error.to_string();
                 match e.info {
@@ -1193,17 +994,12 @@ impl ConnectionHandler for ClientHandler {
                         response,
                         requested_at,
                     } => {
-                        // A timeout is never a malformed chunk, so it scores as a
-                        // plain protocol failure; an `Apply` error may be a
-                        // malformed delivery and is classified as before.
+                        // A timeout is never a malformed chunk; an `Apply` error
+                        // may be a malformed delivery.
                         let kind = apply_error
                             .map_or(FailureKind::Protocol, |e| e.retrieval_failure_kind());
                         if timed_out {
-                            // Sole emission site for the retrieval timeout
-                            // counter: the client handler resolves the response
-                            // here and never routes a chunk-transfer upgrade error
-                            // through the shared headers `UpgradeError::record`
-                            // path, so there is no double count.
+                            // Sole emission site for the retrieval timeout counter.
                             metrics::counter!("swarm.client.retrieval_timeouts_total").increment(1);
                             debug!(
                                 peer_overlay = ?self.overlay(),
@@ -1236,8 +1032,7 @@ impl ConnectionHandler for ClientHandler {
                         let kind = apply_error
                             .map_or(FailureKind::Protocol, |e| e.pushsync_failure_kind());
                         if timed_out {
-                            // Sole emission site for the pushsync timeout counter,
-                            // mirroring the retrieval arm above.
+                            // Sole emission site for the pushsync timeout counter.
                             metrics::counter!("swarm.client.pushsync_timeouts_total").increment(1);
                             debug!(
                                 peer_overlay = ?self.overlay(),
@@ -1283,11 +1078,9 @@ impl ConnectionHandler for ClientHandler {
             }
 
             ConnectionEvent::ListenUpgradeError(e) => {
-                // A peer pushing us a malformed chunk, or sending a malformed
-                // retrieval request, fails reconstruction at inbound decode and
-                // surfaces here. Classify from the typed error so the offending
-                // peer is scored adversely; the chunk is already rejected and
-                // never relayed.
+                // A malformed inbound chunk or retrieval request fails
+                // reconstruction at decode and surfaces here; classify so the
+                // offending peer is scored. The chunk is already rejected.
                 let kind = e.error.inbound_failure_kind();
                 warn!(error = %e.error, ?kind, "Client listen upgrade error");
                 match (kind, self.overlay()) {
@@ -1315,7 +1108,6 @@ impl ConnectionHandler for ClientHandler {
 }
 
 impl ClientHandler {
-    /// Handle an inbound protocol completion.
     fn handle_inbound_output(&mut self, output: ClientInboundOutput) {
         match output {
             ClientInboundOutput::Pricing(threshold) => {
@@ -1354,7 +1146,6 @@ impl ClientHandler {
         }
     }
 
-    /// Handle an outbound protocol completion.
     fn handle_outbound_output(&mut self, output: ClientOutboundOutput, info: ClientOutboundInfo) {
         match (output, info) {
             (ClientOutboundOutput::Pricing, ClientOutboundInfo::Pricing) => {

--- a/crates/swarm/node/src/protocol/storer.rs
+++ b/crates/swarm/node/src/protocol/storer.rs
@@ -1,14 +1,10 @@
-//! The storer ingest capability for the pushsync inbound path.
+//! Storer ingest capability for the pushsync inbound path.
 //!
-//! A client-only node forwards every inbound pushsync delivery to a closer peer
-//! and relays the storer's receipt verbatim — it never takes custody. A storer
-//! node additionally holds this capability, which lets the inbound handler take
-//! custody of a delivery it is responsible for: it puts the chunk into the
-//! reserve and mints (signs) its own custody receipt rather than relaying.
-//!
-//! The capability is optional and cheaply cloned into each connection handler.
-//! When it is absent the handler runs the unchanged client path, so installing
-//! it never regresses a client.
+//! Optional capability that lets the inbound handler take custody of a delivery
+//! it is responsible for: put the chunk into the reserve and sign its own
+//! receipt instead of relaying. When absent, the handler runs the client path
+//! (forward to a closer peer, relay the receipt). Arc-cheap to clone into each
+//! connection handler.
 
 use std::sync::Arc;
 
@@ -17,43 +13,23 @@ use vertex_swarm_api::ReserveStore;
 use vertex_swarm_net_pushsync::ReceiptSigner;
 use vertex_swarm_primitives::{NetworkId, Nonce};
 
-/// Storer-side ingest capability shared into each connection handler.
+/// Reserve plus the node's receipt-signing identity, shared into each handler.
 ///
-/// Bundles what a storer needs to take custody on an inbound pushsync delivery:
-/// the [`ReserveStore`] (responsibility check, stamped `put`, and the declared
-/// storage radius the receipt carries) and the node's receipt-minting identity.
-/// The identity is the signing key plus the two overlay-derivation inputs
-/// (`network_id` and `nonce`) that bind the storer overlay a forwarder recovers
-/// from the minted receipt; this type implements [`ReceiptSigner`] so the
-/// handler passes it straight to [`vertex_swarm_net_pushsync::Receipt::sign`]
-/// without re-threading those inputs as loose parameters.
-///
-/// `put` admits the chunk unconditionally; the reserve is kept within capacity
-/// out of band by the eviction primitives ([`ReserveStore::evict_from_bin`] /
-/// [`evict_batch`](ReserveStore::evict_batch)), not by back-pressure on ingest.
-///
-/// Cloning is `Arc`-cheap; the behaviour clones one of these into every handler
-/// at connection establishment.
+/// `network_id` and `nonce` are the overlay-derivation inputs a forwarder
+/// recovers from the minted receipt; implementing [`ReceiptSigner`] lets the
+/// handler pass this straight to [`vertex_swarm_net_pushsync::Receipt::sign`].
+/// `put` admits unconditionally; capacity is held out of band by the eviction
+/// primitives ([`ReserveStore::evict_from_bin`] /
+/// [`evict_batch`](ReserveStore::evict_batch)), not by ingest back-pressure.
 #[derive(Clone)]
 pub(crate) struct StorerCapability {
-    /// The proximity-ordered, always-stamped reserve. The handler queries
-    /// [`ReserveStore::is_responsible_for`] to decide whether to ingest, calls
-    /// [`vertex_swarm_api::SwarmLocalStore::put`] to take custody, and reads
-    /// [`ReserveStore::storage_radius`] for the receipt's declared radius.
     pub(crate) reserve: Arc<dyn ReserveStore>,
-    /// The receipt signing key, erased to the synchronous signer trait so the
-    /// handler is not generic over the identity's concrete signer.
     signer: Arc<dyn SignerSync + Send + Sync>,
-    /// The network id, one of the two overlay-derivation inputs the receipt mint
-    /// reads from the identity.
     network_id: NetworkId,
-    /// The node's identity nonce, the other overlay-derivation input.
     nonce: Nonce,
 }
 
 impl StorerCapability {
-    /// Bundle the reserve and the node's receipt-minting identity (signer,
-    /// network id, and nonce) into a shareable capability.
     pub(crate) fn new(
         reserve: Arc<dyn ReserveStore>,
         signer: Arc<dyn SignerSync + Send + Sync>,
@@ -69,8 +45,6 @@ impl StorerCapability {
     }
 }
 
-/// The capability carries the node's identity, so it is itself the
-/// [`ReceiptSigner`] the inbound handler mints custody receipts through.
 impl ReceiptSigner for StorerCapability {
     type Signer = dyn SignerSync + Send + Sync;
 
@@ -89,8 +63,7 @@ impl ReceiptSigner for StorerCapability {
 
 impl std::fmt::Debug for StorerCapability {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // The signer key must never be logged; the reserve has no Debug. Only the
-        // public overlay-derivation inputs (network id and nonce) are shown.
+        // Never log the signer key; show only the public overlay-derivation inputs.
         f.debug_struct("StorerCapability")
             .field("network_id", &self.network_id)
             .field("nonce", &self.nonce)

--- a/crates/swarm/postage/src/admission.rs
+++ b/crates/swarm/postage/src/admission.rs
@@ -1,48 +1,10 @@
 //! Synchronous validate-on-ingest admission for stamped chunks.
 //!
-//! The reserve's [`put`](vertex_swarm_api::SwarmLocalStore::put) is synchronous
-//! (the storage lattice trait is sync, redb is sync), so admission must be a
-//! synchronous decision taken inside the same call. The nectar
-//! [`StoreValidator`](nectar_postage::StoreValidator) expresses the canonical
-//! checks by loading the batch through a
-//! [`BatchStore`](nectar_postage::BatchStore) and applying them. This module is
-//! the seam that performs *exactly* the same checks against an already-loaded
-//! [`Batch`], so the reserve can validate on ingest inside its own write
-//! transaction without re-reading the store.
-//!
-//! The validator is **stateless**: each stamp is validated on its own, by
-//! recovering the signer and comparing it to the batch owner. It holds no
-//! per-batch key cache and no sidecar table; the only state it carries is the
-//! confirmation threshold policy.
-//!
-//! # What is reused (and what is not re-implemented)
-//!
-//! The per-stamp checks are nectar's, mirroring
-//! [`StoreValidator::validate`](nectar_postage::StoreValidator) against an
-//! already-loaded batch:
-//!
-//! - the batch is usable (enough confirmations): [`Batch::is_usable`];
-//! - the batch is not expired: [`Batch::is_expired`];
-//! - the stamp index is in bounds: [`Batch::validate_index`];
-//! - the bucket matches the address: [`Batch::validate_bucket`];
-//! - the signature recovers the batch owner: [`Stamp::verify`] (the EIP-191
-//!   ecrecover, byte-equal to bee).
-//!
-//! The digest and ecrecover are never re-implemented here: they live in nectar
-//! and are reached only through [`Stamp`]'s own methods.
-//!
-//! # Deferred optimisation: per-process signer memoisation
-//!
-//! ecrecover is the dominant cost of stamp validation, and a batch's stamps all
-//! share one signer, so the recover-once / [`Stamp::verify_with_pubkey`]-the-rest
-//! pattern (nectar-supported) is a legitimate future optimisation. It is
-//! deliberately **not** implemented here. If profiling justifies it, it must be
-//! a per-process in-memory memoisation of the recovered key, gated behind the
-//! batch-existence check and matched to the batch owner before it is trusted.
-//! It must **never** be a persisted sidecar table: a batch's signer is derivable
-//! from any one of its stamps, so persisting it adds a consensus-irrelevant
-//! table that can drift from the canonical batch store. Until then the validator
-//! recovers per stamp, which keeps validation provably stateless.
+//! The reserve's [`put`](vertex_swarm_api::SwarmLocalStore::put) is synchronous,
+//! so admission runs the per-stamp checks against an already-loaded [`Batch`]
+//! inside the reserve's own write transaction without re-reading the store. Each
+//! stamp is validated on its own, so the validator holds no state beyond the
+//! confirmation threshold.
 
 use nectar_postage::{Batch, PostageContext, Stamp, StampError};
 use nectar_primitives::ChunkAddress;
@@ -52,8 +14,6 @@ use crate::BatchId;
 /// Why a stamped chunk was refused admission to the reserve.
 #[derive(Debug, thiserror::Error)]
 pub enum AdmissionError {
-    /// The referenced batch is not known to the node (the create was missed or
-    /// the batch never existed).
     #[error("postage batch {0} is unknown to the node")]
     UnknownBatch(BatchId),
 
@@ -61,62 +21,43 @@ pub enum AdmissionError {
     #[error("postage batch is not yet usable")]
     BatchNotUsable,
 
-    /// The batch has expired (its value no longer covers the cumulative payout).
+    /// The batch's value no longer covers the cumulative payout.
     #[error("postage batch has expired")]
     BatchExpired,
 
-    /// The recovered signer does not match the batch owner.
     #[error("stamp signer does not match the batch owner")]
     OwnerMismatch,
 
-    /// A structural or cryptographic stamp failure surfaced by nectar.
     #[error("stamp validation failed: {0}")]
     Stamp(#[from] StampError),
 }
 
-/// A synchronous, validate-on-ingest admission validator for stamped chunks.
+/// Synchronous, validate-on-ingest admission validator for stamped chunks.
 ///
-/// Stateless apart from the confirmation threshold the node enforces. Construct
-/// with that threshold; call [`validate`](Self::validate) on the ingest path
-/// with the stamp, the chunk address, the already-loaded [`Batch`], and the
-/// current [`PostageContext`]. The validator performs the nectar checks
-/// synchronously and returns `Ok(())` only when the stamp is admissible.
-///
-/// The batch is loaded by the caller (the reserve holds a
-/// [`BatchStore`](nectar_postage::BatchStore) and reads it before entering its
-/// write transaction); passing it in keeps this validator free of any store
-/// dependency and lets it run inside a synchronous redb transaction.
+/// The caller loads the batch before calling [`validate`](Self::validate), so the
+/// validator carries no store dependency.
 #[derive(Debug)]
 pub struct AdmissionValidator {
-    /// Minimum block confirmations for a batch to be usable.
     confirmation_threshold: u64,
 }
 
 impl AdmissionValidator {
-    /// Create an admission validator enforcing `confirmation_threshold` block
-    /// confirmations before a batch is usable.
     pub const fn new(confirmation_threshold: u64) -> Self {
         Self {
             confirmation_threshold,
         }
     }
 
-    /// The confirmation threshold this validator enforces.
     pub const fn confirmation_threshold(&self) -> u64 {
         self.confirmation_threshold
     }
 
-    /// Validate a stamped chunk for admission, synchronously.
+    /// Validate a stamped chunk for admission.
     ///
-    /// Performs, in order: batch usability and expiry against `context`, the
-    /// structural index/bucket checks, and the signature check (recover the
-    /// signer and compare to the batch owner). Returns `Ok(())` only when every
-    /// check passes.
-    ///
-    /// `batch` must be the batch the stamp references (`stamp.batch() ==
-    /// batch.id()`); the reserve loads it before calling. The owner match uses
-    /// the batch's on-chain owner, so a stamp signed by anyone else is refused
-    /// even if its structure is sound.
+    /// Checks, in order: batch usability and expiry against `context`, the
+    /// structural index/bucket checks, and the signature (recover the signer and
+    /// compare to the batch owner). `batch` must be the batch the stamp
+    /// references (`stamp.batch() == batch.id()`).
     pub fn validate(
         &self,
         stamp: &Stamp,
@@ -124,8 +65,6 @@ impl AdmissionValidator {
         batch: &Batch,
         context: &PostageContext,
     ) -> Result<(), AdmissionError> {
-        // Usability and expiry are policy over the live context, mirroring
-        // nectar's StoreValidator::get_batch_for_stamp (which calls get_usable).
         if !batch.is_usable(context.block(), self.confirmation_threshold) {
             return Err(AdmissionError::BatchNotUsable);
         }
@@ -133,14 +72,10 @@ impl AdmissionValidator {
             return Err(AdmissionError::BatchExpired);
         }
 
-        // Structural checks (nectar, called verbatim).
         batch.validate_index(&stamp.stamp_index())?;
         batch.validate_bucket(&stamp.stamp_index(), address)?;
 
-        // Signature: recover the signer and compare to the batch owner. This is
-        // nectar's Stamp::verify (ecrecover + owner equality), called verbatim;
-        // it maps an owner mismatch to OwnerMismatch so the reserve reports the
-        // precise refusal reason.
+        // Map an owner mismatch to the precise refusal reason.
         match stamp.verify(address, batch.owner()) {
             Ok(()) => Ok(()),
             Err(StampError::OwnerMismatch { .. }) => Err(AdmissionError::OwnerMismatch),
@@ -175,14 +110,14 @@ mod tests {
             .address()
     }
 
-    /// A batch owned by `owner`, created at block 0, depth 18 / bucket depth 16,
-    /// with ample value so it is not expired against a zero cumulative payout.
+    /// Batch owned by `owner`, depth 18 / bucket depth 16, with ample value so it
+    /// is not expired against a zero cumulative payout.
     fn batch_for(owner: Address) -> Batch {
         Batch::new(B256::repeat_byte(0x11), 1_000_000, 0, owner, 18, 16, false)
     }
 
-    /// Sign a real stamp for `address` under `batch` at `timestamp`, using a
-    /// bucket/index consistent with the address so validate_bucket passes.
+    /// Sign a stamp for `address` under `batch`, using a bucket/index consistent
+    /// with the address so `validate_bucket` passes.
     fn signed_stamp(
         signer: &PrivateKeySigner,
         batch: &Batch,
@@ -209,12 +144,11 @@ mod tests {
         let stamp = signed_stamp(&s, &batch, &addr, current_timestamp());
 
         let v = AdmissionValidator::new(THRESHOLD);
-        // Usable at a block well past the threshold, not expired (payout 0).
         let ctx = PostageContext::new(THRESHOLD + 1, 0);
         v.validate(&stamp, &addr, &batch, &ctx).expect("admit");
 
-        // A second, distinct stamp of the same batch validates independently;
-        // the validator carries no per-batch state between calls.
+        // A second stamp of the same batch validates independently: no per-batch
+        // state between calls.
         let addr2 = *ContentChunk::new(b"second payload".to_vec())
             .unwrap()
             .address();
@@ -229,7 +163,7 @@ mod tests {
         let batch = batch_for(s.address());
         let addr = content_address();
 
-        // Sign with a different key: the recovered owner will not match.
+        // Different key: the recovered owner will not match.
         let other = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x99)).unwrap();
         let stamp = signed_stamp(&other, &batch, &addr, current_timestamp());
 
@@ -254,7 +188,7 @@ mod tests {
             AdmissionError::BatchNotUsable
         ));
 
-        // Cumulative payout exceeds the batch value: expired.
+        // Payout exceeds the batch value: expired.
         let expired = PostageContext::new(THRESHOLD + 1, u128::MAX);
         assert!(matches!(
             v.validate(&stamp, &addr, &batch, &expired).unwrap_err(),

--- a/crates/swarm/postage/src/lib.rs
+++ b/crates/swarm/postage/src/lib.rs
@@ -1,73 +1,37 @@
-//! Postage batch storage and the on-chain event ingest seam for the vertex
-//! Swarm node.
+//! Node-side postage state: batch persistence and the on-chain event ingest
+//! seam.
 //!
-//! This crate is the node-side home for postage state. It does not redefine any
-//! postage primitive: the batch model, the stamp model, validation and the
-//! event vocabulary all live in [`nectar_postage`] and are re-exported verbatim
-//! from this crate's root so downstream crates depend on one canonical copy of
-//! each type. What this crate adds is the *node's* concrete persistence and the
-//! *seam* through which on-chain batch state is driven into that persistence:
+//! Postage primitives (batch and stamp models, validation, the event
+//! vocabulary) live in [`nectar_postage`] and are re-exported verbatim so the
+//! workspace shares one canonical copy of each type. This crate adds:
 //!
 //! - [`DbBatchStore`]: a [`nectar_postage::BatchStore`] backed by the
-//!   `vertex-storage` `Database` (redb in production). It persists batches and
-//!   the [`PostageContext`] across restarts, so a node recovers its full batch
-//!   set without replaying the whole chain.
-//! - [`DbBatchStore`] also implements [`nectar_postage::BatchEventHandler`]:
-//!   this is the ingest seam. The four [`BatchEvent`] variants map onto the
-//!   store mutations that keep the node's batch set in step with the contract.
+//!   `vertex-storage` `Database`, persisting batches and the [`PostageContext`]
+//!   so a node recovers its batch set without replaying the chain.
+//! - [`DbBatchStore`]'s [`nectar_postage::BatchEventHandler`] impl: the ingest
+//!   seam mapping each [`BatchEvent`] onto an atomic store mutation (see
+//!   [`DbBatchStore::handle_event`]).
 //!
-//! # Stamp validation is stateless (no per-batch public-key cache)
+//! Stamp validation is stateless: a stamp is valid iff `ecrecover(sig, digest)`
+//! resolves to the batch owner and the index/bucket bounds hold. The owner is
+//! already in the batch store, so [`nectar_postage::StoreValidator`] needs no
+//! side state and this crate ships no per-batch public-key cache.
 //!
-//! A stamp is valid iff `ecrecover(sig, digest)` resolves to the batch owner
-//! and the index/bucket bounds hold. The node already knows `batch.owner` from
-//! the batch store, so validation needs no side state: recover the signer per
-//! stamp and compare to the owner (this is exactly what
-//! [`nectar_postage::StoreValidator`] does, reusing [`Stamp::recover_signer`]
-//! and the nectar digest). This crate therefore ships **no** per-batch
-//! public-key cache.
-//!
-//! nectar does support a cheaper path - recover the signer once with a full
-//! ecrecover ([`Stamp::recover_pubkey`]) and verify the remaining stamps of the
-//! same batch against that key ([`Stamp::verify_with_pubkey`]). That is a
-//! deliberate *future* optimisation: if profiling justifies it, it should be a
-//! per-process in-memory memoisation gated behind the batch-existence check,
-//! and **never** a persisted sidecar table. It is intentionally not implemented
-//! here, so that removing the cache cannot change validation semantics.
-//!
-//! # The ingest seam (and what is deliberately out of scope)
-//!
-//! Postage state on Swarm is owned by the postage-stamp contract on the
-//! settlement chain. A node learns about new batches, top-ups, dilutions and
-//! expiries by watching that contract's logs. The decode path is:
+//! Ingest pipeline:
 //!
 //! ```text
 //!   chain logs --> [ PostageIndexer ] --> BatchEvent --> [ BatchEventHandler ]
 //!   (raw ABI)      (external crate)       (nectar)        (DbBatchStore here)
 //! ```
 //!
-//! This crate owns only the right-hand half: given a [`BatchEvent`], it applies
-//! the correct store mutation atomically (see [`DbBatchStore::handle_event`]).
+//! Only the right-hand half lives here. The event ABI, log decoder, and the
+//! indexer that reduces logs into [`BatchEvent`]s are out of scope, owned by an
+//! external `PostageIndexer` wired up by the node builder.
 //!
-//! The left-hand half - the event ABI, the log decoder, and the indexer that
-//! pulls logs from a chain provider and reduces them into [`BatchEvent`]s - is
-//! **intentionally stubbed / out of scope** in this crate. That work is owned
-//! externally (a `PostageIndexer`) and is wired up by the node builder, not
-//! here. Concretely, this crate defines and documents the *seam*
-//! ([`BatchEventHandler`], re-exported, implemented by [`DbBatchStore`]) but
-//! ships no contract bindings, no `alloy_sol_types` event definitions, and no
-//! log-to-[`BatchEvent`] reducer. Keeping the two halves apart lets the chain
-//! indexer evolve (ABI revisions, reorg handling, batched log fetches) without
-//! touching the persistence layer, and lets this crate be tested with synthetic
-//! [`BatchEvent`]s and no chain at all.
-//!
-//! # Consensus note: keep stamp identity, not just the batch
-//!
-//! The store keys batches by [`BatchId`] alone, which is correct: a batch is a
-//! single on-chain object. It is the *reserve* and the *sampler* (other crates)
-//! that must key stamped entries by the full `(batchID, 8-byte stampIndex)` and
-//! carry the precise winning stamp through an inclusion proof. This crate's job
-//! stops at making the batch available for stamp validation; it does not
-//! collapse distinct stamps of a batch.
+//! The store keys batches by [`BatchId`] alone (a batch is one on-chain object).
+//! Keying stamped entries by the full `(batchID, 8-byte stampIndex)` and
+//! carrying the winning stamp through an inclusion proof is the reserve's and
+//! sampler's job, not this crate's.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -75,21 +39,12 @@ mod admission;
 mod stampindex;
 mod store;
 
-// -------------------------------------------------------------------------
-// Re-export the nectar postage public surface.
-//
-// Downstream vertex crates depend on `vertex-swarm-postage` for postage types
-// and get exactly the nectar definitions, so there is a single canonical copy
-// of `Batch`, `Stamp`, `BatchEvent`, the `BatchStore`/`BatchEventHandler`
-// traits and the validators across the workspace.
-// -------------------------------------------------------------------------
 pub use nectar_postage::{
     Batch, BatchEvent, BatchEventHandler, BatchId, BatchParams, BatchStore, BatchStoreError,
     BatchStoreExt, PostageContext, STAMP_SIZE, Stamp, StampBytes, StampDigest, StampError,
     StampIndex, StampValidator, StoreValidator, VerifyingKey, calculate_bucket, current_timestamp,
 };
 
-// This crate's own additions.
 pub use admission::{AdmissionError, AdmissionValidator};
 pub use stampindex::{
     Arbitration, DbStampIndexArbiter, DisplacedEntry, IncomingStamp, RejectReason,

--- a/crates/swarm/postage/src/stampindex.rs
+++ b/crates/swarm/postage/src/stampindex.rs
@@ -1,50 +1,18 @@
-//! The stamp-index arbiter: newest-timestamp-wins keyed by the full
+//! Stamp-index arbiter: newest-timestamp-wins per slot, keyed by the full
 //! `(batchID, 8-byte stampIndex)`.
 //!
-//! # What this decides
+//! An issuer may re-use a slot, so the reserve must decide whether an incoming
+//! stamp is the newest seen for its `(batch, index)` slot (admit, displacing
+//! the previous occupant) or stale (reject).
 //!
-//! A postage batch is partitioned into *buckets*, and each bucket holds a fixed
-//! number of *index* slots. A stamp commits to one slot via its
-//! [`StampIndex`], whose canonical 8-byte big-endian encoding is
-//! `[bucket: 4][index: 4]` (see [`StampIndex::to_be_bytes`]). The settlement
-//! contract lets an issuer *re-use* a slot: a later stamp under the same batch
-//! and the same `(bucket, index)` supersedes the earlier one. The reserve must
-//! therefore decide, when it sees a stamped chunk, whether that stamp is the
-//! newest the node has seen for its slot (admit, possibly displacing the
-//! previous occupant) or stale (reject).
+//! Consensus-observable rule: ordering is by the stamp timestamp (8-byte
+//! big-endian). `prev >= curr` rejects, so equal timestamps reject (a
+//! re-presentation must not overwrite). The comparison keys on the full
+//! `(batchID, stampIndex)`: two indices within the same bucket are distinct
+//! slots and both admit.
 //!
-//! This module is that decision, and nothing else. It does not touch the
-//! reserve, the payload store, or any of the proximity indexes. PR-D's reserve
-//! calls into it; here it is a self-contained, independently tested unit.
-//!
-//! # The rule (consensus-observable)
-//!
-//! Ordering is by the stamp *timestamp* (an 8-byte big-endian value on the
-//! wire), per slot:
-//!
-//! - **newer** incoming timestamp than the stored one: **admit**, and report
-//!   the displaced entry so the caller can evict the chunk it stamped;
-//! - **no stored entry** for the slot: **admit** with nothing displaced;
-//! - **equal or older** incoming timestamp: **reject**. Equality rejects: a
-//!   re-presentation of an already-seen stamp (same timestamp) must not
-//!   overwrite, and an older stamp is plainly stale. In bee's words,
-//!   `prev >= curr` rejects.
-//!
-//! The comparison is `prev >= curr` on the raw big-endian timestamp, evaluated
-//! against the *full* `(batchID, stampIndex)` key. Keying by the bucket alone
-//! is wrong and was refuted at the design gate: two distinct indices within the
-//! same bucket are different slots and must both be admissible. The
-//! [`distinct_indices_same_bucket_both_admit`](tests) test guards that.
-//!
-//! # Why a hash and an address travel with the timestamp
-//!
-//! When a newer stamp displaces an older one, the caller must remove *exactly*
-//! the chunk the old stamp admitted, identified by its content address and the
-//! precise stamp version (its stamp hash, a keccak over the canonical stamp
-//! bytes). Storing `(timestamp, stamp_hash, address)` in the slot lets the
-//! arbiter hand back a fully-formed [`DisplacedEntry`] without a second lookup,
-//! and lets an inclusion proof later carry the exact stamp a sample slot was
-//! won with rather than re-loading one by batch id alone.
+//! Each slot stores `(timestamp, stamp_hash, address)` so a displacement can
+//! report exactly the chunk to evict without a second lookup.
 
 use alloy_primitives::B256;
 use nectar_postage::{BatchId, StampIndex};
@@ -53,40 +21,28 @@ use std::sync::Arc;
 use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table, table};
 
 // Stamp-index table: `(batchID, stampIndex_be8) -> (timestamp, stampHash, addr)`.
+// The key is laid out big-endian as `[batch: 32][index: 8]` so byte order
+// matches `(batchID, stampIndex)` lexicographic order and a batch's slots are
+// contiguous and ascending. The value is a tiny fixed record (8 + 32 + 32),
+// not worth compressing.
 //
-// The compound key is laid out big-endian as `[batch: 32][index: 8]` so that
-// the byte order matches `(batchID, stampIndex)` lexicographic order: every
-// slot of a batch is contiguous and ascending by `(bucket, index)`. The value
-// is the data needed to identify and evict the slot's current occupant.
-//
-// Uncompressed: the value is a tiny fixed record (8 + 32 + 32 bytes) for which
-// compression is pure overhead.
-//
-// This handle is `pub` and re-exported from the crate root *on purpose*. The
-// reserve (PR-D) decides admission inside its own atomic put transaction rather
-// than calling [`DbStampIndexArbiter`], but it must address the *same* physical
-// table. Rather than re-invoke `table!` there (which would create a second
-// type-level handle to the same on-disk table, free to drift in name or value
-// codec and silently desynchronise it), the reserve imports this single handle.
-// The name and the `(key, value)` codec binding therefore live in exactly one
-// place, here.
+// This handle is `pub` and re-exported so any code addressing the same physical
+// table imports one handle rather than re-invoking `table!` (which would create
+// a second type-level binding free to drift in name or codec). The name and
+// codec binding live only here.
 table!(pub StampIndexTable, "postage_stamp_index", StampSlotKey, StampIndexEntry, compressed = false);
 
 /// The full per-slot key: a postage batch and a stamp index within it.
 ///
-/// This is the *full* `(batchID, 8-byte stampIndex)` key the rule keys on, not
-/// the bucket alone. The 8-byte stamp index is itself `[bucket: 4][index: 4]`
-/// big-endian, so the 40-byte key sorts batch-major, then bucket, then index.
+/// The 8-byte stamp index is `[bucket: 4][index: 4]` big-endian, so the 40-byte
+/// key sorts batch-major, then bucket, then index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StampSlotKey {
-    /// The postage batch the slot belongs to.
     pub batch_id: BatchId,
-    /// The stamp index (bucket and within-bucket position) within the batch.
     pub stamp_index: StampIndex,
 }
 
 impl StampSlotKey {
-    /// Construct a slot key from its batch and stamp index.
     pub const fn new(batch_id: BatchId, stamp_index: StampIndex) -> Self {
         Self {
             batch_id,
@@ -95,11 +51,8 @@ impl StampSlotKey {
     }
 }
 
-// `StampIndex` is a foreign type that implements neither `PartialOrd` nor `Ord`,
-// so `StampSlotKey`'s ordering is defined directly on the canonical 40-byte
-// encoding. This is also exactly the on-disk key order (batch-major, then
-// bucket, then index), so the `Key` bound's `Ord` agrees byte-for-byte with the
-// storage layout.
+// `StampIndex` is foreign and unordered, so ordering is defined on the canonical
+// 40-byte encoding, which equals the on-disk key order (batch, bucket, index).
 impl Ord for StampSlotKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.encode().cmp(&other.encode())
@@ -112,10 +65,7 @@ impl PartialOrd for StampSlotKey {
     }
 }
 
-// The key codec is hand-rolled (rather than a serde derive) so the on-disk byte
-// order is exactly `[batch: 32][index_be8: 8]`. `StampIndex` and `BatchId` are
-// foreign types without local codecs, and serde would not pin the ordering, so
-// the newtype carries the canonical big-endian layout directly.
+// Hand-rolled codec so the on-disk byte order is exactly `[batch: 32][index_be8: 8]`.
 impl Encode for StampSlotKey {
     type Encoded = [u8; 40];
 
@@ -139,12 +89,9 @@ impl Decode for StampSlotKey {
     }
 }
 
-// `StampSlotKey` is used as a redb table key, which requires `serde` (the `Key`
-// blanket bound). It is never actually serialised through serde on the storage
-// path - the `Encode`/`Decode` codec above is - but the bound must be
-// satisfied. The two halves are serialised as a `([u8; 32], [u8; 8])` tuple:
-// serde implements arrays only up to length 32, so the 40-byte encoding cannot
-// be a single array, but the batch and index halves are within that limit.
+// The `Key` blanket bound requires `serde`, though the storage path uses the
+// `Encode`/`Decode` codec above. Serialised as a `([u8; 32], [u8; 8])` tuple
+// because serde implements arrays only up to length 32.
 impl serde::Serialize for StampSlotKey {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let parts: ([u8; 32], [u8; 8]) = (self.batch_id.0, self.stamp_index.to_be_bytes());
@@ -164,22 +111,19 @@ impl<'de> serde::Deserialize<'de> for StampSlotKey {
 
 /// The occupant of a stamp-index slot: the stamp version recorded for it.
 ///
-/// Stored as the [`StampIndexTable`] value. The timestamp is kept in its raw
-/// 8-byte big-endian form so the ordering comparison is byte-exact with the
-/// wire representation and identical to bee's `binary.BigEndian.Uint64`.
+/// Stored as the [`StampIndexTable`] value. The timestamp is kept raw 8-byte
+/// big-endian so the ordering comparison is byte-exact with the wire form.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct StampIndexEntry {
     /// The stamp timestamp, raw 8-byte big-endian (as it appears on the wire).
     pub timestamp: [u8; 8],
-    /// Keccak over the canonical 113-byte stamp, identifying the exact stamp
-    /// version. Lets the caller evict precisely the chunk this stamp admitted.
+    /// Keccak over the canonical 113-byte stamp: the exact stamp version, so the
+    /// caller can evict precisely the chunk this stamp admitted.
     pub stamp_hash: B256,
-    /// The content address the stamp was applied to.
     pub address: ChunkAddress,
 }
 
 impl StampIndexEntry {
-    /// Construct a slot occupant record.
     pub const fn new(timestamp: [u8; 8], stamp_hash: B256, address: ChunkAddress) -> Self {
         Self {
             timestamp,
@@ -188,7 +132,6 @@ impl StampIndexEntry {
         }
     }
 
-    /// The timestamp as a `u64`, decoded from its big-endian bytes.
     #[inline]
     pub const fn timestamp_u64(&self) -> u64 {
         u64::from_be_bytes(self.timestamp)
@@ -196,25 +139,18 @@ impl StampIndexEntry {
 }
 
 /// An incoming stamped-chunk presentation to arbitrate.
-///
-/// Carries the full slot identity `(batch_id, stamp_index)` plus the data that
-/// would be recorded if it wins: its timestamp, stamp hash and address.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IncomingStamp {
-    /// The postage batch the stamp draws on.
     pub batch_id: BatchId,
-    /// The stamp index (bucket and within-bucket position).
     pub stamp_index: StampIndex,
     /// The stamp timestamp, raw 8-byte big-endian.
     pub timestamp: [u8; 8],
     /// Keccak over the canonical 113-byte stamp.
     pub stamp_hash: B256,
-    /// The content address the stamp was applied to.
     pub address: ChunkAddress,
 }
 
 impl IncomingStamp {
-    /// Construct an incoming stamp from its parts.
     pub const fn new(
         batch_id: BatchId,
         stamp_index: StampIndex,
@@ -231,7 +167,6 @@ impl IncomingStamp {
         }
     }
 
-    /// The slot this stamp competes for.
     fn slot(&self) -> StampSlotKey {
         StampSlotKey::new(self.batch_id, self.stamp_index)
     }
@@ -242,70 +177,45 @@ impl IncomingStamp {
     }
 }
 
-/// The entry an admission displaced: the slot's previous occupant.
-///
-/// When an incoming stamp is newer than the one already in its slot, the older
-/// occupant is reported here so the caller can evict exactly the chunk it
-/// admitted (by `address` and `stamp_hash`).
+/// The slot's previous occupant, reported on admission so the caller can evict
+/// exactly the chunk it admitted (by `address` and `stamp_hash`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisplacedEntry {
-    /// The address the displaced stamp was applied to.
     pub address: ChunkAddress,
-    /// The displaced stamp's hash (its precise version).
     pub stamp_hash: B256,
-    /// The displaced stamp's timestamp, raw 8-byte big-endian.
+    /// Raw 8-byte big-endian.
     pub timestamp: [u8; 8],
 }
 
 /// Why an incoming stamp was rejected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RejectReason {
-    /// The slot already holds a stamp whose timestamp is greater than or equal
-    /// to the incoming one (`prev >= curr`). Equal timestamps reject: a
-    /// re-presentation does not overwrite, and an older stamp is stale.
-    NotNewer {
-        /// The stored (previous) timestamp, big-endian.
-        stored: [u8; 8],
-        /// The incoming timestamp, big-endian.
-        incoming: [u8; 8],
-    },
+    /// The slot holds a stamp whose timestamp is `>=` the incoming one. Equal
+    /// rejects, older rejects.
+    NotNewer { stored: [u8; 8], incoming: [u8; 8] },
 }
 
 /// The arbiter's verdict for an incoming stamp.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Arbitration {
-    /// The stamp is the newest seen for its slot and is admitted. If a previous
-    /// occupant was displaced, it is reported so the caller can evict it; a
-    /// `None` means the slot was empty.
-    Admit {
-        /// The previous occupant, if any, that the admission displaced.
-        displaced: Option<DisplacedEntry>,
-    },
-    /// The stamp is stale (equal or older than the stored one) and is rejected.
-    Reject {
-        /// Why the stamp was rejected.
-        reason: RejectReason,
-    },
+    /// Admitted as the newest seen for its slot. `displaced` is the previous
+    /// occupant to evict, or `None` if the slot was empty.
+    Admit { displaced: Option<DisplacedEntry> },
+    /// Rejected as stale.
+    Reject { reason: RejectReason },
 }
 
-/// Pure, storage-free core of the rule.
+/// Pure, storage-free core of the rule: decide the verdict for `incoming`
+/// against the slot's current occupant (`stored`, `None` if empty).
 ///
-/// Given the slot's current occupant (`stored`, `None` if empty) and the
-/// incoming stamp, decide the verdict. Admission does not itself write; the
-/// caller (here [`DbStampIndexArbiter`], in PR-D the reserve, inside its own
-/// transaction) persists the new entry when the verdict is
-/// [`Arbitration::Admit`].
-///
-/// This is split out so the comparison can be reused verbatim inside the
-/// reserve's atomic put transaction without going through this module's own
-/// database handle, keeping the rule defined in exactly one place.
+/// Does not write; the caller persists the new entry on [`Arbitration::Admit`]
+/// inside the atomic put transaction.
 pub fn decide(stored: Option<&StampIndexEntry>, incoming: &IncomingStamp) -> Arbitration {
     match stored {
         None => Arbitration::Admit { displaced: None },
         Some(prev) => {
-            // Compare raw big-endian bytes, which orders identically to the
-            // decoded u64 and is byte-exact with the wire timestamp. `prev >=
-            // curr` rejects (equal rejects, older rejects).
+            // Raw big-endian compare, byte-exact with the wire timestamp;
+            // `prev >= curr` rejects.
             if prev.timestamp >= incoming.timestamp {
                 Arbitration::Reject {
                     reason: RejectReason::NotNewer {
@@ -335,43 +245,32 @@ pub enum StampIndexError {
 }
 
 /// The object-safe arbiter interface.
-///
-/// Arbitrate an incoming stamp against the slot it competes for, persisting the
-/// new occupant on admission and reporting any displaced one. Object-safe (no
-/// generic methods, no `Self`-by-value), so the reserve can hold a
-/// `dyn StampIndexArbiter` if it chooses.
 pub trait StampIndexArbiter {
-    /// Arbitrate `incoming` against its slot.
-    ///
-    /// On [`Arbitration::Admit`] the slot is updated to the incoming stamp
-    /// atomically before returning, and any previous occupant is reported as
-    /// `displaced`. On [`Arbitration::Reject`] the slot is left untouched.
+    /// Arbitrate `incoming` against its slot. On [`Arbitration::Admit`] the slot
+    /// is updated atomically before returning; on [`Arbitration::Reject`] it is
+    /// left untouched.
     fn arbitrate(&self, incoming: &IncomingStamp) -> Result<Arbitration, StampIndexError>;
 
-    /// Look up the current occupant of a slot, if any.
     fn get(&self, slot: &StampSlotKey) -> Result<Option<StampIndexEntry>, StampIndexError>;
 }
 
-/// A [`StampIndexArbiter`] backed by a [`StampIndexTable`] over a
-/// `vertex-storage` `Database`.
+/// A [`StampIndexArbiter`] backed by a [`StampIndexTable`].
 ///
-/// Generic over the backend so the same code serves an in-memory database
-/// (tests) and an on-disk redb database (production). Each arbitration is a
-/// single read-then-conditional-write transaction, so the slot never observes a
-/// partial update and the displaced entry reported is exactly the one removed.
+/// Each arbitration is a single read-then-conditional-write transaction, so the
+/// slot never observes a partial update and the reported displaced entry is
+/// exactly the one removed.
 pub struct DbStampIndexArbiter<DB: Database> {
     db: Arc<DB>,
 }
 
 impl<DB: Database> DbStampIndexArbiter<DB> {
-    /// Create an arbiter over a shared database handle, ensuring the stamp-index
-    /// table exists so the read path works on a fresh database.
+    /// Ensures the stamp-index table exists so the read path works on a fresh
+    /// database.
     pub fn new(db: Arc<DB>) -> Result<Self, StampIndexError> {
         db.update(|tx| tx.ensure_table(StampIndexTable::NAME))?;
         Ok(Self { db })
     }
 
-    /// Borrow the shared database handle.
     pub fn database(&self) -> &Arc<DB> {
         &self.db
     }
@@ -380,11 +279,8 @@ impl<DB: Database> DbStampIndexArbiter<DB> {
 impl<DB: Database> StampIndexArbiter for DbStampIndexArbiter<DB> {
     fn arbitrate(&self, incoming: &IncomingStamp) -> Result<Arbitration, StampIndexError> {
         let slot = incoming.slot();
-        // Read-then-conditional-write in one transaction: the verdict is
-        // computed from the slot's current occupant and, on admission, the new
-        // entry is written before the transaction commits. No await is involved
-        // (redb is synchronous), so the slot cannot change between the read and
-        // the write.
+        // Read-then-conditional-write in one synchronous transaction, so the
+        // slot cannot change between the read and the write.
         let verdict = self.db.update(|tx| {
             let stored = tx.get::<StampIndexTable>(slot)?;
             let verdict = decide(stored.as_ref(), incoming);
@@ -438,15 +334,12 @@ mod tests {
         IncomingStamp::new(batch_id, idx, ts(timestamp), stamp_hash, address)
     }
 
-    // --- the exhaustive timestamp matrix, against a fresh slot each time -----
-
     #[test]
     fn empty_slot_admits_with_nothing_displaced() {
         let a = arbiter();
         let inc = incoming(batch(1), StampIndex::new(3, 7), 100, hash(0xaa), addr(0xa1));
         let verdict = a.arbitrate(&inc).unwrap();
         assert_eq!(verdict, Arbitration::Admit { displaced: None });
-        // The slot now holds the incoming stamp.
         let slot = StampSlotKey::new(batch(1), StampIndex::new(3, 7));
         assert_eq!(
             a.get(&slot).unwrap(),
@@ -473,7 +366,6 @@ mod tests {
                 }),
             }
         );
-        // The slot now holds the newer stamp.
         let slot = StampSlotKey::new(batch(1), idx);
         assert_eq!(
             a.get(&slot).unwrap(),
@@ -500,7 +392,6 @@ mod tests {
                 },
             }
         );
-        // The slot still holds the original stamp.
         let slot = StampSlotKey::new(batch(1), idx);
         assert_eq!(
             a.get(&slot).unwrap(),
@@ -533,14 +424,10 @@ mod tests {
         );
     }
 
-    // --- the design-gate regression guard ----------------------------------
-
     #[test]
     fn distinct_indices_same_bucket_both_admit() {
-        // Two stamps in the SAME bucket but DIFFERENT within-bucket indices are
-        // DIFFERENT slots. Both must admit. Keying by bucket alone (the refuted
-        // design) would have the second reject or displace the first; the full
-        // (batch, stampIndex) key keeps them independent.
+        // Same bucket, different within-bucket index = different slots, both
+        // admit. The full (batch, stampIndex) key keeps them independent.
         let a = arbiter();
         let bucket = 42;
         let one = incoming(
@@ -562,14 +449,11 @@ mod tests {
             a.arbitrate(&one).unwrap(),
             Arbitration::Admit { displaced: None }
         );
-        // Same bucket, same (equal) timestamp, different index: still admits,
-        // displacing nothing, because it is a distinct slot.
         assert_eq!(
             a.arbitrate(&two).unwrap(),
             Arbitration::Admit { displaced: None }
         );
 
-        // Both slots are populated independently.
         assert_eq!(
             a.get(&StampSlotKey::new(batch(1), StampIndex::new(bucket, 0)))
                 .unwrap(),
@@ -584,7 +468,7 @@ mod tests {
 
     #[test]
     fn same_slot_different_batches_are_independent() {
-        // The full key includes the batch id: the same (bucket, index) under two
+        // The batch id is part of the key: same (bucket, index) under two
         // batches are two slots.
         let a = arbiter();
         let idx = StampIndex::new(5, 9);
@@ -599,8 +483,6 @@ mod tests {
             Arbitration::Admit { displaced: None }
         );
     }
-
-    // --- the pure decision core, exhaustively ------------------------------
 
     #[test]
     fn decide_core_matrix() {
@@ -653,8 +535,6 @@ mod tests {
         let e = StampIndexEntry::new(ts(0x0102_0304_0506_0708), hash(0), addr(0));
         assert_eq!(e.timestamp_u64(), 0x0102_0304_0506_0708);
     }
-
-    // --- key codec and ordering --------------------------------------------
 
     #[test]
     fn slot_key_codec_roundtrip() {

--- a/crates/swarm/postage/src/store.rs
+++ b/crates/swarm/postage/src/store.rs
@@ -1,43 +1,29 @@
-//! Persisting batch store over the `vertex-storage` `Database`, and the
-//! [`BatchEventHandler`] ingest seam.
+//! Persisting batch store over the `vertex-storage` `Database`, plus the
+//! [`BatchEventHandler`] on-chain ingest seam.
 //!
-//! [`DbBatchStore`] is generic over the storage backend, so the same code
-//! serves an in-memory database (tests) and an on-disk redb database
-//! (production). It defines two tables:
+//! [`DbBatchStore`] is generic over the backend (in-memory for tests, redb for
+//! production) and defines two tables:
 //!
 //! - [`Batches`]: `BatchId -> Batch`, the authoritative batch set.
-//! - [`ContextTable`]: a single-row table holding the current
-//!   [`PostageContext`]. redb has no schema-level singleton, so the singleton is
-//!   modelled as a one-key table under a fixed key.
+//! - [`ContextTable`]: the current [`PostageContext`], stored as one row under a
+//!   fixed key since redb has no schema-level singleton.
 //!
-//! Every method is a single transaction. The [`BatchStore`] trait is
-//! synchronous (redb is sync), so each method is a plain function and no redb
-//! transaction guard is ever held across an `await` point; async, where it is
-//! needed at all, is added at the true edges (gRPC, FFI), not by the store.
+//! Every method is a single transaction. The [`BatchStore`] trait is sync, so no
+//! transaction guard is ever held across an `await`.
 
 use nectar_postage::{Batch, BatchEvent, BatchEventHandler, BatchId, BatchStore, PostageContext};
 use std::sync::Arc;
 use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table, table};
 
-// Batch table: `BatchId -> Batch`.
-//
-// The authoritative set of batches the node knows about. Values are compressed
-// (the default): `Batch` serialises to a small but compressible record.
+// `BatchId -> Batch`, compressed (the default).
 table!(pub(crate) Batches, "postage_batches", BatchIdKey, Batch);
 
-// Context singleton table: fixed key -> `PostageContext`.
-//
-// redb offers no schema-level singleton, so the postage context is stored as a
-// single row under [`ContextKey::SINGLETON`]. Uncompressed: the value is a tiny
-// fixed record (a u64 and a u128).
+// Single-row `PostageContext` under [`ContextKey::SINGLETON`]. Uncompressed: the
+// value is a tiny fixed record.
 table!(pub(crate) ContextTable, "postage_context", ContextKey, PostageContext, compressed = false);
 
-/// Key newtype wrapping a [`BatchId`] for the [`Batches`] table.
-///
-/// [`BatchId`] is `alloy_primitives::B256`, a foreign type, so the
-/// vertex-storage [`Encode`]/[`Decode`] codecs cannot be implemented on it
-/// directly (orphan rule). This local newtype carries the 32-byte big-endian
-/// encoding, which is also the natural byte order of the id.
+/// Key newtype carrying the 32-byte big-endian [`BatchId`] for the [`Batches`]
+/// table (local newtype works around the orphan rule on the foreign `B256`).
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
@@ -58,16 +44,13 @@ impl Decode for BatchIdKey {
     }
 }
 
-/// Key for the [`ContextTable`] singleton.
-///
-/// The context table holds exactly one row; this single-byte key is its address.
+/// Single-byte key addressing the lone [`ContextTable`] row.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 pub(crate) struct ContextKey(u8);
 
 impl ContextKey {
-    /// The sole key under which the postage context is stored.
     const SINGLETON: Self = Self(0);
 }
 
@@ -86,34 +69,24 @@ impl Decode for ContextKey {
     }
 }
 
-/// Error type returned by [`DbBatchStore`] operations.
-///
-/// Wraps the underlying [`DatabaseError`]; the [`BatchStore`] trait requires the
-/// associated error to implement [`std::error::Error`], which this does (via
-/// `thiserror`).
+/// Error returned by [`DbBatchStore`] operations.
 #[derive(Debug, thiserror::Error)]
 pub enum DbBatchStoreError {
-    /// An error from the underlying database.
     #[error("postage batch store database error: {0}")]
     Database(#[from] DatabaseError),
 }
 
 /// Batch store backed by the `vertex-storage` `Database` trait.
 ///
-/// Generic over the backend, so persistence is decided by whichever database
-/// the node opens. The store is cheap to clone-by-`Arc` and thread-safe for
-/// concurrent reads and writes. It implements both [`BatchStore`] (persistence)
-/// and [`BatchEventHandler`] (the on-chain ingest seam).
+/// Implements both [`BatchStore`] (persistence) and [`BatchEventHandler`]
+/// (on-chain ingest). Cheap to clone by `Arc` and thread-safe.
 pub struct DbBatchStore<DB: Database> {
     db: Arc<DB>,
 }
 
 impl<DB: Database> DbBatchStore<DB> {
-    /// Create a batch store over a shared database handle.
-    ///
-    /// Ensures both the batch table and the context singleton table exist, so
-    /// every read path works on a fresh database without a separate
-    /// initialisation step.
+    /// Create a store, ensuring both tables exist so read paths work on a fresh
+    /// database without a separate init step.
     pub fn new(db: Arc<DB>) -> Result<Self, DbBatchStoreError> {
         db.update(|tx| {
             tx.ensure_table(Batches::NAME)?;
@@ -123,23 +96,13 @@ impl<DB: Database> DbBatchStore<DB> {
         Ok(Self { db })
     }
 
-    /// Borrow the shared database handle.
     pub fn database(&self) -> &Arc<DB> {
         &self.db
     }
 
-    /// Load a batch, apply `mutate` to it, and store it back, all inside a
-    /// single read-write transaction.
-    ///
-    /// This is the atomic read-modify-write the `TopUp` and `DepthIncrease`
-    /// events need: the load and the store share one transaction, so a
-    /// concurrent writer cannot interleave between the read and the write and
-    /// have its update silently clobbered (a lost update). A missing batch is a
-    /// no-op (the event is for a batch the node never saw, or already removed),
+    /// Atomic read-modify-write in one transaction, so a concurrent writer
+    /// cannot clobber the update (lost update). A missing batch is a no-op,
     /// matching the idempotent ingest contract.
-    ///
-    /// `mutate` runs on the loaded value only and performs no I/O, so the
-    /// transaction is held for the minimum span.
     fn mutate_sync(
         &self,
         id: &BatchId,
@@ -155,30 +118,15 @@ impl<DB: Database> DbBatchStore<DB> {
         Ok(())
     }
 
-    /// Remove an expired batch from the store, the *acknowledgement* half of the
-    /// evict-before-remove expiry contract.
-    ///
-    /// This is the bare store removal: it drops the batch row and returns
-    /// whether it existed. It performs **no** reserve eviction, because the
-    /// reserve lives downstream of this crate. It must therefore be driven only
-    /// as the acknowledgement of the reserve's evict-then-acknowledge entry
-    /// point (`ExpirySweep::on_expired_event`), which evicts the batch's stamped
-    /// entries first and runs this acknowledgement only once eviction has
-    /// succeeded. Calling it standalone for a live `Expired` event orphans the
-    /// reserve entries stamped under the batch; see the [`BatchEventHandler`]
-    /// impl docs.
-    ///
-    /// Idempotent: acknowledging an already-removed batch returns `false` and is
-    /// a harmless no-op, so a redelivered `Expired` event is safe.
+    /// Acknowledgement half of the evict-before-remove expiry contract: drops the
+    /// batch row (idempotent) and returns whether it existed, evicting nothing.
+    /// Drive only via the reserve's evict-then-acknowledge path; see the
+    /// [`BatchEventHandler`] impl docs.
     pub fn acknowledge_expired(&self, id: &BatchId) -> Result<bool, DbBatchStoreError> {
         self.remove(id)
     }
 }
 
-// The `BatchStore` trait is synchronous: redb is itself synchronous, so each
-// method is a single transaction with no executor in sight. Async, where it is
-// needed at all, is added at the true edges (a gRPC service, an FFI boundary),
-// not here in the store.
 impl<DB: Database> BatchStore for DbBatchStore<DB> {
     type Error = DbBatchStoreError;
 
@@ -198,9 +146,7 @@ impl<DB: Database> BatchStore for DbBatchStore<DB> {
     }
 
     fn contains(&self, id: &BatchId) -> Result<bool, Self::Error> {
-        // No key-presence primitive on the transaction trait yet, so presence
-        // is a full read whose value is discarded.
-        // TODO(#214): switch to a key-presence check once available.
+        // TODO(#214): switch to a key-presence check once the tx trait has one.
         Ok(self.get(id)?.is_some())
     }
 
@@ -218,10 +164,7 @@ impl<DB: Database> BatchStore for DbBatchStore<DB> {
     }
 
     fn batch_ids(&self) -> Result<Vec<BatchId>, Self::Error> {
-        // Iterate the batch table via the lazy read-only cursor (#396): the
-        // cursor owns its read snapshot, so it is detached from the borrowed
-        // transaction handle. Only keys are needed; values are still decoded by
-        // the cursor, but no per-batch second lookup is performed.
+        // Lazy read-only cursor owns its snapshot; only keys are needed.
         let tx = self.db.tx()?;
         let mut cursor = tx.cursor::<Batches>()?;
         let mut ids = Vec::new();
@@ -240,49 +183,16 @@ impl<DB: Database> BatchStore for DbBatchStore<DB> {
     }
 }
 
-/// The on-chain ingest seam.
+/// On-chain ingest seam: an indexer decodes contract logs into [`BatchEvent`]s
+/// and drives this handler, one transaction per variant. Unknown batches are an
+/// idempotent no-op (ordering is the indexer's responsibility).
 ///
-/// An external `PostageIndexer` decodes contract logs into [`BatchEvent`]s and
-/// drives this handler; see the crate-level documentation. The four variants
-/// map onto store mutations:
-///
-/// - [`BatchEvent::Created`]: the batch is fully described by the event, so it
-///   is written directly (`put`).
-/// - [`BatchEvent::TopUp`]: only the new normalised value is on the wire, so the
-///   batch is loaded, its value updated ([`Batch::set_value`]) and written back
-///   inside one transaction ([`DbBatchStore::mutate_sync`]), so a concurrent
-///   writer cannot clobber the update. A top-up for an unknown batch is a no-op
-///   (the create was missed; the indexer is responsible for ordering, this
-///   handler is idempotent).
-/// - [`BatchEvent::DepthIncrease`]: as top-up, but updates the depth
-///   ([`Batch::set_depth`]).
-/// - [`BatchEvent::Expired`]: the batch is removed via
-///   [`DbBatchStore::acknowledge_expired`].
-///
-/// Each mutation is a single transaction, so the store never observes a partial
-/// event application. Both this handler and the [`BatchStore`] trait are
-/// synchronous, so the handler reuses the store methods (and the `mutate_sync`
-/// helper) directly, with no executor.
-///
-/// # `Expired` is the bare removal, not the orphan-safe path
-///
-/// Handling [`BatchEvent::Expired`] here removes the batch from the store and
-/// nothing more. It does **not** evict the reserve entries stamped under that
-/// batch, because this crate is the parent of the reserve and cannot reach it.
-/// Removing the batch before its entries are evicted orphans those entries: once
-/// the batch leaves the store the reserve's reconciliation sweep can no longer
-/// see it, so the entries are never shed, which inflates the reserve size and
-/// therefore the consensus-committed storage radius.
-///
-/// The enforced ordering is **evict before remove**, and it is owned jointly
-/// with the reserve: the live ingest wiring (#391/#392) must route an `Expired`
-/// event through the reserve's evict-then-acknowledge entry point
-/// (`ExpirySweep::on_expired_event`), passing [`acknowledge_expired`] as the
-/// acknowledgement so the store removal runs *only after* eviction has
-/// succeeded. Driving `handle_event(Expired)` (or [`acknowledge_expired`])
-/// standalone for the live `Expired` path is therefore a bug: it skips the
-/// eviction and strands entries. The other three variants have no reserve
-/// coupling and are safe to drive directly.
+/// `Expired` here is the bare removal: it does not evict the reserve entries
+/// stamped under the batch (the reserve is downstream). Removing the batch
+/// first orphans them, inflating the reserve size and the consensus-committed
+/// storage radius, so live ingest must route `Expired` through the reserve's
+/// evict-then-acknowledge entry point (passing [`acknowledge_expired`]) rather
+/// than calling this directly. The other three variants are safe to drive here.
 ///
 /// [`acknowledge_expired`]: DbBatchStore::acknowledge_expired
 impl<DB: Database> BatchEventHandler for DbBatchStore<DB> {
@@ -443,7 +353,7 @@ mod tests {
             .unwrap();
         assert_eq!(store.get(&id).unwrap().unwrap().value(), 5000);
 
-        // Top-up for an unknown batch is a no-op (idempotent ingest).
+        // Top-up for an unknown batch is a no-op.
         let unknown = B256::repeat_byte(0xff);
         store
             .handle_event(BatchEvent::TopUp {
@@ -488,8 +398,6 @@ mod tests {
 
     #[test]
     fn acknowledge_expired_is_idempotent() {
-        // The explicit removal seam returns whether the batch existed, and a
-        // second acknowledgement is a harmless no-op (redelivered Expired event).
         let store = in_memory_store();
         let batch = sample_batch(0x05, 1000, 20);
         let id = batch.id();
@@ -504,11 +412,8 @@ mod tests {
 
     #[test]
     fn mutate_event_is_single_transaction() {
-        // The TopUp/DepthIncrease path loads, mutates and stores inside one
-        // transaction (mutate_sync), so the round trip is atomic. We cannot
-        // schedule a real interleaving in a single-threaded test, but we can
-        // assert the combined effect of two successive mutations is the last
-        // writer's value with no lost write, exercising the one-transaction path.
+        // Two successive mutations leave both fields at their last-written value,
+        // with no lost write.
         let mut store = in_memory_store();
         let batch = sample_batch(0x06, 1000, 20);
         let id = batch.id();
@@ -532,19 +437,10 @@ mod tests {
         assert_eq!(got.depth(), 30, "depth update applied");
     }
 
-    /// Regression marker for the remove-before-evict race (the orphan hazard).
-    ///
-    /// The orphan-safe ordering (evict the reserve entries, then acknowledge the
-    /// store removal) is enforced by the reserve crate's
-    /// `ExpirySweep::on_expired_event`, which is downstream of this crate, so the
-    /// race cannot be reproduced from `vertex-swarm-postage` alone (there is no
-    /// reserve here to orphan). The end-to-end "removal before sweep orphans
-    /// entries" regression lives in the reserve crate's tests (PR-D/PR-E), where
-    /// both halves are in scope. This crate's contribution is the explicit
-    /// [`DbBatchStore::acknowledge_expired`] seam and the contract documentation;
-    /// this ignored test records the cross-crate gap so it is not lost.
+    /// Marker for the remove-before-evict race: not reproducible here (no reserve
+    /// to orphan), only via the [`DbBatchStore::acknowledge_expired`] seam.
     #[test]
-    #[ignore = "cross-crate: enforced and regression-tested in the reserve crate (PR-D/PR-E)"]
+    #[ignore = "cross-crate: enforced and regression-tested in the reserve crate"]
     fn remove_before_evict_orphans_entries_is_reserve_crate_concern() {}
 
     #[test]

--- a/crates/swarm/primitives/src/stamped.rs
+++ b/crates/swarm/primitives/src/stamped.rs
@@ -4,33 +4,18 @@ use nectar_postage::Stamp;
 use nectar_primitives::{AnyChunk, ChunkAddress};
 
 /// A chunk together with its postage stamp.
-///
-/// Re-exported from `nectar-postage`: the canonical `StampedChunk` now lives
-/// upstream (chunk plus stamp, with the typed/wire codec), so vertex consumes
-/// it directly instead of carrying its own copy. The vertex-specific serve-time
-/// and cache type-states ([`VerifiedStampedChunk`], [`CachedChunk`]) wrap it,
-/// and [`StampedChunkExt`] adds the vertex-only `verify_answers` gate.
 pub use nectar_postage::StampedChunk;
 
-/// Vertex-only extensions to nectar's [`StampedChunk`].
-///
-/// `verify_answers` is a vertex serve-time gate, not a property of the chunk
-/// type, so it cannot be an inherent method on the upstream type (the orphan
-/// rule). It is expressed as an extension trait instead.
+/// Serve-time verification gate on [`StampedChunk`], as an extension trait
+/// because the orphan rule forbids an inherent method on the upstream type.
 pub trait StampedChunkExt {
     /// Prove this chunk answers a request for `requested`, consuming it into a
     /// [`VerifiedStampedChunk`].
     ///
-    /// The chunk's address is derived from its own bytes (the BMT hash for a
-    /// content chunk, owner plus id for a single-owner chunk), so an equal
-    /// address means the bytes are exactly the ones the requester asked for.
-    /// This is the verify-before-the-wire check expressed as a type-state: only
-    /// a [`VerifiedStampedChunk`] can be handed to a responder, so a chunk that
-    /// does not answer the request cannot be served by construction.
-    ///
-    /// Returns the chunk unchanged in [`Err`] on a mismatch so the caller can
-    /// treat it as a miss without losing the value. The error is boxed because a
-    /// [`StampedChunk`] is large (a full chunk payload plus a stamp).
+    /// The chunk's address is derived from its own bytes, so an equal address
+    /// means the bytes are exactly the ones the requester asked for. Returns the
+    /// chunk unchanged in [`Err`] on a mismatch so the caller can treat it as a
+    /// miss without losing the value (boxed because a [`StampedChunk`] is large).
     fn verify_answers(
         self,
         requested: ChunkAddress,
@@ -52,30 +37,24 @@ impl StampedChunkExt for StampedChunk {
 
 /// A [`StampedChunk`] proven to answer a specific request.
 ///
-/// Constructed only by [`StampedChunkExt::verify_answers`], which checks the
-/// chunk's content-derived address against the requested address. A responder
-/// accepts only this type, so a chunk that does not match the request can never
-/// be sent down the wire: the gate is a compile-time guarantee rather than a
-/// runtime check at the send site.
+/// Constructed only by [`StampedChunkExt::verify_answers`]. A responder accepts
+/// only this type, so an unverified chunk cannot be sent down the wire.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedStampedChunk(StampedChunk);
 
 impl VerifiedStampedChunk {
-    /// The chunk's address.
     #[inline]
     #[must_use]
     pub fn address(&self) -> &ChunkAddress {
         self.0.address()
     }
 
-    /// Borrow the underlying stamped chunk.
     #[inline]
     #[must_use]
     pub fn stamped(&self) -> &StampedChunk {
         &self.0
     }
 
-    /// Consume into the underlying stamped chunk for sending down the wire.
     #[inline]
     #[must_use]
     pub fn into_inner(self) -> StampedChunk {
@@ -85,21 +64,11 @@ impl VerifiedStampedChunk {
 
 /// A chunk paired with an *optional* postage stamp, as the local cache holds it.
 ///
-/// The cache stores two kinds of entry that differ only in whether a stamp is
-/// present:
-///
-/// - A content chunk (CAC) is immutable: its address is the BMT hash of its
-///   content, so a cached copy is valid forever and carries no freshness signal.
-///   The retrieval path delivers it stampless (a storer answers a retrieval with
-///   the chunk bytes only), and the cache stores it with `stamp == None`.
-/// - A single-owner chunk (SOC) is mutable at a fixed address; the cache orders
-///   versions by the stamp's signed timestamp, so a cached SOC always carries a
-///   stamp (`stamp == Some`). The retrieval path never caches a SOC, since a
-///   stampless SOC has no version signal and could serve a stale revision.
-///
-/// [`StampedChunk`] remains the always-stamped currency on the network paths
-/// (pushsync, upload, the stamped reserve). This type is the cache value, where
-/// a stampless content chunk is a first-class entry.
+/// A content chunk (CAC) is immutable and cached stampless (`stamp == None`). A
+/// single-owner chunk (SOC) is mutable at a fixed address, ordered by the
+/// stamp's signed timestamp, so a cached SOC always carries a stamp; the
+/// retrieval path never caches a SOC since a stampless one has no version signal.
+/// [`StampedChunk`] remains the always-stamped currency on the network paths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedChunk {
     chunk: AnyChunk,
@@ -107,35 +76,30 @@ pub struct CachedChunk {
 }
 
 impl CachedChunk {
-    /// Pair a chunk with an optional stamp.
     #[inline]
     #[must_use]
     pub fn new(chunk: AnyChunk, stamp: Option<Stamp>) -> Self {
         Self { chunk, stamp }
     }
 
-    /// The chunk.
     #[inline]
     #[must_use]
     pub fn chunk(&self) -> &AnyChunk {
         &self.chunk
     }
 
-    /// The postage stamp, if one was cached with the chunk.
     #[inline]
     #[must_use]
     pub fn stamp(&self) -> Option<&Stamp> {
         self.stamp.as_ref()
     }
 
-    /// The chunk's address (delegates to the chunk).
     #[inline]
     #[must_use]
     pub fn address(&self) -> &ChunkAddress {
         self.chunk.address()
     }
 
-    /// Split into the chunk and its optional stamp.
     #[inline]
     #[must_use]
     pub fn into_parts(self) -> (AnyChunk, Option<Stamp>) {
@@ -159,9 +123,8 @@ mod tests {
 
     use super::*;
 
-    // `StampedChunk` is generic over the chunk body size with a default; the
-    // `reconstruct` constructor takes no argument that pins it, so spell the
-    // default-body-size instantiation out for those call sites.
+    // Pins the default body size for `reconstruct` call sites, which take no
+    // argument that fixes the generic.
     type DefaultStampedChunk = StampedChunk;
 
     fn test_stamp() -> Stamp {
@@ -199,7 +162,7 @@ mod tests {
             .expect("content reconstruct");
         assert!(rebuilt.chunk().is_content());
         assert_eq!(*rebuilt.address(), address);
-        // Encode is byte-identical to the original wire data.
+        // Re-encode is byte-identical to the original wire data.
         assert_eq!(rebuilt.into_parts().0.into_bytes(), data);
     }
 
@@ -235,7 +198,6 @@ mod tests {
             .clone()
             .verify_answers(wrong)
             .expect_err("wrong address must fail");
-        // The value is returned unchanged so the caller can treat it as a miss.
         assert_eq!(*returned, stamped);
     }
 

--- a/crates/swarm/redistribution/benches/redistribution.rs
+++ b/crates/swarm/redistribution/benches/redistribution.rs
@@ -1,28 +1,9 @@
-//! Criterion benchmarks for the redistribution-game primitives.
+//! Criterion benchmarks for the redistribution-game compute primitives:
+//! `transformed_address`, `reserve_sample`, `make_inclusion_proofs`, and
+//! `canonical_neighbourhood`.
 //!
-//! These benchmarks measure the pure-compute primitives in
-//! [`vertex_swarm_redistribution`]: the per-chunk anchor-keyed transformed
-//! address, the reserve-sample selection, the proof-of-entitlement build, and
-//! the committed-depth neighbourhood filter.
-//!
-//! The four measured operations are:
-//!
-//! - [`AnyChunk::transformed_address`]: the per-chunk anchor-keyed consensus
-//!   hash (a prefix-BMT over a 4 KiB body), measured both for a single chunk and
-//!   batched over a full candidate set (hash all N, then sort) at 1k / 10k
-//!   chunks. Reported in [`Throughput::Bytes`] over the hashed body bytes so the
-//!   figure converts directly to an aggregate MB/s.
-//! - [`reserve_sample`]: the min-16 selection over a candidate set that mirrors
-//!   a reserve neighbourhood (1k / 10k / 65k chunks).
-//! - [`make_inclusion_proofs`]: the proof-of-entitlement build over a 16-item
-//!   sample.
-//! - [`canonical_neighbourhood`]: the committed-depth membership filter over a
-//!   parameterised address set.
-//!
-//! Inputs are derived from a deterministic counter-based generator rather than a
-//! random source, so repeated runs use identical inputs and the measurement is
-//! reproducible. All chunk and sample fixtures are built with the typed nectar
-//! constructors *outside* the measured region.
+//! Inputs come from a deterministic counter-based generator, so runs are
+//! reproducible. Fixtures are built outside the measured region.
 
 #![allow(
     clippy::indexing_slicing,
@@ -44,26 +25,19 @@ use vertex_swarm_redistribution::{
     make_inclusion_proofs, reserve_sample,
 };
 
-/// The raw bytes of the sample-time anchor, a fixed 32-byte value so the
-/// transformed-address work is deterministic across runs.
+/// Fixed 32-byte sample-time anchor.
 const ANCHOR_BYTES: &[u8] = b"swarm-test-anchor-deterministic!";
 
-/// The sample-time anchor as the typed [`SampleAnchor`].
 fn sample_anchor() -> SampleAnchor {
     SampleAnchor::new(B256::from_slice(ANCHOR_BYTES))
 }
 
-/// A fixed claim-time anchor (value 30) that drives the witness indices in
-/// [`make_inclusion_proofs`].
 fn claim_anchor() -> ClaimAnchor {
     ClaimAnchor::new(B256::left_padding_from(&[30]))
 }
 
-/// Deterministic 256-bit value generator (SplitMix64 expanded into 32 bytes).
-///
-/// Reproducible across runs so the benchmark inputs never change. Not a CSPRNG;
-/// it only needs to spread addresses across the keyspace so the depth filter
-/// does representative work.
+/// Deterministic 256-bit generator (SplitMix64 expanded to 32 bytes). Not a
+/// CSPRNG; just spreads addresses across the keyspace.
 fn next_b256(state: &mut u64) -> B256 {
     let mut out = [0u8; 32];
     for chunk in out.chunks_mut(8) {
@@ -77,7 +51,6 @@ fn next_b256(state: &mut u64) -> B256 {
     B256::from(out)
 }
 
-/// A deterministic pool of `count` distinct chunk addresses.
 fn address_pool(count: usize) -> Vec<ChunkAddress> {
     let mut state = 0x0DDB_1A5E_5EED_0042u64;
     (0..count)
@@ -85,9 +58,7 @@ fn address_pool(count: usize) -> Vec<ChunkAddress> {
         .collect()
 }
 
-/// A deterministic 4096-byte (`DEFAULT_BODY_SIZE`) CAC body seeded by `n`.
-///
-/// Each body is distinct so transformed addresses spread across the keyspace.
+/// Deterministic `DEFAULT_BODY_SIZE` CAC body seeded by `n`, distinct per `n`.
 fn cac_body(n: u64) -> Vec<u8> {
     let mut state = n.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xD1B5_4A32_D192_ED03;
     let mut body = vec![0u8; DEFAULT_BODY_SIZE];
@@ -103,17 +74,12 @@ fn cac_body(n: u64) -> Vec<u8> {
     body
 }
 
-/// A typed CAC chunk over a deterministic full-size body.
-///
-/// `new` BMT-hashes the content and wraps it with its span, exactly the typed
-/// constructor used by the conformance tests.
 fn cac_chunk(n: u64) -> DefaultAnyChunk {
     DefaultContentChunk::new(cac_body(n))
         .map(DefaultAnyChunk::from)
         .expect("CAC chunk builds")
 }
 
-/// A typed single-owner chunk wrapping a deterministic full-size body.
 fn soc_chunk(n: u64) -> DefaultAnyChunk {
     let mut key = [0u8; 32];
     key[..8].copy_from_slice(&n.to_le_bytes());
@@ -127,15 +93,10 @@ fn soc_chunk(n: u64) -> DefaultAnyChunk {
         .expect("SOC chunk builds")
 }
 
-/// A deterministic synthetic stamp for pool item `n`.
+/// Deterministic synthetic stamp for pool item `n`, with a distinct batch id.
 ///
-/// `make_inclusion_proofs` requires every witnessed slot to carry the exact
-/// stamp it was won with, so the pool pins a distinct, deterministic stamp per
-/// item. The stamp does not feed the sample ordering (the transformed address is
-/// stamp independent) nor the RC/OG/TR BMT proofs, so attaching it leaves the
-/// `reserve_sample` benchmark's measured work unchanged while letting the
-/// `make_inclusion_proofs` benchmark build a proof at all. The batch id varies
-/// with `n` so distinct slots carry distinguishable stamps.
+/// Required because `make_inclusion_proofs` reads each slot's winning stamp; it
+/// does not affect sample ordering or the BMT proofs.
 fn fixture_stamp(n: u64) -> Stamp {
     let mut bytes = [0u8; 32];
     bytes[..8].copy_from_slice(&n.wrapping_mul(0x9E37_79B9_7F4A_7C15).to_le_bytes());
@@ -145,11 +106,8 @@ fn fixture_stamp(n: u64) -> Stamp {
     Stamp::with_index(batch, index, 1, sig)
 }
 
-/// A reserve-shaped pool of `count` sample items over distinct CAC bodies.
-///
-/// Each item carries a real typed CAC, its transformed address and a
-/// deterministic winning stamp, exactly the inputs `reserve_sample` orders by
-/// and `make_inclusion_proofs` witnesses. Built outside the measured region.
+/// Reserve-shaped pool of `count` sample items, each a real CAC with its
+/// transformed address and a winning stamp.
 fn sample_pool(count: usize) -> Vec<SampleItem> {
     let sample = sample_anchor();
     (0..count as u64)
@@ -157,17 +115,9 @@ fn sample_pool(count: usize) -> Vec<SampleItem> {
         .collect()
 }
 
-/// The per-chunk consensus hash: an anchor-keyed prefix-BMT over a 4 KiB body,
-/// for both a CAC and a SOC. Reported in `Throughput::Bytes` over the 4096-byte
-/// body so the figure converts to MB/s.
-///
-/// The `batch/{1000,10000}` cases hash the transformed address of every chunk in
-/// a full candidate set and then sort the set by transformed address, reporting
-/// bytes/s over all hashed bodies. This gives an aggregate MB/s at realistic
-/// candidate-set sizes, directly comparable to an aggregate hash-and-sort figure
-/// from another implementation. It is deliberately distinct from
-/// [`reserve_sample`], which keeps only the smallest 16 via sorted insertion;
-/// this case hashes and sorts the whole set.
+/// Per-chunk consensus hash (anchor-keyed prefix-BMT over the body), for a CAC
+/// and a SOC, reported as MB/s. The `batch/{1000,10000}` cases hash every chunk
+/// in a candidate set then sort by transformed address, for an aggregate MB/s.
 fn bench_transformed_address(c: &mut Criterion) {
     let mut group = c.benchmark_group("transformed_address");
 
@@ -189,8 +139,6 @@ fn bench_transformed_address(c: &mut Criterion) {
         });
     });
 
-    // Aggregate hash-and-sort over a full candidate set, for an MB/s figure at
-    // realistic sample sizes. Chunks are built once outside the measured region.
     for &count in &[1_000usize, 10_000] {
         let chunks: Vec<DefaultAnyChunk> = (0..count as u64).map(cac_chunk).collect();
         group.throughput(Throughput::Bytes((count * DEFAULT_BODY_SIZE) as u64));
@@ -209,10 +157,8 @@ fn bench_transformed_address(c: &mut Criterion) {
     group.finish();
 }
 
-/// The min-16 reserve-sample selection over candidate-set sizes that mirror a
-/// reserve / neighbourhood. The per-item transformed-address work is realistic
-/// (real 4 KiB CAC bodies), so this measures the genuine selection cost, not a
-/// stripped-down sort.
+/// The min-16 reserve-sample selection over neighbourhood-sized candidate sets,
+/// with realistic per-item transformed-address work over real CAC bodies.
 fn bench_reserve_sample(c: &mut Criterion) {
     let mut group = c.benchmark_group("reserve_sample");
 
@@ -234,14 +180,12 @@ fn bench_reserve_sample(c: &mut Criterion) {
     group.finish();
 }
 
-/// The proof-of-entitlement build over a full 16-item sample. The sample is
-/// selected once outside the measured region; only the RC chunk hash plus the
-/// three witnesses (RC + OG + TR BMT proofs each) are timed.
+/// The proof-of-entitlement build over a full 16-item sample (RC chunk hash plus
+/// the RC + OG + TR BMT-proof witnesses); selection happens outside the timer.
 fn bench_make_inclusion_proofs(c: &mut Criterion) {
     let sample = sample_anchor();
     let claim = claim_anchor();
 
-    // A realistic 16-item sample drawn from a 1k reserve-shaped pool.
     let items = reserve_sample(sample_pool(1_024));
     assert_eq!(
         items.len(),
@@ -262,9 +206,8 @@ fn bench_make_inclusion_proofs(c: &mut Criterion) {
     group.finish();
 }
 
-/// The committed-depth membership filter over a parameterised address set.
-/// `depth_0_all` admits every address (pure filter cost); `depth_1_half` keeps
-/// roughly half the keyspace.
+/// The committed-depth membership filter. `depth_0_all` admits every address;
+/// `depth_1_half` keeps roughly half the keyspace.
 fn bench_canonical_neighbourhood(c: &mut Criterion) {
     let anchor = SwarmAddress::zero();
     let depth_0 = CommittedDepth::ZERO;

--- a/crates/swarm/redistribution/src/anchor.rs
+++ b/crates/swarm/redistribution/src/anchor.rs
@@ -1,43 +1,33 @@
 //! The two per-round reserve salts.
 //!
 //! [`SampleAnchor`] and [`ClaimAnchor`] are distinct newtypes over the same
-//! on-chain `bytes32` so that the sample-time and claim-time salts cannot be
-//! transposed: a swap yields garbage proofs and a lost round, and the type
-//! system rejects it at compile time.
+//! on-chain `bytes32` so the sample-time and claim-time salts cannot be
+//! transposed: swapping them yields garbage proofs and a lost round, rejected at
+//! compile time.
 
 use alloy_primitives::B256;
 
-/// The sample-time reserve salt (the first round anchor).
+/// Sample-time reserve salt (first round anchor).
 ///
-/// The `bytes32 currentRoundAnchor` read from `Redistribution.sol`, used as the
-/// BMT prefix that keys transformed addresses (via
+/// Keys transformed addresses (via
 /// [`transformed_address`](nectar_primitives::AnyChunk::transformed_address))
-/// and the transformed (TR) inclusion proof. Fixed-width `B256` because the
-/// on-chain anchor is always a `bytes32`; an earlier `&[u8]` shape over-fit to
-/// the minimal-length anchors that some test vectors use.
-///
-/// A distinct type from [`ClaimAnchor`] so the two round salts, which play
-/// structurally different roles and must never be transposed, cannot be passed
-/// to each other's slot.
+/// and the transformed-address inclusion proof.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SampleAnchor(B256);
 
 impl SampleAnchor {
-    /// Wrap the on-chain sample-time anchor (`bytes32`).
     #[inline]
     #[must_use]
     pub const fn new(anchor: B256) -> Self {
         Self(anchor)
     }
 
-    /// The salt as a fixed-width `bytes32`.
     #[inline]
     #[must_use]
     pub const fn get(self) -> B256 {
         self.0
     }
 
-    /// The raw salt bytes, threaded untouched into the hashing primitives.
     #[inline]
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
@@ -51,31 +41,26 @@ impl From<B256> for SampleAnchor {
     }
 }
 
-/// The claim-time reserve salt (the second round anchor).
+/// Claim-time reserve salt (second round anchor).
 ///
-/// The `bytes32 currentRoundAnchor`, interpreted big-endian to select the
-/// witness slots and the proven segment (see
-/// [`witness_indices`](crate::witness_indices)). See [`SampleAnchor`] for why
-/// this is a fixed-width `B256` and a distinct type.
+/// Interpreted big-endian to select the witness slots and proven segment (see
+/// [`witness_indices`](crate::witness_indices)).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ClaimAnchor(B256);
 
 impl ClaimAnchor {
-    /// Wrap the on-chain claim-time anchor (`bytes32`).
     #[inline]
     #[must_use]
     pub const fn new(anchor: B256) -> Self {
         Self(anchor)
     }
 
-    /// The salt as a fixed-width `bytes32`.
     #[inline]
     #[must_use]
     pub const fn get(self) -> B256 {
         self.0
     }
 
-    /// The raw salt bytes.
     #[inline]
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {

--- a/crates/swarm/redistribution/src/filter.rs
+++ b/crates/swarm/redistribution/src/filter.rs
@@ -1,42 +1,26 @@
 //! Consensus candidate-feed filters for the reserve sampler.
 //!
-//! Before a stamped reserve entry may enter the sample, it must pass a small
-//! set of filters that every honest node applies identically. Because the
-//! sample, the reserve-commitment chunk and the inclusion proofs are verified on
-//! chain, these filters are **consensus load bearing**: a node that admits a
-//! candidate the protocol would have excluded (or excludes one the protocol
-//! would have kept) computes a different sample and loses, or is slashed in, the
-//! round. They are therefore pure functions of their inputs, evaluated against a
-//! single round-consistent batch snapshot.
+//! A stamped reserve entry must pass three independent exclusion gates before it
+//! can enter the sample. These gates are consensus load bearing: disagreeing with
+//! the protocol on a single candidate computes a different sample and loses or is
+//! slashed in the round. They are pure functions of the candidate and a single
+//! round-consistent batch snapshot.
 //!
-//! The three filters below are independent exclusion gates: a candidate failing
-//! any one is dropped, so the final sample does not depend on the order they are
-//! evaluated in (bee splits them across its iterate/assemble phases; we evaluate
-//! them together). [`CandidateFilter::admit`] reports the first gate that fires
-//! so callers can meter each exclusion class. The gates are:
+//! The gates are independent drop conditions, so evaluation order does not affect
+//! the sample; [`CandidateFilter::admit`] returns the first that fires only so
+//! each exclusion class can be metered:
 //!
-//! 1. **Future-timestamp rejection.** The stamp's timestamp, decoded as a
-//!    big-endian `u64` of nanoseconds, must not exceed the round's
-//!    `consensusTime`. A stamp claiming to have been issued after the round was
-//!    fixed cannot have legitimately covered the chunk at sampling time, so it is
-//!    excluded.
-//! 2. **Below-minimum-balance exclusion.** A candidate whose batch's normalised
-//!    per-chunk balance is below the round's `minimumBalance` is excluded. The
-//!    set of such batches is computed once per round from the snapshot
-//!    ([`RoundBatches::is_below_minimum_balance`]) so the same batches are
-//!    excluded uniformly across every candidate.
-//! 3. **Rogue-chunk / valid-stamp rejection.** Only content-addressed (CAC) and
-//!    single-owner (SOC) chunks are admissible; any other shape is a *rogue*
-//!    chunk and is excluded. The stamp must also be admissible for the batch it
-//!    references in the snapshot (the batch exists and is neither expired nor
-//!    below balance). The expensive per-candidate `ecrecover` is deliberately
-//!    **not** repeated here: the reserve only ever admits entries whose stamps
-//!    were signature-validated on ingest, so re-recovering the signer for every
-//!    sampling candidate would be redundant work that changes no outcome. See
-//!    the design note on [`CandidateFilter`].
+//! 1. Future timestamp: the stamp's big-endian timestamp must not exceed the
+//!    round `consensusTime`.
+//! 2. Below minimum balance: batches whose normalised per-chunk balance is below
+//!    the round `minimumBalance`, computed once per round so the exclusion set is
+//!    uniform across candidates.
+//! 3. Rogue chunk / valid stamp: only CAC and SOC shapes are admissible, and the
+//!    stamp's batch must still be admissible in the snapshot. No per-candidate
+//!    `ecrecover`; see [`CandidateFilter`].
 //!
-//! A candidate that passes all three is mapped to a [`SampleItem`] carrying its
-//! exact winning stamp, ready for [`reserve_sample`](crate::reserve_sample).
+//! A passing candidate becomes a [`SampleItem`] carrying its winning stamp, ready
+//! for [`reserve_sample`](crate::reserve_sample).
 
 use nectar_primitives::AnyChunk;
 use vertex_swarm_postage::{BatchId, PostageContext, Stamp};
@@ -44,12 +28,8 @@ use vertex_swarm_postage::{BatchId, PostageContext, Stamp};
 use crate::anchor::SampleAnchor;
 use crate::sample::SampleItem;
 
-/// Why the candidate filter excluded a stamped reserve entry.
-///
-/// Kept as an explicit reason (rather than a bare `bool`) so callers can meter
-/// each exclusion class, exactly as the reference node's sampler statistics do
-/// (future stamps, below-balance, invalid/rogue), without re-deriving which gate
-/// fired.
+/// Why the candidate filter excluded a stamped reserve entry. An explicit reason
+/// (rather than a `bool`) so callers can meter each exclusion class.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FilterRejection {
@@ -64,57 +44,37 @@ pub enum FilterRejection {
     InvalidStamp,
 }
 
-/// A round-consistent view of postage batch state for the sampler.
+/// A frozen, round-consistent view of postage batch state for the sampler.
 ///
-/// The sampler reads batch facts for a single redistribution round through this
-/// trait so that every candidate in the round sees one frozen snapshot: the
-/// `consensusTime`, the `minimumBalance` and the per-batch balance facts must
-/// not move underneath the candidate feed mid-round, or two candidates could be
-/// judged against different state and the sample would no longer be a pure
-/// function of the round inputs.
-///
-/// It is intentionally minimal: the full
-/// [`BatchStore`](vertex_swarm_postage::BatchStore) is consulted once when the
-/// snapshot is taken, not per candidate. The node provides a concrete
-/// implementation (typically a frozen map of the batches in range); the
-/// consensus filters here depend only on this small surface, which keeps them
-/// pure and unit-testable with a synthetic snapshot and no chain.
+/// Every candidate in a round is judged against one snapshot, so the sample is a
+/// pure function of the round inputs. The
+/// [`BatchStore`](vertex_swarm_postage::BatchStore) is read once at snapshot time,
+/// not per candidate, so these filters are unit-testable with no chain.
 pub trait RoundBatches {
-    /// The round's `consensusTime`: the upper bound (inclusive) on a stamp's
-    /// big-endian timestamp, in the same nanosecond unit the stamp carries.
+    /// The round `consensusTime`: inclusive upper bound on a stamp's big-endian
+    /// timestamp, in the nanosecond unit the stamp carries.
     fn consensus_time(&self) -> u64;
 
-    /// Whether `batch` is below the round's minimum balance and must be
-    /// excluded. Computed once per round against the frozen snapshot so the
-    /// exclusion set is identical for every candidate.
+    /// Whether `batch` is below the round's minimum balance and must be excluded.
     fn is_below_minimum_balance(&self, batch: &BatchId) -> bool;
 
-    /// Whether `batch` is admissible at all in this round: present in the
-    /// snapshot and not expired under the round [`PostageContext`]. A stamp
-    /// referencing a batch that fails this is treated as an invalid stamp.
+    /// Whether `batch` is admissible: present in the snapshot and not expired
+    /// under the round [`PostageContext`]. A stamp on a non-admissible batch is
+    /// treated as invalid.
     fn is_admissible(&self, batch: &BatchId) -> bool;
 }
 
 /// The consensus candidate-feed filter for one redistribution round.
 ///
-/// Holds a borrow of the round snapshot and applies the three exclusion gates.
-/// It is the single place the sampler decides whether a stamped reserve entry
-/// may become a sample candidate. The gates are independent drop conditions, so
-/// their evaluation order does not affect the sample; [`admit`](Self::admit)
-/// returns the first that fires only so each exclusion class can be metered.
+/// Borrows the round snapshot and applies the three exclusion gates; the single
+/// place the sampler decides whether a stamped reserve entry may become a sample
+/// candidate.
 ///
-/// # Why no per-candidate `ecrecover`
-///
-/// The stamp digest and EIP-191 `ecrecover` are owned by nectar's stamp
-/// validation and are run when a stamp is admitted to the reserve (on ingest).
-/// By the time a stamped entry is a sampling candidate it has already been
-/// signature-validated, and the reserve never holds an entry whose stamp failed
-/// recovery. Re-recovering the signer for every candidate of every round would
-/// therefore be pure redundant work that cannot change any admission decision.
-/// The valid-stamp gate here is consequently structural: it checks that the
-/// stamp's batch is still admissible (known, unexpired, not below balance) in
-/// the round snapshot, and that the chunk is not a rogue shape. The cryptographic
-/// guarantee is upheld upstream, not re-litigated in the hot sampling loop.
+/// The valid-stamp gate is structural and does not re-run `ecrecover`: the reserve
+/// signature-validates stamps on ingest and never holds an entry whose stamp
+/// failed recovery, so per-candidate recovery cannot change any decision. The gate
+/// only checks that the batch is still admissible and the chunk is not a rogue
+/// shape.
 #[derive(Clone, Copy, Debug)]
 pub struct CandidateFilter<'a, R> {
     batches: &'a R,
@@ -122,66 +82,45 @@ pub struct CandidateFilter<'a, R> {
 }
 
 impl<'a, R: RoundBatches> CandidateFilter<'a, R> {
-    /// Build the filter for a round from its frozen batch snapshot and the
-    /// round's [`PostageContext`].
-    ///
-    /// The context is the frozen round context (block height and cumulative
-    /// payout) and is held so callers and the snapshot implementor can read it
-    /// back via [`context`](Self::context); it is *not* consulted inside
-    /// [`admit`](Self::admit). Expiry is the [`RoundBatches`] implementor's
-    /// responsibility: it must fold the same context into
-    /// [`RoundBatches::is_admissible`] (and the below-balance set) when it freezes
-    /// the snapshot, so every candidate in the round is judged against one
-    /// consistent expiry view.
+    /// The held [`PostageContext`] is not consulted inside [`admit`](Self::admit):
+    /// the [`RoundBatches`] implementor must fold expiry into
+    /// [`RoundBatches::is_admissible`] when it freezes the snapshot.
     #[must_use]
     pub const fn new(batches: &'a R, context: &'a PostageContext) -> Self {
         Self { batches, context }
     }
 
-    /// The round's `consensusTime`, threaded from the snapshot.
     #[must_use]
     pub fn consensus_time(&self) -> u64 {
         self.batches.consensus_time()
     }
 
-    /// The round [`PostageContext`].
     #[must_use]
     pub const fn context(&self) -> &PostageContext {
         self.context
     }
 
-    /// Decide whether `(chunk, stamp)` is an admissible sample candidate.
-    ///
-    /// Applies the three exclusion gates and returns the first reason the
-    /// candidate is excluded, or `Ok(())` if it passes them all. The gates are
-    /// independent, so the reported reason is the first that fires, not a
-    /// protocol-mandated precedence. Pure: it reads only `stamp`, the chunk type,
-    /// and the frozen snapshot.
+    /// Decide whether `(chunk, stamp)` is an admissible sample candidate, or the
+    /// first gate's [`FilterRejection`].
     ///
     /// # Errors
     ///
     /// Returns the [`FilterRejection`] for the first gate the candidate fails.
     pub fn admit(&self, chunk: &AnyChunk, stamp: &Stamp) -> Result<(), FilterRejection> {
-        // (1) Future-timestamp: a stamp timestamped after the round was fixed
-        // could not have legitimately covered the chunk at sampling time.
         if stamp.timestamp() > self.batches.consensus_time() {
             return Err(FilterRejection::FutureTimestamp);
         }
 
         let batch = stamp.batch();
 
-        // (2) Below-minimum-balance: uniform per-round exclusion set.
         if self.batches.is_below_minimum_balance(&batch) {
             return Err(FilterRejection::BelowMinimumBalance);
         }
 
-        // (3a) Rogue chunk: only CAC and SOC are admissible shapes.
         if !(chunk.is_content() || chunk.is_single_owner()) {
             return Err(FilterRejection::RogueChunk);
         }
 
-        // (3b) Valid stamp (structural; no redundant ecrecover): the batch must
-        // still be admissible (known and unexpired) in the round snapshot.
         if !self.batches.is_admissible(&batch) {
             return Err(FilterRejection::InvalidStamp);
         }
@@ -189,13 +128,10 @@ impl<'a, R: RoundBatches> CandidateFilter<'a, R> {
         Ok(())
     }
 
-    /// Build a sample candidate from `(chunk, stamp)` if it passes the filters.
-    ///
-    /// On admission the exact winning stamp travels with the item via
-    /// [`SampleItem::with_stamp`], so the eventual inclusion proof witnesses that
-    /// precise stamp. Returns `None` (with the reason discarded) when the
-    /// candidate is excluded; use [`Self::admit`] directly when the rejection
-    /// reason is needed (e.g. for metrics).
+    /// Build a sample candidate if `(chunk, stamp)` passes the filters; `None`
+    /// otherwise. The winning stamp travels with the item via
+    /// [`SampleItem::with_stamp`] so the inclusion proof witnesses it. Use
+    /// [`Self::admit`] when the rejection reason is needed.
     #[must_use]
     pub fn candidate(
         &self,
@@ -223,8 +159,6 @@ mod tests {
     use std::collections::HashSet;
     use vertex_swarm_postage::{Stamp, StampIndex};
 
-    /// A synthetic round snapshot: a fixed `consensusTime`, a below-balance set
-    /// and an admissible set, all frozen for the round.
     struct TestRound {
         consensus_time: u64,
         below_balance: HashSet<BatchId>,
@@ -247,9 +181,8 @@ mod tests {
         DefaultContentChunk::new(payload.to_vec()).unwrap().into()
     }
 
-    /// A stamp for `batch` at `timestamp`. The signature bytes are irrelevant to
-    /// these structural filters (no ecrecover is performed here), so a fixed
-    /// dummy signature keeps the test focused on the gates.
+    /// Signature bytes are irrelevant to these structural filters (no ecrecover),
+    /// so a fixed dummy signature keeps the test focused on the gates.
     fn stamp_for(batch: BatchId, timestamp: u64) -> Stamp {
         let index = StampIndex::new(0, 0);
         let sig = alloy_primitives::Signature::test_signature();
@@ -323,15 +256,13 @@ mod tests {
         let r = round(1_000);
         let c = ctx();
         let f = CandidateFilter::new(&r, &c);
-        // A batch absent from the admissible set is an invalid stamp.
         let s = stamp_for(batch_id(0xee), 500);
         assert_eq!(f.admit(&cac(b"x"), &s), Err(FilterRejection::InvalidStamp));
     }
 
     #[test]
     fn future_timestamp_excluded_identically_to_below_balance() {
-        // The three exclusion classes all produce no candidate; the feed must
-        // drop them uniformly regardless of which gate fired.
+        // All three exclusion classes must produce no candidate.
         let mut r = round(1_000);
         let poor = batch_id(0x09);
         r.admissible.insert(poor);

--- a/crates/swarm/redistribution/src/lib.rs
+++ b/crates/swarm/redistribution/src/lib.rs
@@ -1,44 +1,35 @@
 //! Swarm redistribution (storage incentives).
 //!
-//! Two concerns live in this crate:
+//! Holds participation configuration ([`RedistributionArgs`], [`StorageConfig`])
+//! and the consensus primitives: a deterministic reserve sample over a
+//! neighbourhood and a proof of entitlement over it. The primitives are pure
+//! functions of their inputs, so every participating node computes identical
+//! results.
 //!
-//! - **Configuration** for participation in the redistribution game
-//!   ([`RedistributionArgs`], [`StorageConfig`]).
-//! - **Consensus primitives**: a deterministic reserve sample over a
-//!   neighbourhood and a proof of entitlement over that sample. These are pure
-//!   functions of their inputs (no I/O, no storage, no node, no async), so they
-//!   produce identical results on every participating node.
+//! Transformed addresses, the selected sample, and the inclusion proofs must be
+//! byte-exact: the same values are re-verified on chain by the
+//! `Redistribution.sol` contract, and any divergence loses or is slashed in the
+//! round. Conformance is pinned by the vectors in `tests/`. The transformed
+//! address that orders the sample is the nectar primitive
+//! [`AnyChunk::transformed_address`](nectar_primitives::AnyChunk::transformed_address),
+//! consumed here rather than re-derived.
 //!
-//! # Consensus conformance
-//!
-//! The transformed addresses, the selected sample and the inclusion proofs must
-//! be byte-exact, because the same values are verified on chain by the
-//! `Redistribution.sol` storage-incentives contract; any divergence loses (or is
-//! slashed in) the round. The algorithm is the one fixed by the Swarm
-//! storage-incentives protocol and the contract's verification logic, validated
-//! against the canonical Swarm reference vectors in `tests/`.
-//!
-//! The anchor-keyed transformed address (the value the sample is ordered by) is
-//! a nectar primitive
-//! ([`AnyChunk::transformed_address`](nectar_primitives::AnyChunk::transformed_address));
-//! this crate consumes it rather than re-deriving it.
-//!
-//! # Building blocks
+//! Building blocks:
 //!
 //! - [`SampleAnchor`] / [`ClaimAnchor`]: the two per-round reserve salts as
-//!   distinct types, so they cannot be transposed.
-//! - [`CommittedDepth`] / [`canonical_neighbourhood`]: the chunk addresses a
-//!   node is responsible for at a given depth.
-//! - [`CandidateFilter`] / [`RoundBatches`]: the consensus candidate-feed
-//!   filters (future timestamp, below-minimum-balance, rogue/invalid stamp)
-//!   applied against a round-consistent batch snapshot before sampling.
+//!   distinct types so they cannot be transposed.
+//! - [`CommittedDepth`] / [`canonical_neighbourhood`]: the addresses a node is
+//!   responsible for at a given depth.
+//! - [`CandidateFilter`] / [`RoundBatches`]: candidate-feed filters (future
+//!   timestamp, below-minimum-balance, rogue/invalid stamp) applied against a
+//!   round-consistent batch snapshot before sampling.
 //! - [`SampleItem`] / [`reserve_sample`]: the [`SAMPLE_SIZE`] chunks with the
-//!   smallest transformed addresses. Each item carries the exact stamp its slot
-//!   was won with.
+//!   smallest transformed addresses, each carrying the stamp its slot was won
+//!   with.
 //! - [`WitnessIndices`] / [`witness_indices`]: the sample slots a claim opens.
 //! - [`make_inclusion_proofs`] / [`ChunkInclusionProof`]: the proof of
-//!   entitlement submitted to the contract, each witness carrying the precise
-//!   winning stamp as its single `PostageProof`.
+//!   entitlement submitted to the contract, each witness carrying its winning
+//!   stamp as its single `PostageProof`.
 
 mod anchor;
 mod args;

--- a/crates/swarm/redistribution/src/neighbourhood.rs
+++ b/crates/swarm/redistribution/src/neighbourhood.rs
@@ -5,17 +5,10 @@ use core::fmt;
 use nectar_primitives::{Bin, ChunkAddress, SwarmAddress};
 use vertex_swarm_api::StorageRadius;
 
-/// The committed neighbourhood depth for a redistribution round: the boundary
-/// at which a storer's reserve is sampled.
+/// The per-round, on-chain-derived depth at which a storer's reserve is sampled.
 ///
-/// Chunks whose proximity to the round anchor meets this depth are the node's
-/// committed sample neighbourhood. It is a distinguished [`Bin`] in a
-/// redistribution-specific role. This is intentionally a distinct type from
-/// vertex's routing [`NeighborhoodDepth`][nd]: that type is the local
-/// connectivity boundary (supply-side, local-only), whereas this is the
-/// per-round, on-chain-derived reserve-commitment depth. The bytes are a plain
-/// `u8 >= u8` compare either way; the separate type keeps the roles from being
-/// conflated.
+/// A distinct type from the routing [`NeighborhoodDepth`][nd] (the local
+/// connectivity boundary) so the two roles are not conflated.
 ///
 /// [nd]: vertex_swarm_api::NeighborhoodDepth
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -25,14 +18,12 @@ impl CommittedDepth {
     /// The shallowest depth (every address is in the neighbourhood).
     pub const ZERO: Self = Self(Bin::ZERO);
 
-    /// Wrap a [`Bin`] as a committed depth.
     #[inline]
     #[must_use]
     pub const fn new(bin: Bin) -> Self {
         Self(bin)
     }
 
-    /// The boundary as a [`Bin`].
     #[inline]
     #[must_use]
     pub const fn bin(self) -> Bin {
@@ -47,65 +38,32 @@ impl CommittedDepth {
     }
 
     /// Whether `bin` is inside the committed neighbourhood (`bin >= depth`).
-    ///
-    /// O(1): a single `u8` comparison, no iteration or allocation despite the
-    /// set-like name.
     #[inline]
     #[must_use]
     pub fn contains(self, bin: Bin) -> bool {
         bin >= self.0
     }
 
-    /// Derive the consensus-committed depth from the reserve's
-    /// [`StorageRadius`] and the node's [`CapacityDoubling`] addend.
+    /// Derive the consensus-committed depth: `storage_radius + capacity_doubling`.
     ///
-    /// This is the network-observable output the redistribution agent commits
-    /// on chain: `committedDepth = storage_radius + capacity_doubling`. The
-    /// storage radius is the reserve's own size-driven responsibility boundary
-    /// (see the storer's [radius controller][rc]); the capacity-doubling addend
-    /// lets an over-provisioned node sample a deeper neighbourhood than its bare
-    /// radius would imply, without changing what it stores.
-    ///
-    /// The addend is applied with a *saturating* `u8` add and then clamped to
-    /// the [`Bin`] range (`0..=MAX_PO`): the sum pins at [`Bin::MAX`] rather than
-    /// wrapping or panicking. With the addend bounded at
-    /// [`CapacityDoubling::MAX`] (`1`) the ceiling is reachable only from a radius
-    /// already at the deepest bin (`MAX_PO + 1`), so the clamp is defensive
-    /// belt-and-braces rather than a routine path, but it keeps the derivation
-    /// total (no fallible path), which is what callers on the commit hot-path
-    /// require. Because both inputs are byte-exact across nodes, so is the
-    /// output, which is the consensus property a redistribution round relies on.
-    ///
-    /// [rc]: https://docs.rs/vertex-swarm-storer (the `radius` module)
+    /// Saturating add then clamp to the [`Bin`] range pins at [`Bin::MAX`] rather
+    /// than wrapping or panicking, keeping the derivation total for the commit
+    /// hot-path. With both inputs byte-exact across nodes the output is too, which
+    /// is the consensus property a redistribution round relies on.
     #[inline]
     #[must_use]
     pub fn from_radius(radius: StorageRadius, doubling: CapacityDoubling) -> Self {
         let raw = radius.get().saturating_add(doubling.get());
-        // Clamp into the bin range; `Bin::try_from` only fails for `> MAX_PO`,
-        // in which case the deepest bin is the correct ceiling.
         Self(Bin::try_from(raw).unwrap_or(Bin::MAX))
     }
 }
 
-/// The capacity-doubling addend a node adds to its [`StorageRadius`] to obtain
-/// the [`CommittedDepth`] it samples and commits on chain.
+/// The addend a node adds to its [`StorageRadius`] to obtain the
+/// [`CommittedDepth`] it samples and commits on chain.
 ///
-/// A node with spare reserve capacity may commit to sampling a neighbourhood
-/// `capacity_doubling` bins deeper than its storage radius alone would define,
-/// effectively committing to hold the equivalent of `2^doubling` times the
-/// baseline reserve. It is a node-configured constant for a round (read from
-/// configuration, not derived from the reserve), distinct from the radius,
-/// which the reserve derives from its own occupancy.
-///
-/// Range is `0..=`[`MAX`](Self::MAX), where `MAX` is `1`: a zero addend means the
-/// committed depth equals the storage radius, and `1` is the deepest doubling the
-/// protocol admits (one bin deeper, twice the baseline reserve). The bound is the
-/// network's, not a representational one: a redistribution round will only ever
-/// observe a committed depth derived from a doubling in `0..=1`, so a larger
-/// addend is a configuration error that would put the node out of consensus with
-/// the rest of the network rather than merely saturating against the bin
-/// ceiling. The constructor rejects it so the misconfiguration surfaces at ingest
-/// rather than producing an out-of-consensus committed depth.
+/// A node-configured constant for a round (not derived from the reserve). Range
+/// is `0..=`[`MAX`](Self::MAX): a doubling of `1` commits to twice the baseline
+/// reserve, one bin deeper.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct CapacityDoubling(u8);
 
@@ -113,13 +71,9 @@ impl CapacityDoubling {
     /// No doubling: the committed depth equals the storage radius.
     pub const ZERO: Self = Self(0);
 
-    /// The maximum doubling the protocol admits.
-    ///
-    /// The network caps the per-node capacity doubling at one bin: a node may
-    /// commit to twice the baseline reserve, no more. A larger value is not a
-    /// representational overflow (it stays well within `u8` and the bin range)
-    /// but an out-of-consensus configuration the network would never produce, so
-    /// the ingress rejects it.
+    /// The maximum doubling the protocol admits. A larger value is a valid `u8`
+    /// and bin index but out-of-consensus configuration, so the ingress rejects
+    /// it rather than clamping.
     pub const MAX: Self = Self(1);
 
     /// The raw addend. For edges only (config display, metrics, the wire).
@@ -130,25 +84,17 @@ impl CapacityDoubling {
     }
 }
 
-/// The error a [`CapacityDoubling`] ingress raises for an addend above the
-/// protocol-permitted maximum ([`CapacityDoubling::MAX`]).
-///
-/// Distinct from a bin-range error: the value is a valid `u8` and a valid bin,
-/// it is the *consensus* bound it violates, so it carries the offending value
-/// and the permitted maximum for a configuration diagnostic.
+/// Raised for an addend above [`CapacityDoubling::MAX`]. Carries the offending
+/// value and permitted maximum for a configuration diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("capacity doubling {value} exceeds the maximum permitted doubling of {max}")]
 pub struct CapacityDoublingError {
-    /// The rejected addend.
     pub value: u8,
-    /// The permitted maximum ([`CapacityDoubling::MAX`]).
     pub max: u8,
 }
 
-/// The sole `u8` ingress for a capacity-doubling addend (typically the node's
-/// configuration). Fallible because the network caps the doubling at
-/// [`CapacityDoubling::MAX`]; an addend above it is a configuration error that
-/// would commit an out-of-consensus depth, not a value to silently clamp.
+/// Fallible because an addend above [`CapacityDoubling::MAX`] is a configuration
+/// error that would commit an out-of-consensus depth, not a value to clamp.
 impl TryFrom<u8> for CapacityDoubling {
     type Error = CapacityDoublingError;
 
@@ -176,9 +122,7 @@ impl fmt::Display for CommittedDepth {
     }
 }
 
-/// The sole `u8` ingress for a committed depth: the on-chain boundary as read
-/// from the redistribution contract. Fallible because a raw `u8` may exceed the
-/// [`Bin`] range (`> MAX_PO`); the in-range cases are exactly the valid depths.
+/// Fallible because a raw `u8` may exceed the [`Bin`] range (`> MAX_PO`).
 impl TryFrom<u8> for CommittedDepth {
     type Error = nectar_primitives::BinError;
 
@@ -187,20 +131,12 @@ impl TryFrom<u8> for CommittedDepth {
     }
 }
 
-/// The deterministic neighbourhood for `anchor` at the given committed `depth`.
+/// The subset of `addrs` whose proximity order to `anchor` is at least `depth`.
 ///
-/// Returns the subset of `addrs` a node is responsible for, i.e. those whose
-/// proximity order to `anchor` is at least `depth`. A [`CommittedDepth::ZERO`]
-/// depth admits every address.
-///
-/// This is a pure membership filter and imposes **no** ordering: the protocol
-/// never orders the neighbourhood by distance, it streams the depth-filtered
-/// chunks and orders the *sample* by transformed address (see
-/// [`reserve_sample`](crate::reserve_sample)). Imposing an extra distance sort
-/// here would be dead work at best and a conformance hazard at worst. Callers
-/// that need a sample feed the result (in any iteration order) into
-/// [`reserve_sample`](crate::reserve_sample), whose output order is fixed by the
-/// transformed addresses and therefore independent of input order.
+/// A pure membership filter imposing no ordering: the protocol orders the
+/// *sample*, not the neighbourhood (see [`reserve_sample`](crate::reserve_sample),
+/// whose output order is fixed by transformed addresses and independent of input
+/// order). [`CommittedDepth::ZERO`] admits every address.
 ///
 /// # Examples
 ///
@@ -261,7 +197,6 @@ mod tests {
 
     #[test]
     fn canonical_neighbourhood_preserves_input_order() {
-        // The function does not sort; it is a pure depth filter.
         let anchor = SwarmAddress::zero();
         let addrs = vec![addr(0x01), addr(0x02), addr(0x03)];
         let hood = canonical_neighbourhood(&anchor, depth(0), addrs.clone());
@@ -286,8 +221,6 @@ mod tests {
 
     #[test]
     fn committed_depth_is_radius_plus_doubling() {
-        // The network-observable consensus formula:
-        // committedDepth = storage_radius + capacity_doubling.
         assert_eq!(
             CommittedDepth::from_radius(radius(8), doubling(0)).get(),
             8,
@@ -307,10 +240,6 @@ mod tests {
 
     #[test]
     fn committed_depth_clamps_to_deepest_bin() {
-        // The only way to reach the ceiling now that the addend is capped at 1
-        // is a radius already at the deepest bin: radius MAX_PO + doubling 1
-        // would be MAX_PO + 1, which saturating-adds then clamps to the deepest
-        // bin rather than panicking or wrapping.
         let d = CommittedDepth::from_radius(radius(MAX_PO), doubling(1));
         assert_eq!(d.get(), MAX_PO, "saturating add then clamp to MAX_PO");
         assert_eq!(d.bin(), Bin::MAX);
@@ -321,10 +250,6 @@ mod tests {
 
     #[test]
     fn capacity_doubling_rejects_above_maximum() {
-        // The network caps the doubling at one bin (parity with bee's
-        // maxAllowedDoubling = 1); 0 and 1 are admitted, 2 and above are
-        // rejected as out-of-consensus configuration even though they are valid
-        // bin indices.
         assert_eq!(CapacityDoubling::try_from(0).unwrap().get(), 0);
         assert_eq!(CapacityDoubling::try_from(1).unwrap().get(), 1);
         assert_eq!(

--- a/crates/swarm/redistribution/src/proof.rs
+++ b/crates/swarm/redistribution/src/proof.rs
@@ -10,38 +10,19 @@ use crate::anchor::{ClaimAnchor, SampleAnchor};
 use crate::sample::{SampleItem, reserve_commitment_content};
 use crate::witness::witness_indices;
 
-/// A single chunk's inclusion proof within the proof of entitlement.
-///
-/// This is the structure submitted to `Redistribution.sol`. It bundles three
-/// BMT proofs for one witnessed sample item plus the exact postage stamp the
-/// slot was won with:
-///
-/// - [`Self::rc_proof`] (`proofSegments`/`proveSegment`): the item's slot in the
-///   reserve-commitment chunk.
-/// - [`Self::og_proof`] (`proofSegments2`/`proveSegment2`/`chunk_span`): a plain
-///   (original) BMT segment proof over the chunk's own body.
-/// - [`Self::tr_proof`] (`proofSegments3`): a sample-anchor-prefixed (transformed)
-///   BMT segment proof over the same body.
-/// - [`Self::postage_proof`]: the single [`Stamp`] the slot was won with. The
-///   consensus rule is that each witness carries **exactly one** postage proof,
-///   and it is the precise stamp `(batchID, 8-byte index, timestamp,
-///   signature)` the candidate was selected under, taken straight off the
-///   winning [`SampleItem::stamp`]. It is never re-loaded by `batchID` alone: a
-///   batch holds many distinct stamps, so a batch-keyed reload could witness a
-///   different stamp than the one that actually won the slot, which the on-chain
-///   verifier would reject.
+/// One witnessed sample item's inclusion proof, as submitted on-chain: three
+/// BMT proofs plus the exact stamp the slot was won with.
 #[derive(Clone, Debug)]
 pub struct ChunkInclusionProof {
-    /// Reserve-commitment chunk inclusion proof (OG of the RC chunk).
+    /// Reserve-commitment chunk inclusion proof.
     pub rc_proof: Proof,
     /// Plain (original) BMT segment proof over the witnessed chunk body.
     pub og_proof: Proof,
     /// Anchor-prefixed (transformed) BMT segment proof over the same body.
     pub tr_proof: Proof,
-    /// The little-endian `u64` span of the witnessed chunk body (`chunkSpan`).
+    /// Little-endian `u64` span of the witnessed chunk body.
     pub chunk_span: u64,
-    /// The exact postage stamp the witnessed slot was won with (the witness's
-    /// single `PostageProof`).
+    /// The exact stamp the witnessed slot was won with.
     pub postage_proof: Stamp,
 }
 
@@ -67,7 +48,6 @@ impl ChunkInclusionProofs {
         &self.0[2]
     }
 
-    /// Iterate the three witness proofs in submission order.
     pub fn iter(&self) -> core::slice::Iter<'_, ChunkInclusionProof> {
         self.0.iter()
     }
@@ -83,21 +63,15 @@ impl<'a> IntoIterator for &'a ChunkInclusionProofs {
 }
 
 /// A BMT-hashable body: a little-endian `u64` span plus its payload.
-///
-/// Private borrowing view that exists only to stop decomposing chunks into bare
-/// `(span, payload)` pairs at internal boundaries. `span` stays a `u64` (the
-/// workspace convention: `Hasher::set_span` and `Proof.span` are both bare
-/// `u64`); what this type removes is the *pairing* smell, by reading both halves
-/// from a single typed source.
 struct Body<'a> {
     span: u64,
     payload: &'a [u8],
 }
 
 impl<'a> Body<'a> {
-    /// The body of a typed chunk: its span and payload, read straight from the
-    /// chunk's BMT-body accessors (identical bytes for a CAC or a SOC, since the
-    /// typed accessors already skip any SOC `id`/`signature` header).
+    /// Span and payload from a chunk's BMT-body accessors. The typed accessors
+    /// expose identical bytes for a CAC or a SOC (the SOC `id`/`signature`
+    /// header is already skipped).
     fn of(chunk: &'a AnyChunk) -> Self {
         let payload: &'a [u8] = chunk.data();
         Self {
@@ -106,7 +80,6 @@ impl<'a> Body<'a> {
         }
     }
 
-    /// Build the hasher for this body, applying `prefix` when given.
     fn hasher(&self, prefix: Option<&[u8]>) -> DefaultHasher {
         let mut hasher = match prefix {
             Some(p) => DefaultHasher::with_prefix(p),
@@ -126,15 +99,10 @@ pub enum ProofError {
     /// The sample did not contain exactly [`SAMPLE_SIZE`] items.
     #[error("reserve sample must have {SAMPLE_SIZE} items, got {0}")]
     SampleSize(usize),
-    /// A witnessed slot had no stamp pinned to it.
-    ///
-    /// Each witness must carry exactly one `PostageProof`: the precise stamp the
-    /// slot was won with (see [`ChunkInclusionProof::postage_proof`]). A winning
-    /// candidate must therefore be built with [`SampleItem::with_stamp`]; a slot
-    /// reaching proof time with [`SampleItem::stamp`] unset is a construction
-    /// bug, refused here rather than papered over by re-loading a stamp by
-    /// `batchID` (which could witness a different stamp than the one that won).
-    /// Carries the offending sample slot index.
+    /// A witnessed slot had no stamp pinned to it. A winning candidate must be
+    /// built with [`SampleItem::with_stamp`]; an unset [`SampleItem::stamp`] at
+    /// proof time is a construction bug, refused rather than reloading a stamp
+    /// by `batchID`. Carries the offending sample slot index.
     #[error("witnessed sample slot {0} has no stamp to prove")]
     MissingStamp(usize),
     /// A BMT proof could not be generated.
@@ -145,36 +113,19 @@ pub enum ProofError {
 
 /// Build the proof of entitlement for `items` from the two round anchors.
 ///
-/// `sample` (the sample-time [`SampleAnchor`]) is the BMT prefix used for the
-/// transformed addresses and the TR proofs; `claim` (the claim-time
-/// [`ClaimAnchor`]) selects the witness slots and segment via
-/// [`witness_indices`]. Their distinct types make a transposition a compile
-/// error rather than a silent, round-losing bug.
+/// `sample` is the BMT prefix for the transformed addresses and TR proofs;
+/// `claim` selects the witness slots and segment via [`witness_indices`]. The
+/// distinct anchor types make a transposition a compile error.
 ///
-/// For each opened slot it emits:
-/// 1. an RC-chunk inclusion proof at segment `2 * slot` (the slot holding the
-///    item's *chunk* address inside the reserve-commitment chunk);
-/// 2. a plain BMT segment proof at `segment_index` over the witnessed chunk's
-///    body (its `chunk_span` is the body's little-endian `u64` span);
-/// 3. a sample-anchor-prefixed BMT segment proof at `segment_index` over the
-///    same body.
-///
-/// The witnessed body is read straight from the typed chunk: [`AnyChunk::span`]
-/// and [`AnyChunk::data`] already delegate to the inner BMT body for both CAC
-/// and SOC, so a SOC needs no `id`/`signature` header slicing.
-///
-/// Each emitted witness also carries the exact stamp its slot was won with
-/// ([`ChunkInclusionProof::postage_proof`]), read from [`SampleItem::stamp`]: it
-/// is the single `PostageProof` the consensus rule requires, and it is never
-/// re-loaded by `batchID` alone.
+/// For each opened slot it emits an RC-chunk inclusion proof at segment
+/// `2 * slot`, a plain BMT segment proof at `segment_index` over the chunk
+/// body, and a sample-anchor-prefixed proof at the same index over that body.
 ///
 /// # Errors
 ///
-/// Returns an error if `items` does not contain exactly [`SAMPLE_SIZE`]
-/// elements, if a witnessed slot has no stamp pinned to it
-/// ([`ProofError::MissingStamp`]), or if any underlying BMT proof generation
-/// fails (e.g. an out-of-range segment index). The anchors are `bytes32` by
-/// construction, so the function never has to check for an unset salt.
+/// Errors if `items` is not exactly [`SAMPLE_SIZE`] elements, if a witnessed
+/// slot has no stamp ([`ProofError::MissingStamp`]), or if BMT proof generation
+/// fails (e.g. an out-of-range segment index).
 pub fn make_inclusion_proofs(
     items: &[SampleItem],
     sample: SampleAnchor,
@@ -196,33 +147,23 @@ pub fn make_inclusion_proofs(
     let rc_hash = rc_body.hasher(None);
 
     let witness = |slot: usize| -> Result<ChunkInclusionProof, ProofError> {
-        // `slot` is one of `witness_indices`' outputs, all `< SAMPLE_SIZE`, and
-        // `items.len() == SAMPLE_SIZE` is enforced above, so this lookup never
-        // misses. The fallible form keeps the hot path index-safe (no panic, no
-        // `#[allow(indexing_slicing)]`); the `ok_or` arm is unreachable by
-        // construction rather than a real `SampleSize` failure.
+        // `slot` is a `witness_indices` output (`< SAMPLE_SIZE`) and
+        // `items.len() == SAMPLE_SIZE` is enforced above, so the `ok_or` arm is
+        // unreachable; the fallible form just keeps the hot path panic-free.
         debug_assert!(slot < items.len(), "witness slot out of sample bounds");
         let item = items.get(slot).ok_or(ProofError::SampleSize(items.len()))?;
 
-        // The single PostageProof for this witness: the exact stamp the slot was
-        // won with, taken straight off the winning item. Never re-loaded by
-        // batchID (a batch holds many stamps), so the witnessed stamp is byte-
-        // identical to the one the candidate was selected under.
         let postage_proof = item.stamp.clone().ok_or(ProofError::MissingStamp(slot))?;
 
         // RC chunk inclusion proof at the even slot holding the chunk address.
         let rc_proof = rc_hash.generate_proof(&rc_content, slot * 2)?;
 
-        // The witnessed chunk's own body. For a SOC the typed accessors already
-        // expose the wrapped CAC's span/payload, so there is no header slicing.
         let body = Body::of(&item.chunk);
 
-        // OG: plain BMT segment proof.
         let og_proof = body
             .hasher(None)
             .generate_proof(body.payload, idx.segment_index)?;
 
-        // TR: sample-anchor-prefixed BMT segment proof over the same body.
         let tr_proof = body
             .hasher(Some(sample.as_bytes()))
             .generate_proof(body.payload, idx.segment_index)?;

--- a/crates/swarm/redistribution/src/sample.rs
+++ b/crates/swarm/redistribution/src/sample.rs
@@ -8,36 +8,16 @@ use crate::anchor::SampleAnchor;
 
 /// A single entry in a reserve sample.
 ///
-/// It carries the typed chunk so that the proof of entitlement can re-derive
-/// both the original (OG) and transformed (TR) BMT proofs without re-parsing
-/// raw bytes or branching on a chunk-type boolean: an [`AnyChunk`] already
-/// knows whether it is a CAC or a SOC, and its
-/// [`span`](AnyChunk::span)/[`data`](AnyChunk::data) accessors delegate to the
-/// inner BMT body for both, so SOC witness reads need no `id`/`signature`
-/// header slicing.
+/// Carries the typed chunk so the proof of entitlement can re-derive both the
+/// original and transformed BMT proofs without re-parsing raw bytes.
 ///
-/// # The winning stamp travels with the item
-///
-/// A chunk's content address is stamp independent, but the reserve admits one
-/// entry per distinct stamped entry `(batchID, 8-byte stampIndex, address)`, and
-/// the consensus rule is that each inclusion-proof witness must carry the
-/// **exact** stamp the sample slot was won with: the precise `(batchID,
-/// stampIndex, timestamp, signature)`, not a stamp re-loaded by `batchID` alone
-/// (a batch holds many distinct stamps; re-loading by batch could witness a
-/// different one). [`Self::stamp`] therefore pins that identity to the slot from
-/// the moment the candidate is selected, and [`make_inclusion_proofs`] reads it
-/// straight off the winning item.
-///
-/// [`make_inclusion_proofs`]: crate::make_inclusion_proofs
-///
-/// The stamp is an [`Option`] only because the consensus *ordering* primitives
-/// ([`reserve_sample`], [`reserve_commitment_content`]) and their byte-for-byte
-/// reference vectors are stamp independent: those fixtures exercise the
-/// transformed-address geometry and carry no stamp. A real candidate feed always
-/// builds items with [`Self::with_stamp`]; a `None` stamp surfaces as a
-/// [`ProofError::MissingStamp`](crate::ProofError::MissingStamp) the moment a
-/// proof of entitlement is built for that slot, so an unstamped item can never
-/// silently win a round.
+/// [`Self::stamp`] pins the exact stamp the slot was won with
+/// (`batchID, stampIndex, timestamp, signature`), since a batch holds many
+/// distinct stamps and the witness must carry the winning one. It is [`Option`]
+/// only because the ordering primitives ([`reserve_sample`],
+/// [`reserve_commitment_content`]) are stamp independent; a `None` stamp fails as
+/// [`ProofError::MissingStamp`](crate::ProofError::MissingStamp) at proof build,
+/// so an unstamped item can never silently win a round.
 ///
 /// [`reserve_commitment_content`]: crate::reserve_commitment_content
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -46,22 +26,14 @@ pub struct SampleItem {
     pub transformed_address: ChunkAddress,
     /// The typed chunk (content or single-owner) this item witnesses.
     pub chunk: AnyChunk,
-    /// The exact stamp this slot was won with: the precise `(batchID,
-    /// stampIndex, timestamp, signature)` carried straight into the inclusion
-    /// proof. `None` only for the stamp-independent ordering fixtures (see the
-    /// type-level note); a candidate feed always sets it.
+    /// The exact stamp this slot was won with, carried into the inclusion proof.
+    /// `None` only for the stamp-independent ordering fixtures.
     pub stamp: Option<Stamp>,
 }
 
 impl SampleItem {
-    /// Build a stamp-independent sample item for `chunk` under the sample-time
-    /// anchor.
-    ///
-    /// The transformed address is computed by nectar's
-    /// [`transformed_address`](AnyChunk::transformed_address). This constructor
-    /// leaves [`Self::stamp`] unset and exists for the consensus *ordering*
-    /// vectors, which are stamp independent. Production candidate feeds use
-    /// [`Self::with_stamp`] so the winning stamp travels with the slot.
+    /// Build a stamp-independent sample item, for the consensus ordering
+    /// vectors. Production candidate feeds use [`Self::with_stamp`].
     #[must_use]
     pub fn new(sample: SampleAnchor, chunk: AnyChunk) -> Self {
         Self {
@@ -71,11 +43,8 @@ impl SampleItem {
         }
     }
 
-    /// Build a sample item carrying the exact `stamp` the slot was won with.
-    ///
-    /// This is the candidate-feed constructor: it pins the precise stamp
-    /// identity to the slot so the proof of entitlement witnesses that stamp and
-    /// no other (see the type-level note).
+    /// Build a sample item carrying the exact `stamp` the slot was won with, so
+    /// the proof of entitlement witnesses that stamp and no other.
     #[must_use]
     pub fn with_stamp(sample: SampleAnchor, chunk: AnyChunk, stamp: Stamp) -> Self {
         Self {
@@ -85,7 +54,6 @@ impl SampleItem {
         }
     }
 
-    /// The chunk's own (content or single-owner) address.
     #[must_use]
     pub fn chunk_address(&self) -> &ChunkAddress {
         self.chunk.address()
@@ -95,50 +63,18 @@ impl SampleItem {
 /// Select the reserve sample from `candidates`.
 ///
 /// Keeps the [`SAMPLE_SIZE`] chunks with the lexicographically smallest
-/// transformed addresses, returned in ascending transformed-address order. This
-/// is a sorted insertion that drops the largest element once the sample is full.
+/// transformed addresses, returned in ascending transformed-address order, via a
+/// sorted insertion that drops the largest element once full.
 ///
-/// On a transformed-address tie the protocol keeps the **content-addressed**
-/// chunk (the equal-address branch replaces the incumbent only when the new item
-/// is *not* a valid SOC), so that the on-chain ordering check cannot be gamed by
-/// a single-owner chunk colliding with a CAC. We reproduce that exact tie-break.
+/// On a transformed-address tie the content-addressed chunk wins the slot, so the
+/// on-chain ordering check cannot be gamed by a SOC colliding with a CAC.
 ///
-/// # Determinism and the same-content multi-batch tie
-///
-/// `candidates` may be supplied in any order: the set of selected slots and the
-/// committed reserve-commitment bytes depend only on the transformed addresses,
-/// not on insertion order.
-///
-/// One subtlety is consensus relevant. The reserve admits one entry per distinct
-/// stamped entry `(batchID, stampIndex, address)`, so the *same content* may be
-/// presented under several batches. Those entries share a content address (it is
-/// stamp independent) and therefore a transformed address, so they tie, and "at
-/// most once" collapses them to a single slot. When two such CAC entries tie the
-/// equal-address branch keeps the **last** CAC seen, so *which batch's stamp*
-/// travels into [`SampleItem::stamp`] (and hence the witness's single
-/// `PostageProof`) is insertion-order dependent.
-///
-/// This matches bee, whose sampler assembles items off a concurrent worker pool
-/// and resolves the same tie by last-CAC-wins, so the kept stamp is likewise not
-/// order-defined there. It is consensus-safe because:
-///
-/// 1. The value committed on chain is the reserve-commitment hash over each
-///    slot's `chunk_address || transformed_address`
-///    ([`reserve_commitment_content`]). Both halves are identical for every tied
-///    entry (same content => same chunk address and, under one anchor, the same
-///    transformed address), so the commitment is byte-identical regardless of
-///    which batch wins the slot.
-/// 2. A witness's `PostageProof` is verified standalone by `Redistribution.sol`:
-///    the stamp signature must bind that chunk address and the batch must be a
-///    valid, funded batch. *Any* owning batch's stamp satisfies that check, so
-///    the contract accepts whichever tied stamp the slot carries.
-///
-/// The tie-break is therefore not extended to pick a canonical stamp: doing so
-/// would diverge from bee for no on-chain benefit, since the committed bytes are
-/// stable and the chain binds the stamp to the chunk, not to a canonical batch.
-/// (Two *different* contents colliding on a transformed address would commit
-/// different `chunk_address` bytes, but that is a 256-bit HMAC-keyed BMT
-/// collision, not a reachable consensus case; bee resolves it the same way.)
+/// Selection and the committed bytes are insertion-order independent. Only the
+/// kept stamp is order-dependent: the same content under several batches ties and
+/// collapses to one slot keeping the last CAC seen. This is consensus-safe, since
+/// the commitment hashes `chunk_address || transformed_address`
+/// ([`reserve_commitment_content`]) which is identical across the tied entries and
+/// the contract accepts any owning batch's stamp.
 #[must_use]
 pub fn reserve_sample(candidates: impl IntoIterator<Item = SampleItem>) -> Vec<SampleItem> {
     let mut sample: Vec<SampleItem> = Vec::with_capacity(SAMPLE_SIZE + 1);
@@ -150,19 +86,15 @@ pub fn reserve_sample(candidates: impl IntoIterator<Item = SampleItem>) -> Vec<S
     sample
 }
 
-/// Insert `item` into the running sorted sample, mirroring the canonical
-/// sorted-insert semantics.
 fn insert_sample_item(sample: &mut Vec<SampleItem>, item: SampleItem) {
     let key = item.transformed_address;
 
-    // First slot whose transformed address is not strictly smaller than `key`:
-    // either a tie or the insertion point.
+    // First slot not strictly smaller than `key`: a tie or the insertion point.
     let Some(pos) = sample
         .iter()
         .position(|s| s.transformed_address.as_slice() >= key.as_slice())
     else {
-        // Larger than every incumbent: append only while the sample is not yet
-        // full, mirroring the canonical append-only-while-not-full guard.
+        // Larger than every incumbent: append only while not yet full.
         if sample.len() < SAMPLE_SIZE {
             sample.push(item);
         }
@@ -170,24 +102,15 @@ fn insert_sample_item(sample: &mut Vec<SampleItem>, item: SampleItem) {
     };
 
     match sample.get_mut(pos) {
-        // Tie on the transformed address: the incumbent is replaced only when
-        // the new chunk is a CAC (not a valid SOC), so a CAC always wins the
-        // slot. Either way no new slot is consumed. For two CACs of the same
-        // content under different batches this keeps the last CAC seen, so the
-        // kept stamp is insertion-order dependent; the committed bytes are
-        // identical regardless and the chain binds the stamp to the chunk, so
-        // this is consensus-safe (see the function-level note, and it mirrors
-        // bee's concurrent last-CAC-wins assembly).
+        // Tie: a CAC replaces the incumbent, a SOC does not, so a CAC always
+        // wins the slot. No new slot is consumed either way.
         Some(incumbent) if incumbent.transformed_address == key => {
             if item.chunk.is_content() {
                 *incumbent = item;
             }
         }
-        // Strictly smaller than the incumbent at `pos`: insert before it.
         _ => {
             sample.insert(pos, item);
-            // Trim to SampleSize after a sorted insertion (the slice re-append
-            // can transiently overshoot by one).
             if sample.len() > SAMPLE_SIZE {
                 sample.truncate(SAMPLE_SIZE);
             }
@@ -195,12 +118,9 @@ fn insert_sample_item(sample: &mut Vec<SampleItem>, item: SampleItem) {
     }
 }
 
-/// Build the content-addressed "reserve commitment" (RC) chunk body.
-///
-/// The RC chunk content is the concatenation of each sample item's
-/// `chunk_address || transformed_address`, i.e. `SAMPLE_SIZE * 64` bytes. This
-/// returns the body only (no span header); callers BMT-hash it with span
-/// `64 * SAMPLE_SIZE`.
+/// Build the reserve-commitment chunk body: each item's `chunk_address ||
+/// transformed_address` concatenated, `SAMPLE_SIZE * 64` bytes. Returns the body
+/// only; callers BMT-hash it with span `64 * SAMPLE_SIZE`.
 #[must_use]
 pub fn reserve_commitment_content(items: &[SampleItem]) -> Vec<u8> {
     let mut content = Vec::with_capacity(items.len() * 64);
@@ -222,18 +142,15 @@ mod tests {
     use alloy_primitives::B256;
     use nectar_primitives::DefaultContentChunk;
 
-    /// A CAC sample item from a payload, transformed under `anchor`.
     fn cac_item(anchor: SampleAnchor, payload: &[u8]) -> SampleItem {
         let chunk = DefaultContentChunk::new(payload.to_vec()).unwrap();
         SampleItem::new(anchor, chunk.into())
     }
 
-    /// A deterministic 32-byte sample-time anchor.
     fn sample_anchor() -> SampleAnchor {
         SampleAnchor::new(B256::from_slice(b"swarm-test-anchor-deterministic!"))
     }
 
-    /// A deterministic single-owner chunk for the tie-break test.
     fn soc_chunk() -> AnyChunk {
         use nectar_primitives::DefaultSingleOwnerChunk;
         let signer = alloy_signer_local::PrivateKeySigner::from_slice(&[0x42u8; 32]).unwrap();
@@ -288,15 +205,14 @@ mod tests {
     #[test]
     fn reserve_sample_tie_break_prefers_cac() {
         let anchor = SampleAnchor::new(B256::repeat_byte(0xaa));
-        // A CAC and a fabricated SOC sharing the same transformed address but
-        // differing in type; the CAC must always win the slot.
+        // A CAC and a SOC sharing a transformed address; the CAC must win.
         let base = cac_item(anchor, &[7; 16]);
         let soc_dup = SampleItem {
             chunk: soc_chunk(),
             ..base.clone()
         };
 
-        // SOC inserted first, then CAC: CAC must win the slot.
+        // SOC first, then CAC.
         let out = reserve_sample(vec![soc_dup.clone(), base.clone()]);
         assert_eq!(out.len(), 1);
         assert!(
@@ -304,7 +220,7 @@ mod tests {
             "CAC must replace SOC on a transformed tie"
         );
 
-        // CAC inserted first, then SOC: CAC must be retained.
+        // CAC first, then SOC.
         let out = reserve_sample(vec![base.clone(), soc_dup]);
         assert_eq!(out.len(), 1);
         assert!(

--- a/crates/swarm/redistribution/src/witness.rs
+++ b/crates/swarm/redistribution/src/witness.rs
@@ -1,50 +1,34 @@
 //! Witness selection for the proof of entitlement.
 //!
-//! At claim time the prover must open a few sample slots as witnesses. The
-//! claim anchor deterministically picks which ones, so a node cannot predict in
-//! advance which chunks it must hold.
+//! The claim anchor deterministically picks which sample slots a prover must
+//! open as witnesses, so a node cannot predict in advance which chunks it must
+//! hold.
 
 use crate::SAMPLE_SIZE;
 use crate::anchor::ClaimAnchor;
 
-/// The sample slots a claim opens as witnesses.
-///
-/// In the redistribution game the prover opens three slots of the reserve
-/// sample: the two [`challenged`](Self::challenged) slots the claim anchor
-/// pseudo-randomly selects (so the prover cannot precompute which chunks to
-/// fake), and the [`last`](Self::last) slot, whose maximal transformed address
-/// the game uses to estimate the reserve size. All three are opened at the same
-/// BMT [`segment_index`](Self::segment_index).
+/// The three sample slots a claim opens as witnesses, all at one BMT
+/// [`segment_index`](Self::segment_index).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WitnessIndices {
-    /// The two slots the claim anchor pseudo-randomly selects to challenge, in
-    /// submission order: `claim mod (SAMPLE_SIZE - 1)`, and a second draw
-    /// `claim mod (SAMPLE_SIZE - 2)` bumped past the first so the two stay
-    /// distinct.
+    /// The two anchor-selected slots, in submission order: `claim mod
+    /// (SAMPLE_SIZE - 1)`, then `claim mod (SAMPLE_SIZE - 2)` bumped past the
+    /// first so the two stay distinct.
     pub challenged: [usize; 2],
-    /// The final sample slot (`SAMPLE_SIZE - 1`), always opened; its maximal
-    /// transformed address anchors the reserve-size estimate.
+    /// The final sample slot (`SAMPLE_SIZE - 1`); its maximal transformed
+    /// address anchors the reserve-size estimate.
     pub last: usize,
     /// The BMT segment opened within each witnessed chunk: `claim mod 128`.
     pub segment_index: usize,
 }
 
-/// Derive the witness slots from the claim-time anchor.
-///
-/// The claim anchor is interpreted as a **big-endian** unsigned integer:
-///
-/// - `challenged[0] = claim mod 15`
-/// - `challenged[1] = claim mod 14`, incremented by one if `>= challenged[0]` so
-///   the two challenged slots are distinct.
-/// - `last = 15` (the final sample slot).
-/// - `segment_index = claim mod 128`.
-///
-/// These big-endian moduli are unrelated to the little-endian `u64` BMT spans;
-/// the two must not be conflated.
+/// Derive the witness slots from the claim-time anchor, read as a big-endian
+/// unsigned integer. These big-endian moduli are unrelated to the little-endian
+/// `u64` BMT spans; do not conflate the two.
 #[must_use]
 pub fn witness_indices(claim: ClaimAnchor) -> WitnessIndices {
     let bytes = claim.as_bytes();
-    let last = SAMPLE_SIZE - 1; // 15
+    let last = SAMPLE_SIZE - 1;
     let first = mod_be(bytes, last as u64) as usize;
     let mut second = mod_be(bytes, (last - 1) as u64) as usize;
     if second >= first {

--- a/crates/swarm/redistribution/tests/conformance.rs
+++ b/crates/swarm/redistribution/tests/conformance.rs
@@ -1,21 +1,15 @@
 //! Conformance tests against the canonical Swarm reference vectors.
 //!
-//! These are consensus checks. The vertex sampler and proof of entitlement must
-//! be byte-exact, because the same values are verified on chain by
-//! `Redistribution.sol`. The fixtures here are authoritative oracles for the
-//! Swarm storage-incentives protocol:
+//! Consensus checks: the sampler and proof of entitlement must be byte-exact,
+//! since the same values are verified on chain by `Redistribution.sol`.
+//! Fixtures: a single-CAC transformed-address vector (anchor
+//! `swarm-test-anchor-deterministic!` over a 4 KiB pattern chunk) and
+//! `fixtures/inclusion_proofs.json` (`anchor1 = 100`, `anchor2 = 30`: 16 sorted
+//! sample items plus the three inclusion proofs).
 //!
-//! - The single-CAC transformed-address vector uses the deterministic anchor
-//!   `swarm-test-anchor-deterministic!` over a 4 KiB pattern chunk.
-//! - `fixtures/inclusion_proofs.json` captures a deterministic regression
-//!   scenario (`anchor1 = 100`, `anchor2 = 30`): the 16 sorted sample items
-//!   (chunk address, transformed address, full chunk data, type) and the three
-//!   inclusion proofs (`proof1`/`proof2`/`proofLast`).
-//!
-//! The anchor-keyed transformed address itself is a nectar primitive
-//! ([`AnyChunk::transformed_address`]); nectar owns its conformance vectors.
-//! These tests exercise the *redistribution* layer on top of it: sampling, the
-//! reserve-commitment chunk, the witness indices and the inclusion proofs.
+//! These exercise the redistribution layer (sampling, reserve-commitment chunk,
+//! witness indices, inclusion proofs); the transformed address itself is a
+//! nectar primitive ([`AnyChunk::transformed_address`]) with its own vectors.
 
 #![allow(
     clippy::unwrap_used,
@@ -39,15 +33,10 @@ use nectar_primitives::{
 
 use vertex_swarm_postage::{BatchId, Stamp, StampIndex};
 
-/// A deterministic synthetic stamp for fixture item `slot`.
-///
-/// The reference inclusion-proof vectors are stamp independent (they pin the
-/// RC/OG/TR BMT geometry, which the stamp never feeds), but a proof of
-/// entitlement now requires each witnessed slot to carry the exact stamp it was
-/// won with. We therefore pin a distinct, deterministic stamp per slot so the
-/// byte-for-byte proof assertions remain unchanged while the proof can also be
-/// shown to witness *that precise* stamp (see the exact-stamp test). The batch
-/// id is the slot index so different slots carry distinguishable stamps.
+/// A deterministic synthetic stamp for fixture item `slot`, distinct per slot so
+/// the exact-stamp witness test can confirm each slot carries its own. The stamp
+/// never feeds the RC/OG/TR BMT geometry, so the byte-for-byte proof vectors are
+/// unaffected.
 fn fixture_stamp(slot: usize) -> Stamp {
     let batch: BatchId = B256::repeat_byte(0xc0 + slot as u8);
     let index = StampIndex::new(slot as u32, slot as u32);
@@ -61,8 +50,8 @@ const ANCHOR_CAC: &[u8] = b"swarm-test-anchor-deterministic!";
 const WANT_CHUNK_ADDR: &str = "902406053a7a2f3a17f16097e1d0b4b6a4abeae6b84968f5503ae621f9522e16";
 const WANT_TRANSFORMED: &str = "9dee91d1ed794460474ffc942996bd713176731db4581a3c6470fe9862905a60";
 
-/// Reproduce the canonical single-CAC chunk-address and transformed-address
-/// vector. The chunk content is 4096 bytes of the repeating pattern `i % 256`.
+/// Single-CAC chunk-address and transformed-address vector over 4096 bytes of
+/// the repeating pattern `i % 256`.
 #[test]
 fn cac_transformed_address_matches_reference_vector() {
     let mut content = vec![0u8; 4096];
@@ -143,20 +132,16 @@ fn h(s: &str) -> B256 {
     B256::from_slice(&hex::decode(s.trim_start_matches("0x")).expect("hex"))
 }
 
-/// Decode the sample-time anchor (`anchor1`, a bytes32) from the oracle's hex.
 fn sample_anchor(oracle: &Oracle) -> SampleAnchor {
     SampleAnchor::new(h(&oracle.anchor1))
 }
 
-/// Decode the claim-time anchor (`anchor2`, a bytes32) from the oracle's hex.
 fn claim_anchor(oracle: &Oracle) -> ClaimAnchor {
     ClaimAnchor::new(h(&oracle.anchor2))
 }
 
-/// Parse one oracle item's raw chunk wire bytes into the typed [`AnyChunk`] the
-/// sampler operates on. A `CAC` is a `span || payload` content body; a `SOC` is
-/// `id || signature || span || payload`. The chunk's `TryFrom` enforces the
-/// minimum sizes, so malformed bytes become parse errors, not panics.
+/// Parse one oracle item's raw wire bytes into a typed [`AnyChunk`]. A `CAC` is
+/// `span || payload`; a `SOC` is `id || signature || span || payload`.
 fn parse_chunk(it: &OracleItem) -> DefaultAnyChunk {
     let bytes = hex::decode(&it.chunk_data).expect("chunk data hex");
     if it.chunk_type == "SOC" {
@@ -170,15 +155,9 @@ fn parse_chunk(it: &OracleItem) -> DefaultAnyChunk {
     }
 }
 
-/// Rebuild every sample item from the oracle (typed chunk + transformed address),
-/// asserting the parsed chunk address and the recomputed transformed address
-/// both match the reference.
-///
-/// Each item is pinned with a deterministic [`fixture_stamp`] so a proof of
-/// entitlement can be built (it requires the winning stamp on every witnessed
-/// slot). The stamp does not feed the RC/OG/TR BMT proofs, so attaching it
-/// leaves every byte-for-byte proof assertion unchanged; it does let the
-/// exact-stamp test confirm the proof witnesses *that* stamp.
+/// Rebuild every sample item from the oracle, asserting the parsed chunk address
+/// and recomputed transformed address both match the reference. Each item is
+/// pinned with a [`fixture_stamp`] so a proof of entitlement can be built.
 fn rebuild_items(oracle: &Oracle, sample: SampleAnchor) -> Vec<SampleItem> {
     oracle
         .items
@@ -210,7 +189,6 @@ fn transformed_addresses_match_reference_for_all_sample_items() {
     let sample = sample_anchor(&oracle);
     let items = rebuild_items(&oracle, sample);
     assert_eq!(items.len(), SAMPLE_SIZE);
-    // rebuild_items asserts every transformed address internally.
 }
 
 #[test]
@@ -219,8 +197,8 @@ fn reserve_sample_reproduces_reference_sorted_order() {
     let sample = sample_anchor(&oracle);
     let items = rebuild_items(&oracle, sample);
 
-    // The reference sample is already the sorted 16; feeding it (in any order)
-    // to reserve_sample must reproduce the exact same ordering.
+    // The reference sample is the sorted 16; feeding it in any order must
+    // reproduce the same ordering.
     let mut shuffled = items.clone();
     shuffled.reverse();
     let got = reserve_sample(shuffled);
@@ -262,8 +240,8 @@ fn witness_indices_match_reference() {
     assert_eq!(idx.segment_index, oracle.segment_index);
 }
 
-/// The headline conformance check: every proof segment, prove segment and chunk
-/// span of the proof of entitlement must equal the reference, byte for byte.
+/// Every proof segment, prove segment and chunk span of the proof of entitlement
+/// must equal the reference, byte for byte.
 #[test]
 fn inclusion_proofs_match_reference_byte_for_byte() {
     let oracle = load_oracle();
@@ -286,9 +264,8 @@ fn inclusion_proofs_match_reference_byte_for_byte() {
     assert_proof(&proofs.0[2], &oracle.proof_last, "proofLast (last slot)");
 }
 
-/// Each witness must carry the *exact* stamp the sample slot was won with: the
-/// `postage_proof` of witness *k* must be byte-identical to the stamp pinned to
-/// the slot that witness opens, never a stamp re-loaded by batch id alone.
+/// Each witness's `postage_proof` must be byte-identical to the stamp pinned to
+/// the slot it opens, not a stamp re-loaded by batch id alone.
 #[test]
 fn inclusion_proof_witnesses_the_exact_winning_stamp() {
     let oracle = load_oracle();
@@ -299,8 +276,7 @@ fn inclusion_proof_witnesses_the_exact_winning_stamp() {
     let idx = witness_indices(claim);
     let proofs = make_inclusion_proofs(&items, sample, claim).expect("proofs build");
 
-    // Submission order is [challenged0, challenged1, last]; each carried stamp
-    // must equal the stamp pinned to the very slot it opened.
+    // Submission order is [challenged0, challenged1, last].
     for (proof, slot) in [
         (&proofs.0[0], idx.challenged[0]),
         (&proofs.0[1], idx.challenged[1]),
@@ -311,8 +287,7 @@ fn inclusion_proof_witnesses_the_exact_winning_stamp() {
             proof.postage_proof, won_with,
             "witness for slot {slot} must carry that slot's exact winning stamp",
         );
-        // The precise identity the consensus rule pins: batch id and the full
-        // 8-byte stamp index, not merely the batch.
+        // The consensus identity is batch id plus the full 8-byte stamp index.
         assert_eq!(proof.postage_proof.batch(), won_with.batch());
         assert_eq!(
             proof.postage_proof.stamp_index().to_be_bytes(),
@@ -321,16 +296,15 @@ fn inclusion_proof_witnesses_the_exact_winning_stamp() {
         );
     }
 
-    // A distinct slot carries a distinct stamp, so a batch-keyed reload (which
-    // could not tell two stamps of one batch apart) would not satisfy this.
+    // Distinct slots carry distinct stamps, so a batch-keyed reload would not
+    // satisfy this.
     assert_ne!(
         proofs.0[0].postage_proof, proofs.0[2].postage_proof,
         "different witnessed slots must carry their own distinct stamps",
     );
 }
 
-/// A sample slot that reaches proof time with no pinned stamp is refused, rather
-/// than papered over by re-loading a stamp by batch id.
+/// A sample slot that reaches proof time with no pinned stamp is refused.
 #[test]
 fn inclusion_proof_rejects_a_slot_without_a_stamp() {
     use vertex_swarm_redistribution::ProofError;
@@ -351,19 +325,18 @@ fn inclusion_proof_rejects_a_slot_without_a_stamp() {
     );
 }
 
-/// The same content presented under two different batches is sampled **at most
-/// once**, and the committed reserve-commitment bytes are identical regardless
-/// of insertion order. Only *which batch's stamp* travels with the surviving
-/// slot is order dependent, which is consensus-safe: the chain commits the
-/// (order-invariant) `chunk_address || transformed_address` pair and binds the
-/// witnessed stamp to the chunk, not to a canonical batch. See the
-/// `reserve_sample` function note.
+/// The same content under two batches is sampled at most once, and the committed
+/// reserve-commitment bytes are identical regardless of insertion order. Only
+/// which batch's stamp travels with the surviving slot is order dependent, which
+/// is consensus-safe: the chain commits the order-invariant
+/// `chunk_address || transformed_address` pair and binds the witnessed stamp to
+/// the chunk, not to a canonical batch.
 #[test]
 fn same_content_multi_batch_ties_to_one_slot_with_stable_commitment() {
     let anchor = SampleAnchor::new(B256::repeat_byte(0x5a));
 
-    // One content chunk, two distinct batches: same chunk address and (under one
-    // anchor) the same transformed address, so they tie.
+    // One content chunk, two distinct batches: same chunk and transformed
+    // address under one anchor, so they tie.
     let chunk: DefaultAnyChunk =
         DefaultContentChunk::new(b"shared payload under two batches".to_vec())
             .expect("cac builds")
@@ -398,22 +371,20 @@ fn same_content_multi_batch_ties_to_one_slot_with_stable_commitment() {
     let forward = reserve_sample(vec![item_a.clone(), item_b.clone()]);
     let reverse = reserve_sample(vec![item_b.clone(), item_a.clone()]);
 
-    // At most once: a single slot in either order.
     assert_eq!(forward.len(), 1, "tied content must collapse to one slot");
     assert_eq!(reverse.len(), 1, "tied content must collapse to one slot");
 
-    // The committed bytes (chunk_address || transformed_address) are byte-
-    // identical across orders: nothing order dependent reaches the chain.
+    // The committed bytes are byte-identical across orders: nothing order
+    // dependent reaches the chain.
     assert_eq!(
         reserve_commitment_content(&forward),
         reserve_commitment_content(&reverse),
         "the reserve commitment must be insertion-order invariant",
     );
 
-    // The only order-dependent quantity is which batch's stamp survives; both
-    // orders keep the last CAC seen (consensus-safe, documented as order-agnostic
-    // against bee). This pins the observed behaviour without asserting it is
-    // consensus-binding.
+    // The only order-dependent quantity is which batch's stamp survives: both
+    // orders keep the last CAC seen. Pins the observed behaviour without
+    // asserting it is consensus-binding.
     assert_eq!(
         forward[0].stamp.as_ref().map(Stamp::batch),
         Some(stamp_b.batch()),
@@ -431,7 +402,7 @@ fn assert_proof(
     want: &OracleProof,
     label: &str,
 ) {
-    // RC chunk inclusion proof: proofSegments / proveSegment.
+    // RC: proofSegments / proveSegment.
     assert_eq!(
         got.rc_proof.segment,
         h(&want.prove_segment),
@@ -444,7 +415,7 @@ fn assert_proof(
         "RC",
     );
 
-    // OG (plain) BMT segment proof: proofSegments2 / proveSegment2 / chunkSpan.
+    // OG (plain BMT): proofSegments2 / proveSegment2 / chunkSpan.
     assert_eq!(
         got.og_proof.segment,
         h(&want.prove_segment2),
@@ -458,8 +429,8 @@ fn assert_proof(
     );
     assert_eq!(got.chunk_span, want.chunk_span, "{label}: chunk span");
 
-    // TR (anchor-prefixed) BMT segment proof: proofSegments3. The protocol proves
-    // the same segment content as OG, so the proven segment must agree too.
+    // TR (anchor-prefixed BMT): proofSegments3, proving the same segment content
+    // as OG.
     assert_eq!(
         got.tr_proof.segment,
         h(&want.prove_segment2),
@@ -484,8 +455,8 @@ fn assert_segments(got: &[B256], want: &[String], label: &str, which: &str) {
     }
 }
 
-/// Each witnessed proof must self-verify against the relevant BMT root, a
-/// secondary guard on top of the byte-for-byte fixture comparison.
+/// Each witnessed proof self-verifies against the relevant BMT root, guarding on
+/// top of the byte-for-byte fixture comparison.
 #[test]
 fn witness_proofs_self_verify() {
     let oracle = load_oracle();
@@ -512,7 +483,6 @@ fn witness_proofs_self_verify() {
             "RC proof must verify against the reserve-commitment root",
         );
 
-        // OG proof verifies against the witnessed body's plain BMT root.
         assert!(
             p.og_proof
                 .verify(plain_root(&items[require].chunk).as_slice())
@@ -520,9 +490,8 @@ fn witness_proofs_self_verify() {
             "OG proof must verify against the chunk's plain BMT root",
         );
 
-        // TR proof verifies against the inner body's anchor-prefixed BMT root.
-        // For a CAC that root *is* the transformed address; for a SOC the
-        // transformed address is keccak(soc_addr || this root), so we verify
+        // For a CAC the prefixed root is the transformed address; for a SOC the
+        // transformed address is keccak(soc_addr || this root), so verify
         // against the prefixed root directly.
         assert!(
             p.tr_proof
@@ -534,8 +503,7 @@ fn witness_proofs_self_verify() {
 }
 
 /// The plain BMT root of the witnessed chunk body. For a CAC this is the chunk
-/// address; for a SOC it is the wrapped CAC's address. The typed `span`/`data`
-/// accessors already expose the inner body, so there is no header slicing.
+/// address; for a SOC it is the wrapped CAC's address.
 fn plain_root(chunk: &DefaultAnyChunk) -> SwarmAddress {
     let mut hasher = DefaultHasher::new();
     hasher.set_span(chunk.span());
@@ -544,8 +512,8 @@ fn plain_root(chunk: &DefaultAnyChunk) -> SwarmAddress {
 }
 
 /// The anchor-prefixed BMT root of the witnessed chunk body (the TR proof's
-/// root). For a CAC this equals the transformed address; for a SOC it is the
-/// inner component of the transformed address.
+/// root). For a CAC this equals the transformed address; for a SOC it is its
+/// inner component.
 fn prefixed_root(chunk: &DefaultAnyChunk, anchor: &[u8]) -> SwarmAddress {
     let mut hasher = DefaultHasher::with_prefix(anchor);
     hasher.set_span(chunk.span());

--- a/crates/swarm/rpc/src/adapter.rs
+++ b/crates/swarm/rpc/src/adapter.rs
@@ -1,13 +1,10 @@
-//! gRPC adapter wrapping an api component container.
+//! gRPC adapter over an api component container.
 //!
-//! [`GrpcAdapter<C>`] is the gRPC transport's view of a built node: it wraps an
-//! api component container `C` and registers exactly the services the container's
-//! capabilities expose. The node status service is gated on [`HasTopology`]; the
-//! chunk service is gated on [`HasChunkClient`]. Registration is driven through
-//! per-shape [`RegistersGrpcServices`] impls (one per concrete container) so the
-//! optional chunk capability never produces overlapping blanket impls.
-//!
-//! The adapter is constructed only at `bin/vertex`, the gRPC selection point.
+//! [`GrpcAdapter<C>`] registers exactly the services `C`'s capabilities expose:
+//! the node status service is gated on [`HasTopology`], the chunk service on
+//! [`HasChunkClient`]. Registration uses per-shape [`RegistersGrpcServices`]
+//! impls (one per concrete container) to avoid overlapping blanket impls for the
+//! optional chunk capability.
 
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
 use vertex_swarm_api::{
@@ -18,27 +15,22 @@ use vertex_swarm_stream::ChunkClient;
 
 use crate::{ChunkService, NodeService, proto};
 
-/// gRPC transport adapter over an api component container `C`.
-///
-/// The gRPC surface is driven by the capabilities `C` exposes. Capability access
-/// ([`HasTopology`], [`HasChunkClient`]) delegates to `C`.
+/// gRPC adapter over an api component container `C`; capability accessors
+/// delegate to `C`.
 #[derive(Debug, Clone)]
 pub struct GrpcAdapter<C> {
     components: C,
 }
 
 impl<C> GrpcAdapter<C> {
-    /// Wrap a components container.
     pub fn new(components: C) -> Self {
         Self { components }
     }
 
-    /// Access the wrapped components.
     pub fn components(&self) -> &C {
         &self.components
     }
 
-    /// Consume and return the wrapped components.
     pub fn into_components(self) -> C {
         self.components
     }
@@ -62,9 +54,6 @@ impl<C: HasChunkClient> HasChunkClient for GrpcAdapter<C> {
 
 impl<C> GrpcAdapter<C> {
     /// Register the node status service and the shared reflection descriptor.
-    ///
-    /// Gated on [`HasTopology`]: any container carrying a topology that satisfies
-    /// the node service bounds can expose status and topology queries.
     pub fn register_node(&self, registry: &mut GrpcRegistry)
     where
         C: HasTopology,
@@ -83,9 +72,6 @@ impl<C> GrpcAdapter<C> {
     }
 
     /// Register the chunk upload/download service.
-    ///
-    /// Gated on [`HasChunkClient`]: only containers carrying a chunk client
-    /// expose the chunk service.
     pub fn register_chunk(&self, registry: &mut GrpcRegistry)
     where
         C: HasChunkClient,
@@ -119,13 +105,8 @@ where
     }
 }
 
-/// Storer nodes register the node status service and the chunk service.
-///
-/// `StorerComponents` exposes the topology and chunk client through the same
-/// `HasTopology`/`HasChunkClient` accessors the client container does (it
-/// delegates to its embedded `ClientComponents`), so the same two services
-/// register. The store axis (`S`) carries no served capability yet: a
-/// reserve-specific service can be gated on `HasReserve` once one exists.
+/// Storer nodes register the node status service and the chunk service; the
+/// store axis (`S`) carries no served capability yet.
 impl<T, C, S> RegistersGrpcServices for GrpcAdapter<StorerComponents<T, C, S>>
 where
     T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Clone + Send + Sync + 'static,

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -15,29 +15,19 @@ use vertex_swarm_stream::{
     get_stream_from, parse_address,
 };
 
-/// Whether the chunk service trusts a caller's per-request `validate` flag or
-/// always validates the postage stamp signature on upload.
-///
-/// The `validate` flag on an upload request is caller-controlled, so on a
-/// publicly reachable endpoint a caller could set `validate = false` and have
-/// the node forward a chunk carrying an unverified (or forged) stamp. This
-/// policy moves that decision server-side: a public endpoint enforces
-/// validation; a private/trusted endpoint may honour the per-request flag.
-/// Embedded callers (FFI, wasm) trust the implementer and do not pass through
-/// this service, so they keep honouring their own flag.
+/// Server-side policy for the caller-controlled per-request `validate` flag. A
+/// public endpoint must not let a caller skip stamp-signature validation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum StampValidation {
-    /// Always validate the stamp signature, ignoring the request's `validate`
-    /// flag. The safe default for a publicly reachable gRPC endpoint.
+    /// Always validate, ignoring the request flag. Default for public endpoints.
     #[default]
     Enforce,
-    /// Honour the request's `validate` flag (trust by default, opt in to
-    /// validation). For a private or otherwise trusted endpoint.
+    /// Honour the request's `validate` flag. For trusted/private endpoints.
     PerRequest,
 }
 
 impl StampValidation {
-    /// The effective validate decision for a request whose flag is `requested`.
+    /// Effective validate decision for a request whose flag is `requested`.
     #[must_use]
     pub fn resolve(self, requested: bool) -> bool {
         match self {
@@ -54,9 +44,7 @@ pub struct ChunkService<P> {
 }
 
 impl<P> ChunkService<P> {
-    /// Create a new chunk service. Defaults to [`StampValidation::Enforce`]: a
-    /// gRPC endpoint validates stamps unless an operator opts into trusting the
-    /// per-request flag via [`Self::with_stamp_validation`].
+    /// Defaults to [`StampValidation::Enforce`].
     pub fn new(provider: P) -> Self {
         Self {
             provider,
@@ -64,8 +52,6 @@ impl<P> ChunkService<P> {
         }
     }
 
-    /// Set the stamp-validation policy (e.g. [`StampValidation::PerRequest`] for
-    /// a trusted/private endpoint).
     #[must_use]
     pub fn with_stamp_validation(mut self, stamp_validation: StampValidation) -> Self {
         self.stamp_validation = stamp_validation;
@@ -73,16 +59,13 @@ impl<P> ChunkService<P> {
     }
 }
 
-/// Parse a 32-byte chunk address, mapping the core [`parse_address`] error to a
-/// gRPC `invalid_argument` status.
 #[allow(clippy::result_large_err)]
 fn parse_chunk_address(bytes: &[u8]) -> Result<ChunkAddress, Status> {
     parse_address(bytes).map_err(|e| Status::invalid_argument(e.to_string()))
 }
 
-/// Build a [`StampedChunk`] from an upload request: the bytes self-validate
-/// against the supplied address (an address that does not match the bytes is
-/// rejected, which also pins the chunk variant).
+/// Build a [`StampedChunk`], rejecting bytes that do not hash to the supplied
+/// address (which also pins the chunk variant).
 #[allow(clippy::result_large_err)]
 fn parse_stamped_chunk(req: &UploadChunkRequest) -> Result<StampedChunk, Status> {
     let address = parse_chunk_address(&req.address)?;
@@ -95,8 +78,7 @@ fn parse_stamped_chunk(req: &UploadChunkRequest) -> Result<StampedChunk, Status>
     })
 }
 
-/// Map a unary retrieval failure to a gRPC status: absence becomes `not_found`,
-/// all else `internal`.
+/// Absence becomes `not_found`, all else `internal`.
 #[allow(clippy::result_large_err)]
 fn retrieval_status(error: &SwarmError) -> Status {
     match error {
@@ -107,7 +89,6 @@ fn retrieval_status(error: &SwarmError) -> Status {
     }
 }
 
-/// A successful retrieval response carrying the chunk and its address.
 fn retrieved_response(
     address: ChunkAddress,
     data: Vec<u8>,
@@ -124,8 +105,8 @@ fn retrieved_response(
     }
 }
 
-/// A per-address retrieval failure response. `address` is the raw requested
-/// bytes, echoed for correlation (even when they failed to parse).
+/// `address` is the raw requested bytes, echoed for correlation even when they
+/// failed to parse.
 fn retrieve_error(address: Vec<u8>, message: String) -> RetrieveChunkResponse {
     RetrieveChunkResponse {
         result: Some(retrieve_chunk_response::Result::Error(ChunkError {
@@ -135,9 +116,6 @@ fn retrieve_error(address: Vec<u8>, message: String) -> RetrieveChunkResponse {
     }
 }
 
-/// Map a verified download item onto the wire response, carrying the real
-/// `served_by` the streaming retrieve path now threads through (previously
-/// emitted empty).
 fn verified_response(address: ChunkAddress, verified: VerifiedChunk) -> RetrieveChunkResponse {
     let served_by = verified.served_by().as_bytes().to_vec();
     let (chunk, stamp) = verified.into_parts();
@@ -149,7 +127,6 @@ fn verified_response(address: ChunkAddress, verified: VerifiedChunk) -> Retrieve
     )
 }
 
-/// A successful upload receipt response carrying the chunk address.
 fn receipt_response(address: ChunkAddress, receipt: PushReceipt) -> UploadChunkResponse {
     let PushReceipt {
         storer,
@@ -169,8 +146,8 @@ fn receipt_response(address: ChunkAddress, receipt: PushReceipt) -> UploadChunkR
     }
 }
 
-/// A per-chunk upload failure response. `address` is the raw request bytes,
-/// echoed for correlation (even when they failed to parse).
+/// `address` is the raw request bytes, echoed for correlation even when they
+/// failed to parse.
 fn upload_error(address: Vec<u8>, message: String) -> UploadChunkResponse {
     UploadChunkResponse {
         result: Some(upload_chunk_response::Result::Error(ChunkError {
@@ -192,8 +169,7 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
         let req = request.into_inner();
         let address = parse_chunk_address(&req.address)?;
 
-        // Verify-by-default: `get` proves the bytes answer the address before
-        // responding, so a wrong-bytes delivery errors instead of returning.
+        // `get` verifies the bytes answer the address, so wrong bytes error.
         match self.provider.get(address).await {
             Ok(verified) => Ok(Response::new(verified_response(address, verified))),
             Err(e) => Err(retrieval_status(&e)),
@@ -221,8 +197,6 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
         let address = parse_chunk_address(&req.address)?;
         let stamped = parse_stamped_chunk(&req)?;
 
-        // The endpoint's policy resolves the effective decision from the caller's
-        // flag: a public endpoint (Enforce) always validates the stamp.
         let validate = self.stamp_validation.resolve(req.validate);
         let receipt = self
             .provider
@@ -235,13 +209,10 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
 
     type UploadChunksStream = ResponseStream<UploadChunkResponse>;
 
-    /// Upload a stream of pre-stamped chunks; receipts return in completion
-    /// order, each carrying its address. A per-chunk failure is one error item,
-    /// not a teardown.
-    ///
-    /// Pushes are driven directly off the inbound stream via `buffer_unordered`,
-    /// which pulls a new request only as a push slot frees, so server memory is
-    /// bounded by the concurrency, not by the (untrusted) request count.
+    /// Receipts return in completion order; a per-chunk failure is one error
+    /// item, not a teardown. `buffer_unordered` pulls a new request only as a
+    /// push slot frees, bounding server memory by the concurrency rather than
+    /// the untrusted request count.
     async fn upload_chunks(
         &self,
         request: Request<Streaming<UploadChunkRequest>>,
@@ -257,11 +228,9 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
                     let req = item.map_err(|status| {
                         Status::internal(format!("inbound stream error: {status}"))
                     })?;
-                    // Apply the endpoint policy, same as the unary RPC.
                     let validate = stamp_validation.resolve(req.validate);
                     Ok(match parse_stamped_chunk(&req) {
-                        // Echo the raw requested bytes so a malformed address is
-                        // still correlatable by the client.
+                        // Echo the raw bytes so a malformed address stays correlatable.
                         Err(status) => upload_error(req.address, status.message().to_string()),
                         Ok(stamped) => {
                             let address = *stamped.address();
@@ -280,41 +249,23 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
 
     type RetrieveChunksStream = ResponseStream<RetrieveChunkResponse>;
 
-    /// Retrieve a stream of chunks by address; responses return in completion
-    /// order, each carrying its address and its serving overlay. A per-address
-    /// failure is one error item, not a teardown.
-    ///
-    /// Valid addresses route through the core [`get_stream_from`], so this path
-    /// shares one bounded, verify-by-default prefetch with the FFI and wasm
-    /// download paths instead of a hand-rolled `buffer_unordered`. The native
-    /// preset keeps enough forwarding retrievals in flight to saturate a bulk
-    /// download. Malformed addresses and inbound-stream errors are emitted as
-    /// their own error items, interleaved with the verified deliveries.
+    /// Per-address failure is one error item, not a teardown. Valid addresses
+    /// route through the bounded, verify-by-default [`get_stream_from`] prefetch
+    /// shared with the FFI and wasm download paths; malformed addresses and
+    /// inbound-stream errors interleave as their own error items.
     async fn retrieve_chunks(
         &self,
         request: Request<Streaming<RetrieveChunkRequest>>,
     ) -> Result<Response<Self::RetrieveChunksStream>, Status> {
         let inbound = request.into_inner();
 
-        // Malformed addresses and inbound-stream errors are not addresses the
-        // core can retrieve, but must still surface as their own error items
-        // rather than tear the stream down. They go onto this channel as a side
-        // effect of parsing, and are interleaved with the core's deliveries
-        // below.
-        //
-        // The channel is *bounded*: malformed requests never occupy a core
-        // prefetch slot, so an unbounded channel would let a client streaming
-        // nothing but bad requests faster than the consumer drains responses
-        // grow the heap without limit (the core's prefetch only gates valid
-        // addresses). A bounded channel makes `send` park the parser when the
-        // consumer is slow, which transitively pauses the inbound reads, capping
-        // buffered errors at the same chunk-count order as the valid-address
-        // prefetch.
+        // Side channel for errors that never reach the prefetch (malformed
+        // bytes, inbound errors). Bounded so a flood of bad requests cannot
+        // outrun a slow consumer: `send` parks the parser, back-pressuring the
+        // inbound reads.
         let (err_tx, err_rx) =
             tokio::sync::mpsc::channel::<RetrieveChunkResponse>(NATIVE_DOWNLOAD_CONCURRENCY);
 
-        // Parse the inbound feed into the core's address source, diverting every
-        // non-address (malformed bytes, inbound error) onto the error channel.
         let addresses = inbound.filter_map(move |item| {
             let err_tx = err_tx.clone();
             async move {
@@ -330,7 +281,6 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
                     }
                     Ok(req) => match parse_chunk_address(&req.address) {
                         Ok(address) => Some(address),
-                        // Echo the raw requested bytes for client-side correlation.
                         Err(status) => {
                             let _ = err_tx
                                 .send(retrieve_error(req.address, status.message().to_string()))
@@ -342,8 +292,6 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
             }
         });
 
-        // Valid addresses route through the core: one bounded, verify-by-default
-        // prefetch shared with the FFI and wasm download paths.
         let verified = get_stream_from(
             self.provider.clone(),
             addresses,
@@ -361,8 +309,8 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
 
     type HasChunksStream = ResponseStream<HasChunkResponse>;
 
-    /// Stream existence checks. `has_chunk` is a local sync lookup, so each
-    /// request maps straight to a response carrying its address.
+    /// `has_chunk` is a local sync lookup, so each request maps straight to a
+    /// response.
     async fn has_chunks(
         &self,
         request: Request<Streaming<HasChunkRequest>>,
@@ -392,7 +340,6 @@ mod tests {
     use super::*;
     use crate::proto::chunk::ChunkType;
 
-    /// Build a content chunk and return its wire encoding plus address.
     fn content_wire(data: &[u8]) -> (Vec<u8>, ChunkAddress) {
         let chunk: ContentChunk = ContentChunk::new(data.to_vec()).expect("valid content chunk");
         let address = *chunk.address();
@@ -455,8 +402,6 @@ mod tests {
 
     #[test]
     fn stamp_validation_resolves_per_policy() {
-        // Enforce always validates, ignoring the caller's flag; PerRequest
-        // honours it. The default is the safe Enforce.
         assert!(StampValidation::Enforce.resolve(false));
         assert!(StampValidation::Enforce.resolve(true));
         assert!(!StampValidation::PerRequest.resolve(false));
@@ -464,10 +409,8 @@ mod tests {
         assert_eq!(StampValidation::default(), StampValidation::Enforce);
     }
 
-    /// Streaming retrieve now threads the serving overlay through: a verified
-    /// item maps onto the wire response with a populated `served_by`, where the
-    /// streaming path previously emitted it empty. This drives the same
-    /// `get_stream_from` core the RPC routes through.
+    /// A verified item maps onto the wire response with a populated `served_by`,
+    /// driving the same `get_stream_from` core the RPC routes through.
     #[tokio::test]
     async fn retrieve_chunks_emits_served_by() {
         use vertex_swarm_api::{ChunkRetrievalResult, OverlayAddress, SwarmResult};
@@ -475,7 +418,6 @@ mod tests {
 
         const SERVED_BY: [u8; 32] = [0x5b; 32];
 
-        /// Provider serving one known content chunk from a fixed overlay.
         #[derive(Clone)]
         struct OneChunkProvider {
             chunk: AnyChunk,
@@ -505,8 +447,6 @@ mod tests {
             chunk: AnyChunk::Content(content),
         };
 
-        // Route a single address through the very core `retrieve_chunks` uses,
-        // then map it the same way the RPC does.
         let mut out = get_stream_from(
             provider,
             futures::stream::iter(vec![address]),

--- a/crates/swarm/storer/src/db_reserve/consensus_spec.rs
+++ b/crates/swarm/storer/src/db_reserve/consensus_spec.rs
@@ -1,13 +1,12 @@
 //! Consensus spec tests for the per-entry reserve.
 //!
-//! Each test builds a `DbReserve` over an in-memory redb-backed `vertex-storage`
-//! `Database`, a `DbBatchStore` populated with a real `Batch`, and signs real
-//! stamps with an `alloy-signer-local` wallet so the validate-on-ingest admission
-//! path runs exactly as in production. The invariants asserted here are the
-//! consensus-load-bearing ones: per-entry size counting, newest-wins / equal- and
-//! older-reject arbitration on the full `(batchID, stampIndex)` slot, refcounted
-//! payload survival under partial eviction, exact-stamp-in-proof, and full
-//! compaction (no tombstones) on removal.
+//! Each test builds a `DbReserve` over an in-memory redb `Database` and a
+//! `DbBatchStore` with a real `Batch`, signing real stamps so the
+//! validate-on-ingest path runs as in production. Covers the
+//! consensus-load-bearing invariants: per-entry size counting, newest-wins
+//! arbitration on the full `(batchID, stampIndex)` slot, refcounted payload
+//! survival under partial eviction, exact-stamp-in-proof, and full compaction
+//! (no tombstones) on removal.
 
 #![allow(
     clippy::unwrap_used,
@@ -29,10 +28,8 @@ use vertex_swarm_postage::DbBatchStore;
 use vertex_swarm_test_utils::MockIdentity;
 
 const THRESHOLD: u64 = 8;
-// bucket_depth 1 splits the address space by the top bit, so two distinct
-// content addresses can be coerced into the *same* bucket (top bit 0) and
-// therefore compete for the same `(batch, stampIndex)` arbiter slot. depth 18
-// gives ample per-bucket capacity for index 0.
+// bucket_depth 1 splits by the top bit, so distinct addresses can be coerced
+// into the same bucket (top bit 0) to compete for one arbiter slot.
 const BUCKET_DEPTH: u8 = 1;
 const DEPTH: u8 = 18;
 
@@ -40,27 +37,23 @@ fn signer() -> PrivateKeySigner {
     PrivateKeySigner::from_bytes(&B256::repeat_byte(0x42)).expect("valid signer")
 }
 
-/// A batch owned by `owner`, created at block 0, with ample value so it is
-/// not expired against a zero cumulative payout.
+/// Ample value so it is not expired against a zero cumulative payout.
 fn batch_for(owner: Address, id: B256) -> Batch {
     Batch::new(id, 1_000_000, 0, owner, DEPTH, BUCKET_DEPTH, false)
 }
 
-/// A live context past the confirmation threshold with zero payout (so a
-/// fresh batch is usable and not expired).
+/// Past the confirmation threshold with zero payout, so a fresh batch is usable.
 fn live_context() -> PostageContext {
     PostageContext::new(THRESHOLD + 1, 0)
 }
 
-/// A content chunk whose address falls in bucket 0 of a `BUCKET_DEPTH` batch
-/// (top bit clear), searched by varying the payload. Returns the chunk and
-/// its address.
+/// A content chunk whose address falls in bucket 0 (top bit clear), found by
+/// varying the payload.
 fn content_chunk_in_bucket0(seed: u64) -> (nectar_primitives::AnyChunk, ChunkAddress) {
     for n in 0..100_000u64 {
         let payload = format!("vertex reserve consensus fixture {seed}/{n}").into_bytes();
         let chunk = ContentChunk::new(payload).expect("valid content chunk");
         let addr = *chunk.address();
-        // bucket_for_address with bucket_depth 1 == top bit of byte 0.
         if addr.as_slice()[0] & 0x80 == 0 {
             return (chunk.into(), addr);
         }
@@ -68,9 +61,7 @@ fn content_chunk_in_bucket0(seed: u64) -> (nectar_primitives::AnyChunk, ChunkAdd
     panic!("no bucket-0 content chunk found within the search bound");
 }
 
-/// Sign a real stamp for `address` under `batch` at `timestamp`, at the given
-/// within-bucket `index`, with the bucket derived from the address so
-/// `validate_bucket` passes.
+/// Bucket is derived from the address so `validate_bucket` passes.
 fn signed_stamp(
     signer: &PrivateKeySigner,
     batch: &Batch,
@@ -89,13 +80,9 @@ fn signed_stamp(
     Stamp::with_index(batch.id(), stamp_index, timestamp, sig)
 }
 
-/// A test reserve and its shared database, plus the batch store the
-/// validate-on-ingest path reads.
-///
-/// The reserve owns its own `DbBatchStore` (the `BatchStore` trait is
-/// implemented on the store, not on `Arc<store>`), and the fixture holds a
-/// second store over the *same* database for populating and reading batches:
-/// both see identical persisted state.
+/// A test reserve and its shared database. The reserve owns its own
+/// `DbBatchStore`; the fixture holds a second store over the same database for
+/// populating and reading batches, so both see identical persisted state.
 struct Fixture {
     reserve: DbReserve<RedbDatabase, DbBatchStore<RedbDatabase>>,
     db: Arc<RedbDatabase>,
@@ -105,14 +92,11 @@ struct Fixture {
 }
 
 impl Fixture {
-    /// Build a reserve over a fresh in-memory database with a single batch
-    /// already registered and the live context persisted.
     fn new() -> Self {
         Self::with_batches(&[B256::repeat_byte(0x11)])
     }
 
-    /// Build a reserve whose batch store already holds the given batch ids
-    /// (all owned by the shared signer), with the live context persisted.
+    /// All batches are owned by the shared signer, with the live context persisted.
     fn with_batches(batch_ids: &[B256]) -> Self {
         let db = RedbDatabase::in_memory().unwrap().into_arc();
         let batches = DbBatchStore::new(Arc::clone(&db)).unwrap();
@@ -125,7 +109,6 @@ impl Fixture {
 
         let identity = MockIdentity::with_first_byte(0x00);
         let overlay = identity.overlay_address();
-        // The reserve's own store handle over the same shared database.
         let reserve_batches = DbBatchStore::new(Arc::clone(&db)).unwrap();
         let reserve = DbReserve::new(
             Arc::clone(&db),
@@ -146,7 +129,6 @@ impl Fixture {
         }
     }
 
-    /// The single batch id this fixture was built with.
     fn batch_id(&self) -> BatchId {
         BatchId::repeat_byte(0x11)
     }
@@ -166,12 +148,10 @@ impl Fixture {
             .put(CachedChunk::new(chunk.clone(), Some(stamp)))
     }
 
-    /// Count rows in a table via a full cursor walk.
     fn row_count<T: Table>(&self) -> u64 {
         self.db.view(|tx| tx.count::<T>()).unwrap() as u64
     }
 
-    /// The refcount stored for an address's payload, or `None` if absent.
     fn payload_refcnt(&self, addr: &ChunkAddress) -> Option<u64> {
         self.db
             .view(|tx| Ok(tx.get::<Payload>(*addr)?.map(|p| p.refcnt)))
@@ -181,10 +161,9 @@ impl Fixture {
 
 #[test]
 fn reserve_size_counts_stamped_entries_not_addresses() {
-    // Same content address stamped under N distinct batches must leave the
-    // reserve size == N (one Entry row per (batchID, stampIndex, address)),
-    // NOT 1. The reserve size feeds storage_radius / committedDepth, which is
-    // consensus-committed.
+    // One content address under N batches leaves size == N (one Entry per
+    // (batchID, stampIndex, address)), not 1. Size feeds the consensus-committed
+    // storage_radius.
     let ids = [
         B256::repeat_byte(0x11),
         B256::repeat_byte(0x22),
@@ -207,38 +186,33 @@ fn reserve_size_counts_stamped_entries_not_addresses() {
         ids.len() as u64,
         "one Entry row per stamped entry"
     );
-    // One shared, refcounted payload: N entries, one body, refcnt == N.
     assert_eq!(fx.row_count::<Payload>(), 1, "one shared content payload");
     assert_eq!(fx.payload_refcnt(&addr), Some(ids.len() as u64));
 }
 
 #[test]
 fn newest_timestamp_wins_full_index_keying() {
-    // Two stamps for the SAME (batchID, full 8-byte stampIndex): a newer
-    // timestamp displaces the older entry (size stays 1, slot updated); an
-    // EQUAL timestamp REJECTS (prev >= curr); an OLDER timestamp REJECTS.
-    // Distinct indices in the same bucket are different slots and both admit
-    // (the gate-refuted bucket-only keying must NOT collapse them).
+    // On one (batchID, stampIndex) slot: a newer timestamp displaces the entry,
+    // an equal or older timestamp rejects (prev >= curr). Distinct indices in
+    // the same bucket are separate slots and both admit.
     let fx = Fixture::new();
     let id = fx.batch_id();
     let (chunk, addr) = content_chunk_in_bucket0(2);
 
-    // First stamp at index 0, timestamp 100.
     fx.put(&chunk, &addr, id, 0, 100).unwrap();
     assert_eq!(fx.reserve.count().unwrap(), 1);
 
-    // Newer timestamp on the SAME slot: restamp, size unchanged.
+    // Newer timestamp: restamp, size unchanged, newer stamp survives.
     fx.put(&chunk, &addr, id, 0, 200).unwrap();
     assert_eq!(
         fx.reserve.count().unwrap(),
         1,
         "restamp displaces the old entry; size unchanged"
     );
-    // The surviving entry carries the newer stamp (timestamp 200).
     let got = fx.reserve.get(&addr).unwrap().expect("present");
     assert_eq!(got.stamp().expect("stamped").timestamp(), 200);
 
-    // Equal timestamp on the same slot: REJECT, nothing changes.
+    // Equal timestamp: reject.
     fx.put(&chunk, &addr, id, 0, 200).unwrap();
     assert_eq!(fx.reserve.count().unwrap(), 1);
     assert_eq!(
@@ -253,7 +227,7 @@ fn newest_timestamp_wins_full_index_keying() {
         "equal-timestamp re-presentation does not overwrite"
     );
 
-    // Older timestamp on the same slot: REJECT.
+    // Older timestamp: reject.
     fx.put(&chunk, &addr, id, 0, 150).unwrap();
     assert_eq!(
         fx.reserve
@@ -267,8 +241,7 @@ fn newest_timestamp_wins_full_index_keying() {
         "older stamp is stale and rejected"
     );
 
-    // A DISTINCT index in the same bucket is a different slot: it admits and
-    // adds a second entry (bucket-only keying would wrongly collapse these).
+    // A distinct index in the same bucket is a different slot: it admits.
     fx.put(&chunk, &addr, id, 1, 50).unwrap();
     assert_eq!(
         fx.reserve.count().unwrap(),
@@ -279,10 +252,9 @@ fn newest_timestamp_wins_full_index_keying() {
 
 #[test]
 fn refcounted_payload_survives_partial_eviction() {
-    // Same content under two batches: one Payload row, refcnt 2. The
-    // second-batch put must NOT rewrite the body (refcnt bump only). Evicting
-    // one entry leaves the body present (refcnt 1) and the surviving entry
-    // still resolves.
+    // Same content under two batches: one Payload row at refcnt 2; the second
+    // put bumps the refcount without rewriting the body. Evicting one entry
+    // leaves the body (refcnt 1); evicting the last drops it.
     let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(3);
@@ -312,7 +284,6 @@ fn refcounted_payload_survives_partial_eviction() {
     );
     assert_eq!(fx.reserve.count().unwrap(), 2, "two stamped entries");
 
-    // Evict the furthest entry: one entry goes, the body survives (refcnt 1).
     let evicted = fx.reserve.evict_furthest().unwrap();
     assert_eq!(evicted, Some(addr));
     assert_eq!(fx.reserve.count().unwrap(), 1, "one entry removed");
@@ -321,11 +292,9 @@ fn refcounted_payload_survives_partial_eviction() {
         Some(1),
         "shared body survives partial eviction"
     );
-    // The surviving entry still resolves to the chunk.
     let got = fx.reserve.get(&addr).unwrap().expect("survivor present");
     assert_eq!(got.address(), &addr);
 
-    // Evicting the last entry drops the body entirely (no tombstone).
     fx.reserve.evict_furthest().unwrap();
     assert_eq!(fx.reserve.count().unwrap(), 0);
     assert_eq!(fx.payload_refcnt(&addr), None, "last entry drops the body");
@@ -333,24 +302,22 @@ fn refcounted_payload_survives_partial_eviction() {
 
 #[test]
 fn restamp_to_different_address_cleans_displaced_rows() {
-    // A restamp re-points the (batchID, stampIndex) slot at a DIFFERENT
-    // content address. The displaced entry's rows must be deleted using the
-    // DISPLACED address's proximity (regression guard for the orphaned-row /
-    // leaked-refcount bug), and its payload refcount decremented exactly once.
+    // Restamping the (batchID, stampIndex) slot onto a different address must
+    // delete the displaced entry's rows using the displaced address's proximity
+    // and decrement its payload refcount exactly once (no orphaned rows, no
+    // leaked refcount).
     let fx = Fixture::new();
     let id = fx.batch_id();
-    // Two distinct addresses, both in bucket 0, so they share index slot 0.
+    // Both in bucket 0, so they share index slot 0.
     let (chunk_a, addr_a) = content_chunk_in_bucket0(10);
     let (chunk_b, addr_b) = content_chunk_in_bucket0(20);
     assert_ne!(addr_a, addr_b, "fixtures must be distinct addresses");
 
-    // Stamp A into slot (id, index 0) at timestamp 100.
     fx.put(&chunk_a, &addr_a, id, 0, 100).unwrap();
     assert_eq!(fx.reserve.count().unwrap(), 1);
     assert!(fx.reserve.contains(&addr_a));
 
-    // Restamp the SAME slot onto address B at a newer timestamp: A is
-    // displaced, B admitted. Size unchanged (one displaced, one added).
+    // Restamp the slot onto B at a newer timestamp: A displaced, B admitted.
     fx.put(&chunk_b, &addr_b, id, 0, 200).unwrap();
     assert_eq!(
         fx.reserve.count().unwrap(),
@@ -358,14 +325,12 @@ fn restamp_to_different_address_cleans_displaced_rows() {
         "restamp to a different address displaces A and admits B"
     );
 
-    // A's body and all its index rows are gone (no orphaned rows, no leaked
-    // refcount); B is present and resolves.
     assert!(!fx.reserve.contains(&addr_a), "displaced A body removed");
     assert_eq!(fx.payload_refcnt(&addr_a), None, "A refcount not leaked");
     assert!(fx.reserve.contains(&addr_b), "B present");
     assert_eq!(fx.payload_refcnt(&addr_b), Some(1));
 
-    // Exactly one of each index row remains (B's), no A residue.
+    // Exactly one of each row remains (B's), no A residue.
     assert_eq!(fx.row_count::<Entry>(), 1, "one Entry row (B)");
     assert_eq!(fx.row_count::<BatchGroup>(), 1, "one BatchGroup row (B)");
     assert_eq!(fx.row_count::<Replay>(), 1, "one Replay row (B)");
@@ -374,9 +339,8 @@ fn restamp_to_different_address_cleans_displaced_rows() {
 
 #[test]
 fn get_returns_exact_admitting_stamp() {
-    // get() must surface the PRECISE stamp the entry was admitted with
-    // (stored per entry), byte-for-byte, not a stamp re-loaded by batchID
-    // alone. An inclusion proof carries exactly this stamp.
+    // get() surfaces the per-entry admitting stamp byte-for-byte, not one
+    // re-loaded by batchID alone. An inclusion proof carries exactly this stamp.
     let fx = Fixture::new();
     let id = fx.batch_id();
     let (chunk, addr) = content_chunk_in_bucket0(4);
@@ -401,10 +365,8 @@ fn get_returns_exact_admitting_stamp() {
 
 #[test]
 fn removal_fully_compacts_all_tables_no_tombstones() {
-    // remove() must delete every row of every stamped entry for an address
-    // across all six tables, leaving no tombstone. Store the same content
-    // under two batches (two entries, one shared payload), then remove and
-    // assert all tables are empty.
+    // remove() deletes every row of every stamped entry for an address across
+    // all six tables, leaving no tombstone.
     let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(5);
@@ -421,8 +383,7 @@ fn removal_fully_compacts_all_tables_no_tombstones() {
     assert_eq!(fx.row_count::<BatchGroup>(), 0, "no BatchGroup tombstones");
     assert_eq!(fx.row_count::<Replay>(), 0, "no Replay tombstones");
     assert_eq!(fx.row_count::<Payload>(), 0, "no Payload tombstones");
-    // The arbiter slots for both batches are cleared, so a later older stamp
-    // is admitted afresh (slot did not pin a stale newest).
+    // The arbiter slot is cleared, so it does not pin a stale newest timestamp.
     let slot0 = StampSlotKey::new(BatchId::from(ids[0]), StampIndex::new(0, 0));
     assert!(
         fx.db
@@ -435,8 +396,8 @@ fn removal_fully_compacts_all_tables_no_tombstones() {
 
 #[test]
 fn unknown_batch_and_stampless_puts_are_rejected() {
-    // A stamp referencing a batch the node does not know is refused, and a
-    // stampless put is invalid; neither writes anything.
+    // A stamp for an unknown batch and a stampless put are both refused, writing
+    // nothing.
     let fx = Fixture::new();
     let (chunk, addr) = content_chunk_in_bucket0(6);
 
@@ -448,7 +409,7 @@ fn unknown_batch_and_stampless_puts_are_rejected() {
     assert!(matches!(err, SwarmError::InvalidChunk { .. }));
     assert!(!fx.reserve.contains(&addr));
 
-    // Unknown batch: sign under a batch id the store does not hold.
+    // Sign under a batch id the store does not hold.
     let unknown = Batch::new(
         B256::repeat_byte(0x99),
         1_000_000,
@@ -469,9 +430,8 @@ fn unknown_batch_and_stampless_puts_are_rejected() {
 
 #[test]
 fn bin_scan_replays_entries_in_insertion_order() {
-    // The Replay table feeds the redistribution/sync consumer in per-bin
-    // insertion order, surfacing the precise (address, batch, stampHash) of
-    // each stamped entry without a body read.
+    // The Replay table surfaces each entry's (address, batch, stampHash) in
+    // per-bin insertion order without a body read.
     let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(7);
@@ -494,32 +454,21 @@ fn bin_scan_replays_entries_in_insertion_order() {
     assert!(items.iter().all(|i| i.address == addr));
 }
 
-// sample-at-most-once (a chunk under N batches contributes at most one slot to
-// a sample, equal transformed address collapses, CAC beats SOC) is a SAMPLER
-// property, not a reserve one: the reserve exposes the per-entry Replay
-// projection (address, batch, stampHash, chunk_type) the sampler consumes, but
-// the collapse is performed by the sampler (PR-F), not here. The reserve-side
-// guarantee that the projection is per-entry and carries the chunk type is
-// covered by bin_scan_replays_entries_in_insertion_order plus the ReplayValue
-// schema; the collapse itself is asserted in PR-F.
+// Sample-at-most-once collapse is a sampler property; the reserve only supplies
+// the per-entry Replay projection, covered by
+// bin_scan_replays_entries_in_insertion_order.
 #[test]
-#[ignore = "sample-at-most-once collapse is a PR-F sampler property; reserve only supplies the per-entry Replay projection"]
-fn sample_collapses_duplicate_transformed_address() {
-    // Intentionally deferred to PR-F (sampler). See the comment above: the
-    // reserve's responsibility (a per-entry, chunk-typed Replay projection) is
-    // covered by the bin-scan test; the at-most-once collapse over transformed
-    // addresses belongs to the sampler that consumes that projection.
-}
+#[ignore = "sampler property; reserve only supplies the per-entry Replay projection"]
+fn sample_collapses_duplicate_transformed_address() {}
 
-// --- radius dynamics (PR-E): expiry -> evict_batch end to end -----------
+// --- radius dynamics: expiry -> evict_batch end to end -----------
 
 #[test]
 fn batch_expiry_sweep_evicts_only_the_expired_batch() {
     use crate::expiry::ExpirySweep;
 
-    // Two batches, each holding one stamped entry of a distinct content
-    // address (distinct addresses so neither eviction touches the other's
-    // refcounted payload).
+    // Two batches with distinct content addresses, so neither eviction touches
+    // the other's refcounted payload.
     let live_id = B256::repeat_byte(0x11);
     let expiring_id = B256::repeat_byte(0x22);
     let fx = Fixture::with_batches(&[live_id, expiring_id]);
@@ -530,19 +479,16 @@ fn batch_expiry_sweep_evicts_only_the_expired_batch() {
     fx.put(&chunk_b, &addr_b, expiring_id, 0, 100).unwrap();
     assert_eq!(fx.reserve.count().unwrap(), 2, "two stamped entries");
 
-    // batch_for sets value = 1_000_000. Advance the chain's cumulative
-    // payout so it catches one batch's value but not the other: lower the
-    // expiring batch's value below total_amount, leave the live one above.
+    // Lower the expiring batch's value below the cumulative payout, leaving the
+    // live one above, so only the expiring batch is expired.
     let mut expiring = fx.batches.get(&expiring_id).unwrap().unwrap();
     expiring.set_value(500);
     fx.batches.put(expiring).unwrap();
-    // total_amount = 1000 >= the expiring batch's value (500), but < the
-    // live batch's value (1_000_000).
+    // total_amount 1000 >= expiring value (500), < live value (1_000_000).
     fx.batches
         .set_context(PostageContext::new(THRESHOLD + 1, 1000))
         .unwrap();
 
-    // Run the sweep through the reserve's own batch-store handle (same DB).
     let reserve_batches = DbBatchStore::new(Arc::clone(&fx.db)).unwrap();
     let report = ExpirySweep::new(&reserve_batches, &fx.reserve)
         .run()
@@ -559,7 +505,6 @@ fn batch_expiry_sweep_evicts_only_the_expired_batch() {
         1,
         "the live batch's entry survives expiry of the other"
     );
-    // The expired batch's payload is gone; the live one's remains.
     assert_eq!(fx.payload_refcnt(&addr_b), None, "expired payload removed");
     assert_eq!(
         fx.payload_refcnt(&addr_a),
@@ -577,11 +522,8 @@ fn batch_expiry_sweep_evicts_only_the_expired_batch() {
 
 #[test]
 fn settable_radius_cell_round_trips_through_the_read_seam() {
-    // The settable radius cell (the SEAM the train was missing): a write via
-    // SettableRadius::set_storage_radius is observed by the ReserveStore read
-    // seam (storage_radius / is_responsible_for). Before this cell existed the
-    // derived radius had no write target and committedDepth could never change
-    // at runtime.
+    // A write via SettableRadius::set_storage_radius is observed by the
+    // storage_radius / is_responsible_for reads.
     use vertex_swarm_api::SettableRadius;
 
     let fx = Fixture::new();
@@ -592,17 +534,16 @@ fn settable_radius_cell_round_trips_through_the_read_seam() {
     );
 
     let target = StorageRadius::new(Bin::try_from(5).unwrap());
-    // Drive the write through the trait object form to prove object safety.
+    // Through the trait object form to prove object safety.
     let dyn_reserve: &dyn SettableRadius = &fx.reserve;
     dyn_reserve.set_storage_radius(target);
 
     assert_eq!(
         fx.reserve.storage_radius(),
         target,
-        "the read seam observes the committed radius"
+        "the read observes the committed radius"
     );
-    // is_responsible_for now evaluates against the new radius: an address at
-    // proximity 5+ is in responsibility, a shallower one is not.
+    // is_responsible_for evaluates against the new radius.
     let (_chunk, addr) = content_chunk_in_bucket0(909);
     let po = addr.proximity(&fx.overlay).get();
     assert_eq!(
@@ -614,13 +555,12 @@ fn settable_radius_cell_round_trips_through_the_read_seam() {
 
 #[test]
 fn radius_controller_apply_commits_a_shrink_through_the_seam() {
-    // The apply path (the wiring seam #391 consumes): from a radius above the
-    // floor, an under-filled, idle reserve shrinks one step, and apply commits
-    // the shallower radius through SettableRadius so the read seam sees it.
+    // From a radius above the floor, an under-filled idle reserve shrinks one
+    // step, and apply commits the shallower radius through SettableRadius.
     use crate::RadiusController;
 
     let fx = Fixture::new();
-    // Start above the floor with no entries (within-radius 0 < threshold).
+    // Above the floor with no entries (within-radius 0 < threshold).
     fx.reserve
         .set_storage_radius(StorageRadius::new(Bin::try_from(5).unwrap()));
 
@@ -677,10 +617,9 @@ fn nothing_evicted_when_no_batch_is_expired() {
 
 #[test]
 fn expired_event_evicts_reserve_before_store_removal() {
-    // The orphan-avoidance contract: on an `Expired` event the reserve
-    // entries must be shed BEFORE the batch leaves the store, otherwise the
-    // reconciliation sweep (which reads batch_ids) could never see them and
-    // they would be orphaned, inflating reserve size and the radius.
+    // On an `Expired` event the reserve entries are shed before the batch leaves
+    // the store; otherwise the reconciliation sweep (which reads batch_ids)
+    // could never see them and they would be orphaned, inflating size and radius.
     use crate::expiry::ExpirySweep;
     use std::cell::Cell;
 
@@ -693,8 +632,8 @@ fn expired_event_evicts_reserve_before_store_removal() {
     let reserve_batches = DbBatchStore::new(Arc::clone(&fx.db)).unwrap();
     let sweep = ExpirySweep::new(&reserve_batches, &fx.reserve);
 
-    // The acknowledgement (store removal) asserts the reserve is already
-    // empty of the batch by the time it runs, proving the ordering.
+    // The acknowledgement (store removal) asserts the reserve is already empty,
+    // proving the ordering.
     let acked = Cell::new(false);
     let removed = sweep
         .on_expired_event::<_, std::io::Error>(expiring_id, || {
@@ -716,10 +655,8 @@ fn expired_event_evicts_reserve_before_store_removal() {
 
 #[test]
 fn expired_event_does_not_acknowledge_when_eviction_fails_is_skipped() {
-    // Documents the short-circuit contract: a failing acknowledgement leaves
-    // the eviction done but surfaces the error so the caller can retry the
-    // removal. (Eviction failure itself is exercised by the reserve's own
-    // error tests; here we cover the acknowledge-error funnel.)
+    // A failing acknowledgement leaves the eviction done but surfaces the error
+    // so the caller can retry the removal.
     use crate::expiry::ExpirySweep;
 
     let expiring_id = B256::repeat_byte(0x44);
@@ -740,8 +677,7 @@ fn expired_event_does_not_acknowledge_when_eviction_fails_is_skipped() {
         "acknowledge error is funnelled through SwarmError::storage"
     );
     // The eviction still happened (it precedes the acknowledge); the caller
-    // is responsible for retrying the store removal, which a later `run`
-    // backstop would also catch were the batch still present.
+    // retries the store removal, which a later `run` backstop also catches.
     assert_eq!(fx.reserve.count().unwrap(), 0, "eviction already applied");
     assert_eq!(fx.payload_refcnt(&addr), None);
 }

--- a/crates/swarm/storer/src/db_reserve/mod.rs
+++ b/crates/swarm/storer/src/db_reserve/mod.rs
@@ -1,84 +1,53 @@
 //! Per-stamped-entry, proximity-ordered reserve over the vertex-storage
 //! `Database`.
 //!
-//! [`DbReserve`] is the storer's authoritative reserve: the canonical,
-//! per-stamped-entry chunk store. It is the reworked successor of the original
-//! address-keyed / first-stamp-wins reserve, rebuilt around the consensus
-//! invariant that the reserve's *size* counts distinct *stamped entries*
-//! (distinct `(batchID, stampIndex, address)`), not distinct content addresses.
+//! [`DbReserve`] is the storer's authoritative reserve. Its *size* counts
+//! distinct *stamped entries* (`(batchID, stampIndex, address)`), not distinct
+//! content addresses: one chunk can be stored under several batches, a slot can
+//! be re-stamped, and an inclusion proof must carry the precise stamp a sample
+//! slot was won with. Primary rows are keyed by full stamped-entry identity; the
+//! large chunk body is shared by refcount so evicting one batch's entry never
+//! drops a body another entry still needs.
 //!
-//! # Why per-entry, not per-address
+//! # Tables
 //!
-//! On Swarm a single content chunk can be stored under several postage batches
-//! at once, and a slot within a batch can be *re-stamped* (a newer stamp for the
-//! same `(batchID, stampIndex)` supersedes the older one). The redistribution
-//! game samples *stamped entries*, the reserve size that drives the storage
-//! radius counts *stamped entries*, and an inclusion proof must carry the
-//! *precise* stamp a sample slot was won with. An address-keyed, first-stamp-wins
-//! store cannot represent any of that. This reserve therefore keys its primary
-//! rows by the full stamped-entry identity and shares the (large) chunk payload
-//! by reference count so partial eviction of one batch's entry never drops a
-//! payload another batch's entry still needs.
+//! Compound keys are big-endian, so key byte order is the field lexicographic
+//! order (pinned by tests). Every mutation commits all affected rows in one
+//! `db.update` transaction, so removals leave no dangling rows (no tombstones).
 //!
-//! # The six tables
-//!
-//! All compound keys are big-endian so the byte order of the encoded key is the
-//! `(field, field, ...)` lexicographic order; the orderings are pinned by tests.
-//! Every mutation writes (or compacts) all the affected rows inside one
-//! `db.update` transaction, so a stamped entry and its index rows commit
-//! atomically and a removal never leaves a dangling row (no tombstones).
-//!
-//! - [`Payload`](schema::Payload): `addr -> (refcnt, typed_bytes)`. The
-//!   refcounted, content-addressed chunk body (the type-tagged [`AnyChunk`] bytes,
-//!   *without* a stamp, since stamps differ per entry). Present iff at least one
-//!   stamped entry references the address; the refcount is the number of such
-//!   entries. A second batch storing the same content bumps the refcount and
-//!   rewrites no payload; evicting one of several entries decrements it and keeps
-//!   the body.
+//! - [`Payload`](schema::Payload): `addr -> (refcnt, typed_bytes)`. Refcounted,
+//!   content-addressed body ([`AnyChunk`] bytes *without* a stamp). Refcount is
+//!   the number of entries referencing the address; the body is rewritten only
+//!   on first store.
 //! - [`Entry`](schema::Entry): `(po, batch, stampHash, addr) -> EntryValue
 //!   { binid, stamp }`. One row per stamped entry; the reserve size is this
-//!   table's count. The value carries the bin sequence the entry landed at (for
-//!   [`Replay`](schema::Replay) compaction) and the precise stamp the entry was
-//!   admitted with (so `get` can hand back the chunk with a real stamp and an
-//!   inclusion proof can carry exactly that stamp).
+//!   table's count. Carries the bin sequence (for [`Replay`](schema::Replay)
+//!   compaction) and the exact admitting stamp.
 //! - [`BatchGroup`](schema::BatchGroup): `(batch, po, addr, stampHash) -> ()`.
-//!   Groups every entry by batch (then bin, then address), so a whole batch or a
-//!   batch's shallow bins can be evicted with one prefix cursor scan.
+//!   Per-batch grouping so a batch or its shallow bins evict with one prefix scan.
 //! - [`Replay`](schema::Replay): `(bin, binid) -> ReplayValue { addr, batch,
-//!   stampHash, chunk_type }`. The append-only per-bin insertion-order index a
-//!   redistribution/sync consumer replays without rehydrating the chunk body.
-//!   `chunk_type` lets the sampler resolve the CAC-beats-SOC tie without a body
-//!   read.
-//! - [`BinCounter`](schema::BinCounter): `bin -> u64`. The per-bin monotonically
-//!   increasing insertion sequence (the bin cursor). Never rewound on eviction,
-//!   so sequences are never reused (sync resumability).
+//!   stampHash, chunk_type }`. Append-only per-bin insertion-order index replayed
+//!   without rehydrating the body; `chunk_type` resolves the CAC-beats-SOC tie
+//!   without a body read.
+//! - [`BinCounter`](schema::BinCounter): `bin -> u64`. Monotonic per-bin
+//!   insertion sequence; never rewound on eviction, so sequences never repeat
+//!   (sync resumability).
 //! - [`StampIndexTable`]: `(batch, stampIndex_be8) -> (timestamp, stampHash,
-//!   addr)`. The newest-timestamp-wins arbiter slot, keyed by the *full*
-//!   `(batchID, 8-byte stampIndex)`. Reused verbatim from the postage crate
-//!   (PR-C); the reserve performs the arbitration *inside* its own put
-//!   transaction with [`postage::decide`] so admission and the six-table write
-//!   commit together.
+//!   addr)`. Newest-timestamp-wins arbiter slot. The reserve arbitrates inside
+//!   its own put transaction with [`postage::decide`] so admission and the table
+//!   write commit together.
 //!
-//! # Put, restamp, and second-batch coexistence
+//! # Put and eviction
 //!
-//! `put` first validates the stamp on ingest through the stateless
-//! [`AdmissionValidator`] (the nectar batch checks plus a per-stamp ecrecover
-//! against the batch owner), then, in one transaction:
+//! `put` validates the stamp through the stateless [`AdmissionValidator`], then
+//! in one transaction arbitrates against the `(batch, stampIndex)` slot
+//! ([`postage::decide`], equal-or-older rejects). A restamp deletes the displaced
+//! entry's rows and decrements its payload before writing the incoming rows; a
+//! new slot writes the rows and bumps the refcount if the body already exists.
 //!
-//! - arbitrates the stamp against its `(batch, stampIndex)` slot
-//!   ([`postage::decide`], newest-wins, equal-or-older rejects);
-//! - on a *restamp* (the slot held an older stamp) deletes the four rows of the
-//!   displaced entry (`Entry`, `BatchGroup`, `Replay`, and the slot occupant is
-//!   overwritten) and decrements/compacts its payload, then writes the four new
-//!   rows for the incoming entry;
-//! - on a *new slot* writes the four rows and, if the same content already had a
-//!   payload (a second batch storing it), bumps the refcount instead of
-//!   rewriting the body.
-//!
-//! Eviction (`evict_furthest` / `evict_from_bin` / `evict_batch`) operates on
-//! *entries*: it removes an entry's four index rows, the stamp-index slot it
-//! owns, and decrements the shared payload, dropping the body only when the last
-//! entry referencing it goes.
+//! Eviction operates on entries: remove the index rows and stamp-index slot,
+//! decrement the shared payload, drop the body only when the last referencing
+//! entry goes.
 //!
 //! [`AnyChunk`]: nectar_primitives::AnyChunk
 //! [`AdmissionValidator`]: vertex_swarm_postage::AdmissionValidator
@@ -96,16 +65,10 @@ use alloy_primitives::B256;
 use nectar_primitives::ChunkAddress;
 use vertex_swarm_primitives::BatchId;
 
-// The public surface: `DbReserve` is re-exported so `crate::db_reserve::DbReserve`
-// and `crate::DbReserve` resolve exactly as before the split.
 pub use store::DbReserve;
 
-// The consensus spec tests reference the schema and the surrounding API by their
-// historical flat names through `use super::*`. Before the split those names
-// were in scope in the single module (its tables, plus its top-level `use`
-// imports); the re-exports below reproduce exactly that scope so the test bodies
-// stay unchanged. They are `#[cfg(test)]` so the production build keeps a minimal
-// surface.
+// Re-exports for the consensus spec tests, which reach the schema and API by
+// flat name through `use super::*`. `#[cfg(test)]` keeps them out of the build.
 #[cfg(test)]
 pub(crate) use crate::EvictionStrategy;
 #[cfg(test)]
@@ -119,11 +82,8 @@ pub(crate) use {
     vertex_swarm_primitives::{CachedChunk, OverlayAddress, StorageRadius},
 };
 
-/// The identity of one stamped entry to evict: its batch, stamp hash and address.
-///
-/// This is the one record shared across the `store` (put/get/evict) and `tx`
-/// (delete) submodules, so it lives in the module root both can reach without a
-/// submodule dependency cycle.
+/// Identity of one stamped entry to evict. Shared by the `store` and `tx`
+/// submodules, so it lives in the module root.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct EvictTarget {
     pub(crate) batch: BatchId,

--- a/crates/swarm/storer/src/db_reserve/schema.rs
+++ b/crates/swarm/storer/src/db_reserve/schema.rs
@@ -1,8 +1,8 @@
-//! The six-table schema: the `table!` definitions plus every compound-key and
-//! value codec they bind.
+//! Six-table reserve schema: `table!` definitions plus their compound-key and
+//! value codecs.
 //!
-//! All compound keys are big-endian so the byte order of the encoded key is the
-//! `(field, field, ...)` lexicographic order; the orderings are pinned by the
+//! All compound keys are big-endian, so encoded byte order equals
+//! `(field, field, ...)` lexicographic order. The orderings are pinned by the
 //! tests at the foot of this module.
 
 use alloy_primitives::{B256, keccak256};
@@ -13,79 +13,41 @@ use vertex_storage::{DatabaseError, Decode, Encode, table};
 
 use vertex_swarm_primitives::BatchId;
 
-// -------------------------------------------------------------------------
-// Tables (the six-table per-stamped-entry schema).
-// -------------------------------------------------------------------------
-
-// Refcounted content payload: `addr -> (refcnt, typed_bytes)`.
-//
-// One row per distinct *address* (not per entry). The body is the type-tagged
-// `AnyChunk` encoding, shared by every stamped entry of that content; the
-// refcount is the number of live entries referencing it. Present iff refcnt >=
-// 1. Declared uncompressed on the assumption that chunk bodies are
-// arbitrary/encrypted, so compression would cost CPU without saving space.
-// That assumption is untested: for some workloads (for example unencrypted
-// content-addressed bodies) compression may still recover space. Making this a
-// configuration option (with an uncompressed-to-compressed migration for
-// analysis) is tracked as a follow-up, because `compressed` is a compile-time
-// `table!` parameter and a runtime toggle is a storage-layer change, not a
-// reserve change.
+// Refcounted content payload: `addr -> (refcnt, typed_bytes)`. One row per
+// distinct address (not per entry); the body is shared by every stamped entry of
+// that content. Uncompressed: chunk bodies are arbitrary/encrypted.
 table!(pub(crate) Payload, "reserve_payload", ChunkAddress, PayloadValue, compressed = false);
 
 // Per-stamped-entry primary index: `(po, batch, stampHash, addr) -> EntryValue`.
-//
-// One row per stamped entry; the reserve size is the count of this table. Keyed
-// proximity-major so the furthest entry (smallest po) is the table's first key
-// and a proximity-bin's entries are contiguous. The value carries the bin
-// sequence (to address the matching `Replay` row on removal) and the precise
-// stamp (so `get` and inclusion proofs use the exact admitting stamp).
+// One row per stamped entry; the reserve size is this table's count. Keyed
+// proximity-major so the furthest entry (smallest po) is the first key and a
+// bin's entries are contiguous.
 table!(pub(crate) Entry, "reserve_entry", EntryKey, EntryValue, compressed = false);
 
-// Batch grouping: `(batch, po, addr, stampHash) -> ()`.
-//
-// One row per stamped entry, batch-major then bin then address, so a prefix
-// cursor over a batch yields its entries bin-ascending for batch eviction.
+// Batch grouping: `(batch, po, addr, stampHash) -> ()`. Batch-major then bin then
+// address, so a prefix cursor over a batch yields its entries bin-ascending for
+// batch eviction.
 table!(pub(crate) BatchGroup, "reserve_batch_group", BatchGroupKey, (), compressed = false);
 
-// Insertion-order replay: `(bin, binid) -> ReplayValue`.
-//
-// The append-only per-bin index a redistribution/sync consumer replays. Keyed
-// `(bin, binid)` big-endian so a bin's rows are contiguous and ascending by
-// sequence. The value projects what a consumer needs without a body read.
+// Insertion-order replay: `(bin, binid) -> ReplayValue`. Append-only per-bin
+// index a redistribution/sync consumer replays; keyed so a bin's rows are
+// contiguous and ascending by sequence.
 table!(pub(crate) Replay, "reserve_replay", ReplayKey, ReplayValue, compressed = false);
 
-// Per-bin insertion cursor: `bin -> u64`.
-//
-// The highest sequence assigned in each bin so far; the next insertion writes
-// `cursor + 1`. Never rewound on eviction, so its value is the lifetime count
-// of entries ever admitted to the bin and sequences are never reused (the
-// guarantee a sync consumer's resume point depends on). Exhausting the `u64`
-// would require more than 1.8e19 admissions into a single bin, which is
-// unreachable in any node lifetime; the increment site in `store::put` surfaces
-// the impossible overflow as a hard error rather than wrapping (see there).
+// Per-bin insertion cursor: `bin -> u64`. Highest sequence assigned in each bin;
+// next insertion writes `cursor + 1`. Never rewound on eviction, so sequences are
+// never reused (the guarantee a sync consumer's resume point depends on). The
+// increment in `store::put` surfaces overflow as a hard error rather than
+// wrapping.
 table!(pub(crate) BinCounter, "reserve_bin_counter", BinKey, u64, compressed = false);
 
-// Stamp-index arbiter slot: `(batch, stampIndex_be8) -> (timestamp, stampHash,
-// addr)`.
-//
-// This is *the* postage stamp-index table. The reserve does not re-invoke
-// `table!` to declare a second type-level handle to the same physical table
-// (which would be free to drift in name or value codec and silently
-// desynchronise the on-disk slot): it imports the single `StampIndexTable`
-// handle the postage crate (PR-C) owns and re-exports. The name and the
-// `(key, value)` codec binding therefore live in exactly one place. The reserve
-// only changes *when* it is written: rather than calling `DbStampIndexArbiter`,
-// it runs the same `decide` arbitration *inside* its own atomic put transaction
-// so admission and the six-table write commit together.
+// Stamp-index arbiter slot is the `StampIndexTable` handle owned by the postage
+// crate. The reserve only controls *when* it is written: it runs `decide`
+// arbitration inside its own atomic put so admission and the six-table write
+// commit together.
 
-// -------------------------------------------------------------------------
-// Key newtypes and value records.
-// -------------------------------------------------------------------------
-
-/// Newtype key wrapping a [`Bin`] for [`BinCounter`].
-///
-/// [`Bin`] is a foreign (nectar) type, so the vertex-storage codecs cannot be
-/// implemented for it directly (orphan rule). Carries the single-byte encoding.
+/// Newtype key wrapping a [`Bin`] for [`BinCounter`] (orphan rule: [`Bin`] is a
+/// foreign type, so codecs cannot be implemented on it directly).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct BinKey(pub u8);
 
@@ -110,24 +72,19 @@ impl Decode for BinKey {
     }
 }
 
-/// The refcounted content payload value: `(refcnt, typed_bytes)`.
-///
-/// `typed_bytes` is the type-tagged [`AnyChunk`] encoding (no stamp), shared by
-/// every stamped entry of the content. `refcnt` is the number of live entries
-/// referencing it; the row is deleted when it reaches zero.
+/// Refcounted content payload value. `typed_bytes` is the type-tagged
+/// [`AnyChunk`] encoding (no stamp), shared across referencing entries.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PayloadValue {
-    /// Number of live stamped entries referencing this content.
+    /// Live entries referencing this content; the row is deleted at zero.
     pub(crate) refcnt: u64,
-    /// The type-tagged chunk body, shared across all referencing entries.
     pub(crate) typed_bytes: Vec<u8>,
 }
 
 /// Compound key `(po, batch, stampHash, addr)` for [`Entry`].
 ///
-/// Big-endian `[po: 1][batch: 32][stampHash: 32][addr: 32]` (97 bytes): the byte
-/// order is proximity-major, so the globally furthest entry (smallest po) is the
-/// table's first key and a proximity bin's entries are contiguous.
+/// Big-endian `[po: 1][batch: 32][stampHash: 32][addr: 32]` (97 bytes),
+/// proximity-major: the furthest entry (smallest po) is the table's first key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct EntryKey {
     pub(crate) po: u8,
@@ -177,28 +134,24 @@ impl Decode for EntryKey {
     }
 }
 
-/// The per-entry value: the bin sequence the entry landed at, plus the precise
-/// stamp the entry was admitted with (canonical 113-byte encoding).
+/// Per-entry value: the bin sequence the entry landed at plus its exact admitting
+/// stamp (canonical 113-byte encoding).
 ///
-/// The stamp is stored *per entry*, not in the shared payload, because distinct
-/// entries of the same content carry distinct stamps. Holding the exact stamp
-/// lets [`get`](crate::DbReserve) reconstruct a stamped chunk and lets a
-/// later inclusion proof carry the precise stamp the slot was won with, rather
-/// than re-loading one by batch id alone.
+/// The stamp is stored per entry, not in the shared payload, because distinct
+/// entries of the same content carry distinct stamps; this lets
+/// [`get`](crate::DbReserve) reconstruct a stamped chunk and lets an inclusion
+/// proof carry the precise stamp the slot was won with.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct EntryValue {
-    /// The bin and sequence this entry occupies in [`Replay`].
     pub(crate) bin: u8,
     pub(crate) binid: u64,
-    /// The exact admitting stamp, canonical 113-byte encoding.
     pub(crate) stamp_bytes: Vec<u8>,
 }
 
 /// Compound key `(batch, po, addr, stampHash)` for [`BatchGroup`].
 ///
-/// Big-endian `[batch: 32][po: 1][addr: 32][stampHash: 32]` (97 bytes): grouped
-/// by batch then bin then address, so a batch's entries are a contiguous prefix
-/// ascending by bin.
+/// Big-endian `[batch: 32][po: 1][addr: 32][stampHash: 32]` (97 bytes): a batch's
+/// entries are a contiguous prefix ascending by bin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct BatchGroupKey {
     pub(crate) batch: BatchId,
@@ -250,8 +203,8 @@ impl Decode for BatchGroupKey {
 
 /// Compound key `(bin, binid)` for [`Replay`].
 ///
-/// Big-endian `[bin: 1][binid: 8]` so a bin's rows are contiguous and ascending
-/// by sequence, exactly the order the bin scan walks.
+/// Big-endian `[bin: 1][binid: 8]`: a bin's rows are contiguous and ascending by
+/// sequence, the order the bin scan walks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub(crate) struct ReplayKey {
     pub(crate) bin: u8,
@@ -287,32 +240,27 @@ impl Decode for ReplayKey {
     }
 }
 
-/// The insertion-order replay value: a flat projection of the stamped entry that
-/// landed at a `(bin, binid)`, including the chunk type so a sampler resolves the
-/// CAC-beats-SOC tie without a body read.
+/// Flat projection of the stamped entry at a `(bin, binid)`, including the chunk
+/// type so a sampler resolves the CAC-beats-SOC tie without a body read.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ReplayValue {
     pub(crate) address: ChunkAddress,
     pub(crate) batch_id: BatchId,
     pub(crate) stamp_hash: B256,
-    /// The chunk type id ([`ChunkTypeId::as_u8`]): 0 = content, 1 = single-owner.
+    /// Chunk type id ([`ChunkTypeId::as_u8`]): 0 = content, 1 = single-owner.
     pub(crate) chunk_type: u8,
 }
 
-/// A stable hash of the exact stamp version that admitted an entry.
+/// Stable hash of the exact stamp version that admitted an entry.
 ///
-/// Keccak over the stamp's canonical 113-byte serialization, so a re-stamp of
-/// the same content under a different batch/index/timestamp yields a different
-/// hash. The stamp-entry identity is `(batchID, stampIndex, address)`, but the
-/// stamp hash is a compact, collision-resistant stand-in carried in the index
-/// rows and is what a consumer compares to detect a re-stamp.
+/// Keccak over the stamp's canonical 113-byte serialization, so a re-stamp under
+/// a different batch/index/timestamp yields a different hash. Carried in the index
+/// rows as a compact stand-in a consumer compares to detect a re-stamp.
 pub(crate) fn stamp_hash(stamp: &Stamp) -> B256 {
     keccak256(stamp.to_bytes())
 }
 
-// ---------------------------------------------------------------------------
 // Key-codec ordering tests (pure, no database).
-// ---------------------------------------------------------------------------
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -325,7 +273,6 @@ mod key_codec_tests {
 
     #[test]
     fn entry_key_round_trips_and_orders_proximity_major() {
-        // Round-trip.
         let k = EntryKey::new(
             7,
             BatchId::repeat_byte(0x11),
@@ -334,8 +281,7 @@ mod key_codec_tests {
         );
         assert_eq!(EntryKey::decode(k.encode().as_ref()).unwrap(), k);
 
-        // Proximity-major: a smaller po sorts first regardless of the trailing
-        // fields, so `first()` over the table is always the furthest entry.
+        // Smaller po sorts first regardless of trailing fields.
         let far = EntryKey::new(
             1,
             BatchId::repeat_byte(0xff),
@@ -371,7 +317,6 @@ mod key_codec_tests {
         );
         assert_eq!(BatchGroupKey::decode(k.encode().as_ref()).unwrap(), k);
 
-        // A batch's entries are a contiguous prefix, ascending by bin.
         let batch = BatchId::repeat_byte(0x07);
         let lo = BatchGroupKey::new(batch, 1, ChunkAddress::from([0u8; 32]), B256::ZERO).encode();
         let hi = BatchGroupKey::new(batch, 2, ChunkAddress::from([0u8; 32]), B256::ZERO).encode();

--- a/crates/swarm/storer/src/db_reserve/store.rs
+++ b/crates/swarm/storer/src/db_reserve/store.rs
@@ -1,6 +1,6 @@
-//! The [`DbReserve`] store: its construction and accessors, and the storage
-//! lattice implementations (`SwarmLocalStore`, `ReserveStore`, `BinCursorStore`)
-//! plus the lazy bin-scan iterator.
+//! The [`DbReserve`] store: construction, accessors, and the storage lattice
+//! impls (`SwarmLocalStore`, `ReserveStore`, `BinCursorStore`) plus the lazy
+//! bin-scan iterator.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -33,47 +33,30 @@ use super::tx::{
 
 /// Persisting, proximity-ordered, per-stamped-entry reserve.
 ///
-/// Owns a shared database handle (so the payload and all index rows commit in
-/// one transaction), an [`AdmissionValidator`] (validate-on-ingest), a
-/// [`BatchStore`] (to load the batch a stamp references for validation), the
-/// capacity/eviction [`Reserve`] counter, the local overlay and the storage
-/// radius. Implements the storage lattice [`SwarmLocalStore`] ->
-/// [`ReserveStore`] -> [`BinCursorStore`].
+/// Implements the storage lattice [`SwarmLocalStore`] -> [`ReserveStore`] ->
+/// [`BinCursorStore`]. The payload and all index rows commit in one transaction
+/// per operation via the shared database handle.
 pub struct DbReserve<DB: Database, BS: BatchStore> {
-    /// Shared database handle: the payload and every secondary row are written
-    /// in one transaction per operation.
     db: Arc<DB>,
-    /// Validate-on-ingest admission for stamped chunks (PR-A).
+    /// Validate-on-ingest admission for stamped chunks.
     admission: AdmissionValidator,
-    /// The batch store the admission path reads to load a stamp's batch.
+    /// Loads the batch a stamp references, and the live [`PostageContext`].
     batches: BS,
-    /// Confirmation context cache is the validator's; the batch store provides
-    /// the live [`PostageContext`] on each put.
-    /// Capacity counter; see [`Reserve`]. The authoritative size is the [`Entry`]
-    /// table count, but the in-memory counter is kept in step for cheap reads.
+    /// In-memory size counter, kept in step with the authoritative [`Entry`]
+    /// table count for cheap reads.
     reserve: Reserve,
-    /// Local overlay address, resolved once at construction.
     overlay: OverlayAddress,
-    /// Current storage-responsibility radius, behind a cheap lock-free cell.
+    /// Current storage-responsibility radius (a single `0..=MAX_PO` byte).
     ///
-    /// The radius is the consensus-load-bearing output of the size-driven
-    /// dynamics ([`crate::radius`]): the [`RadiusController`](crate::RadiusController)
-    /// applies a new value via [`set_storage_radius`](Self::set_storage_radius)
-    /// as the reserve fills or drains, and [`storage_radius`](ReserveStore::storage_radius)
-    /// reads it. A single byte (`0..=MAX_PO`) is all the radius ever is, so an
-    /// [`AtomicU8`] is both the cheapest write target and a lock-free read on the
-    /// hot `is_responsible_for` path; `Relaxed` ordering suffices because the
-    /// radius carries no happens-before relationship with other reserve state
-    /// (callers that need a consistent (radius, occupancy) pair re-derive the
-    /// radius from the occupancy themselves).
+    /// `Relaxed` suffices: the radius carries no happens-before relationship
+    /// with other reserve state, so callers needing a consistent
+    /// (radius, occupancy) pair re-derive the radius from the occupancy.
     radius: AtomicU8,
 }
 
 impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
-    /// Construct a per-entry reserve over a shared database.
-    ///
-    /// Ensures all six tables exist, threads the identity through [`Reserve`] for
-    /// the overlay, and initialises the in-memory size from the persisted
+    /// Construct a per-entry reserve over a shared database, ensuring all six
+    /// tables exist and initialising the in-memory size from the persisted
     /// [`Entry`] table (per-entry count, not per-address).
     pub fn new(
         db: Arc<DB>,
@@ -96,7 +79,6 @@ impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
 
         let overlay = identity.overlay_address();
         let reserve = Reserve::with_strategy(capacity, strategy).with_identity(identity);
-        // Per-entry size: initialise from the Entry table count.
         let size = db.view(|tx| tx.count::<Entry>())? as u64;
         reserve.set_count(size);
 
@@ -110,12 +92,9 @@ impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
         })
     }
 
-    /// Read the current radius cell back into a [`StorageRadius`].
-    ///
-    /// The cell only ever holds a value written from a [`StorageRadius`] (a valid
-    /// `0..=MAX_PO` bin), so the `Bin::try_from` reconstruction never fails; the
-    /// `unwrap_or(StorageRadius::ZERO)` is a total fallback that keeps the read
-    /// infallible rather than panicking on a value the cell cannot hold.
+    /// Read the radius cell back into a [`StorageRadius`]. The cell only ever
+    /// holds a valid `0..=MAX_PO` bin, so the fallback is unreachable but keeps
+    /// the read infallible.
     fn load_radius(&self) -> StorageRadius {
         let raw = self.radius.load(Ordering::Relaxed);
         Bin::try_from(raw)
@@ -123,36 +102,23 @@ impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
             .unwrap_or(StorageRadius::ZERO)
     }
 
-    /// Apply a new storage-responsibility radius.
-    ///
-    /// This is the write seam the size-driven dynamics ([`crate::radius`]) feed:
-    /// the [`RadiusController`](crate::RadiusController) derives the radius from
-    /// the reserve's occupancy against its capacity and calls this to commit it,
-    /// after which [`storage_radius`](ReserveStore::storage_radius) and
-    /// [`is_responsible_for`](ReserveStore::is_responsible_for) observe the new
-    /// value. Committing the radius is a single relaxed atomic store; it does not
-    /// itself move any chunk (the controller sheds bins through the eviction
-    /// verbs before narrowing responsibility), so it never blocks or fails.
-    ///
-    /// Exposed both as this inherent method and through the
-    /// [`SettableRadius`](vertex_swarm_api::SettableRadius) extension trait so the
-    /// control loop can target it either concretely or generically over a
-    /// [`ReserveStore`].
+    /// Apply a new storage-responsibility radius (a single relaxed atomic
+    /// store). The controller sheds bins via the eviction verbs before
+    /// narrowing responsibility, so this moves no chunk and never fails. Also
+    /// exposed via the [`SettableRadius`](vertex_swarm_api::SettableRadius)
+    /// trait for generic callers.
     pub fn set_storage_radius(&self, radius: StorageRadius) {
         self.radius.store(radius.get(), Ordering::Relaxed);
     }
 
-    /// The local overlay address.
     fn overlay(&self) -> OverlayAddress {
         self.overlay
     }
 
-    /// The proximity order of a chunk address relative to the local overlay.
     fn po_of(&self, address: &ChunkAddress) -> u8 {
         address.proximity(&self.overlay).get()
     }
 
-    /// The bin a chunk address falls into relative to the local overlay.
     fn bin_of(&self, address: &ChunkAddress) -> Bin {
         address.bin(&self.overlay)
     }
@@ -181,42 +147,32 @@ impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
     }
 }
 
-/// The batch-store reads on the synchronous `put` path. These map the typed
-/// [`BatchStore::Error`] straight into [`SwarmError::storage`], which preserves
-/// it as the diagnostic source; that conversion needs the error to be
-/// `Send + Sync + 'static`, so it is the only bound this seam adds (on the
-/// associated error, never on the store itself).
+/// Batch-store reads on the synchronous `put` path. The typed
+/// [`BatchStore::Error`] maps into [`SwarmError::storage`] (preserved as the
+/// diagnostic source), which requires the `Send + Sync + 'static` bound on the
+/// associated error.
 impl<DB: Database, BS: BatchStore> DbReserve<DB, BS>
 where
     BS::Error: Send + Sync + 'static,
 {
     /// Load the batch a stamp references, returning `None` if unknown.
-    ///
-    /// [`BatchStore`] is synchronous, so the read is a direct call on the
-    /// `put` path with no executor or bridge.
     fn load_batch(&self, batch_id: &BatchId) -> SwarmResult<Option<nectar_postage::Batch>> {
         self.batches.get(batch_id).map_err(SwarmError::storage)
     }
 
-    /// The current postage context from the batch store.
     fn context(&self) -> SwarmResult<PostageContext> {
         self.batches.context().map_err(SwarmError::storage)
     }
 }
 
-// The storage lattice (`SwarmLocalStore: Send + Sync`) requires the store to be
-// shareable across the node's async tasks, so the lattice impls keep the
-// `BS: Send + Sync` bound. This is the lattice's own threading contract, not the
-// async-trait colouring the sync-core change removed: `BatchStore` is now
-// synchronous, but `DbReserve` is still held behind a shared handle and read
-// from several tasks. The `BS::Error` bound is what lets the typed batch-store
-// error map into `SwarmError::storage` on the `put` path.
+// `SwarmLocalStore: Send + Sync` requires the store to be shareable across the
+// node's async tasks, hence the `BS: Send + Sync` bound. The `BS::Error` bound
+// lets the typed batch-store error map into `SwarmError::storage` on `put`.
 impl<DB: Database, BS: BatchStore + Send + Sync> SwarmLocalStore for DbReserve<DB, BS>
 where
     BS::Error: Send + Sync + 'static,
 {
     fn put(&self, chunk: CachedChunk) -> SwarmResult<()> {
-        // The reserve is always stamped: a stampless put is invalid.
         let address = *chunk.address();
         let (any, stamp) = chunk.into_parts();
         let stamp = stamp.ok_or_else(|| SwarmError::InvalidChunk {
@@ -224,10 +180,8 @@ where
             reason: "reserve put requires a stamp; a stampless put is invalid".into(),
         })?;
 
-        // --- validate-on-ingest (PR-A) --------------------------------------
-        // Load the batch and validate the stamp before any write. A stamp for an
-        // unknown batch, or one that fails structural/signature checks, is
-        // rejected and nothing is written.
+        // Validate the stamp against its batch before any write. An unknown
+        // batch or a failed structural/signature check rejects without writing.
         let batch = self
             .load_batch(&stamp.batch())?
             .ok_or_else(|| SwarmError::InvalidChunk {
@@ -242,7 +196,6 @@ where
                 reason: format!("stamp failed admission: {e}"),
             })?;
 
-        // Project the per-entry data.
         let hash = stamp_hash(&stamp);
         let po = self.po_of(&address);
         let bin = self.bin_of(&address);
@@ -258,20 +211,16 @@ where
             address,
         );
 
-        // --- arbitrate + write, atomically ----------------------------------
         let outcome = self
             .db
             .update(|tx| {
                 // Newest-wins arbitration against the full (batch, stampIndex)
-                // slot, evaluated inside this transaction so the slot cannot
-                // change between the read and the conditional write.
+                // slot, inside the tx so the slot cannot change between the read
+                // and the conditional write.
                 let stored = tx.get::<StampIndexTable>(slot)?;
                 match decide(stored.as_ref(), &incoming) {
                     Arbitration::Reject { .. } => Ok(PutOutcome::Rejected),
                     Arbitration::Admit { displaced } => {
-                        // Restamp: the slot held an older stamp for this slot.
-                        // Delete the four rows of the displaced entry and
-                        // decrement its payload before writing the new entry.
                         if let Some(d) = displaced {
                             let target = EvictTarget {
                                 batch: incoming.batch_id,
@@ -279,29 +228,20 @@ where
                                 addr: d.address,
                             };
                             // A restamp may re-point the slot at a DIFFERENT
-                            // content address, whose proximity order (and hence
-                            // po-major Entry/BatchGroup key) differs from the
-                            // incoming chunk's `po`. Delete the displaced rows
-                            // using the displaced address's own proximity, never
-                            // the incoming chunk's, or the lookup misses and the
-                            // displaced rows are orphaned with a leaked refcount.
+                            // content address whose proximity order differs from
+                            // the incoming chunk's. Delete the displaced rows
+                            // under the displaced address's own proximity, or the
+                            // lookup misses and the rows leak a refcount.
                             let displaced_po = self.po_of(&d.address);
-                            let removed = delete_entry_rows_in_tx(tx, displaced_po, &target)?;
-                            // The slot occupant is overwritten below; do not
-                            // touch BinCounter (monotonic).
-                            let _ = removed;
+                            let _ = delete_entry_rows_in_tx(tx, displaced_po, &target)?;
                         }
 
-                        // Assign the next bin sequence and write Replay. The
-                        // counter is monotonic and never rewound on eviction, so
-                        // its value is the count of entries ever admitted to this
-                        // bin. Exhausting a u64 requires more than 1.8e19 puts
-                        // into a single bin, which is unreachable in any node
-                        // lifetime (over half a million years at one million puts
-                        // per second). A silent wrap would reuse sequence 0 and
+                        // BinCounter is monotonic and never rewound on eviction,
+                        // so its value is the count of entries ever admitted to
+                        // this bin. A silent wrap would reuse sequence 0 and
                         // overwrite a live Replay row, corrupting sync cursor
-                        // ordering and resumability, so the overflow is surfaced
-                        // as a hard error rather than wrapped.
+                        // ordering, so overflow is a hard error (unreachable: a
+                        // u64 outlasts any node lifetime).
                         let next = tx
                             .get::<BinCounter>(BinKey::from_bin(bin))?
                             .unwrap_or(0)
@@ -323,7 +263,6 @@ where
                             },
                         )?;
 
-                        // Entry + BatchGroup.
                         tx.put::<Entry>(
                             EntryKey::new(po, incoming.batch_id, hash, address),
                             EntryValue {
@@ -337,10 +276,8 @@ where
                             (),
                         )?;
 
-                        // Refcounted payload: bump if present, else write body.
                         bump_or_insert_payload(tx, address, &typed_bytes)?;
 
-                        // Update the arbiter slot to the incoming stamp.
                         tx.put::<StampIndexTable>(slot, incoming.entry())?;
 
                         Ok(if displaced.is_some() {
@@ -354,8 +291,8 @@ where
             .map_err(storage_err)?;
 
         match outcome {
-            // A new entry: size grows by one. A restamp displaced one entry and
-            // added one, so the size is unchanged. A reject writes nothing.
+            // Restamp is size-neutral (one displaced, one added); reject writes
+            // nothing.
             PutOutcome::Admitted => self.reserve.on_added(),
             PutOutcome::Restamped | PutOutcome::Rejected => {}
         }
@@ -363,21 +300,15 @@ where
     }
 
     fn get(&self, address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
-        // Return the chunk with its NEWEST valid stamp. The content body lives in
-        // the refcounted payload; the stamps live per entry. The newest stamp is
-        // the one with the greatest timestamp among this address's entries. (A
-        // chunk under N batches has up to N entries here; document: get resolves
-        // the single newest. Per-entry/per-stamp access is via the bin scan.)
+        // Resolve the chunk with its newest stamp (greatest timestamp). The body
+        // is the refcounted payload; stamps are per entry. An address under N
+        // batches has up to N entries; per-entry access is via the bin scan.
         let result = self.db.view(|tx| {
             let Some(payload) = tx.get::<Payload>(*address)? else {
                 return Ok(None);
             };
-            // Find the newest stamp across this address's entries by scanning the
-            // proximity-keyed Entry table is O(n); instead read entries grouped
-            // by address is not directly keyed, so walk this address's entries by
-            // probing every (po) is unnecessary: the address pins the po, so the
-            // entries for an address share one po prefix and differ by (batch,
-            // stampHash). Walk that contiguous sub-range.
+            // The address pins the po, so its entries share one po prefix and
+            // differ by (batch, stampHash). Walk that contiguous sub-range.
             let po = address.proximity(&self.overlay).get();
             let mut cursor = tx.cursor::<Entry>()?;
             let mut best: Option<(u64, Vec<u8>)> = None;
@@ -407,30 +338,28 @@ where
             Some(v) => v,
         };
         let Some((_, stamp_bytes)) = best else {
-            // Payload present but no entry: should not happen (refcount
-            // invariant), treat as absent.
+            // Payload without an entry violates the refcount invariant; treat as
+            // absent.
             return Ok(None);
         };
         let stamp = decode_stamp(&stamp_bytes).map_err(|e| SwarmError::InvalidChunk {
             address: Some(*address),
             reason: format!("stored entry stamp failed to decode: {e}"),
         })?;
-        // Recombine the shared body with the newest stamp and decode.
         let stamped = StampedChunk::new(decode_body(address, &typed_bytes)?, stamp);
         Ok(Some(CachedChunk::from(stamped)))
     }
 
     fn contains(&self, address: &ChunkAddress) -> bool {
-        // Present iff a payload row exists (refcount >= 1). A backend error is
-        // treated as "not present" per the infallible contract.
+        // Present iff a payload row exists. A backend error reads as "not
+        // present" per the infallible contract.
         self.db
             .view(|tx| Ok(tx.get::<Payload>(*address)?.is_some()))
             .unwrap_or(false)
     }
 
     fn remove(&self, address: &ChunkAddress) -> SwarmResult<()> {
-        // Remove EVERY stamped entry for the address (and the shared payload).
-        // Collect the entries first (read cursor), then delete in one tx.
+        // Remove every stamped entry for the address and the shared payload.
         let targets = self.entries_for_address(address)?;
         let _ = self.evict_entries(&targets)?;
         Ok(())
@@ -439,8 +368,8 @@ where
 
 impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
     /// Collect every stamped entry for an address (its `(batch, stampHash)`
-    /// pairs), for a full removal. The address pins the proximity order, so the
-    /// entries are a contiguous sub-range of the `po` prefix.
+    /// pairs). The address pins the proximity order, so the entries are a
+    /// contiguous sub-range of the `po` prefix.
     fn entries_for_address(&self, address: &ChunkAddress) -> SwarmResult<Vec<EvictTarget>> {
         let po = self.po_of(address);
         let mut targets = Vec::new();
@@ -484,7 +413,6 @@ where
     }
 
     fn count(&self) -> SwarmResult<u64> {
-        // Per-entry size: the Entry table count.
         Ok(self
             .db
             .view(|tx| tx.count::<Entry>())
@@ -496,9 +424,8 @@ where
     }
 
     fn count_in(&self, po: ProximityOrder) -> SwarmResult<u64> {
-        // Cursor range over the Entry `(po, ...)` prefix: every entry at this
-        // proximity order is contiguous (po is the leading key byte), so seek to
-        // the first key at this po and count forward while po stays equal.
+        // po is the leading Entry key byte, so entries at this po are contiguous:
+        // seek and count forward while po stays equal.
         let target = po.get();
         let tx = self.db.tx().map_err(storage_err)?;
         let mut cursor = tx.cursor::<Entry>().map_err(storage_err)?;
@@ -522,9 +449,8 @@ where
     }
 
     fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>> {
-        // The furthest entry is the one with the smallest proximity order; the
-        // Entry table is keyed `[po][...]`, so `first()` is that entry in
-        // O(log n). Eviction is per-entry: a single furthest stamped entry goes.
+        // The furthest entry has the smallest po; the Entry table is keyed
+        // `[po][...]`, so `first()` is that entry. Per-entry eviction: one goes.
         let target = {
             let tx = self.db.tx().map_err(storage_err)?;
             let mut cursor = tx.cursor::<Entry>().map_err(storage_err)?;
@@ -551,11 +477,9 @@ where
         if max == 0 {
             return Ok(0);
         }
-        // Collect up to `max` entries in this proximity bin via the Entry `[po]`
-        // prefix, then delete them in one atomic tx. The Entry table is keyed by
-        // proximity-order-to-overlay; for the reserve a `Bin` *is* that proximity
-        // order (see `ReserveStore`), so cross the boundary explicitly here rather
-        // than punning the byte.
+        // Collect up to `max` entries in this bin via the Entry `[po]` prefix,
+        // then delete in one atomic tx. For the reserve a `Bin` is the proximity
+        // order, so cross the boundary explicitly rather than punning the byte.
         let target = po_of_reserve_bin(bin);
         let mut targets: Vec<EvictTarget> = Vec::new();
         {
@@ -592,10 +516,10 @@ where
             return Ok(0);
         }
         // Collect up to `max` of the batch's entries via the BatchGroup
-        // `[batch][po][addr][stampHash]` prefix. A `Some(b)` bound (bins strictly
-        // shallower than `b`) is a contiguous front slice: stop as soon as po >=
-        // b. Then delete in one atomic tx. The bound is a reserve `Bin`, i.e. a
-        // proximity-order-to-overlay; cross to the keyed proximity order explicitly.
+        // `[batch][po][addr][stampHash]` prefix, then delete in one atomic tx. A
+        // `Some(b)` bound selects bins strictly shallower than `b`, a contiguous
+        // front slice: stop as soon as po >= b. The bound is a reserve `Bin`;
+        // cross to the keyed proximity order explicitly.
         let bound = up_to_bin.map(po_of_reserve_bin);
         let mut targets: Vec<EvictTarget> = Vec::new();
         {
@@ -636,8 +560,6 @@ where
     BS::Error: Send + Sync + 'static,
 {
     fn set_storage_radius(&self, radius: StorageRadius) {
-        // Delegates to the inherent method (the same write the controller's apply
-        // path takes); the trait exposes that write generically over a reserve.
         DbReserve::set_storage_radius(self, radius);
     }
 }
@@ -660,9 +582,9 @@ where
         bin: Bin,
         start_seq: u64,
     ) -> SwarmResult<Box<dyn Iterator<Item = SwarmResult<BinScanItem>> + Send + 'a>> {
-        // Lazy cursor over Replay: seek to `(bin, start_seq)` and stream forward
-        // while the key's bin stays equal. The cursor owns its read snapshot, so
-        // the iterator outlives this call.
+        // Seek to `(bin, start_seq)` and stream forward while the key's bin stays
+        // equal. The cursor owns its read snapshot, so the iterator outlives this
+        // call.
         let tx = self.db.tx().map_err(storage_err)?;
         let mut cursor = tx.cursor::<Replay>().map_err(storage_err)?;
         let seek = cursor

--- a/crates/swarm/storer/src/db_reserve/tx.rs
+++ b/crates/swarm/storer/src/db_reserve/tx.rs
@@ -1,7 +1,7 @@
-//! The per-entry transaction primitives: the refcount bump/decrement, the
-//! entry-row and full-entry deletes, and the small decode and error helpers
-//! they share. Every function here runs inside a caller-provided transaction so
-//! a stamped entry and its index rows commit atomically.
+//! Per-entry transaction primitives: refcount bump/decrement, entry-row and
+//! full-entry deletes, and shared decode/error helpers. Each runs inside a
+//! caller-provided transaction so a stamped entry and its index rows commit
+//! atomically.
 
 use nectar_postage::Stamp;
 use nectar_primitives::ChunkAddress;
@@ -17,8 +17,8 @@ use super::schema::{
 
 /// Bump the refcount of an existing payload, or insert it with refcount 1.
 ///
-/// Content-addressed: a second stamped entry of the same content shares the body
-/// and increments the refcount; the body is never rewritten while present.
+/// Content-addressed: a second stamped entry of the same content shares the body;
+/// the body is never rewritten while present.
 pub(crate) fn bump_or_insert_payload<T: DbTxMut>(
     tx: &T,
     address: ChunkAddress,
@@ -42,10 +42,8 @@ pub(crate) fn bump_or_insert_payload<T: DbTxMut>(
     Ok(())
 }
 
-/// Decrement the refcount of a payload, deleting the body when it reaches zero.
-///
-/// The shared body survives partial eviction: it is dropped only when the last
-/// stamped entry referencing it is removed.
+/// Decrement the refcount of a payload, deleting the body when it reaches zero
+/// (the last stamped entry referencing it).
 pub(crate) fn dec_payload<T: DbTxMut>(tx: &T, address: ChunkAddress) -> Result<(), DatabaseError> {
     if let Some(mut p) = tx.get::<Payload>(address)? {
         if p.refcnt <= 1 {
@@ -58,13 +56,12 @@ pub(crate) fn dec_payload<T: DbTxMut>(tx: &T, address: ChunkAddress) -> Result<(
     Ok(())
 }
 
-/// Delete the four index rows of one stamped entry (`Entry`, `BatchGroup`,
-/// `Replay`) and decrement the shared payload, without touching the arbiter slot
-/// or the BinCounter. Returns whether the entry existed.
+/// Delete one stamped entry's index rows (`Entry`, `BatchGroup`, `Replay`) and
+/// decrement the shared payload, leaving the arbiter slot and BinCounter
+/// untouched. Returns whether the entry existed.
 ///
-/// Used both by the restamp path (displacing the older entry, slot rewritten by
-/// the caller) and by `delete_entry_in_tx` (full removal, which also clears the
-/// slot).
+/// The slot is the caller's responsibility: the restamp path rewrites it,
+/// [`delete_entry_in_tx`] clears it.
 pub(crate) fn delete_entry_rows_in_tx<T: DbTxMut>(
     tx: &T,
     po: u8,
@@ -74,7 +71,6 @@ pub(crate) fn delete_entry_rows_in_tx<T: DbTxMut>(
     let Some(value) = tx.get::<Entry>(entry_key)? else {
         return Ok(false);
     };
-    // Replay row, addressed by the entry's stored (bin, binid).
     tx.delete::<Replay>(ReplayKey::new(value.bin, value.binid))?;
     tx.delete::<BatchGroup>(BatchGroupKey::new(
         target.batch,
@@ -87,9 +83,9 @@ pub(crate) fn delete_entry_rows_in_tx<T: DbTxMut>(
     Ok(true)
 }
 
-/// Fully delete a stamped entry: its four index rows, the shared payload
-/// decrement, AND its arbiter slot (so the slot does not pin a stale newest
-/// stamp after the entry is gone). Returns whether the entry existed.
+/// Fully delete a stamped entry: index rows, payload decrement, and its arbiter
+/// slot (so the slot does not pin a stale newest stamp after the entry is gone).
+/// Returns whether the entry existed.
 pub(crate) fn delete_entry_in_tx<T: DbTxMut>(
     tx: &T,
     overlay: &OverlayAddress,
@@ -97,9 +93,8 @@ pub(crate) fn delete_entry_in_tx<T: DbTxMut>(
 ) -> Result<bool, DatabaseError> {
     let po = target.addr.proximity(overlay).get();
     let entry_key = EntryKey::new(po, target.batch, target.stamp_hash, target.addr);
-    // Read the entry's stamp to recover its slot key (batch, stampIndex) so the
-    // arbiter slot can be cleared. The stamp index is not in the key, so it is
-    // decoded from the stored stamp bytes.
+    // Slot key (batch, stampIndex) is recovered from the stored stamp bytes; the
+    // stamp index is not part of the entry key.
     let slot = tx
         .get::<Entry>(entry_key)?
         .and_then(|v| decode_stamp(&v.stamp_bytes).ok())
@@ -107,8 +102,8 @@ pub(crate) fn delete_entry_in_tx<T: DbTxMut>(
 
     let removed = delete_entry_rows_in_tx(tx, po, target)?;
     if removed && let Some(slot) = slot {
-        // Clear the slot only if it still points at this entry's stamp hash,
-        // so a concurrent restamp's slot is not clobbered.
+        // Clear only if the slot still points at this entry's stamp hash, so a
+        // concurrent restamp's slot is not clobbered.
         if let Some(occupant) = tx.get::<StampIndexTable>(slot)?
             && occupant.stamp_hash == target.stamp_hash
         {
@@ -133,8 +128,8 @@ pub(crate) fn decode_stamp(bytes: &[u8]) -> Result<Stamp, nectar_postage::StampE
     Stamp::try_from_slice(bytes)
 }
 
-/// The big-endian timestamp embedded in a canonical stamp encoding (bytes
-/// 40..48), used to pick the newest stamp for an address without a full decode.
+/// The big-endian timestamp at bytes 40..48 of a canonical stamp encoding, used
+/// to rank stamps for an address without a full decode.
 pub(crate) fn stamp_timestamp(bytes: &[u8]) -> u64 {
     bytes
         .get(40..48)
@@ -142,8 +137,7 @@ pub(crate) fn stamp_timestamp(bytes: &[u8]) -> u64 {
         .map_or(0, u64::from_be_bytes)
 }
 
-/// Decode the shared content body (type-tagged [`AnyChunk`] bytes) for an
-/// address.
+/// Decode the shared content body (type-tagged [`AnyChunk`] bytes) for an address.
 pub(crate) fn decode_body(
     address: &ChunkAddress,
     typed_bytes: &[u8],
@@ -156,29 +150,18 @@ pub(crate) fn decode_body(
     })
 }
 
-/// The proximity order (relative to the local overlay) a reserve [`Bin`] denotes.
-///
-/// For the reserve a routing [`Bin`] and the [`ProximityOrder`] the Entry/
-/// BatchGroup tables key on are the *same* quantity measured against the local
-/// overlay (see [`ReserveStore`]); they merely have distinct nectar types because
-/// one is a slot and the other a metric, and they share the `0..=MAX_PO` range.
-/// This is the single, explicit crossing of that boundary: a `Bin` in, the
-/// proximity order it keys on out. The byte value is identical, but routing the
-/// conversion through one named helper keeps the `Bin`-vs-`ProximityOrder`
-/// conflation intentional and greppable rather than an inline `bin.get()` pun.
+/// The proximity order a reserve [`Bin`] denotes: for the reserve a routing
+/// [`Bin`] and the table-keying [`ProximityOrder`] are the same quantity
+/// measured against the local overlay. Named to keep that crossing greppable.
 ///
 /// [`Bin`]: nectar_primitives::Bin
 /// [`ProximityOrder`]: nectar_primitives::ProximityOrder
-/// [`ReserveStore`]: vertex_swarm_api::ReserveStore
 #[inline]
 pub(crate) fn po_of_reserve_bin(bin: nectar_primitives::Bin) -> u8 {
-    // A `Bin` is range-validated to `0..=MAX_PO`, which is exactly the
-    // `ProximityOrder` range, so the proximity order it denotes is its raw byte.
     bin.get()
 }
 
-/// Map a storer/database error onto the API's storage error, preserving the
-/// source.
+/// Map a storer/database error onto the API's storage error, preserving the source.
 pub(crate) fn storage_err<E>(err: E) -> SwarmError
 where
     E: std::error::Error + Send + Sync + 'static,

--- a/crates/swarm/storer/src/expiry.rs
+++ b/crates/swarm/storer/src/expiry.rs
@@ -1,95 +1,31 @@
 //! Batch-expiry driven eviction.
 //!
-//! A postage batch expires when the chain's cumulative payout per chunk catches
-//! up with the batch's per-chunk balance. Concretely, with
-//! [`PostageContext::total_amount`] the cumulative payout and [`Batch::value`]
-//! the batch's per-chunk balance, the batch is expired iff
-//! `value <= total_amount` ([`Batch::is_expired`]). As the chain advances,
-//! `total_amount` only ever increases, so expiry is monotone: once a batch is
-//! expired it stays expired.
-//!
-//! When a batch expires, every stamped entry the reserve holds under that batch
-//! is no longer paid for and must be unreserved. This module is the seam that
-//! turns the chain-side expiry signal into reserve evictions: it reads the live
-//! [`PostageContext`] and the batch set from the [`BatchStore`], decides which
-//! batches have become expired, and drives
+//! A batch is expired iff `value <= total_amount` ([`Batch::is_expired`], where
+//! `value` is [`Batch::value`] and `total_amount` is
+//! [`PostageContext::total_amount`]). `total_amount` only ever rises, so expiry
+//! is monotone. An expired batch's stamped entries are no longer paid for and
+//! must be unreserved; this module turns that chain-side signal into
 //! [`ReserveStore::evict_batch(batch, None, max)`](ReserveStore::evict_batch)
-//! over the reserve's `BatchGroup` index for each. `up_to_bin = None` evicts the
-//! *whole* batch, which is correct for expiry (an expired batch is paid for at
-//! no bin), as opposed to the radius-growth case which sheds only a batch's
-//! shallow, out-of-responsibility bins.
+//! calls, where `up_to_bin = None` evicts the whole batch.
 //!
-//! # Where the signal comes from
+//! Invariant: evict before remove. [`run`](ExpirySweep::run) only evicts batches
+//! still in the [`BatchStore`], so removing a batch before its reserve entries
+//! are evicted orphans those entries and inflates the reserve count. An `Expired`
+//! event goes through [`on_expired_event`](ExpirySweep::on_expired_event) (evict,
+//! then acknowledge removal); `run` is the backstop for value-threshold expiry
+//! and crash recovery. Both paths are idempotent.
 //!
-//! The chain indexer is out of scope (it is stubbed; see the postage crate). It
-//! reduces contract logs into [`BatchEvent`](nectar_postage::BatchEvent)s and
-//! advances the [`PostageContext`] (its `total_amount` rises as
-//! redistribution rounds pay out, and an `Expired` event removes the batch from
-//! the store).
-//!
-//! There are two paths into this module, and they have different guarantees:
-//!
-//! - **The event path (authoritative).** When the indexer delivers a
-//!   [`BatchEvent::Expired`](nectar_postage::BatchEvent::Expired) the reserve
-//!   must shed that batch's entries *before* the batch leaves the
-//!   [`BatchStore`]. [`ExpirySweep::on_expired_event`] enforces exactly this
-//!   ordering: it evicts the batch's reserve entries first and only then runs
-//!   the supplied acknowledgement (the store removal). This is the only
-//!   ordering that cannot orphan entries.
-//! - **The reconciliation path (backstop).** [`ExpirySweep::run`] samples the
-//!   *resulting state* (the batch store and its context) and evicts any batch
-//!   that is value-expired (`value <= total_amount`) but is still present in the
-//!   store. It is a backstop for value-threshold expiry the chain crossed
-//!   without (or before) an explicit `Expired` event, and for crash recovery. It
-//!   is idempotent and replay-safe: a second run at the same context evicts
-//!   nothing, because the batch's entries are already gone.
-//!
-//! # Eviction must precede removal (orphan-avoidance contract)
-//!
-//! [`run`](ExpirySweep::run) can only evict batches it can still *see* in the
-//! [`BatchStore`]: it infers the expired set from
-//! [`batch_ids`](BatchStore::batch_ids). If a batch is removed from the store
-//! before its reserve entries are evicted, those entries are orphaned - they
-//! never appear in any future `batch_ids` snapshot, so no later `run` will ever
-//! shed them. Orphaned entries inflate the reserve count, which drives the
-//! storage radius and therefore the consensus-committed depth, so this is a
-//! correctness hazard, not merely a leak.
-//!
-//! The contract is therefore: **evict before remove.** The live ingest wiring
-//! (#391/#392) must route an `Expired` event through
-//! [`on_expired_event`](ExpirySweep::on_expired_event) (evict, then acknowledge
-//! removal) rather than removing the batch from the store directly and relying on
-//! the next `run` to catch up. `run` remains correct for value-threshold expiry
-//! (where the batch is still present) and as a crash-recovery reconciliation, but
-//! it is not a substitute for the ordered event path.
-//!
-//! # Purity seam
-//!
-//! The decision - *which* of a set of batches are expired at a given
-//! `total_amount` - is the pure [`expired_batches`] function, tested in
-//! isolation. The driver [`ExpirySweep`] does the I/O (read the store, call
-//! `evict_batch`) around it.
+//! [`expired_batches`] is the pure decision; [`ExpirySweep`] drives the I/O.
 
 use nectar_postage::{Batch, BatchId, BatchStore, PostageContext};
 use vertex_swarm_api::{ReserveStore, SwarmError, SwarmResult};
 
-/// The maximum number of entries a single [`ExpirySweep::run`] will evict per
-/// batch in one call.
-///
-/// Eviction is one atomic transaction per `evict_batch` call; this bounds the
-/// transaction size so a pathologically large batch does not stall the control
-/// loop. The sweep re-runs on the next context advance, so a batch with more
-/// than `EVICT_BATCH_MAX` entries drains over successive sweeps rather than in
-/// one giant transaction.
+/// Max entries evicted per batch per `evict_batch` call. Bounds the single
+/// eviction transaction; a larger batch drains over successive sweeps.
 pub const EVICT_BATCH_MAX: u64 = 10_000;
 
-/// Decide which of the given batches are expired at `total_amount`.
-///
-/// Pure and total. `batches` yields `(BatchId, value)` pairs where `value` is
-/// the batch's per-chunk balance ([`Batch::value`]); a batch is expired iff
-/// `value <= total_amount`, matching [`Batch::is_expired`]. Returns the expired
-/// IDs in iteration order. Separated from the I/O so the rule is unit-tested
-/// without a store or a reserve.
+/// The expired IDs (`value <= total_amount`, per [`Batch::is_expired`]) from
+/// `(BatchId, value)` pairs, in iteration order.
 pub fn expired_batches<I>(batches: I, total_amount: u128) -> Vec<BatchId>
 where
     I: IntoIterator<Item = (BatchId, u128)>,
@@ -101,21 +37,17 @@ where
         .collect()
 }
 
-/// The result of one expiry sweep: which batches were evicted and how many
-/// stamped entries went with them.
+/// The outcome of one expiry sweep.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SweepReport {
-    /// The batches found expired and evicted this sweep.
     pub evicted_batches: Vec<BatchId>,
-    /// The total stamped entries removed across all evicted batches.
+    /// Total stamped entries removed across all evicted batches.
     pub evicted_entries: u64,
 }
 
 /// Drives batch-expiry eviction against a [`BatchStore`] and a [`ReserveStore`].
 ///
-/// Borrows both for the duration of a sweep; holds no state of its own, so it is
-/// cheap to construct per sweep. See the [module docs](self) for the signal and
-/// the purity seam.
+/// Borrows both, holds no state of its own, cheap to construct per sweep.
 #[derive(Debug, Clone, Copy)]
 pub struct ExpirySweep<'a, BS, R: ?Sized> {
     batches: &'a BS,
@@ -125,50 +57,28 @@ pub struct ExpirySweep<'a, BS, R: ?Sized> {
 impl<'a, BS, R> ExpirySweep<'a, BS, R>
 where
     BS: BatchStore,
-    // The synchronous [`BatchStore`] returns its own typed error; funnelling it
-    // into [`SwarmError::storage`] (whose source is a boxed
-    // `Error + Send + Sync`) requires the store's error be thread-safe. This is
-    // the same bound `DbReserve` carries on its own batch-store reads.
+    // The store error funnels into SwarmError::storage (a boxed
+    // Error + Send + Sync), so it must be thread-safe.
     BS::Error: Send + Sync + 'static,
     R: ReserveStore + ?Sized,
 {
-    /// Construct a sweep over the given batch store and reserve.
     #[must_use]
     pub const fn new(batches: &'a BS, reserve: &'a R) -> Self {
         Self { batches, reserve }
     }
 
-    /// Run one reconciliation sweep: evict every batch that is value-expired at
-    /// the store's current [`PostageContext`] *and still present in the store*.
-    ///
-    /// Reads the live context and batch set, applies [`expired_batches`] to find
-    /// the expired IDs, then calls
-    /// [`evict_batch(id, None, EVICT_BATCH_MAX)`](ReserveStore::evict_batch) for
-    /// each. Idempotent: a second run at the same context evicts nothing and
-    /// reports no batches, since an expired batch's entries are already gone (a
-    /// batch is reported only when the call actually removed entries).
-    ///
-    /// This is the **backstop** path (see the [module docs](self)): it can only
-    /// shed batches it can still see in the [`BatchStore`]. A batch removed from
-    /// the store before its entries were evicted is invisible here and would be
-    /// orphaned, so the authoritative path for an `Expired` event is
-    /// [`on_expired_event`](Self::on_expired_event), which evicts before the
-    /// store removal. Use `run` for value-threshold expiry (the batch is still
-    /// present) and crash-recovery reconciliation.
-    ///
-    /// The [`BatchStore`] surface is synchronous (its production redb backing is
-    /// synchronous and its in-memory test backing is too), so a synchronous
-    /// control loop can call this directly without any executor bridge.
+    /// Reconciliation sweep: evict every batch value-expired at the store's
+    /// current [`PostageContext`] and still present in the store. The backstop
+    /// path for value-threshold expiry and crash recovery; `Expired` events go
+    /// through [`on_expired_event`](Self::on_expired_event). Idempotent.
     pub fn run(&self) -> SwarmResult<SweepReport> {
         let context = self.context()?;
         let total_amount = context.total_amount();
 
-        // Resolve the (id, value) pairs the rule consumes from the live store.
         let ids = self.batch_ids()?;
         let mut pairs: Vec<(BatchId, u128)> = Vec::with_capacity(ids.len());
         for id in ids {
             if let Some(batch) = self.batch(&id)? {
-                // Reuse Batch::is_expired's exact predicate via the value.
                 pairs.push((id, batch.value()));
             }
         }
@@ -178,11 +88,9 @@ where
         let mut report = SweepReport::default();
         for id in expired {
             let removed = self.reserve.evict_batch(id, None, EVICT_BATCH_MAX)?;
-            // Only record a batch as swept when it actually had entries to shed.
-            // An expired batch may linger in the batch store until the indexer
-            // applies its `Expired` event, so a later sweep re-detects it as
-            // expired but finds nothing to evict; reporting it again would be
-            // misleading and would break idempotency of the report.
+            // An expired batch may linger in the store until its Expired event
+            // is applied; only report a batch that actually shed entries, so the
+            // report stays idempotent across re-detection.
             if removed > 0 {
                 report.evicted_entries = report.evicted_entries.saturating_add(removed);
                 report.evicted_batches.push(id);
@@ -192,60 +100,31 @@ where
     }
 
     /// Handle an `Expired`
-    /// [`BatchEvent`](nectar_postage::BatchEvent::Expired) in the orphan-safe
-    /// order: evict the batch's reserve entries first, then run `acknowledge`
-    /// (the batch-store removal) only once eviction has succeeded.
+    /// [`BatchEvent`](nectar_postage::BatchEvent::Expired) orphan-safely: evict
+    /// the batch's reserve entries, then run `acknowledge` (the store removal)
+    /// only once eviction succeeds.
     ///
-    /// This is the **authoritative** event path (see the [module docs](self)).
-    /// Evicting before removal is what guarantees no entry is orphaned: once the
-    /// batch leaves the [`BatchStore`] the reconciliation [`run`](Self::run) can
-    /// no longer see it, so removal must never happen first. If eviction fails
-    /// the error short-circuits and `acknowledge` is *not* run, leaving the batch
-    /// in the store so the next attempt (event redelivery or a `run` backstop)
-    /// retries cleanly rather than stranding entries.
-    ///
-    /// `acknowledge` is the caller's store-removal step (typically the indexer's
-    /// [`BatchEventHandler`](nectar_postage::BatchEventHandler) applying the
-    /// `Expired` event). Returns the number of stamped entries evicted.
-    ///
-    /// Idempotent: replaying the same `Expired` event evicts nothing the second
-    /// time (the entries are gone) and still acknowledges, so a redelivered event
-    /// is safe.
+    /// Evicting first guarantees no orphaned entry: once the batch leaves the
+    /// store [`run`](Self::run) can no longer see it. On eviction failure
+    /// `acknowledge` is not run, leaving the batch for a clean retry. Idempotent.
+    /// Returns the number of stamped entries evicted.
     pub fn on_expired_event<A, E>(&self, batch: BatchId, acknowledge: A) -> SwarmResult<u64>
     where
         A: FnOnce() -> Result<(), E>,
         E: core::error::Error + Send + Sync + 'static,
     {
-        // Evict first: while the batch is still in the store its entries are
-        // reachable by `run` as a fallback, so a failure here strands nothing.
         let removed = self.evict_expired_batch(batch)?;
-        // Only now that the reserve no longer holds the batch is it safe to drop
-        // it from the store. The acknowledgement is the caller's store removal,
-        // not a batch-store read; its error is funnelled into
-        // `SwarmError::storage` directly.
         acknowledge().map_err(SwarmError::storage)?;
         Ok(removed)
     }
 
-    /// Evict a single batch's whole footprint without touching the batch store,
-    /// the eviction primitive [`on_expired_event`](Self::on_expired_event) is
-    /// built on.
-    ///
-    /// Exposed for callers that own the store-removal ordering themselves; most
+    /// Evict a batch's whole footprint without touching the batch store. Most
     /// callers want [`on_expired_event`](Self::on_expired_event), which enforces
-    /// the evict-before-remove contract. Returns the number of stamped entries
-    /// removed.
+    /// evict-before-remove. Returns the number of stamped entries removed.
     pub fn evict_expired_batch(&self, batch: BatchId) -> SwarmResult<u64> {
         self.reserve.evict_batch(batch, None, EVICT_BATCH_MAX)
     }
 
-    /// The live [`PostageContext`], read straight from the synchronous
-    /// [`BatchStore`].
-    ///
-    /// The reserve (PR-D) and this sweep both read the [`BatchStore`] from
-    /// synchronous control paths. The store surface is itself synchronous, so the
-    /// read is a plain call whose typed error maps straight into
-    /// [`SwarmError::storage`]; there is no executor bridge.
     fn context(&self) -> SwarmResult<PostageContext> {
         self.batches.context().map_err(SwarmError::storage)
     }
@@ -273,17 +152,13 @@ mod tests {
 
     #[test]
     fn expired_iff_value_at_or_below_total_amount() {
-        // value <= total_amount expires; value > total_amount survives.
         let batches = [(id(1), 100u128), (id(2), 200), (id(3), 300)];
-        // total_amount = 200: batches with value 100 and 200 expire, 300 lives.
         let expired = expired_batches(batches, 200);
         assert_eq!(expired, vec![id(1), id(2)]);
     }
 
     #[test]
     fn boundary_equal_value_expires() {
-        // The predicate is `value <= total_amount`, so equality expires
-        // (matches Batch::is_expired), it does not survive.
         assert_eq!(expired_batches([(id(1), 500u128)], 500), vec![id(1)]);
         assert_eq!(
             expired_batches([(id(1), 501u128)], 500),
@@ -299,15 +174,12 @@ mod tests {
 
     #[test]
     fn monotone_in_total_amount() {
-        // As total_amount rises the expired set only grows (chain payout is
-        // monotone), so expiry never un-expires a batch.
         let batches = [(id(1), 100u128), (id(2), 200), (id(3), 300)];
         let lo = expired_batches(batches, 150);
         let hi = expired_batches(batches, 250);
         assert_eq!(lo, vec![id(1)]);
         assert_eq!(hi, vec![id(1), id(2)]);
-        // Every batch expired at the lower threshold is still expired at the
-        // higher one.
+        // Never un-expires: the lower set is contained in the higher.
         for b in &lo {
             assert!(hi.contains(b));
         }
@@ -315,8 +187,8 @@ mod tests {
 
     #[test]
     fn agrees_with_batch_is_expired() {
-        // Cross-check the pure rule against nectar's own predicate so the two
-        // never drift. Construct a batch and compare for a sweep of amounts.
+        // Cross-check the pure rule against Batch::is_expired so the two never
+        // drift.
         let batch = Batch::new(
             id(7),
             /* value */ 1_000u128,

--- a/crates/swarm/storer/src/lib.rs
+++ b/crates/swarm/storer/src/lib.rs
@@ -1,27 +1,9 @@
 //! Storer node storage backend: the persisting chunk store and reserve.
 //!
-//! This crate provides the storage primitives for Storer nodes:
-//! - [`ChunkStore`] - Backend trait for chunk persistence
-//! - [`DbChunkStore`] - Implementation over the vertex-storage `Database` trait
-//! - [`Reserve`] - Capacity management and garbage collection
-//!
-//! The storer's `SwarmLocalStore` implementation (a persisting reserve that
-//! stores chunk and stamp as separate fields, evicts furthest-from-neighbourhood,
-//! and signs receipts on pushsync) is built on top of these primitives. It is
-//! tracked separately from the cache-only client and is not part of this crate
-//! yet.
-//!
-//! # Architecture
-//!
-//! ```text
-//! DbChunkStore
-//! └── store: ChunkStore (Database-trait backend)
-//!
-//! Reserve
-//! ├── capacity: u64 (max chunks)
-//! ├── used: u64 (current count)
-//! └── eviction_strategy: EvictionStrategy
-//! ```
+//! Storage primitives for Storer nodes: [`ChunkStore`]/[`DbChunkStore`] for
+//! chunk persistence over the vertex-storage `Database` trait, and [`Reserve`]
+//! for capacity management and eviction. The persisting `SwarmLocalStore`
+//! reserve is built on top of these.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/swarm/storer/src/radius.rs
+++ b/crates/swarm/storer/src/radius.rs
@@ -1,105 +1,45 @@
 //! Size-driven storage-radius dynamics.
 //!
-//! The reserve's [`StorageRadius`] is not a static configuration value: it is
-//! derived from the reserve's own occupancy relative to its capacity, and that
-//! derived radius (plus a node-configured capacity-doubling addend) is the
-//! consensus-committed depth a redistribution round samples and commits on
-//! chain. This module is the clean-room, hand-derived specification of that
-//! derivation, expressed as a pure decision function so it can be unit-tested
-//! in isolation and reused by both the live eviction-control loop and the
-//! conformance tests.
+//! The reserve's [`StorageRadius`] is derived from its occupancy relative to
+//! capacity, not configured statically. [`derive_radius`] is the pure decision
+//! function; [`RadiusController::apply`] threads the eviction I/O and the
+//! [`SettableRadius`] write around it.
 //!
-//! # Clean-room specification
+//! The rule over an occupancy snapshot:
 //!
-//! Derived from the Swarm reserve worker's intent (size-driven radius growth
-//! and shrink), encoded here from first principles rather than transcribed from
-//! the reference implementation. The rule, stated as a state machine over an
-//! occupancy snapshot:
+//! - **Grow** (radius + 1) when `total > capacity`, after shedding the
+//!   shallowest in-radius bin. A deeper radius narrows responsibility, shedding
+//!   load. Capped at [`MAX_PO`], beyond which the node is over-provisioned and
+//!   the loop surfaces [`RadiusOutcome::AtCeiling`]. This is a hard constraint
+//!   and takes precedence over shrink.
+//! - **Shrink** (radius - 1) when within-radius occupancy is below
+//!   [`shrink_threshold`], the node is not mid-sync, and the radius is above its
+//!   configured floor. A shallower radius widens responsibility so an
+//!   under-filled node pulls in more chunks. Syncing must be idle because an
+//!   in-progress sync is still filling the reserve, so its low occupancy is not
+//!   spare capacity.
+//! - **Hold** otherwise.
 //!
-//! - **Within-capacity is the invariant.** The reserve must never sit above its
-//!   capacity once the control loop has converged: `total <= capacity`. The
-//!   grow rule restores this invariant whenever it is violated.
-//! - **Shrink threshold.** A reserve is considered comfortably under-filled when
-//!   its within-radius population sits below half its capacity. The `threshold`
-//!   is `capacity * 5 / 10` (equivalently `capacity / 2`). Below this the radius
-//!   may shrink; at or above it the radius holds.
-//! - **Shrink (radius decrease).** When the within-radius count is below the
-//!   threshold *and* the node is not actively syncing historical content
-//!   (`syncRate == 0`) *and* the radius is above its configured minimum, the
-//!   radius decreases by one. This widens responsibility (a shallower radius
-//!   admits more of the address space) so an under-utilised node pulls in more
-//!   chunks. The minimum-radius floor prevents a freshly started or sparsely
-//!   populated node from collapsing its radius to zero. Syncing must be idle
-//!   because an in-progress sync is still filling the reserve, so its momentary
-//!   low occupancy is not evidence of spare long-term capacity.
-//! - **Grow (radius increase).** When the reserve exceeds capacity, the node
-//!   sheds its furthest (shallowest-bin) chunks via unreserve/eviction and, if
-//!   shedding the current shallowest bin is not enough to get back within
-//!   capacity, increases the radius by one and repeats. A deeper radius narrows
-//!   responsibility (fewer addresses qualify), shedding load. The radius is
-//!   capped at the deepest bin ([`MAX_PO`]): a node that is still over capacity
-//!   at the maximum radius is genuinely over-provisioned and the control loop
-//!   surfaces [`RadiusOutcome::AtCeiling`].
-//!
-//! The derivation ([`derive_radius`]) is *pure*: it consumes occupancy counts
-//! and produces a [`RadiusDecision`]. Applying a decision (evicting a bin,
-//! committing the new radius) is [`RadiusController::apply`]'s job, which threads
-//! the eviction I/O and the [`SettableRadius`] write around the pure rule; see
-//! the [`RadiusController`] driver and the documented [reserve seam](#reserve-seam).
-//!
-//! # Differential oracle (planned)
-//!
-//! This module is the *hand-derived* specification: the rules above are encoded
-//! and tested against their own documented behaviour. A bee differential oracle
-//! (replaying a recorded sequence of `(occupancy, sync state)` snapshots through
-//! both this controller and the reference reserve worker, and asserting the
-//! radius trajectory matches step for step) is the planned follow-up conformance
-//! check. It is intentionally *not* part of this car: it needs a recorded oracle
-//! trace and a harness that are owned separately, and folding it in here would
-//! couple the pure policy to a fixture. The seam for it is the pure
-//! [`derive_radius`] function, which the oracle harness can drive directly. See
-//! the `radius_oracle_is_planned_followup` ignored test, which documents the
-//! exact comparison the oracle will perform.
-//!
-//! # Reserve seam
-//!
-//! The controller reads three quantities from the reserve and writes one back:
-//!
-//! - reserve population within the current radius
-//!   ([`ReserveOccupancy::within_radius`]),
-//! - total reserve population ([`ReserveOccupancy::total`]),
-//! - capacity ([`ReserveOccupancy::capacity`]),
-//! - and, on grow, the per-bin eviction primitive
-//!   ([`ReserveStore::evict_from_bin`]).
-//!
-//! The reads are exactly the existing [`ReserveStore`] surface
-//! (`count`/`count_in`/`capacity`/`storage_radius`/`evict_from_bin`); the write
-//! is the [`SettableRadius`] extension trait. [`DbReserve`](crate::DbReserve)
-//! implements both, so wiring the controller needs no new reserve verbs.
-//! [`occupancy_of`] builds the snapshot from any [`ReserveStore`], and
-//! [`RadiusController::apply`] reads it, applies the decision (shedding through
-//! [`evict_from_bin`](ReserveStore::evict_from_bin) on grow) and commits the
-//! derived radius through [`SettableRadius::set_storage_radius`]. #391 only wires
-//! the loop that calls `apply`; the runtime mutability already lives here.
+//! The reserve seam: [`occupancy_of`] reads `count`/`count_in`/`capacity`/
+//! `storage_radius` from a [`ReserveStore`]; grow sheds via
+//! [`ReserveStore::evict_from_bin`]; the committed radius is written back
+//! through [`SettableRadius`]. [`DbReserve`](crate::DbReserve) implements both.
 
 use nectar_primitives::{Bin, MAX_PO, ProximityOrder};
 use vertex_swarm_api::{ReserveStore, SettableRadius, StorageRadius, SwarmError, SwarmResult};
 
 /// A single radius-adjustment decision derived from reserve occupancy.
 ///
-/// The output of the pure derivation. Holding is the common case; shrink/grow
-/// move the radius by exactly one step so the control loop converges
+/// Shrink/grow move the radius by exactly one step so the loop converges
 /// monotonically rather than overshooting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RadiusDecision {
-    /// The radius is well-matched to occupancy; leave it unchanged.
+    /// Leave the radius unchanged.
     Hold,
-    /// The reserve is under-filled and idle; widen responsibility by lowering
-    /// the radius one step (to the contained value).
+    /// Under-filled and idle: lower the radius to the contained value.
     Shrink(StorageRadius),
-    /// The reserve is over capacity; narrow responsibility by raising the
-    /// radius one step (to the contained value), after shedding the shallowest
-    /// bin.
+    /// Over capacity: raise the radius to the contained value after shedding the
+    /// shallowest bin.
     Grow(StorageRadius),
 }
 
@@ -117,9 +57,6 @@ pub enum RadiusOutcome {
 ///
 /// Counts are per *stamped entry* (distinct `(batchID, stampIndex, address)`),
 /// matching the consensus reserve-size definition, not per content address.
-/// The within-radius count is the population in bins at or deeper than the
-/// current radius; it is the quantity the shrink rule tests against the
-/// capacity threshold.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReserveOccupancy {
     /// Entries in bins at or deeper than the current radius.
@@ -134,35 +71,27 @@ pub struct ReserveOccupancy {
 
 /// The capacity threshold below which the radius may shrink: `capacity * 5 / 10`.
 ///
-/// The multiply-then-divide form mirrors the protocol's `capacity * 5 / 10`
-/// exactly (same truncation), and avoids the temptation to read `capacity / 2`
-/// as a different fraction if the proportion is ever retuned.
+/// The multiply-then-divide form keeps the same truncation if the proportion is
+/// ever retuned.
 #[inline]
 #[must_use]
 pub const fn shrink_threshold(capacity: u64) -> u64 {
-    // saturating_mul guards the (astronomically large) capacity that would
-    // overflow `* 5`; the reserve never approaches it, but the policy stays
-    // total rather than panicking in a debug build.
+    // saturating_mul keeps the policy total at capacities that would overflow `* 5`.
     capacity.saturating_mul(5) / 10
 }
 
 /// Derive the next radius adjustment from a reserve-occupancy snapshot.
 ///
-/// Pure and total. `minimum_radius` is the configured floor the shrink rule
-/// will not cross; `syncing_idle` is true when no historical sync is in flight
-/// (a sync in progress, `syncRate != 0`, suppresses shrinking, since low
-/// occupancy then reflects an unfinished fill rather than spare capacity).
-///
-/// Precedence: over-capacity (grow) is checked first because it is a hard
-/// constraint (the reserve must not exceed capacity); shrink is a soft
-/// optimisation considered only when within capacity.
+/// Pure and total. `minimum_radius` is the floor the shrink rule will not cross;
+/// `syncing_idle` is false while a historical sync is in flight, which suppresses
+/// shrinking. Over-capacity (grow) is checked first as a hard constraint; shrink
+/// is considered only when within capacity.
 #[must_use]
 pub fn derive_radius(
     occ: ReserveOccupancy,
     minimum_radius: StorageRadius,
     syncing_idle: bool,
 ) -> RadiusDecision {
-    // Hard constraint first: shed load if over capacity by narrowing.
     if occ.total > occ.capacity {
         return match step_up(occ.radius) {
             Some(next) => RadiusDecision::Grow(next),
@@ -170,8 +99,6 @@ pub fn derive_radius(
         };
     }
 
-    // Soft optimisation: widen responsibility when comfortably under-filled and
-    // not mid-sync, never below the configured floor.
     if syncing_idle
         && occ.within_radius < shrink_threshold(occ.capacity)
         && occ.radius > minimum_radius
@@ -207,23 +134,15 @@ fn step_down(radius: StorageRadius) -> Option<StorageRadius> {
 
 /// Build a [`ReserveOccupancy`] snapshot from a live [`ReserveStore`].
 ///
-/// Reads the within-radius population (the sum of `count_in` over bins at or
-/// deeper than the current radius), the total population, the capacity and the
-/// radius. This is the read half of the [reserve seam](self#reserve-seam): the
-/// controller decides from the snapshot, the live loop applies the decision.
-///
 /// The within-radius sum walks at most `MAX_PO - radius + 1` bins, each an
-/// O(log n + matches) cursor count, so the snapshot is cheap relative to a full
-/// scan. A `total` already counted by the reserve is reused rather than
-/// re-summed.
+/// O(log n + matches) cursor count.
 pub fn occupancy_of<R: ReserveStore + ?Sized>(reserve: &R) -> SwarmResult<ReserveOccupancy> {
     let radius = reserve.storage_radius();
     let total = reserve.count()?;
     let mut within_radius = 0u64;
     for po in radius.get()..=MAX_PO {
-        // `po` ranges over a valid bin index by construction (radius.get() and
-        // MAX_PO are both valid), so the conversion cannot fail; fall back to
-        // the deepest bin defensively rather than unwrapping.
+        // `po` is a valid bin index by construction; fall back to the deepest bin
+        // defensively rather than unwrapping.
         let bin = ProximityOrder::new(po).unwrap_or(ProximityOrder::MAX);
         within_radius = within_radius.saturating_add(reserve.count_in(bin)?);
     }
@@ -235,30 +154,18 @@ pub fn occupancy_of<R: ReserveStore + ?Sized>(reserve: &R) -> SwarmResult<Reserv
     })
 }
 
-/// Drives the grow loop to convergence over a pure shed function.
+/// Drives the grow loop to convergence over a pure shed function, keeping radius
+/// stepping and ceiling detection separate from the eviction I/O.
 ///
-/// The live wiring passes a closure that sheds the shallowest in-radius bin via
-/// [`ReserveStore::evict_from_bin`] and reports the resulting total. This keeps
-/// the convergence logic (radius stepping, ceiling detection) pure and testable
-/// while leaving the I/O to the caller. The loop steps the radius up at most
-/// `MAX_PO - start` times, so it always terminates.
+/// `shed(radius)` evicts the bin at the current radius boundary (`bin == radius`,
+/// the shallowest bin that leaves responsibility when the radius rises) and
+/// returns the new total. The loop stops once the total is within capacity, and
+/// steps up at most `MAX_PO - start` times so it always terminates.
 ///
-/// `shed` is invoked as `shed(radius)`: it should evict the bin at the current
-/// radius boundary (`bin == radius`), which is the shallowest bin that falls out
-/// of responsibility the moment the radius rises by one, and return the new
-/// total entry count. The loop stops as soon as the total is within capacity,
-/// returning the radius reached.
-///
-/// # Radius accounting
-///
-/// Responsibility is the set of bins *at or deeper than* the radius
-/// ([`ReserveStore::storage_radius`] semantics), so shedding bin `K` and raising
-/// the radius are one step: the node sheds bin `K` precisely because it is no
-/// longer responsible for it once the boundary moves to `K + 1`. The returned
-/// radius is therefore always one deeper than the deepest bin that was shed,
-/// matching the single-step [`derive_radius`] convention where
-/// [`RadiusDecision::Grow`] carries `radius + 1`. Equivalently: increment the
-/// radius, then evict the bins now shallower than it.
+/// The returned radius is always one deeper than the deepest bin shed:
+/// responsibility is bins at or deeper than the radius, so shedding bin `K` and
+/// moving the boundary to `K + 1` are one step. This matches the single-step
+/// [`RadiusDecision::Grow`] convention of `radius + 1`.
 pub fn grow_to_capacity<F>(
     start: StorageRadius,
     capacity: u64,
@@ -272,10 +179,8 @@ where
     while total > capacity {
         match step_up(radius) {
             Some(next) => {
-                // Shed the bin at the current boundary; it falls out of
-                // responsibility as the radius rises to `next`. The new radius
-                // is `next` regardless of whether this shed sufficed, because
-                // bin `radius` is gone either way.
+                // The radius becomes `next` regardless of whether this shed
+                // sufficed, because bin `radius` is gone either way.
                 total = shed(radius);
                 radius = next;
                 if total <= capacity {
@@ -290,10 +195,7 @@ where
 
 /// A thin stateful driver around [`derive_radius`] for the live control loop.
 ///
-/// Holds the configured floor; the radius itself lives in the reserve. The
-/// driver is deliberately tiny: it exists so the loop has one place to apply
-/// policy and so the policy is covered by tests independently of the
-/// redb-backed reserve.
+/// Holds the configured floor; the radius itself lives in the reserve.
 #[derive(Debug, Clone, Copy)]
 pub struct RadiusController {
     /// The configured minimum radius the shrink rule will not cross.
@@ -301,29 +203,22 @@ pub struct RadiusController {
 }
 
 impl RadiusController {
-    /// Construct a controller with the given minimum-radius floor.
     #[must_use]
     pub const fn new(minimum_radius: StorageRadius) -> Self {
         Self { minimum_radius }
     }
 
-    /// The configured minimum radius.
     #[must_use]
     pub const fn minimum_radius(&self) -> StorageRadius {
         self.minimum_radius
     }
 
-    /// Decide the next radius adjustment for the given occupancy.
     #[must_use]
     pub fn decide(&self, occ: ReserveOccupancy, syncing_idle: bool) -> RadiusDecision {
         derive_radius(occ, self.minimum_radius, syncing_idle)
     }
 
-    /// Decide the next radius adjustment for a live reserve, reading its
-    /// occupancy through the [reserve seam](self#reserve-seam).
-    ///
-    /// A convenience over [`occupancy_of`] + [`Self::decide`] for the live loop;
-    /// the pure two-step form remains available for tests and the oracle.
+    /// [`occupancy_of`] + [`Self::decide`] in one call for the live loop.
     pub fn decide_for<R: ReserveStore + ?Sized>(
         &self,
         reserve: &R,
@@ -332,33 +227,22 @@ impl RadiusController {
         Ok(self.decide(occupancy_of(reserve)?, syncing_idle))
     }
 
-    /// Decide *and apply* one radius adjustment against a live reserve, returning
+    /// Decide and apply one radius adjustment against a live reserve, returning
     /// the radius now committed.
     ///
-    /// This is the write half of the [reserve seam](self#reserve-seam) and the
-    /// single entry the live eviction-control loop (#391) calls: it reads the
-    /// occupancy, runs [`derive_radius`], performs the I/O the decision implies,
-    /// and commits the resulting radius through [`SettableRadius`] so subsequent
-    /// [`storage_radius`](ReserveStore::storage_radius) reads observe it. Before
-    /// this existed the dynamics were architecturally orphaned: there was no write
-    /// target for the derived radius, so it could never change at runtime.
+    /// Reads the occupancy, runs [`derive_radius`], performs the implied I/O, and
+    /// commits the resulting radius through [`SettableRadius`]:
     ///
-    /// The decision maps to action as follows:
+    /// - [`Hold`](RadiusDecision::Hold): commit nothing, return the current radius.
+    /// - [`Shrink`](RadiusDecision::Shrink): widening evicts nothing, so commit the
+    ///   shallower radius directly.
+    /// - [`Grow`](RadiusDecision::Grow): run [`grow_to_capacity`], shedding the
+    ///   boundary bin via [`evict_from_bin`](ReserveStore::evict_from_bin) and
+    ///   stepping the radius until within capacity (or at the ceiling), then commit.
+    ///   Eviction precedes the commit so the reserve never advertises a narrower
+    ///   radius than its contents justify.
     ///
-    /// - [`Hold`](RadiusDecision::Hold): commit nothing, return the current
-    ///   radius unchanged.
-    /// - [`Shrink`](RadiusDecision::Shrink): widening responsibility evicts
-    ///   nothing (the node simply admits more of the address space), so this
-    ///   commits the shallower radius directly.
-    /// - [`Grow`](RadiusDecision::Grow): the reserve is over capacity, so this
-    ///   runs [`grow_to_capacity`], shedding the boundary bin via
-    ///   [`evict_from_bin`](ReserveStore::evict_from_bin) and stepping the radius
-    ///   until the reserve is within capacity (or the ceiling is hit), then
-    ///   commits the converged radius. Eviction precedes the commit so the reserve
-    ///   never advertises a narrower radius than its contents justify.
-    ///
-    /// `syncing_idle` carries the same meaning as in [`derive_radius`]. Returns a
-    /// [`SwarmResult`] because the grow path performs reserve I/O.
+    /// Returns a [`SwarmResult`] because the grow path performs reserve I/O.
     pub fn apply<R: SettableRadius + ?Sized>(
         &self,
         reserve: &R,
@@ -372,15 +256,13 @@ impl RadiusController {
                 Ok(next)
             }
             RadiusDecision::Grow(_) => {
-                // The grow loop sheds the boundary bin and steps the radius until
-                // within capacity; thread its eviction through `evict_from_bin`.
                 // A reserve I/O error inside the closure is captured and surfaced
                 // after the loop rather than panicking through the pure driver.
                 let mut shed_err: Option<SwarmError> = None;
                 let outcome = grow_to_capacity(occ.radius, occ.capacity, occ.total, |radius| {
                     if shed_err.is_some() {
-                        // A prior shed failed; stop shedding (report the count as
-                        // still over capacity so the loop makes no further claim).
+                        // A prior shed failed; report still over capacity so the
+                        // loop makes no further claim.
                         return occ.total;
                     }
                     match reserve.evict_from_bin(radius.bin(), BIN_EVICT_MAX) {
@@ -410,13 +292,12 @@ impl RadiusController {
     }
 }
 
-/// The maximum entries [`RadiusController::apply`] sheds from one bin in a single
+/// The maximum entries [`RadiusController::apply`] sheds from one bin per
 /// [`evict_from_bin`](ReserveStore::evict_from_bin) call.
 ///
 /// Bounds the per-bin eviction transaction so a pathologically populated bin
-/// does not stall the control loop in one giant transaction; the loop re-runs on
-/// the next tick to drain any remainder. Matches the batch-eviction bound the
-/// expiry sweep uses.
+/// does not stall the loop; the loop re-runs on the next tick to drain any
+/// remainder.
 pub const BIN_EVICT_MAX: u64 = 10_000;
 
 #[cfg(test)]
@@ -446,7 +327,6 @@ mod tests {
         assert_eq!(shrink_threshold(1), 0);
         assert_eq!(shrink_threshold(10), 5);
         assert_eq!(shrink_threshold(11), 5);
-        // Matches the protocol's capacity * 5 / 10 for representative sizes.
         for c in [0u64, 1, 2, 9, 10, 1000, 4_194_304] {
             assert_eq!(shrink_threshold(c), c * 5 / 10);
         }
@@ -477,8 +357,8 @@ mod tests {
 
     #[test]
     fn does_not_shrink_while_syncing() {
-        // Under-filled but a sync is in flight (syncRate != 0): low occupancy is
-        // not spare capacity, so hold.
+        // Under-filled but a sync is in flight: low occupancy is not spare
+        // capacity, so hold.
         assert_eq!(
             derive_radius(occ(1, 8, 10, 8), r(0), false),
             RadiusDecision::Hold
@@ -562,16 +442,11 @@ mod tests {
             remaining
         });
         // Shed bin 8 (radius -> 9), total 16 -> 13 still over; shed bin 9
-        // (radius -> 10), total 13 -> 10 within. Responsibility is bins >= radius
-        // and bins 8 and 9 are now evicted, so the converged radius is 10, one
-        // deeper than the deepest bin shed.
+        // (radius -> 10), total 13 -> 10 within. Converged radius is 10.
         assert_eq!(shed_at, vec![8, 9], "sheds the boundary bin each step");
         assert_eq!(out, RadiusOutcome::WithinCapacity(r(10)));
-        // The converged radius is the lowest bin still in responsibility:
-        // responsibility is bins >= radius, every shed bin is now below it, and
-        // the deepest shed bin (9) is exactly radius - 1. This is the consensus
-        // property: storage_radius feeds committedDepth, so an off-by-one here
-        // diverges on chain.
+        // The deepest shed bin is exactly radius - 1. This is consensus-observable:
+        // storage_radius feeds committedDepth, so an off-by-one diverges on chain.
         let radius = match out {
             RadiusOutcome::WithinCapacity(rdx) | RadiusOutcome::AtCeiling(rdx) => rdx.get(),
         };
@@ -614,19 +489,12 @@ mod tests {
         );
     }
 
-    /// The bee differential oracle is a planned follow-up: it will replay a
-    /// recorded `(occupancy, syncing_idle)` trace through both [`derive_radius`]
-    /// and bee's reserve worker and assert the radius trajectory matches step
-    /// for step. The fixture and harness are owned separately; this test
-    /// documents the comparison and the seam (drive [`derive_radius`] directly)
-    /// rather than asserting a green result that does not run.
+    /// Differential oracle: replay a recorded `(occupancy, syncing_idle)` trace
+    /// through [`derive_radius`] and assert the radius trajectory matches a
+    /// reference trace step for step.
     #[test]
-    #[ignore = "bee differential oracle: needs a recorded reference trace (planned follow-up)"]
-    fn radius_oracle_is_planned_followup() {
-        // Placeholder shape of the oracle step:
-        //   for (snapshot, idle, expected) in recorded_trace() {
-        //       assert_eq!(derive_radius(snapshot, floor, idle), expected);
-        //   }
+    #[ignore = "differential oracle: needs a recorded reference trace"]
+    fn radius_oracle() {
         unimplemented!("differential oracle trace not yet recorded");
     }
 }

--- a/crates/swarm/storer/src/reserve.rs
+++ b/crates/swarm/storer/src/reserve.rs
@@ -10,44 +10,31 @@ use vertex_swarm_primitives::OverlayAddress;
 
 use crate::{ChunkStore, StorerError, StorerResult};
 
-/// Eviction strategy when reserve is full.
+/// Eviction strategy for the in-memory reserve when full.
 ///
-/// Note: [`DbReserve`](crate::DbReserve) does not consult this in-memory
-/// strategy. Its capacity is managed by the caller through the proximity- and
-/// batch-scoped eviction primitives on
-/// [`ReserveStore`](vertex_swarm_api::ReserveStore)
-/// (`evict_furthest`/`evict_from_bin`/`evict_batch`), which compact the on-disk
-/// indexes atomically. This enum and [`Reserve::try_reserve`] remain for the
-/// in-memory store paths and are superseded for the db reserve.
+/// [`DbReserve`](crate::DbReserve) ignores this; it evicts through the
+/// proximity- and batch-scoped [`ReserveStore`](vertex_swarm_api::ReserveStore) primitives.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum EvictionStrategy {
-    /// Don't evict, return error when full.
+    /// Return an error when full instead of evicting.
     #[default]
     NoEviction,
-    /// Evict oldest chunks (FIFO-like based on iteration order).
+    /// Evict the oldest chunk by iteration order.
     EvictOldest,
-    /// Evict chunks furthest from our address (requires overlay).
+    /// Evict the chunk furthest from our overlay address.
     EvictFurthest,
 }
 
-/// Reserve capacity tracker.
-///
-/// Manages the storage quota and handles eviction when needed.
+/// Reserve capacity tracker with eviction.
 pub struct Reserve {
-    /// Maximum chunk capacity.
     capacity: u64,
-    /// Current chunk count.
     count: RwLock<u64>,
-    /// Eviction strategy.
     strategy: EvictionStrategy,
-    /// Local overlay address, threaded from the node identity at construction.
-    /// Required by [`EvictionStrategy::EvictFurthest`] to rank chunks by
-    /// proximity; `None` for the proximity-agnostic strategies.
+    /// Required by [`EvictionStrategy::EvictFurthest`]; `None` otherwise.
     overlay: Option<OverlayAddress>,
 }
 
 impl Reserve {
-    /// Create a new reserve with the given capacity.
     pub fn new(capacity: u64) -> Self {
         Self {
             capacity,
@@ -57,7 +44,6 @@ impl Reserve {
         }
     }
 
-    /// Create a reserve with a specific eviction strategy.
     pub fn with_strategy(capacity: u64, strategy: EvictionStrategy) -> Self {
         Self {
             capacity,
@@ -67,23 +53,19 @@ impl Reserve {
         }
     }
 
-    /// Thread the node identity, enabling proximity-ranked eviction
-    /// ([`EvictionStrategy::EvictFurthest`]). Stores the derived overlay address
-    /// (the reserve only needs its own location in address space, not the
-    /// identity's signing capability), matching how the rest of the node is
-    /// wired off the identity.
+    /// Set the overlay address from the node identity, enabling
+    /// [`EvictionStrategy::EvictFurthest`].
     #[must_use]
     pub fn with_identity(mut self, identity: &impl SwarmIdentity) -> Self {
         self.overlay = Some(identity.overlay_address());
         self
     }
 
-    /// The local overlay address, if set. Required for `EvictFurthest`.
     pub fn overlay(&self) -> Option<OverlayAddress> {
         self.overlay
     }
 
-    /// Initialize count from an existing store.
+    /// Seed the count from an existing store.
     pub fn initialize_from<S: ChunkStore>(&self, store: &S) -> StorerResult<()> {
         let count = store.count()?;
         *self.count.write() = count;
@@ -91,37 +73,28 @@ impl Reserve {
         Ok(())
     }
 
-    /// Get the capacity.
     pub fn capacity(&self) -> u64 {
         self.capacity
     }
 
-    /// Get the current count.
     pub fn count(&self) -> u64 {
         *self.count.read()
     }
 
-    /// Set the current count directly.
-    ///
-    /// Used by the per-entry [`DbReserve`](crate::DbReserve) to seed the
-    /// in-memory size from the persisted entry-table count at construction (the
-    /// authoritative size is the entry count, not the address count).
     pub fn set_count(&self, count: u64) {
         *self.count.write() = count;
     }
 
-    /// Get available space.
     pub fn available(&self) -> u64 {
         let count = *self.count.read();
         self.capacity.saturating_sub(count)
     }
 
-    /// Check if there's room for a new chunk.
     pub fn has_room(&self) -> bool {
         *self.count.read() < self.capacity
     }
 
-    /// Get utilization percentage (0-100).
+    /// Utilization percentage (0-100).
     pub fn utilization(&self) -> u8 {
         let count = *self.count.read();
         if self.capacity == 0 {
@@ -130,10 +103,7 @@ impl Reserve {
         ((count * 100) / self.capacity) as u8
     }
 
-    /// Try to reserve space for a new chunk.
-    ///
-    /// Returns `Ok(())` if space is available, or attempts eviction
-    /// based on the configured strategy.
+    /// Reserve space for a chunk, evicting per the configured strategy if full.
     pub fn try_reserve<S: ChunkStore>(&self, store: &S) -> StorerResult<()> {
         if self.has_room() {
             return Ok(());
@@ -149,39 +119,35 @@ impl Reserve {
             }
             EvictionStrategy::EvictOldest => self.evict_oldest(store),
             EvictionStrategy::EvictFurthest => {
-                // For now, fall back to oldest
-                // TODO: Implement furthest eviction with overlay address
+                // TODO: rank by proximity to self.overlay; for now fall back.
                 warn!("EvictFurthest not implemented, falling back to EvictOldest");
                 self.evict_oldest(store)
             }
         }
     }
 
-    /// Record that a chunk was added.
     pub fn on_added(&self) {
         let mut count = self.count.write();
         *count += 1;
     }
 
-    /// Record that a chunk was removed.
     pub fn on_removed(&self) {
         let mut count = self.count.write();
         *count = count.saturating_sub(1);
     }
 
-    /// Record that `n` chunks were removed at once (a batch/bin eviction).
+    /// Decrement the count by `n` after a batch or bin eviction.
     pub fn on_removed_n(&self, n: u64) {
         let mut count = self.count.write();
         *count = count.saturating_sub(n);
     }
 
-    /// Evict the oldest chunk (first one encountered in iteration).
     fn evict_oldest<S: ChunkStore>(&self, store: &S) -> StorerResult<()> {
         let mut to_evict = None;
 
         store.for_each(|addr| {
             to_evict = Some(*addr);
-            false // Stop after first
+            false // stop after the first
         })?;
 
         if let Some(addr) = to_evict {
@@ -190,7 +156,7 @@ impl Reserve {
             self.on_removed();
             Ok(())
         } else {
-            // Store is empty but we're "full"? Shouldn't happen
+            // Empty but reported full; should not happen.
             Err(StorerError::StorageFull {
                 capacity: self.capacity,
                 used: 0,
@@ -199,21 +165,16 @@ impl Reserve {
     }
 }
 
-/// Statistics about the reserve.
+/// Reserve statistics snapshot.
 #[derive(Debug, Clone)]
 pub struct ReserveStats {
-    /// Total capacity in chunks.
     pub capacity: u64,
-    /// Current chunk count.
     pub count: u64,
-    /// Available space.
     pub available: u64,
-    /// Utilization percentage.
     pub utilization: u8,
 }
 
 impl Reserve {
-    /// Get reserve statistics.
     pub fn stats(&self) -> ReserveStats {
         ReserveStats {
             capacity: self.capacity,
@@ -253,7 +214,6 @@ mod tests {
         let reserve =
             Reserve::with_strategy(2, EvictionStrategy::EvictFurthest).with_identity(&identity);
         assert_eq!(reserve.overlay(), Some(identity.overlay_address()));
-        // The proximity-agnostic constructors leave it unset.
         assert_eq!(Reserve::new(2).overlay(), None);
     }
 

--- a/crates/swarm/stream/src/lib.rs
+++ b/crates/swarm/stream/src/lib.rs
@@ -1,42 +1,19 @@
 //! Memory-bounded streaming multi-chunk get/put pipelines.
 //!
-//! The single-chunk [`SwarmChunkProvider::retrieve_chunk`] and
-//! [`SwarmChunkSender`] entry points serve one address at a time. A file is
-//! thousands of chunks, so a caller that wants a whole manifest has two bad
-//! options on its own: issue them one by one and eat the round-trip latency, or
-//! spawn one future per address and let an unbounded fan-out blow the heap on a
-//! slow or hostile consumer. This module is the third option: a stream that
-//! prefetches ahead of the consumer up to a fixed number of chunks, never more,
-//! and stops pulling new work the instant the consumer stops draining.
+//! Turns the single-chunk [`SwarmChunkProvider`] / [`SwarmChunkSender`] entry
+//! points into [`Stream`]s over a whole address list, prefetching ahead of the
+//! consumer up to a fixed number of chunks and stopping the instant it stops
+//! draining. Backpressure is transitive: a slow consumer pauses the network
+//! reads, so memory stays flat regardless of list length.
 //!
-//! Limiting is by chunk count, not bytes: a Swarm chunk is size-bounded, so a
-//! count bounds memory without inspecting each chunk. Byte/bandwidth limiting is
-//! a separate seam at the libp2p connection layer. Both pipelines are plain
-//! [`Stream`]s, FFI-agnostic and `Send` where the provider is, and advance only
-//! when polled. A host that polls slowly (a paused Dart `StreamSink`, a browser
-//! `ReadableStream` under backpressure) transitively pauses the network reads,
-//! so memory stays flat no matter how long the address list is.
+//! Transport-agnostic core shared by the FFI, wasm, and gRPC chunk adapters;
+//! depends only on the trait surface, never on a node internal type.
 //!
-//! The crate is the transport-agnostic core that every chunk-bulk consumer
-//! shares: the native FFI adapter in `vertex-ffi` wraps these streams as Dart
-//! sinks, the browser adapter in the [`wasm`] module surfaces them to
-//! JavaScript as async iterators, and the future gRPC chunk service streams
-//! the same items over the wire. The pipelines depend only on the
-//! [`SwarmChunkProvider`] and [`SwarmChunkSender`] traits, never on a node
-//! internal type, so the same combinator serves all three.
-//!
-//! Downloads deliver [`VerifiedChunk`] only: every chunk is proven to answer the
-//! address that requested it before it leaves the stream, so a peer that returns
-//! the wrong bytes for an address surfaces as an error item, never as a chunk a
-//! consumer might trust. The stamp on a delivery is optional (a storer may omit
-//! it), so the verified item carries an `Option<Stamp>`.
-//!
-//! The in-window concurrency is built on the per-request outbound futures: each
-//! retrieval or push is a self-contained future correlated by its own substream,
-//! so racing many addresses at once never aliases response state. Items are
-//! yielded in completion order, not input order: ordering it costs head-of-line
-//! blocking, so every item carries its chunk address and reordering is the
-//! consumer's job.
+//! Limiting is by chunk count, not bytes (a Swarm chunk is size-bounded);
+//! byte/bandwidth limiting lives at the libp2p connection layer. Items are
+//! yielded in completion order, so each carries its chunk address and reordering
+//! is the consumer's job. Downloads yield [`VerifiedChunk`] only: a chunk proven
+//! to answer the requested address surfaces wrong bytes as an error item.
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
@@ -52,29 +29,15 @@ use vertex_swarm_api::{
     OverlayAddress, PushReceipt, Stamp, StampedChunk, SwarmChunkProvider, SwarmChunkSender,
     SwarmError, SwarmResult,
 };
-// `MaybeSendBoxFuture` (native = `Send`, wasm = `!Send`) is the crate's MaybeSend
-// seam: every boxed core future is held in a `Send`-on-native / `!Send`-on-wasm
-// alias so the streams stay `Send` for tonic on native without forcing `Send` on
-// wasm. The later `ChunkClientExt` extension trait reuses this same convention
-// (via [`MaybeSendIter`] and this alias) for its RPITIT return types.
+// `MaybeSendBoxFuture` is `Send` on native (so the streams stay `Send` for
+// tonic) and `!Send` on wasm. The `MaybeSend*` markers below follow the same
+// split.
 use vertex_tasks::MaybeSendBoxFuture;
 
 /// A downloaded chunk proven to answer the address that requested it.
 ///
-/// The chunk's address is derived from its own bytes (the BMT hash for a content
-/// chunk, owner plus signature for a single-owner chunk), and the download stream
-/// proves that address equals the requested one before yielding the item, so a
-/// peer that returns the wrong bytes surfaces as an error rather than a trusted
-/// chunk.
-///
-/// The stamp is optional: a storer answers a retrieval with the chunk bytes and
-/// may omit the stamp from the delivery, which is never re-read on the download
-/// path. Address integrity does not depend on the stamp, so a stampless delivery
-/// is still a fully verified chunk.
-///
-/// The overlay of the peer that served the chunk is carried through as
-/// `served_by`, so the streaming retrieve path can report provenance the same way
-/// the unary path does (it previously emitted an empty `served_by`).
+/// The stamp is optional: address integrity does not depend on it, so a
+/// stampless delivery is still fully verified.
 #[derive(Debug, Clone)]
 pub struct VerifiedChunk {
     chunk: AnyChunk,
@@ -83,19 +46,16 @@ pub struct VerifiedChunk {
 }
 
 impl VerifiedChunk {
-    /// The verified chunk.
     #[must_use]
     pub fn chunk(&self) -> &AnyChunk {
         &self.chunk
     }
 
-    /// The chunk's address (delegates to the chunk).
     #[must_use]
     pub fn address(&self) -> &ChunkAddress {
         self.chunk.address()
     }
 
-    /// The postage stamp the responder attached, if any.
     #[must_use]
     pub fn stamp(&self) -> Option<&Stamp> {
         self.stamp.as_ref()
@@ -107,7 +67,6 @@ impl VerifiedChunk {
         self.served_by
     }
 
-    /// Split into the chunk and its optional stamp.
     #[must_use]
     pub fn into_parts(self) -> (AnyChunk, Option<Stamp>) {
         (self.chunk, self.stamp)
@@ -115,8 +74,7 @@ impl VerifiedChunk {
 }
 
 /// Maximum wire size of a single Swarm chunk: an 8-byte span plus a 4096-byte
-/// body. A chunk is size-bounded, which is why these pipelines bound memory by
-/// chunk count rather than by bytes.
+/// body.
 pub const MAX_CHUNK_BYTES: usize = 8 + nectar_primitives::DEFAULT_BODY_SIZE;
 
 /// Sustained rate (chunks/s) a native node is assumed to serve from one bulk
@@ -134,12 +92,6 @@ pub const NATIVE_DOWNLOAD_CONCURRENCY: usize =
         / (1000 * 100);
 
 /// How many chunks a streaming pipeline keeps in flight at once.
-///
-/// Limiting is by chunk count, not bytes: a Swarm chunk is size-bounded
-/// ([`MAX_CHUNK_BYTES`]), so a count bounds memory just as well without
-/// inspecting each chunk. Byte/bandwidth limiting is a separate concern that
-/// belongs at the libp2p connection layer, where it can rate-limit specific
-/// peers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StreamConfig {
     /// Hard cap on chunks in flight at once.
@@ -147,24 +99,18 @@ pub struct StreamConfig {
 }
 
 impl StreamConfig {
-    /// Up to 32 chunks in flight: a typical mobile or browser client, enough
-    /// prefetch to hide round-trip latency without a long list growing the heap.
+    /// Up to 32 chunks in flight: a typical mobile or browser client.
     pub const DEFAULT: Self = Self {
         max_concurrency: 32,
     };
 
-    /// High-throughput preset for a native node serving a bulk download.
-    ///
-    /// Concurrency is the bandwidth-delay product (Little's law): the in-flight
-    /// retrievals needed to keep a sustained serve rate saturated across one mean
-    /// retrieval latency, plus headroom for jitter. Derived from
-    /// [`NATIVE_DOWNLOAD_CONCURRENCY`] rather than picked by hand.
+    /// High-throughput preset for a native node serving a bulk download:
+    /// the bandwidth-delay product of [`NATIVE_DOWNLOAD_CONCURRENCY`].
     pub const NATIVE_DOWNLOAD: Self = Self {
         max_concurrency: NATIVE_DOWNLOAD_CONCURRENCY,
     };
 
-    /// Build a config, clamping to at least one in flight so the stream always
-    /// makes forward progress.
+    /// Clamps to at least one in flight so the stream always makes progress.
     #[must_use]
     pub fn new(max_concurrency: usize) -> Self {
         Self {
@@ -180,10 +126,6 @@ impl Default for StreamConfig {
 }
 
 /// A chunk address parse failed: the input was not exactly 32 bytes.
-///
-/// One neutral error every adapter (FFI, wasm, gRPC) maps onto its own error
-/// type, so the address-length check lives once in [`parse_address`] instead of
-/// three near-identical copies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("invalid chunk address: expected 32 bytes, got {got}")]
 pub struct ParseAddressError {
@@ -192,10 +134,6 @@ pub struct ParseAddressError {
 }
 
 /// Parse a 32-byte chunk address from raw bytes.
-///
-/// The single source of the address-length check shared by the FFI, wasm, and
-/// gRPC boundaries. Each adapter maps [`ParseAddressError`] onto its own error
-/// type at the call site.
 pub fn parse_address(bytes: &[u8]) -> Result<ChunkAddress, ParseAddressError> {
     ChunkAddress::from_slice(bytes).map_err(|_| ParseAddressError { got: bytes.len() })
 }
@@ -221,19 +159,15 @@ where
         provider,
         pending: addresses.into_iter().collect(),
         in_flight: FuturesUnordered::new(),
-        // Clamp to at least one even on a raw `StreamConfig { max_concurrency: 0 }`
-        // literal, so the pipeline never busy-loops without admitting work.
+        // Clamp to >= 1 so a raw `StreamConfig { max_concurrency: 0 }` literal
+        // never busy-loops without admitting work.
         limit: config.max_concurrency.max(1),
     }
 }
 
 pin_project_lite::pin_project! {
-    /// Stream returned by [`get_stream`].
-    ///
-    /// Holds the provider, the queue of addresses not yet requested, and the set
-    /// of in-flight retrievals. Each poll tops the in-flight set up to the
-    /// concurrency limit (prefetch), then yields the next completed retrieval.
-    /// Pin-projected so the provider need not be [`Unpin`].
+    /// Stream returned by [`get_stream`]. Each poll tops the in-flight set up to
+    /// the concurrency limit, then yields the next completed retrieval.
     #[must_use = "a stream does nothing unless polled"]
     pub struct GetStream<P> {
         provider: P,
@@ -243,13 +177,8 @@ pin_project_lite::pin_project! {
     }
 }
 
-/// Retrieve one chunk and prove it answers `address`.
-///
-/// The provider establishes content integrity (the chunk hashes to its own
-/// address); this proves that address equals the requested one, turning a
-/// delivery into a [`VerifiedChunk`]. A mismatch is treated as invalid data from
-/// the peer, not a value to hand back. The stamp is carried through unchanged: it
-/// is optional, and address integrity does not depend on it.
+/// Retrieve one chunk and prove its address equals the requested one, turning
+/// the delivery into a [`VerifiedChunk`]. A mismatch is an invalid-data error.
 pub async fn retrieve_verified<P>(provider: P, address: ChunkAddress) -> SwarmResult<VerifiedChunk>
 where
     P: SwarmChunkProvider,
@@ -268,9 +197,9 @@ where
     })
 }
 
-/// Prefetch: admit pending addresses until the in-flight set hits the
-/// concurrency limit or the queue drains. Each future carries its address out so
-/// a completion-ordered item stays correlatable.
+/// Admit pending addresses until the in-flight set hits the limit or the queue
+/// drains. Each future carries its address out so a completion-ordered item
+/// stays correlatable.
 fn get_refill<P>(
     provider: &P,
     pending: &mut VecDeque<ChunkAddress>,
@@ -301,24 +230,19 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
 
-        // Prefetch first: top the in-flight window up before polling it, so a
-        // drained slot is immediately refilled from the pending queue.
+        // Top the window up before polling it, so a drained slot is refilled.
         get_refill(this.provider, this.pending, this.in_flight, *this.limit);
 
         match this.in_flight.poll_next_unpin(cx) {
-            // A slot completed. Refill so the next poll already has work queued,
-            // then hand the result out. This is where backpressure lives: the
-            // refill admits exactly one replacement per drained slot, so a
-            // consumer that stops polling stops all new requests.
+            // Backpressure: refill admits exactly one replacement per drained
+            // slot, so a consumer that stops polling stops all new requests.
             Poll::Ready(Some(item)) => {
                 get_refill(this.provider, this.pending, this.in_flight, *this.limit);
                 Poll::Ready(Some(item))
             }
-            // No in-flight work and nothing pending: the stream is done.
             Poll::Ready(None) if this.pending.is_empty() => Poll::Ready(None),
-            // The in-flight set is momentarily empty but addresses remain (the
-            // limit was zero-length this tick). Refill admitted them above;
-            // re-poll on the next wake.
+            // Empty in-flight set but addresses remain; refill admitted them
+            // above, so re-poll on the next wake.
             Poll::Ready(None) => {
                 cx.waker().wake_by_ref();
                 Poll::Pending
@@ -333,9 +257,7 @@ where
     }
 }
 
-/// Marker for the address-source stream's thread-safety requirement: `Send` on
-/// native so [`GetStreamFrom`] stays `Send` for tonic, unconstrained on wasm.
-/// Mirrors [`MaybeSendIter`] for a [`Stream`] source. Blanket-implemented, so
+/// `Send` bound on an address-source [`Stream`], native-only. Blanket-impl;
 /// callers never name it.
 #[cfg(not(target_arch = "wasm32"))]
 pub trait MaybeSendStream: Send {}
@@ -346,11 +268,8 @@ pub trait MaybeSendStream {}
 #[cfg(target_arch = "wasm32")]
 impl<T> MaybeSendStream for T {}
 
-/// Marker bound for a value's thread-safety requirement: `Send` on native so an
-/// `impl Future + MaybeSend` returned from [`ChunkClientExt`] stays `Send` for
-/// the generic tonic handler, unconstrained on wasm. Mirrors [`MaybeSendIter`]
-/// and the [`MaybeSendBoxFuture`] split. Blanket-implemented, so callers never
-/// name it.
+/// `Send` bound on a [`ChunkClientExt`] return value, native-only. Blanket-impl;
+/// callers never name it.
 #[cfg(not(target_arch = "wasm32"))]
 pub trait MaybeSend: Send {}
 #[cfg(not(target_arch = "wasm32"))]
@@ -361,16 +280,11 @@ pub trait MaybeSend {}
 impl<T> MaybeSend for T {}
 
 /// Capability alias for a lean chunk client: retrieves, sends, cloneable, and
-/// shareable across threads for the lifetime of the program.
+/// shareable across threads. Blanket-impl, so callers never name it.
 ///
-/// A blanket impl means any type satisfying the bound is a `ChunkClient` without
-/// naming it; the alias only exists so the capability is stated once instead of
-/// repeated at every consumer (the gRPC chunk service, the FFI client, etc.).
-///
-/// `Send + Sync + 'static` is required even on wasm here: a chunk client is held
-/// behind the wasm `Arc<dyn SwarmChunkProvider>` export and shared, so the alias
-/// is uniform across targets. The per-call `Send` divergence lives in
-/// [`MaybeSend`] on the [`ChunkClientExt`] return types, not in this bound.
+/// `Send + Sync + 'static` holds even on wasm (a client is shared behind an
+/// `Arc<dyn SwarmChunkProvider>`); the per-call `Send` divergence lives in
+/// [`MaybeSend`] on the [`ChunkClientExt`] return types instead.
 pub trait ChunkClient:
     SwarmChunkProvider + SwarmChunkSender + Clone + Send + Sync + 'static
 {
@@ -381,24 +295,12 @@ impl<T> ChunkClient for T where
 {
 }
 
-/// Ergonomic chunk verbs over a [`ChunkClient`], as default methods.
-///
-/// Blanket-implemented for every [`ChunkClient`], so a consumer calls `get` /
-/// `put` / `get_many` / `put_many` directly on its client without importing the
-/// free functions or hand-rolling verification. The single-chunk methods are
-/// `async` returning `impl Future<Output = …> + MaybeSend` via RPITIT (not
-/// async-fn-in-trait), so the future stays `Send` on native for the generic
-/// tonic handler while wasm stays `!Send`. The bulk methods return the existing
-/// [`GetStream`] / [`PutStream`] types unchanged.
-///
-/// The chunk core is complete as a primitive; these verbs compose it, they do
-/// not add new ones.
+/// Ergonomic chunk verbs (`get` / `put` / `get_many` / `put_many`) over a
+/// [`ChunkClient`], blanket-implemented as default methods. The single-chunk
+/// methods return `impl Future + MaybeSend` (RPITIT) so the future stays `Send`
+/// on native; the bulk methods return [`GetStream`] / [`PutStream`].
 pub trait ChunkClientExt: ChunkClient {
-    /// Retrieve and verify one chunk, proving it answers `address`.
-    ///
-    /// Wraps [`retrieve_verified`]: the returned chunk is proven to hash to the
-    /// requested address, so a peer answering with the wrong bytes surfaces as an
-    /// error rather than a trusted chunk.
+    /// Retrieve and verify one chunk via [`retrieve_verified`].
     fn get(
         &self,
         address: ChunkAddress,
@@ -406,11 +308,8 @@ pub trait ChunkClientExt: ChunkClient {
         retrieve_verified(self.clone(), address)
     }
 
-    /// Upload one stamped chunk.
-    ///
-    /// `validate` selects the stamp-signature check: `true` dispatches to
-    /// [`SwarmChunkSender::send_chunk`] (validates the stamp matches the chunk),
-    /// `false` to [`SwarmChunkSender::send_chunk_unchecked`] (trusts the caller).
+    /// Upload one stamped chunk. `validate` selects [`SwarmChunkSender::send_chunk`]
+    /// (checks the stamp) over [`SwarmChunkSender::send_chunk_unchecked`].
     fn put(
         &self,
         chunk: StampedChunk,
@@ -426,10 +325,7 @@ pub trait ChunkClientExt: ChunkClient {
         }
     }
 
-    /// Retrieve and verify many chunks as a bounded, completion-ordered stream.
-    ///
-    /// Returns the same [`GetStream`] as [`get_stream`]; see it for the prefetch
-    /// and verification semantics.
+    /// Retrieve and verify many chunks; see [`get_stream`].
     fn get_many(
         &self,
         addresses: impl IntoIterator<Item = ChunkAddress>,
@@ -438,10 +334,7 @@ pub trait ChunkClientExt: ChunkClient {
         get_stream(self.clone(), addresses, config)
     }
 
-    /// Upload many stamped chunks as a bounded, completion-ordered stream.
-    ///
-    /// Returns the same [`PutStream`] as [`put_stream`]; see it for the bounded
-    /// concurrency and lazy-materialization semantics.
+    /// Upload many stamped chunks; see [`put_stream`].
     fn put_many<I>(&self, chunks: I, config: StreamConfig) -> PutStream<Self>
     where
         I: IntoIterator<Item = StampedChunk>,
@@ -453,16 +346,9 @@ pub trait ChunkClientExt: ChunkClient {
 
 impl<T: ChunkClient> ChunkClientExt for T {}
 
-/// Like [`get_stream`], but sourced from a [`Stream`] of addresses instead of an
-/// iterator.
-///
-/// The gRPC inbound retrieve path receives addresses as a wire stream, not an
-/// eager list; this routes that path through the same refill/verify core
-/// ([`retrieve_verified`]) instead of a hand-rolled `buffer_unordered`. Same
-/// bounded prefetch and completion-order semantics as [`get_stream`]: at most
-/// [`StreamConfig::max_concurrency`] retrievals are in flight, and a new address
-/// is pulled from the source only as a slot frees, so a slow source or consumer
-/// transitively pauses the network reads.
+/// Like [`get_stream`], but sourced from a [`Stream`] of addresses (a wire
+/// stream) instead of an eager iterator. Same bounded-prefetch and
+/// completion-order semantics: a new address is pulled only as a slot frees.
 pub fn get_stream_from<P, St>(
     provider: P,
     addresses: St,
@@ -481,14 +367,9 @@ where
 }
 
 pin_project_lite::pin_project! {
-    /// Stream returned by [`get_stream_from`].
-    ///
-    /// Holds the provider, the (pinned) address source, and the set of in-flight
-    /// retrievals. Each poll tops the in-flight set up to the concurrency limit
-    /// by pulling ready addresses from the source, then yields the next completed
-    /// retrieval. The source is taken to `None` once exhausted so it is no longer
-    /// polled. Pin-projected so neither the provider nor the source need be
-    /// [`Unpin`].
+    /// Stream returned by [`get_stream_from`]. Each poll pulls ready addresses
+    /// from the source up to the limit, then yields the next completed
+    /// retrieval; the source is taken to `None` once exhausted.
     #[must_use = "a stream does nothing unless polled"]
     pub struct GetStreamFrom<P, St> {
         provider: P,
@@ -509,10 +390,8 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
-        // Prefetch: admit ready addresses from the source until the in-flight set
-        // hits the limit or the source has no address ready. A pending source
-        // stops admitting without parking the whole pipeline, since in-flight work
-        // may still complete below.
+        // Admit ready addresses up to the limit. A pending source stops admitting
+        // without parking the pipeline, since in-flight work may still complete.
         let mut source_pending = false;
         while this.in_flight.len() < *this.limit {
             let Some(source) = this.source.as_mut().as_pin_mut() else {
@@ -525,7 +404,7 @@ where
                         (address, retrieve_verified(provider, address).await)
                     }));
                 }
-                // Source drained: drop it so it is never polled again.
+                // Drained: drop the source so it is never polled again.
                 Poll::Ready(None) => {
                     this.source.set(None);
                     break;
@@ -538,14 +417,10 @@ where
         }
 
         match this.in_flight.poll_next_unpin(cx) {
-            // A slot completed: hand it out. The next poll refills, exactly one
-            // replacement per drained slot, so a stalled consumer stops all reads.
             Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
-            // Nothing in flight and the source is exhausted: the stream is done.
             Poll::Ready(None) if this.source.is_none() => Poll::Ready(None),
-            // Nothing in flight but the source could still yield. If the source
-            // parked it will wake us; otherwise it had an address ready that the
-            // limit admitted this tick, so re-poll.
+            // Nothing in flight but the source could still yield. If it parked it
+            // will wake us; otherwise an address was admitted this tick, re-poll.
             Poll::Ready(None) => {
                 if !source_pending {
                     cx.waker().wake_by_ref();
@@ -557,21 +432,17 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        // The source is a lazy stream, so only the in-flight set is a known lower
-        // bound; the upper bound is unknown until the source ends.
+        // Lazy source: only the in-flight set is a known lower bound.
         (self.in_flight.len(), None)
     }
 }
 
 /// Stream of push receipts for a list of chunks to upload.
 ///
-/// Yields `(address, result)` per input chunk in completion order. At most
-/// [`StreamConfig::max_concurrency`] pushes run at once.
-///
-/// `chunks` is consumed lazily: the pipeline pulls the next [`StampedChunk`] from
-/// the iterator only when it admits a push, so a caller that builds each chunk on
-/// demand holds at most `max_concurrency` materialized chunks at once, not the
-/// whole list.
+/// Yields `(address, result)` per input chunk in completion order, at most
+/// [`StreamConfig::max_concurrency`] pushes at once. `chunks` is pulled lazily as
+/// pushes are admitted, so a caller that builds chunks on demand holds at most
+/// `max_concurrency` of them resident, not the whole list.
 pub fn put_stream<S, I>(sender: S, chunks: I, config: StreamConfig) -> PutStream<S>
 where
     S: SwarmChunkSender + Clone + 'static,
@@ -587,11 +458,9 @@ where
 
 /// Stream of push receipts for a feed of fallibly-produced chunks.
 ///
-/// Like [`put_stream`], but each feed entry pairs a target `address` with a
-/// `SwarmResult<StampedChunk>`, so a per-chunk build failure (byte/address
-/// mismatch, bad stamp) surfaces as that address's error item instead of
-/// aborting the upload. A feed `Err` issues no push. The address is carried
-/// through so a completion-ordered receipt stays correlatable.
+/// Like [`put_stream`], but each entry pairs an `address` with a
+/// `SwarmResult<StampedChunk>`: a per-chunk build failure surfaces as that
+/// address's error item (issuing no push) instead of aborting the upload.
 pub fn try_put_stream<S, I>(sender: S, chunks: I, config: StreamConfig) -> PutStream<S>
 where
     S: SwarmChunkSender + Clone + 'static,
@@ -602,17 +471,14 @@ where
         sender,
         pending: BoxedChunks::box_chunks(chunks.into_iter()).peekable(),
         in_flight: FuturesUnordered::new(),
-        // Clamp to at least one even on a raw `StreamConfig { max_concurrency: 0 }`
-        // literal, so the pipeline never busy-loops without admitting work.
+        // Clamp to >= 1 so a raw `StreamConfig { max_concurrency: 0 }` literal
+        // never busy-loops without admitting work.
         limit: config.max_concurrency.max(1),
     }
 }
 
-/// Marker for the pending-chunk iterator's thread-safety requirement: `Send` on
-/// native so [`PutStream`] stays `Send` (the FFI handle is driven across the
-/// runtime and the tests spawn it), unconstrained on wasm. Mirrors the native vs
-/// wasm split of [`MaybeSendBoxFuture`]. Blanket-implemented, so callers never
-/// name it.
+/// `Send` bound on the pending-chunk iterator so [`PutStream`] stays `Send`,
+/// native-only. Blanket-impl; callers never name it.
 #[cfg(not(target_arch = "wasm32"))]
 pub trait MaybeSendIter: Send {}
 #[cfg(not(target_arch = "wasm32"))]
@@ -622,14 +488,13 @@ pub trait MaybeSendIter {}
 #[cfg(target_arch = "wasm32")]
 impl<T> MaybeSendIter for T {}
 
-/// Boxed pending-chunk feed. `Send` on native so [`PutStream`] stays `Send`;
-/// not required `Send` on wasm.
+/// Boxed pending-chunk feed, `Send` on native so [`PutStream`] stays `Send`.
 #[cfg(not(target_arch = "wasm32"))]
 type BoxedChunks = Box<dyn Iterator<Item = (ChunkAddress, SwarmResult<StampedChunk>)> + Send>;
 #[cfg(target_arch = "wasm32")]
 type BoxedChunks = Box<dyn Iterator<Item = (ChunkAddress, SwarmResult<StampedChunk>)>>;
 
-/// Box a feed iterator into [`BoxedChunks`] with the right `Send`-ness per target.
+/// Box a feed iterator into [`BoxedChunks`] with the per-target `Send`-ness.
 trait BoxedChunksExt {
     fn box_chunks<
         I: Iterator<Item = (ChunkAddress, SwarmResult<StampedChunk>)> + MaybeSendIter + 'static,
@@ -648,17 +513,14 @@ impl BoxedChunksExt for BoxedChunks {
     }
 }
 
-/// Iterator the upload pipeline pulls chunks from. Boxed so the stream type is
-/// independent of how the caller produces chunks (an eager `Vec` or a lazy
-/// reconstruct-on-demand feed), and peekable so the stream can detect the end.
+/// Source the upload pipeline pulls chunks from. Boxed so the stream type is
+/// independent of how the caller produces chunks; peekable so the stream can
+/// detect the end.
 type PendingChunks = std::iter::Peekable<BoxedChunks>;
 
 pin_project_lite::pin_project! {
-    /// Stream returned by [`put_stream`].
-    ///
-    /// Admits up to `limit` pushes at once and pulls pending chunks lazily, so
-    /// only admitted chunks are materialized. Pin-projected so the sender need
-    /// not be [`Unpin`].
+    /// Stream returned by [`put_stream`]. Admits up to `limit` pushes at once,
+    /// pulling pending chunks lazily so only admitted chunks are materialized.
     #[must_use = "a stream does nothing unless polled"]
     pub struct PutStream<S> {
         sender: S,
@@ -668,8 +530,8 @@ pin_project_lite::pin_project! {
     }
 }
 
-/// Push one chunk, carrying its address out alongside the receipt so a
-/// completion-ordered item stays correlatable.
+/// Push one chunk, carrying its address out alongside the receipt for
+/// correlation.
 async fn push_chunk<S>(
     sender: S,
     address: ChunkAddress,
@@ -682,9 +544,8 @@ where
     (address, receipt)
 }
 
-/// Admit pending chunks up to the concurrency cap. Each in-flight future carries
-/// its address out for correlation; a feed error issues no push and is yielded
-/// from a ready future carrying its address.
+/// Admit pending chunks up to the cap. A feed error issues no push and is
+/// yielded from a ready future carrying its address.
 fn put_refill<S>(
     sender: &S,
     pending: &mut PendingChunks,
@@ -719,9 +580,8 @@ where
         put_refill(this.sender, this.pending, this.in_flight, *this.limit);
 
         match this.in_flight.poll_next_unpin(cx) {
-            // A push completed. Refill so the next poll already has work queued:
-            // exactly one replacement per drained slot, so a consumer that stops
-            // polling stops all new pushes.
+            // Backpressure: exactly one replacement per drained slot, so a
+            // consumer that stops polling stops all new pushes.
             Poll::Ready(Some((address, result))) => {
                 put_refill(this.sender, this.pending, this.in_flight, *this.limit);
                 Poll::Ready(Some((address, result)))
@@ -736,9 +596,8 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        // The pending source is a lazy iterator, so only its declared bound is
-        // known; the in-flight set is exact. The lower bound counts in-flight
-        // plus whatever the iterator guarantees remain.
+        // Lazy pending iterator: only its declared bound is known; in-flight is
+        // exact.
         let (pending_lo, pending_hi) = self.pending.size_hint();
         let lower = pending_lo + self.in_flight.len();
         let upper = pending_hi.map(|hi| hi + self.in_flight.len());
@@ -766,8 +625,7 @@ mod tests {
         Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
     }
 
-    /// Build a content chunk from distinct bytes so each test chunk has a unique
-    /// address.
+    /// A content chunk seeded so each test chunk has a unique address.
     fn chunk_for(seed: u8) -> StampedChunk {
         let payload = vec![seed; 64];
         let chunk = ContentChunk::new(payload).expect("valid content chunk");
@@ -938,8 +796,7 @@ mod tests {
         let mut seen = std::collections::HashSet::new();
         for (address, result) in results {
             let verified = result.expect("retrieval succeeds");
-            // The item's address correlates to the verified chunk; order is the
-            // consumer's job, so we assert membership not position.
+            // Unordered: assert membership not position.
             assert_eq!(*verified.address(), address);
             seen.insert(address);
         }
@@ -948,8 +805,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_stream_caps_concurrency() {
-        // A cap of 3 permits exactly 3 concurrent retrievals even though many
-        // addresses are pending.
+        // A cap of 3 permits exactly 3 concurrent retrievals.
         let chunks: Vec<_> = (0..16).map(chunk_for).collect();
         let addresses: Vec<_> = chunks.iter().map(|c| *c.address()).collect();
         let provider = MapProvider::gated(chunks);
@@ -959,14 +815,11 @@ mod tests {
 
         let mut stream = get_stream(provider, addresses, StreamConfig::new(3));
 
-        // Drive the stream forward without consuming: poll it so it fills the
-        // in-flight set, then let the gated retrievals settle.
         let driver = tokio::spawn(async move {
             let _ = stream.next().await;
             stream
         });
 
-        // Wait until the pipeline has saturated its in-flight set.
         loop {
             if in_flight.load(Ordering::SeqCst) >= 3 {
                 break;
@@ -1076,7 +929,7 @@ mod tests {
     }
 
     /// A stampless delivery still verifies against its address and is yielded as
-    /// a `VerifiedChunk` carrying no stamp. This is the bee-interop download path.
+    /// a `VerifiedChunk` carrying no stamp.
     #[tokio::test]
     async fn get_stream_accepts_stampless_delivery() {
         let chunk = chunk_for(5).into_parts().0;
@@ -1092,8 +945,7 @@ mod tests {
         assert!(verified.stamp().is_none(), "no stamp is carried through");
     }
 
-    /// The verified chunk carries the overlay the provider reported as
-    /// `served_by`, so the streaming retrieve path no longer loses provenance.
+    /// The verified chunk carries the overlay the provider reported as `served_by`.
     #[tokio::test]
     async fn get_stream_carries_served_by() {
         let chunk = chunk_for(7);

--- a/crates/swarm/stream/src/wasm.rs
+++ b/crates/swarm/stream/src/wasm.rs
@@ -1,24 +1,10 @@
-//! Browser binding for the streaming get/put pipelines.
+//! wasm-bindgen adapter exposing [`get_stream`](crate::get_stream) and
+//! [`put_stream`](crate::put_stream) to JavaScript as async iterators.
 //!
-//! This is the wasm-bindgen adapter over the transport-agnostic core in this
-//! crate: the same [`get_stream`](crate::get_stream) and
-//! [`put_stream`](crate::put_stream) pipelines, surfaced to JavaScript as async
-//! iterators. A browser host drives them with `for await (const item of
-//! stream)`; each `next()` resolves to a plain object carrying the chunk (or the
-//! per-item error) and a `done` flag, the JS async-iterator protocol.
-//!
-//! The bound lives in Rust exactly as on native: the adapter holds the core
-//! stream and polls it one item per `next()` call, so a browser consumer that
-//! awaits slowly transitively pauses the network reads. Payload crosses the
-//! boundary as a `js_sys` `Uint8Array` copied once per item; inside Rust the
-//! chunk stays `Bytes`.
-//!
-//! The provider and sender are taken as trait objects
-//! (`Arc<dyn SwarmChunkProvider>`, `Arc<dyn SwarmChunkSender>`) so the exported
-//! types are concrete (wasm-bindgen cannot export generics) while still wrapping
-//! the one core. The browser client wires its real provider in when the wasm
-//! client builder lands; until then the adapter is exercised against in-memory
-//! providers in tests, the same core path the native FFI uses.
+//! Each `next()` polls the core stream once, so a slowly-awaiting consumer
+//! transitively pauses the network reads. Provider and sender are trait objects
+//! because wasm-bindgen cannot export generics. Payload crosses the boundary as
+//! a `Uint8Array` copied once per item; inside Rust the chunk stays `Bytes`.
 
 use std::pin::Pin;
 use std::sync::Arc;
@@ -34,26 +20,16 @@ use wasm_bindgen::prelude::*;
 
 use crate::{StreamConfig, VerifiedChunk, get_stream, put_stream};
 
-/// Boxed core download stream over a trait-object provider.
 type CoreGetStream = Pin<Box<dyn Stream<Item = (ChunkAddress, SwarmResult<VerifiedChunk>)>>>;
-/// Boxed core upload stream over a trait-object sender.
 type CorePutStream = Pin<Box<dyn Stream<Item = (ChunkAddress, SwarmResult<PushReceipt>)>>>;
 
-/// Translate the boundary stream config from JS into the core config.
-///
-/// Limiting is by chunk count: only `max_concurrency` is used. `window_bytes` is
-/// kept in the JS signature for stability but ignored (byte/bandwidth limiting
-/// belongs at the connection layer). The core clamps to at least one.
+/// `window_bytes` is kept for ABI stability but ignored; limiting is by chunk count.
 fn config_from(_window_bytes: u32, max_concurrency: u32) -> StreamConfig {
     StreamConfig::new(max_concurrency as usize)
 }
 
-/// Build the JS result object `{ done, address, data, error }` for one download
-/// item.
-///
-/// `data` is a `Uint8Array` of the chunk's wire bytes on success, or `null` on a
-/// per-address error; `error` carries the failure message. A single object shape
-/// keeps the JS async-iterator contract uniform across success and failure.
+/// Build `{ done, address, data, stamp, error }` for one download item. `data`
+/// is a `Uint8Array` on success or `null` on a per-address error.
 fn download_item(
     address: &ChunkAddress,
     result: SwarmResult<VerifiedChunk>,
@@ -68,14 +44,12 @@ fn download_item(
     match result {
         Ok(verified) => {
             let (chunk, stamp) = verified.into_parts();
-            // One copy at the boundary; the chunk stayed `Bytes` until here.
             set(
                 &obj,
                 "data",
                 &Uint8Array::from(chunk.into_bytes().as_ref()).into(),
             )?;
-            // A storer may omit the stamp from a delivery; emit a null stamp
-            // when absent.
+            // A storer may omit the stamp from a delivery.
             let stamp_value = match stamp {
                 Some(stamp) => Uint8Array::from(stamp.to_bytes().as_ref()).into(),
                 None => JsValue::NULL,
@@ -92,7 +66,7 @@ fn download_item(
     Ok(obj.into())
 }
 
-/// Build the JS result object `{ done, address, error }` for one upload ack.
+/// Build `{ done, address, storer, error }` for one upload ack.
 fn upload_item(
     address: &ChunkAddress,
     result: SwarmResult<PushReceipt>,
@@ -121,32 +95,24 @@ fn upload_item(
     Ok(obj.into())
 }
 
-/// The terminal `{ done: true }` object every async iterator returns once the
-/// stream is exhausted.
+/// The terminal `{ done: true }` object returned once the stream is exhausted.
 fn done_item() -> Result<JsValue, JsValue> {
     let obj = Object::new();
     set(&obj, "done", &JsValue::TRUE)?;
     Ok(obj.into())
 }
 
-/// Set `key` to `value` on `obj`, mapping a reflection failure to a `JsValue`
-/// error.
 fn set(obj: &Object, key: &str, value: &JsValue) -> Result<(), JsValue> {
     Reflect::set(obj, &JsValue::from_str(key), value).map(|_| ())
 }
 
-/// Parse a 32-byte chunk address from a JS byte array, rejecting a wrong length.
 fn parse_address(bytes: &[u8]) -> Result<ChunkAddress, JsValue> {
     ChunkAddress::from_slice(bytes)
         .map_err(|_| JsValue::from_str(&format!("invalid chunk address: {} bytes", bytes.len())))
 }
 
-/// A browser-facing streaming download.
-///
-/// Constructed by [`get_stream_wasm`]. Drive it from JS with the async-iterator
-/// protocol: each `await stream.next()` yields the next download item, ending
-/// with `{ done: true }`. The pipeline keeps at most `max_concurrency` chunks in
-/// flight.
+/// Browser-facing streaming download. Constructed by [`get_stream_wasm`]; drive
+/// with `await stream.next()` until `{ done: true }`.
 #[wasm_bindgen]
 pub struct WasmGetStream {
     inner: CoreGetStream,
@@ -154,11 +120,8 @@ pub struct WasmGetStream {
 
 #[wasm_bindgen]
 impl WasmGetStream {
-    /// Resolve the next download item, or `{ done: true }` when exhausted.
-    ///
-    /// Polls the core stream once. Because the adapter advances only when JS
-    /// awaits, a slow consumer paces the network reads. Items arrive in
-    /// completion order, each carrying its address.
+    /// Resolve the next download item, or `{ done: true }` when exhausted. Items
+    /// arrive in completion order, each carrying its address.
     pub async fn next(&mut self) -> Result<JsValue, JsValue> {
         match self.inner.next().await {
             Some((address, result)) => download_item(&address, result),
@@ -167,11 +130,8 @@ impl WasmGetStream {
     }
 }
 
-/// A browser-facing streaming upload.
-///
-/// Constructed by [`put_stream_wasm`]. Each `await stream.next()` feeds the next
-/// chunk's push to completion and yields its ack, ending with `{ done: true }`.
-/// Rust owns the bounded in-flight window, so a slow consumer pauses the pushes.
+/// Browser-facing streaming upload. Constructed by [`put_stream_wasm`]; each
+/// `await stream.next()` drives the next push to completion and yields its ack.
 #[wasm_bindgen]
 pub struct WasmPutStream {
     inner: CorePutStream,
@@ -189,11 +149,8 @@ impl WasmPutStream {
     }
 }
 
-/// Open a byte-bounded streaming download over `provider`.
-///
-/// `addresses` is a flat list of 32-byte chunk addresses; a malformed entry is
-/// rejected up front. The returned [`WasmGetStream`] is a JS async iterator over
-/// the verified chunks, at most `max_concurrency` in flight.
+/// Open a streaming download over `provider`. `addresses` is a flat list of
+/// 32-byte chunk addresses; a malformed entry is rejected up front.
 pub fn get_stream_wasm(
     provider: Arc<dyn SwarmChunkProvider>,
     addresses: Vec<Vec<u8>>,
@@ -209,12 +166,8 @@ pub fn get_stream_wasm(
     Ok(WasmGetStream { inner })
 }
 
-/// Open a byte-bounded streaming upload over `sender`.
-///
-/// `chunks` are pre-reconstructed [`StampedChunk`]s; the caller (the wasm client)
-/// reconstructs them from wire bytes before calling, the same way the native FFI
-/// does at its boundary. The returned [`WasmPutStream`] is a JS async iterator
-/// over the per-chunk acks, at most `max_concurrency` in flight.
+/// Open a streaming upload over `sender`. `chunks` are pre-reconstructed
+/// [`StampedChunk`]s; the caller reconstructs them from wire bytes first.
 pub fn put_stream_wasm(
     sender: Arc<dyn SwarmChunkSender>,
     chunks: Vec<StampedChunk>,


### PR DESCRIPTION
The rebase-merged #350 stack landed with essay-style rustdoc. This editorial pass dials the verbosity back across the 48 affected `.rs` files, calibrating from the as-merged level down to roughly a fifth of it.

## What changed

Doc and comment only. No code, signatures, attributes, imports, or behaviour were touched.

- Multi-section module essays ("# What this decides", "# The rule", "# Why X", "# Notes") collapse to a few terse lines: what the module is plus the one non-obvious invariant a reader needs.
- Item docs that merely restated the signature are dropped; the name carries them.
- Inline comments that narrated the next line are removed.

## What was kept (terse)

- Wire-format and on-disk layout invariants (byte orders, key layouts, encodings).
- Consensus-observable rules (for example the stamp-index `prev >= curr` rejects boundary).
- Genuine safety, correctness, and ordering rationale.
- Doctest and example code (only the surrounding prose was trimmed).

## Also removed

- Inline references to the reference implementation.
- Internal plan labels (PR-x and similar) and design-process narration.

## Net

48 files changed, 1765 insertions, 4488 deletions.

## Verification

- `cargo fmt --all`
- `cargo clippy --lib --all-features -- -D warnings`
- `cargo clippy --tests --benches --all-features -- -D warnings`
- doctests for the three crates carrying doc-comment examples
- restored terse one-line docs on the six public items in `vertex-swarm-api` that the pass had stripped (the crate is `#![warn(missing_docs)]`)

No intra-doc links were broken by this pass.

---

AI Assistance: Claude Code (Claude Opus) used for the implementation, commit messages, and this PR description.