### PR TITLE
refactor(swarm-bandwidth-pseudosettle): decouple the provider from the node crate

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,26 +41,19 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # just
+        with:
+          tool: just
       - name: Clippy (production)
         run: cargo clippy --lib --all-features -- -D warnings
       - name: Clippy (tests)
         run: cargo clippy --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::indexing_slicing
-      # Keep the embedded FFI cone free of the native observability server stack
-      # (Prometheus exporter, OTLP appender). Pure `cargo tree`, no compile.
-      - name: Cone guard (ffi)
-        run: |
-          tree="$(cargo tree -p vertex-ffi -e normal)"
-          leaked=""
-          for crate in metrics-exporter-prometheus opentelemetry-appender-tracing; do
-            if grep -q "$crate" <<<"$tree"; then
-              leaked="$leaked $crate"
-            fi
-          done
-          if [ -n "$leaked" ]; then
-            echo "cone guard: vertex-ffi pulls the observability server stack:$leaked" >&2
-            exit 1
-          fi
-          echo "cone guard: vertex-ffi is free of the observability server stack"
+      # Cone guards live in one place: the `check-cone` just target. It keeps the
+      # embedded FFI cone free of the native observability server stack and asserts
+      # the pseudosettle provider never pulls the libp2p-aware node crate. Calling
+      # the target here is the single source of truth so the two never drift.
+      - name: Cone guard
+        run: just check-cone
 
   test:
     name: test
@@ -117,7 +110,7 @@ jobs:
       # `+nightly` is load-bearing: rust-toolchain.toml pins the stable
       # channel and would otherwise override the installed nightly.
       - name: Build peer stack for wasm32
-        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager -p vertex-tasks -p vertex-net-dnsaddr-doh
+        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager -p vertex-tasks -p vertex-net-dnsaddr-doh -p vertex-swarm-bandwidth-pseudosettle
       # The full client cone: `vertex-swarm-node` pulls topology and every
       # `/swarm/...` wire protocol, so this is the milestone wasm build for a
       # browser client node.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8788,7 +8788,6 @@ dependencies = [
  "vertex-swarm-api",
  "vertex-swarm-bandwidth",
  "vertex-swarm-net-pseudosettle",
- "vertex-swarm-node",
  "vertex-swarm-primitives",
  "vertex-swarm-test-utils",
  "vertex-tasks",

--- a/crates/swarm/bandwidth/pseudosettle/Cargo.toml
+++ b/crates/swarm/bandwidth/pseudosettle/Cargo.toml
@@ -10,7 +10,6 @@ description = "Time-based settlement provider for Swarm bandwidth accounting"
 
 [dependencies]
 vertex-swarm-bandwidth = { workspace = true }
-vertex-swarm-node = { workspace = true }
 vertex-swarm-net-pseudosettle = { workspace = true }
 vertex-swarm-primitives = { workspace = true }
 vertex-swarm-api = { workspace = true }
@@ -18,13 +17,13 @@ vertex-tasks = { workspace = true }
 vertex-util-runtime = { workspace = true }
 alloy-primitives = { workspace = true }
 async-trait = { workspace = true }
-parking_lot = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
+parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 vertex-swarm-test-utils = { workspace = true }
 

--- a/crates/swarm/bandwidth/pseudosettle/src/event.rs
+++ b/crates/swarm/bandwidth/pseudosettle/src/event.rs
@@ -1,0 +1,51 @@
+//! Pseudosettle settlement boundary types.
+//!
+//! The crate's own inbound/outbound message shapes. Keeping the boundary local
+//! lets the provider build without a node crate, so the crate stays compilable
+//! for `wasm32-unknown-unknown`.
+
+use alloy_primitives::U256;
+use vertex_swarm_net_pseudosettle::PaymentAck;
+use vertex_swarm_primitives::OverlayAddress;
+
+/// A pseudosettle event routed to the service from the network layer.
+#[derive(Debug, Clone)]
+pub enum PseudosettleEvent {
+    /// We sent a pseudosettle and the peer acked it.
+    Sent {
+        /// The peer we settled with.
+        peer: OverlayAddress,
+        /// The acknowledgment the peer returned.
+        ack: PaymentAck,
+    },
+    /// A peer sent us a pseudosettle request.
+    Received {
+        /// The peer that sent the request.
+        peer: OverlayAddress,
+        /// The payment amount the peer requested, in wire units.
+        amount: U256,
+        /// Request identifier used to address the ack back to the peer.
+        request_id: u64,
+    },
+}
+
+/// An outbound pseudosettle command the service hands to the network layer.
+#[derive(Debug, Clone)]
+pub enum PseudosettleNetworkCommand {
+    /// Send a pseudosettle payment to a peer.
+    Send {
+        /// The peer to pay.
+        peer: OverlayAddress,
+        /// The amount to pay, in wire units.
+        amount: U256,
+    },
+    /// Acknowledge a pseudosettle request from a peer.
+    Ack {
+        /// The peer to ack.
+        peer: OverlayAddress,
+        /// Request identifier from the received payment.
+        request_id: u64,
+        /// The ack to return.
+        ack: PaymentAck,
+    },
+}

