### PR TITLE
feat(storage): add key-presence DbTx primitives and migrate cursor consumers

### DIFF
--- a/crates/storage/redb/src/cursor.rs
+++ b/crates/storage/redb/src/cursor.rs
@@ -21,6 +21,11 @@ use vertex_storage::{DatabaseError, DatabaseErrorInfo, DbCursorRO, Decode, Encod
 
 use crate::tx::decode_value;
 
+/// redb's raw byte-keyed read-only table backing every cursor.
+type RawTable = ReadOnlyTable<&'static [u8], &'static [u8]>;
+/// A forward range over [`RawTable`], pinned to the cursor's snapshot.
+type RawRange = Range<'static, &'static [u8], &'static [u8]>;
+
 /// Raw encoded key/value bytes for the cursor's current entry.
 struct Position {
     key: Vec<u8>,
@@ -32,9 +37,9 @@ struct Position {
 /// Owns its [`ReadOnlyTable`] (which `Arc`-pins the read snapshot), so it may be
 /// held across calls and returned from a function, outliving the originating tx.
 pub struct RedbCursorRO<T: Table> {
-    table: ReadOnlyTable<&'static [u8], &'static [u8]>,
+    table: RawTable,
     /// Live forward range driving `next()`; rebuilt by seeking/backward moves.
-    forward: Option<Range<'static, &'static [u8], &'static [u8]>>,
+    forward: Option<RawRange>,
     current: Option<Position>,
     /// Raw key the cursor logically sits at, used as the exclusive upper bound
     /// for `prev()`. On a seek miss it holds the absent seek key, so the
@@ -50,7 +55,7 @@ fn read_err(context: &str, err: redb::StorageError) -> DatabaseError {
 }
 
 impl<T: Table> RedbCursorRO<T> {
-    pub(crate) fn new(table: ReadOnlyTable<&'static [u8], &'static [u8]>) -> Self {
+    pub(crate) fn new(table: RawTable) -> Self {
         Self {
             table,
             forward: None,
@@ -80,7 +85,7 @@ impl<T: Table> RedbCursorRO<T> {
 
     /// Full-table forward range. The explicit byte-slice bound avoids the
     /// `RangeFull` type-inference ambiguity on the generic `range()` method.
-    fn full_range(&self) -> Result<Range<'static, &'static [u8], &'static [u8]>, DatabaseError> {
+    fn full_range(&self) -> Result<RawRange, DatabaseError> {
         let empty: &[u8] = &[];
         self.table
             .range(empty..)
@@ -88,10 +93,7 @@ impl<T: Table> RedbCursorRO<T> {
     }
 
     /// Forward range starting at and including `from`.
-    fn range_from(
-        &self,
-        from: &[u8],
-    ) -> Result<Range<'static, &'static [u8], &'static [u8]>, DatabaseError> {
+    fn range_from(&self, from: &[u8]) -> Result<RawRange, DatabaseError> {
         self.table
             .range(from..)
             .map_err(|e| read_err(&format!("cursor seek {}", T::NAME), e))
@@ -601,5 +603,79 @@ mod tests {
         c.next().unwrap();
         // Exactly three values decoded, not 1000.
         assert_eq!(DECODE_COUNT.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn exists_does_not_deserialise_value() {
+        use vertex_storage::DbTx;
+
+        let db = setup();
+        fill_nums(&db, &[10, 20, 30]);
+
+        DECODE_COUNT.store(0, Ordering::SeqCst);
+        let tx = db.tx().unwrap();
+        assert!(tx.exists::<CountTable>(K(20)).unwrap());
+        assert!(!tx.exists::<CountTable>(K(25)).unwrap());
+        // Presence is probed without ever decoding the stored value.
+        assert_eq!(DECODE_COUNT.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn exists_works_on_write_tx() {
+        use vertex_storage::DbTx;
+
+        // A write transaction has no cursor, so `exists` must not fall through
+        // to the cursor-based default; the duplicate check in the storer's
+        // `put` relies on this.
+        let db = setup();
+        db.update(|tx| {
+            assert!(!tx.exists::<NumTable>(K(7)).unwrap());
+            tx.put::<NumTable>(K(7), 70)?;
+            assert!(tx.exists::<NumTable>(K(7)).unwrap());
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn first_key_empty_and_non_empty() {
+        use vertex_storage::DbTx;
+
+        let db = setup();
+        // Empty table reports no first key on both tx kinds.
+        let tx = db.tx().unwrap();
+        assert_eq!(tx.first_key::<NumTable>().unwrap(), None);
+        drop(tx);
+        db.update(|tx| {
+            assert_eq!(tx.first_key::<NumTable>().unwrap(), None);
+            Ok(())
+        })
+        .unwrap();
+
+        fill_nums(&db, &[30, 10, 20]);
+        // Lowest-ordered key, on the read tx.
+        let tx = db.tx().unwrap();
+        assert_eq!(tx.first_key::<NumTable>().unwrap(), Some(K(10)));
+        drop(tx);
+        // And on the write tx, where the cursor default would error.
+        db.update(|tx| {
+            assert_eq!(tx.first_key::<NumTable>().unwrap(), Some(K(10)));
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn first_key_does_not_deserialise_value() {
+        use vertex_storage::DbTx;
+
+        let db = setup();
+        fill_nums(&db, &[10, 20, 30]);
+
+        DECODE_COUNT.store(0, Ordering::SeqCst);
+        let tx = db.tx().unwrap();
+        assert_eq!(tx.first_key::<CountTable>().unwrap(), Some(K(10)));
+        // Only the key is decoded; the value guard is dropped undecoded.
+        assert_eq!(DECODE_COUNT.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/storage/redb/src/tx.rs
+++ b/crates/storage/redb/src/tx.rs
@@ -95,6 +95,70 @@ macro_rules! impl_db_tx_reads {
             result
         }
 
+        fn exists<T: Table>(&self, key: T::Key) -> Result<bool, DatabaseError> {
+            let start = Instant::now();
+            let _span = tracing::trace_span!("db_exists", table = T::NAME).entered();
+
+            let def = table_def(T::NAME);
+            let table = self.inner.open_table(def).map_err(|e| {
+                DatabaseError::Read(DatabaseErrorInfo::with_source(
+                    format!("open table {}", T::NAME),
+                    e,
+                ))
+            })?;
+            let encoded = key.encode();
+            // `get` returns an AccessGuard; probing `is_some()` never calls
+            // `.value()`, so the stored value is not decoded.
+            let present = table
+                .get(encoded.as_ref())
+                .map_err(|e| {
+                    DatabaseError::Read(DatabaseErrorInfo::with_source(
+                        format!("exists in {}", T::NAME),
+                        e,
+                    ))
+                })?
+                .is_some();
+
+            record_op(
+                T::NAME,
+                operation::GET,
+                "success",
+                start.elapsed().as_secs_f64(),
+            );
+            Ok(present)
+        }
+
+        fn first_key<T: Table>(&self) -> Result<Option<T::Key>, DatabaseError> {
+            let start = Instant::now();
+            let _span = tracing::trace_span!("db_first_key", table = T::NAME).entered();
+
+            let def = table_def(T::NAME);
+            let table = self.inner.open_table(def).map_err(|e| {
+                DatabaseError::Read(DatabaseErrorInfo::with_source(
+                    format!("open table {}", T::NAME),
+                    e,
+                ))
+            })?;
+            // `first` decodes only the key; the value guard is dropped undecoded.
+            let key = match table.first().map_err(|e| {
+                DatabaseError::Read(DatabaseErrorInfo::with_source(
+                    format!("first_key in {}", T::NAME),
+                    e,
+                ))
+            })? {
+                Some((k, _v)) => Some(T::Key::decode(k.value())?),
+                None => None,
+            };
+
+            record_op(
+                T::NAME,
+                operation::KEYS,
+                "success",
+                start.elapsed().as_secs_f64(),
+            );
+            Ok(key)
+        }
+
         fn entries<T: Table>(&self) -> Result<Vec<(T::Key, T::Value)>, DatabaseError> {
             let start = Instant::now();
             let _span = tracing::trace_span!("db_entries", table = T::NAME).entered();

--- a/crates/storage/src/traits.rs
+++ b/crates/storage/src/traits.rs
@@ -99,6 +99,16 @@ pub trait DbTx: Send + Sync {
     /// Get a value by key from a table. Returns `None` if not found.
     fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError>;
 
+    /// Check whether a key exists in a table without deserializing its value.
+    fn exists<T: Table>(&self, key: T::Key) -> Result<bool, DatabaseError> {
+        Ok(self.get::<T>(key)?.is_some())
+    }
+
+    /// Get the first (lowest-ordered) key in a table without deserializing values.
+    fn first_key<T: Table>(&self) -> Result<Option<T::Key>, DatabaseError> {
+        Ok(self.cursor::<T>()?.first()?.map(|(k, _)| k))
+    }
+
     /// Get all entries from a table as key/value pairs.
     fn entries<T: Table>(&self) -> Result<Vec<(T::Key, T::Value)>, DatabaseError>;
 
@@ -195,9 +205,8 @@ impl<T: DbTx + ?Sized> IndexedRead for T {
         &self,
         index_key: I::Key,
     ) -> Result<Option<<I::Primary as Table>::Value>, DatabaseError> {
-        let pk = match self.get::<I>(index_key)? {
-            Some(pk) => pk,
-            None => return Ok(None),
+        let Some(pk) = self.get::<I>(index_key)? else {
+            return Ok(None);
         };
         self.get::<I::Primary>(pk)
     }
@@ -247,9 +256,8 @@ impl<T: DbTxMut + ?Sized> IndexedWrite for T {
         &self,
         pk: <I::Primary as Table>::Key,
     ) -> Result<bool, DatabaseError> {
-        let value = match self.get::<I::Primary>(pk.clone())? {
-            Some(v) => v,
-            None => return Ok(false),
+        let Some(value) = self.get::<I::Primary>(pk.clone())? else {
+            return Ok(false);
         };
         let idx = I::extract(&value);
         self.delete::<I::Primary>(pk)?;

--- a/crates/swarm/postage/src/store.rs
+++ b/crates/swarm/postage/src/store.rs
@@ -146,8 +146,8 @@ impl<DB: Database> BatchStore for DbBatchStore<DB> {
     }
 
     fn contains(&self, id: &BatchId) -> Result<bool, Self::Error> {
-        // TODO(#214): switch to a key-presence check once the tx trait has one.
-        Ok(self.get(id)?.is_some())
+        // Key-presence probe: never decodes the batch value.
+        Ok(self.db.view(|tx| tx.exists::<Batches>(BatchIdKey(*id)))?)
     }
 
     fn context(&self) -> Result<PostageContext, Self::Error> {
@@ -164,7 +164,8 @@ impl<DB: Database> BatchStore for DbBatchStore<DB> {
     }
 
     fn batch_ids(&self) -> Result<Vec<BatchId>, Self::Error> {
-        // Lazy read-only cursor owns its snapshot; only keys are needed.
+        // Lazy read-only cursor owns its snapshot. Each step decodes its value
+        // because the cursor has no key-only mode; only the keys are retained.
         let tx = self.db.tx()?;
         let mut cursor = tx.cursor::<Batches>()?;
         let mut ids = Vec::new();

--- a/crates/swarm/storer/src/db_store.rs
+++ b/crates/swarm/storer/src/db_store.rs
@@ -41,11 +41,8 @@ impl<DB: Database> ChunkStore for DbChunkStore<DB> {
     fn put(&self, address: &ChunkAddress, data: &[u8]) -> StorerResult<()> {
         self.db.update(|tx| {
             // Chunks are content-addressed: never overwrite an existing entry.
-            // The duplicate probe deserializes the existing value because the
-            // transaction trait has no key-presence primitive; the table is
-            // uncompressed so the cost is one length parse plus a copy.
-            // TODO(#214): switch to a key-presence check once available.
-            if tx.get::<ChunkTable>(*address)?.is_none() {
+            // The duplicate probe checks key presence without decoding the value.
+            if !tx.exists::<ChunkTable>(*address)? {
                 tx.put::<ChunkTable>(*address, data.to_vec())?;
             }
             Ok(())
@@ -58,13 +55,8 @@ impl<DB: Database> ChunkStore for DbChunkStore<DB> {
     }
 
     fn contains(&self, address: &ChunkAddress) -> StorerResult<bool> {
-        // Presence is probed via a full value read: the transaction trait has
-        // no key-presence primitive yet, so this deserializes the chunk and
-        // discards it.
-        // TODO(#214): switch to a key-presence check once available.
-        Ok(self
-            .db
-            .view(|tx| Ok(tx.get::<ChunkTable>(*address)?.is_some()))?)
+        // Key-presence probe: never decodes the chunk value.
+        Ok(self.db.view(|tx| tx.exists::<ChunkTable>(*address))?)
     }
 
     fn delete(&self, address: &ChunkAddress) -> StorerResult<()> {
@@ -84,17 +76,18 @@ impl<DB: Database> ChunkStore for DbChunkStore<DB> {
     where
         F: FnMut(&ChunkAddress) -> bool,
     {
-        // The transaction trait has no streaming or cursor read, so all keys
-        // are materialized up front (values are never deserialized). Early
-        // exit via the callback still skips the rest of the walk, but callers
-        // that only need the first key, such as Reserve::evict_oldest, pay an
-        // O(N) key scan per call.
-        // TODO(#214): iterate via a cursor once the trait exposes one.
-        let keys = self.db.view(|tx| tx.keys::<ChunkTable>())?;
-        for address in &keys {
-            if !callback(address) {
+        // Stream entries via a lazy cursor: callers that only need the first key,
+        // such as Reserve::evict_oldest, stop after one step instead of paying an
+        // O(N) scan. Each step still decodes its value because the cursor has no
+        // key-only mode.
+        let tx = self.db.tx()?;
+        let mut cursor = tx.cursor::<ChunkTable>()?;
+        let mut entry = cursor.first()?;
+        while let Some((address, _data)) = entry {
+            if !callback(&address) {
                 break;
             }
+            entry = cursor.next()?;
         }
         Ok(())
     }


### PR DESCRIPTION
Closes #214 (the residual after the cursor half landed in #396).

## What

Adds two key-presence read primitives to the `DbTx` trait and migrates the four `TODO(#214)` consumers off full-value reads and O(N) key materialisation.

- `DbTx::exists<T>(key)` and `DbTx::first_key<T>()` as default methods, overridden on the redb backend.
- The redb `exists` probes `table.get(key)?.is_some()` without ever calling `.value()`, so no value decode happens. It is implemented on both the read and the write transaction, because the storer `put` duplicate check runs inside a write transaction where no cursor is available.
- The redb `first_key` reads `table.first()` and decodes only the key.

## Consumers migrated (TODO(#214) removed)

- `storer/db_store.rs::contains()` and the `put()` duplicate check use `exists`.
- `storer/db_store.rs::for_each()` streams via the lazy cursor with early exit, so `Reserve::evict_oldest` (the only caller) stops after the first key instead of materialising every key plus a 32*N-byte allocation.
- `postage/store.rs::contains()` uses `exists`.

## Notes

Pure performance and cleanup: no wire change, no behaviour change beyond avoiding redundant deserialisation and full scans.

Implemented and reviewed with an adversarial QA pass (rust-idiomacy and correctness lenses). New redb tests prove the no-deserialise property via the existing decode-counter harness: `exists_does_not_deserialise_value`, `exists_works_on_write_tx`, `first_key_empty_and_non_empty`, `first_key_does_not_deserialise_value`.

## Verification

- `cargo clippy --lib --all-features -- -D warnings`
- `cargo clippy --tests --benches --all-features -- -D warnings`
- `cargo test -p vertex-storage-redb -p vertex-swarm-storer -p vertex-swarm-postage`

---

AI Assistance: Claude Code (Claude Opus) used for the implementation, commit messages, and this PR description.