--- a/crates/swarm/bandwidth/pseudosettle/src/lib.rs
+++ b/crates/swarm/bandwidth/pseudosettle/src/lib.rs
@@ -1,13 +1,8 @@
 //! Time-based settlement provider for bandwidth accounting.
 //!
-//! Peers accumulate a time-based allowance (refresh rate × elapsed seconds)
+//! Peers accumulate a time-based allowance (refresh rate * elapsed seconds)
 //! that forgives debt periodically, enabling bandwidth usage without payments.
-//!
-//! # Usage
-//!
-//! Use [`create_pseudosettle_actor`] to create a service/handle pair.
-//! The [`PseudosettleProvider`] implements [`SwarmSettlementProvider`] for
-//! integration with [`Accounting`].
+//! [`PseudosettleProvider`] implements [`SwarmSettlementProvider`].
 //!
 //! [`SwarmSettlementProvider`]: vertex_swarm_api::SwarmSettlementProvider
 
@@ -16,6 +11,7 @@
 extern crate alloc;
 
 mod error;
+mod event;
 mod handle;
 mod service;
 
@@ -27,32 +23,25 @@ use vertex_swarm_api::{
     SwarmPeerState, SwarmResult, SwarmSettlementProvider,
 };
 use vertex_swarm_bandwidth::Accounting;
-use vertex_swarm_node::ClientCommand;
 use vertex_swarm_primitives::OverlayAddress;
 
 pub use error::PseudosettleSettlementError;
+pub use event::{PseudosettleEvent, PseudosettleNetworkCommand};
 pub use handle::PseudosettleHandle;
 pub use service::{PseudosettleCommand, PseudosettleService};
-pub use vertex_swarm_node::PseudosettleEvent;
 
 /// Time-based debt forgiveness provider.
 ///
-/// On `pre_allow()`, credits the peer based on elapsed time:
-/// `credit = min(elapsed_seconds × refresh_rate, abs(debt))`
-///
-/// With a handle, `settle()` delegates to the network service.
-/// Without a handle, only local refresh via `pre_allow()` is performed.
+/// On `pre_allow()`, credits the peer by `min(elapsed_seconds * refresh_rate,
+/// abs(debt))`. With a handle, `settle()` delegates to the network service;
+/// without one, only local refresh via `pre_allow()` happens.
 pub struct PseudosettleProvider<C> {
     config: C,
-    /// Optional handle for delegating to the service.
     handle: Option<PseudosettleHandle>,
 }
 
 impl<C: SwarmAccountingConfig> PseudosettleProvider<C> {
-    /// Create a new pseudosettle provider with the given configuration.
-    ///
-    /// This creates a provider without network settlement capability.
-    /// Use [`create_pseudosettle_actor`] for full functionality.
+    /// Create a provider without network settlement capability.
     pub fn new(config: C) -> Self {
         Self {
             config,
@@ -60,7 +49,7 @@ impl<C: SwarmAccountingConfig> PseudosettleProvider<C> {
         }
     }
 
-    /// Create a new pseudosettle provider with a handle for network settlement.
+    /// Create a provider with a handle for network settlement.
     pub fn with_handle(config: C, handle: PseudosettleHandle) -> Self {
         Self {
             config,
@@ -68,12 +57,12 @@ impl<C: SwarmAccountingConfig> PseudosettleProvider<C> {
         }
     }
 
-    /// Get the refresh rate in AU per second from the configuration.
+    /// Refresh rate in AU per second from the configuration.
     pub fn refresh_rate(&self) -> Au {
         self.config.refresh_rate()
     }
 
-    /// Get a reference to the configuration.
+    /// The configuration.
     pub fn config(&self) -> &C {
         &self.config
     }
@@ -90,11 +79,10 @@ impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for Pseudosettl
     }
 
     async fn settle(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> SwarmResult<Au> {
-        // If we have a handle, delegate to the service
         if let Some(handle) = &self.handle {
             let balance = state.balance();
             if !balance.is_negative() {
-                return Ok(Au::ZERO); // Nothing to settle
+                return Ok(Au::ZERO);
             }
 
             let amount = balance.unsigned_abs();
@@ -105,7 +93,6 @@ impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for Pseudosettl
 
             Ok(accepted)
         } else {
-            // No handle - refresh happens automatically in pre_allow()
             Ok(Au::ZERO)
         }
     }
@@ -117,11 +104,11 @@ impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for Pseudosettl
 
 /// Create a pseudosettle actor (service + handle pair).
 ///
-/// Spawn the service as a background task. Use the handle to create
-/// a [`PseudosettleProvider`].
+/// The service emits [`PseudosettleNetworkCommand`]s on `network_command_tx`
+/// for the node layer to dispatch on the pseudosettle wire protocol.
 pub fn create_pseudosettle_actor<A: SwarmBandwidthAccounting + 'static>(
     event_rx: mpsc::UnboundedReceiver<PseudosettleEvent>,
-    client_command_tx: mpsc::UnboundedSender<ClientCommand>,
+    network_command_tx: mpsc::UnboundedSender<PseudosettleNetworkCommand>,
     accounting: Arc<A>,
     refresh_rate: Au,
 ) -> (PseudosettleService<A>, PseudosettleHandle) {
@@ -130,7 +117,7 @@ pub fn create_pseudosettle_actor<A: SwarmBandwidthAccounting + 'static>(
     let service = PseudosettleService::new(
         command_rx,
         event_rx,
-        client_command_tx,
+        network_command_tx,
         accounting,
         refresh_rate,
     );
@@ -155,15 +142,12 @@ fn refresh_allowance(state: &dyn SwarmPeerState, refresh_rate: Au) -> Au {
         return Au::ZERO;
     }
 
-    // Allowance is refresh_rate AU per elapsed second. The scaling is checked
-    // so a large rate times a long gap cannot wrap into a tiny allowance; on
-    // overflow the allowance saturates at the maximum, which is then capped by
-    // the actual debt below.
+    // Checked scaling so a large rate over a long gap cannot wrap into a tiny
+    // allowance; on overflow it saturates and the debt cap below still bounds it.
     let allowance = refresh_rate
         .checked_scale(elapsed)
         .unwrap_or(Au::from_amount(u64::MAX));
 
-    // Only add credit if balance is negative (we owe them)
     let balance = state.balance();
     let credit = if balance.is_negative() {
         let credit = allowance.min(-balance);
@@ -177,15 +161,11 @@ fn refresh_allowance(state: &dyn SwarmPeerState, refresh_rate: Au) -> Au {
     credit
 }
 
-/// Get current timestamp in seconds.
 fn current_timestamp() -> u64 {
     vertex_util_runtime::time::now_unix_secs()
 }
 
-/// Create a new pseudosettle-only accounting instance.
-///
-/// This is a convenience function that creates a `Accounting` with
-/// a `PseudosettleProvider`.
+/// Create an `Accounting` instance backed by a single `PseudosettleProvider`.
 pub fn new_pseudosettle_accounting<C: SwarmAccountingConfig + Clone + 'static, I: SwarmIdentity>(
     config: C,
     identity: I,
@@ -329,11 +309,8 @@ mod tests {
 
     #[test]
     fn test_refresh_allowance_does_not_overflow_into_a_tiny_allowance() {
-        // A very large refresh rate over a long gap previously multiplied with a
-        // raw saturating multiply: the checked scaling now bounds it instead of
-        // wrapping into a small allowance. The credit is still capped at the
-        // actual debt, so a large debt is fully forgiven and never under-credited
-        // by a wrapped allowance.
+        // A large rate over a long gap saturates instead of wrapping; the debt
+        // cap still bounds the credit, so the debt is fully forgiven.
         let state = PeerState::new(Au::from_amount(u64::MAX), Au::from_amount(u64::MAX));
         let debt = i64::MAX / 2;
         state.add_balance(Au::new(-debt));
@@ -341,7 +318,6 @@ mod tests {
 
         let credit = refresh_allowance(&state, Au::from_amount(u64::MAX));
 
-        // The whole debt is forgiven; the allowance never wrapped below it.
         assert_eq!(credit, Au::new(debt));
         assert_eq!(state.balance(), Au::ZERO);
     }

--- a/crates/swarm/bandwidth/pseudosettle/src/service.rs
+++ b/crates/swarm/bandwidth/pseudosettle/src/service.rs
@@ -12,11 +12,11 @@ use vertex_swarm_api::{
     SwarmScoringEvent,
 };
 use vertex_swarm_net_pseudosettle::PaymentAck;
-use vertex_swarm_node::{ClientCommand, PseudosettleEvent};
 use vertex_swarm_primitives::OverlayAddress;
 use vertex_tasks::{GracefulShutdown, SpawnableTask};
 
 use crate::error::PseudosettleSettlementError;
+use crate::event::{PseudosettleEvent, PseudosettleNetworkCommand};
 
 /// Commands from the handle to the service.
 pub enum PseudosettleCommand {
@@ -46,7 +46,7 @@ pub struct PseudosettleService<A: SwarmBandwidthAccounting> {
     /// Receive events routed from the network layer.
     event_rx: mpsc::UnboundedReceiver<PseudosettleEvent>,
     /// Send commands to the network layer.
-    command_tx: mpsc::UnboundedSender<ClientCommand>,
+    command_tx: mpsc::UnboundedSender<PseudosettleNetworkCommand>,
     /// Reference to accounting for balance updates.
     accounting: Arc<A>,
     /// AU per second for rate limiting settlements.
@@ -64,7 +64,7 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
     pub fn new(
         command_rx: mpsc::UnboundedReceiver<PseudosettleCommand>,
         event_rx: mpsc::UnboundedReceiver<PseudosettleEvent>,
-        command_tx: mpsc::UnboundedSender<ClientCommand>,
+        command_tx: mpsc::UnboundedSender<PseudosettleNetworkCommand>,
         accounting: Arc<A>,
         refresh_rate: Au,
     ) -> Self {
@@ -81,15 +81,11 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
     }
 
     /// Attach a peer reporter so settlement violations feed peer scoring.
-    ///
-    /// Reporting is best-effort and non-blocking. Without a reporter the
-    /// service behaves exactly as before.
     pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
         self.reporter = Some(reporter);
         self
     }
 
-    /// Report an accounting violation if a reporter is attached.
     fn report_violation(&self, peer: &OverlayAddress) {
         if let Some(reporter) = &self.reporter {
             reporter.report_peer(
@@ -100,7 +96,6 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
         }
     }
 
-    /// Run the service event loop with graceful shutdown support.
     async fn run(mut self, shutdown: GracefulShutdown) {
         let mut shutdown = std::pin::pin!(shutdown);
 
@@ -133,14 +128,12 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
                 amount,
                 response_tx,
             } => {
-                // Check if we already have a pending settlement with this peer
                 if self.pending.contains_key(&peer) {
                     let _ =
                         response_tx.send(Err(PseudosettleSettlementError::SettlementInProgress));
                     return;
                 }
 
-                // Check rate limiting
                 let now = current_timestamp();
                 if let Some(&last) = self.last_settlement.get(&peer)
                     && now <= last
@@ -149,7 +142,6 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
                     return;
                 }
 
-                // Store the offer and response channel for when we get the ack
                 self.pending.insert(
                     peer,
                     PendingSettlement {
@@ -161,13 +153,11 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
 
                 debug!(%peer, %amount, "Sending pseudosettle request");
 
-                // Send via network
-                if let Err(e) = self.command_tx.send(ClientCommand::SendPseudosettle {
+                if let Err(e) = self.command_tx.send(PseudosettleNetworkCommand::Send {
                     peer,
                     amount: wire_from_au(amount),
                 }) {
                     warn!(%peer, error = ?e, "Failed to send pseudosettle command");
-                    // Remove the pending entry and notify failure
                     if let Some(pending) = self.pending.remove(&peer) {
                         let _ = pending.response_tx.send(Err(
                             PseudosettleSettlementError::NetworkError(e.to_string()),
@@ -183,18 +173,15 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
             PseudosettleEvent::Sent { peer, ack } => {
                 debug!(%peer, amount = %ack.amount, "Pseudosettle ack received");
 
-                // Complete pending request with accepted amount
                 if let Some(pending) = self.pending.remove(&peer) {
+                    // An ack may accept at most the offered amount; over-acceptance
+                    // desyncs the mutual books.
                     if ack.amount > wire_from_au(pending.amount) {
-                        // Law broken: an ack may accept at most the amount
-                        // offered for settlement; over-acceptance desyncs
-                        // the mutual books.
                         self.report_violation(&peer);
                     }
 
                     let accepted = au_from_wire(ack.amount);
 
-                    // Credit our balance (we paid, debt reduced)
                     let handle = self.accounting.for_peer(peer);
                     handle.record(accepted, Direction::Upload);
 
@@ -210,14 +197,12 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
             } => {
                 debug!(%peer, %amount, %request_id, "Pseudosettle request received");
 
-                // Check rate limiting
                 let now = current_timestamp();
                 if let Some(&last) = self.last_settlement.get(&peer)
                     && now <= last
                 {
-                    // Too soon - ack with 0 amount
                     let ack = PaymentAck::now(U256::ZERO);
-                    let _ = self.command_tx.send(ClientCommand::AckPseudosettle {
+                    let _ = self.command_tx.send(PseudosettleNetworkCommand::Ack {
                         peer,
                         request_id,
                         ack,
@@ -225,22 +210,19 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
                     return;
                 }
 
-                // Calculate acceptable amount based on time-based refresh
                 let handle = self.accounting.for_peer(peer);
                 let acceptable = self.calculate_acceptable(&peer, &handle, au_from_wire(amount));
 
                 if acceptable.is_positive() {
-                    // Credit peer's balance (they paid us)
                     handle.record(acceptable, Direction::Download);
                     self.last_settlement.insert(peer, now);
                 }
 
-                // Ack with accepted amount
                 let ack = PaymentAck::now(wire_from_au(acceptable));
 
                 debug!(%peer, %acceptable, "Sending pseudosettle ack");
 
-                if let Err(e) = self.command_tx.send(ClientCommand::AckPseudosettle {
+                if let Err(e) = self.command_tx.send(PseudosettleNetworkCommand::Ack {
                     peer,
                     request_id,
                     ack,
@@ -251,24 +233,20 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
         }
     }
 
-    /// Calculate acceptable amount, capped at what the peer owes us and the
-    /// time-based allowance since the last settlement.
+    /// Acceptable amount, capped at what the peer owes us and the time-based
+    /// allowance since the last settlement.
     fn calculate_acceptable(&self, peer: &OverlayAddress, handle: &A::Peer, requested: Au) -> Au {
         let balance = handle.balance();
 
-        // They can only pay us if they owe us (positive balance means they owe us)
+        // A positive balance means they owe us; only then can they pay.
         if !balance.is_positive() {
             return Au::ZERO;
         }
 
-        // Cap at what they actually owe us
         let owed = balance;
 
-        // Cap at time-based allowance: refresh_rate AU accumulate per second.
-        // The scaling is checked so a large rate times a long gap cannot wrap
-        // into a tiny allowance, which is the bug behind the historical
-        // saturating multiply; on overflow the allowance saturates at the
-        // maximum and the request and owed caps below still bound the result.
+        // Checked scaling so a large rate over a long gap cannot wrap into a tiny
+        // allowance; on overflow it saturates and the caps below still bound it.
         let now = current_timestamp();
         let elapsed = self
             .last_settlement
@@ -283,18 +261,13 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
     }
 }
 
-/// Convert a wire settlement amount (`U256`) into AU.
-///
-/// Pseudosettle amounts on the wire are at most a `u64` of AU, so this takes
-/// the low 64 bits, matching the legacy behaviour. It is the only `U256` to AU
-/// crossing in this crate.
+/// Wire settlement amount (`U256`) to AU. Wire amounts are at most a `u64` of
+/// AU, so this takes the low 64 bits. The only `U256` to AU crossing here.
 fn au_from_wire(amount: U256) -> Au {
     Au::from_amount(amount.as_limbs()[0])
 }
 
-/// Convert an AU amount into the wire settlement representation (`U256`).
-///
-/// The only AU to `U256` crossing in this crate.
+/// AU to its wire representation (`U256`). The only AU to `U256` crossing here.
 fn wire_from_au(amount: Au) -> U256 {
     U256::from(amount.as_amount())
 }
@@ -305,7 +278,6 @@ impl<A: SwarmBandwidthAccounting + 'static> SpawnableTask for PseudosettleServic
     }
 }
 
-/// Get current timestamp in seconds.
 fn current_timestamp() -> u64 {
     vertex_util_runtime::time::now_unix_secs()
 }
@@ -388,8 +360,7 @@ mod tests {
         // The accounting effect of the ack is unchanged by reporting.
         assert_eq!(rx.try_recv().unwrap().unwrap(), Au::from_amount(200));
 
-        // Every over-acceptance ack is an independent wire-level violation,
-        // so a repeat offence reports again (no debounce).
+        // Each over-acceptance is an independent violation, so it reports again.
         let _rx = insert_pending(&mut svc, peer, Au::from_amount(100));
         svc.handle_event(PseudosettleEvent::Sent {
             peer,
@@ -423,8 +394,8 @@ mod tests {
         .await;
         assert_eq!(rx.try_recv().unwrap().unwrap(), Au::from_amount(10));
 
-        // An ack with no pending settlement is ignored, not reported: it can
-        // be a local race rather than provable peer misbehaviour.
+        // An ack with no pending settlement is ignored, not reported: it can be
+        // a local race rather than provable misbehaviour.
         svc.handle_event(PseudosettleEvent::Sent {
             peer,
             ack: PaymentAck::now(U256::from(10u64)),

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ check:
 # the wasm32-unknown-unknown target; rustflags come from .cargo/config.toml.
 # See docs/agents/wasm.md.
 wasm-peers:
-    cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager
+    cargo +nightly build --target wasm32-unknown-unknown -p vertex-util-runtime -p vertex-swarm-peer-score -p vertex-swarm-peer-manager -p vertex-swarm-bandwidth-pseudosettle
 
 # Assert the embedded FFI cone stays free of the native observability server
 # stack. The server feature of vertex-observability pulls the Prometheus
@@ -47,6 +47,19 @@ check-cone:
         exit 1
     fi
     echo "cone guard: vertex-ffi is free of the observability server stack"
+
+    # The pseudosettle settlement provider runs in the wasm client. It must not
+    # pull the libp2p-aware node crate; it owns its own settlement boundary types
+    # instead. Assert vertex-swarm-node never appears in its dependency tree. This
+    # guard is a necessary-not-sufficient marker: the actual wasm32 compile of the
+    # crate is exercised by the `wasm` CI job (and the `wasm-peers` target above),
+    # which is what proves it stays in the wasm cone.
+    ps_tree="$(cargo tree -p vertex-swarm-bandwidth-pseudosettle -e normal --all-features)"
+    if grep -q "vertex-swarm-node" <<<"$ps_tree"; then
+        echo "cone guard: vertex-swarm-bandwidth-pseudosettle pulls vertex-swarm-node" >&2
+        exit 1
+    fi
+    echo "cone guard: vertex-swarm-bandwidth-pseudosettle is free of vertex-swarm-node"
 
 build:
     cargo build --all-features


### PR DESCRIPTION
Closes #415. Stack 1/8 (base: main).

Removes the `vertex_swarm_node::ClientCommand` dependency from `PseudosettleProvider` so it is wasm-clean, and extends `just check-cone` to guard it. Cone guard now asserts `vertex-swarm-bandwidth-pseudosettle` is free of `vertex-swarm-node`. 3 red-team/QA must-fix applied.

Part of the node-type API stack (RFC: `docs/design/node-type-api.md`, PR #414). Built by a gated workflow: implemented, then QA + red-team reviewed, fixes applied, committed only when green (compiles default + all-features, clippy -D warnings, affected tests).

---

AI Assistance: Claude Code (Claude Opus) used for the implementation, tests, commit messages, and this PR description. Each component was reviewed by an automated QA and red-team pass before commit; I have reviewed the result and can explain it.