### PR TITLE
fix(swarm-builder): wire pseudosettle by default and seed bandwidth mode from node type

### DIFF
--- a/crates/swarm/bandwidth/core/src/args.rs
+++ b/crates/swarm/bandwidth/core/src/args.rs
@@ -55,9 +55,10 @@ impl From<BandwidthMode> for BandwidthModeArg {
 #[command(next_help_heading = "Bandwidth Accounting")]
 #[serde(default)]
 pub struct BandwidthArgs {
-    /// Bandwidth accounting mode.
-    #[arg(long = "bandwidth.mode", value_enum, default_value_t = BandwidthModeArg::Pseudosettle)]
-    pub mode: BandwidthModeArg,
+    /// Bandwidth accounting mode. Unset derives the mode from the node type
+    /// ([`BandwidthMode::default_for`]); setting it overrides that default.
+    #[arg(long = "bandwidth.mode", value_enum)]
+    pub mode: Option<BandwidthModeArg>,
 
     /// Payment threshold (triggers settlement when exceeded).
     #[arg(long = "bandwidth.threshold", default_value_t = DEFAULT_PAYMENT_THRESHOLD)]
@@ -93,7 +94,7 @@ pub struct BandwidthArgs {
 impl Default for BandwidthArgs {
     fn default() -> Self {
         Self {
-            mode: BandwidthModeArg::default(),
+            mode: None,
             payment_threshold: DEFAULT_PAYMENT_THRESHOLD,
             payment_tolerance_percent: DEFAULT_PAYMENT_TOLERANCE_PERCENT,
             refresh_rate: DEFAULT_REFRESH_RATE,
@@ -106,10 +107,21 @@ impl Default for BandwidthArgs {
 }
 
 impl BandwidthArgs {
-    /// Create validated BandwidthConfig from these CLI arguments.
+    /// Validated config, mode seeded from `node_type` unless `--bandwidth.mode` is set.
     pub fn accounting_config(
         &self,
+        node_type: vertex_swarm_primitives::SwarmNodeType,
     ) -> Result<crate::DefaultBandwidthConfig, crate::BandwidthConfigError> {
-        crate::BandwidthConfig::try_from(self)
+        crate::BandwidthConfig::try_from((node_type, self))
+    }
+
+    /// The override when set, otherwise the node-type default.
+    pub fn effective_mode(
+        &self,
+        node_type: vertex_swarm_primitives::SwarmNodeType,
+    ) -> BandwidthMode {
+        self.mode
+            .map(BandwidthMode::from)
+            .unwrap_or_else(|| BandwidthMode::default_for(node_type))
     }
 }

--- a/crates/swarm/bandwidth/core/src/config.rs
+++ b/crates/swarm/bandwidth/core/src/config.rs
@@ -1,9 +1,11 @@
 //! Validated bandwidth accounting configuration.
 
-use vertex_swarm_api::{Au, BandwidthMode, SwarmAccountingConfig, SwarmPricingConfig};
+use vertex_swarm_api::{
+    Au, BandwidthMode, SwarmAccountingConfig, SwarmNodeType, SwarmPricingConfig,
+};
 use vertex_swarm_bandwidth_pricing::FixedPricingConfig;
 
-use crate::args::{BandwidthArgs, BandwidthModeArg};
+use crate::args::BandwidthArgs;
 use crate::constants::*;
 
 /// Error during bandwidth configuration validation.
@@ -64,6 +66,14 @@ impl<P> BandwidthConfig<P> {
         }
     }
 
+    /// Apply an operator mode override; `None` keeps the seeded node-type default.
+    pub fn with_mode_override(mut self, override_mode: Option<BandwidthMode>) -> Self {
+        if let Some(mode) = override_mode {
+            self.mode = mode;
+        }
+        self
+    }
+
     /// Get the pricing configuration.
     pub fn pricing(&self) -> &P {
         &self.pricing
@@ -77,14 +87,29 @@ impl<P> BandwidthConfig<P> {
     }
 }
 
-impl TryFrom<&BandwidthArgs> for BandwidthConfig<FixedPricingConfig> {
+impl BandwidthConfig<FixedPricingConfig> {
+    /// Mode seeded from the node type via [`BandwidthMode::default_for`], every
+    /// other field at its [`Default`]. Fresh-defaults only: operator-tuned fields
+    /// flow through [`TryFrom<(SwarmNodeType, &BandwidthArgs)>`](BandwidthConfig#impl-TryFrom).
+    pub fn for_node_type(node_type: SwarmNodeType) -> Self {
+        Self {
+            mode: BandwidthMode::default_for(node_type),
+            ..Self::default()
+        }
+    }
+}
+
+impl TryFrom<(SwarmNodeType, &BandwidthArgs)> for BandwidthConfig<FixedPricingConfig> {
     type Error = BandwidthConfigError;
 
-    fn try_from(args: &BandwidthArgs) -> Result<Self, Self::Error> {
+    /// Validated config, mode seeded from `node_type` unless `--bandwidth.mode`
+    /// is set. Cross-field validation runs against the effective mode.
+    fn try_from((node_type, args): (SwarmNodeType, &BandwidthArgs)) -> Result<Self, Self::Error> {
         let default = BandwidthArgs::default();
+        let mode = args.effective_mode(node_type);
 
-        match args.mode {
-            BandwidthModeArg::None => {
+        match mode {
+            BandwidthMode::None => {
                 let has_non_default = args.refresh_rate != default.refresh_rate
                     || args.payment_threshold != default.payment_threshold
                     || args.payment_tolerance_percent != default.payment_tolerance_percent
@@ -94,17 +119,17 @@ impl TryFrom<&BandwidthArgs> for BandwidthConfig<FixedPricingConfig> {
                     return Err(BandwidthConfigError::OptionsWithDisabledMode);
                 }
             }
-            BandwidthModeArg::Pseudosettle => {
+            BandwidthMode::Pseudosettle => {
                 if args.early_payment_percent != default.early_payment_percent {
                     return Err(BandwidthConfigError::EarlyPercentWithoutSwap);
                 }
             }
-            BandwidthModeArg::Swap => {
+            BandwidthMode::Swap => {
                 if args.refresh_rate != default.refresh_rate {
                     return Err(BandwidthConfigError::RefreshRateWithoutPseudosettle);
                 }
             }
-            BandwidthModeArg::Both => {}
+            BandwidthMode::Both => {}
         }
 
         if !(1..=100).contains(&args.throttle_allowance_percent) {
@@ -112,7 +137,7 @@ impl TryFrom<&BandwidthArgs> for BandwidthConfig<FixedPricingConfig> {
         }
 
         Ok(Self {
-            mode: args.mode.into(),
+            mode,
             payment_threshold: args.payment_threshold,
             payment_tolerance_percent: args.payment_tolerance_percent,
             refresh_rate: args.refresh_rate,
@@ -127,6 +152,8 @@ impl TryFrom<&BandwidthArgs> for BandwidthConfig<FixedPricingConfig> {
 impl Default for BandwidthConfig<FixedPricingConfig> {
     fn default() -> Self {
         Self {
+            // Pinned to pseudosettle, not the enum's `#[default]`, so the bare
+            // `Default` path is stable as node-type defaults evolve.
             mode: BandwidthMode::Pseudosettle,
             payment_threshold: DEFAULT_PAYMENT_THRESHOLD,
             payment_tolerance_percent: DEFAULT_PAYMENT_TOLERANCE_PERCENT,
@@ -182,6 +209,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::args::BandwidthModeArg;
 
     #[test]
     fn default_throttle_allowance_percent() {
@@ -193,13 +221,109 @@ mod tests {
     }
 
     #[test]
+    fn for_node_type_seeds_the_mode() {
+        assert_eq!(
+            DefaultBandwidthConfig::for_node_type(SwarmNodeType::Bootnode).mode(),
+            BandwidthMode::None
+        );
+        assert_eq!(
+            DefaultBandwidthConfig::for_node_type(SwarmNodeType::Client).mode(),
+            BandwidthMode::Pseudosettle
+        );
+        assert_eq!(
+            DefaultBandwidthConfig::for_node_type(SwarmNodeType::Storer).mode(),
+            BandwidthMode::Both
+        );
+    }
+
+    #[test]
+    fn mode_override_replaces_only_when_some() {
+        // None keeps the node-type default (a storer stays on Both).
+        let derived =
+            DefaultBandwidthConfig::for_node_type(SwarmNodeType::Storer).with_mode_override(None);
+        assert_eq!(derived.mode(), BandwidthMode::Both);
+
+        // Some replaces it: explicit Pseudosettle on a storer is not upgraded to Both.
+        let overridden = DefaultBandwidthConfig::for_node_type(SwarmNodeType::Storer)
+            .with_mode_override(Some(BandwidthMode::Pseudosettle));
+        assert_eq!(overridden.mode(), BandwidthMode::Pseudosettle);
+    }
+
+    #[test]
+    fn default_mode_is_pinned_to_pseudosettle() {
+        // A bare default always pseudosettles, independent of the enum's #[default].
+        assert_eq!(
+            DefaultBandwidthConfig::default().mode(),
+            BandwidthMode::Pseudosettle
+        );
+    }
+
+    #[test]
+    fn try_from_seeds_mode_from_node_type() {
+        for (node_type, expected) in [
+            (SwarmNodeType::Bootnode, BandwidthMode::None),
+            (SwarmNodeType::Client, BandwidthMode::Pseudosettle),
+            (SwarmNodeType::Storer, BandwidthMode::Both),
+        ] {
+            let args = BandwidthArgs::default();
+            let config =
+                BandwidthConfig::try_from((node_type, &args)).expect("default args validate");
+            assert_eq!(config.mode(), expected, "node type {node_type:?}");
+        }
+    }
+
+    #[test]
+    fn try_from_honors_explicit_mode_override() {
+        // Explicit Pseudosettle on a storer is not upgraded to Both.
+        let args = BandwidthArgs {
+            mode: Some(BandwidthModeArg::Pseudosettle),
+            ..BandwidthArgs::default()
+        };
+        let config =
+            BandwidthConfig::try_from((SwarmNodeType::Storer, &args)).expect("valid override");
+        assert_eq!(config.mode(), BandwidthMode::Pseudosettle);
+    }
+
+    #[test]
+    fn try_from_validates_against_effective_mode() {
+        // A storer derives Both, so a non-default refresh-rate is accepted.
+        let args = BandwidthArgs {
+            refresh_rate: DEFAULT_REFRESH_RATE + 1,
+            ..BandwidthArgs::default()
+        };
+        assert!(BandwidthConfig::try_from((SwarmNodeType::Storer, &args)).is_ok());
+
+        // An explicit swap override forbids a non-default refresh-rate.
+        let args = BandwidthArgs {
+            mode: Some(BandwidthModeArg::Swap),
+            refresh_rate: DEFAULT_REFRESH_RATE + 1,
+            ..BandwidthArgs::default()
+        };
+        assert!(matches!(
+            BandwidthConfig::try_from((SwarmNodeType::Storer, &args)),
+            Err(BandwidthConfigError::RefreshRateWithoutPseudosettle)
+        ));
+
+        // A bootnode derives None, so any non-default tuning is rejected.
+        let args = BandwidthArgs {
+            payment_threshold: DEFAULT_PAYMENT_THRESHOLD + 1,
+            ..BandwidthArgs::default()
+        };
+        assert!(matches!(
+            BandwidthConfig::try_from((SwarmNodeType::Bootnode, &args)),
+            Err(BandwidthConfigError::OptionsWithDisabledMode)
+        ));
+    }
+
+    #[test]
     fn throttle_allowance_percent_in_range_is_accepted() {
         for pct in [1u8, 50, 85, 100] {
             let args = BandwidthArgs {
                 throttle_allowance_percent: pct,
                 ..BandwidthArgs::default()
             };
-            let config = BandwidthConfig::try_from(&args).expect("valid percent");
+            let config =
+                BandwidthConfig::try_from((SwarmNodeType::Client, &args)).expect("valid percent");
             assert_eq!(config.throttle_allowance_percent(), pct);
         }
     }
@@ -212,7 +336,7 @@ mod tests {
                 ..BandwidthArgs::default()
             };
             assert!(matches!(
-                BandwidthConfig::try_from(&args),
+                BandwidthConfig::try_from((SwarmNodeType::Client, &args)),
                 Err(BandwidthConfigError::ThrottleAllowancePercentOutOfRange)
             ));
         }

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -9,15 +9,16 @@ use tracing::{info, warn};
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_node_api::InfrastructureContext;
 use vertex_storage_redb::RedbDatabase;
-use vertex_swarm_api::{
-    BootnodeComponents, ClientComponents, PeerReporter, StorerComponents, SwarmClientAccounting,
-    SwarmLaunchConfig, SwarmNodeType, construct,
-};
 #[cfg(feature = "chain")]
-use vertex_swarm_api::{SwarmAccountingConfig, SwarmSpec};
+use vertex_swarm_api::SwarmSpec;
+use vertex_swarm_api::{
+    BootnodeComponents, ClientComponents, PeerReporter, StorerComponents, SwarmAccountingConfig,
+    SwarmClientAccounting, SwarmLaunchConfig, SwarmNodeType, construct,
+};
 use vertex_swarm_bandwidth::{
     Accounting, AccountingBuilder, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
 };
+use vertex_swarm_bandwidth_pseudosettle::PseudosettleProvider;
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::args::NetworkConfig;
 use vertex_swarm_node::{AccountingSettlement, BootNode, ClientNode, PeerSelector, SelfThrottle};
@@ -218,17 +219,27 @@ type StoreFactory<'a> =
 
 /// The node's local store, plus the storer reserve view when the node is a storer.
 ///
-/// A storer's local store *is* its reserve: both views point at the one
-/// `DbReserve` so it is reused without rebuilding (`local` for retrieval and
-/// components, `reserve` for pushsync ingest). A client leaves `reserve` `None`.
+/// A storer's local store *is* its reserve. `ReserveStore: SwarmLocalStore`, so
+/// the one `DbReserve` upcasts to the local-store view (trait upcasting is stable
+/// at the workspace MSRV); both views are carried so the single instance is reused
+/// without rebuilding: `local` for retrieval and components, `reserve` for
+/// pushsync ingest. A client leaves `reserve` `None`.
 struct NodeStore {
     local: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
     reserve: Option<Arc<dyn vertex_swarm_api::ReserveStore>>,
 }
 
-/// A cache override supplied through the builder. With no seam the launch path
-/// builds the default in-memory [`vertex_swarm_localstore::ChunkStore`] sized
-/// from the local-store config.
+/// A cache override supplied through the builder.
+///
+/// `Ready` hands the launch path a fully constructed cache; `Factory` defers
+/// construction to build time and is given the opened shared database (if any),
+/// so an embedder can size or back the cache from the same handle the rest of
+/// the node uses. When no seam is supplied the launch path builds the default
+/// in-memory [`vertex_swarm_localstore::ChunkStore`] sized from the local-store
+/// config, leaving existing callers unchanged.
+///
+/// This crate is native-only (see the crate-root docs), so both variants are
+/// always available.
 pub(crate) enum CacheSeam {
     /// A pre-built cache, used as-is.
     Ready(Arc<dyn vertex_swarm_api::SwarmLocalStore>),
@@ -236,9 +247,11 @@ pub(crate) enum CacheSeam {
     Factory(CacheFactory),
 }
 
-/// A reserve override supplied through the builder. With no seam the storer
-/// launch path builds the default admission-gated [`DbReserve`] over the shared
-/// database.
+/// A reserve override supplied through the builder.
+///
+/// Mirrors [`CacheSeam`] for the storer reserve view. When no seam is supplied
+/// the storer launch path builds the default admission-gated [`DbReserve`] over
+/// the shared database.
 pub(crate) enum ReserveSeam {
     /// A pre-built reserve, used as-is.
     Ready(Arc<dyn vertex_swarm_api::ReserveStore>),
@@ -247,6 +260,9 @@ pub(crate) enum ReserveSeam {
 }
 
 /// Builds a cache from the opened shared database (if any).
+///
+/// The database handle is `RedbDatabase`-typed; this crate is native-only (see
+/// the crate-root docs), so the factory is always available.
 pub(crate) type CacheFactory = Box<
     dyn FnOnce(
             Option<Arc<RedbDatabase>>,
@@ -288,6 +304,19 @@ struct ClientNodeParts {
     /// The node's local store, erased to the trait; the storer wires this same
     /// instance into its components so retrieval and storage share one store.
     store: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
+}
+
+/// Wire the pseudosettle provider when the mode enables it. The caller adds swap
+/// afterwards, so `Both` ends up pseudosettle-then-swap.
+fn with_default_settlement<P>(
+    builder: AccountingBuilder<DefaultBandwidthConfig, P>,
+    bandwidth: &DefaultBandwidthConfig,
+) -> AccountingBuilder<DefaultBandwidthConfig, P> {
+    if SwarmAccountingConfig::mode(bandwidth).pseudosettle_enabled() {
+        builder.with_settlement(PseudosettleProvider::new(bandwidth.clone()))
+    } else {
+        builder
+    }
 }
 
 /// Shared launch path for the client- and storer-backed node types.
@@ -347,6 +376,10 @@ async fn build_client_backed_node(
     let accounting_builder = AccountingBuilder::new(params.bandwidth.clone())
         .with_pricer_from_config(Arc::clone(params.spec))
         .with_reporter(Arc::clone(&reporter));
+
+    // Pseudosettle before swap, so settlement tries time-based forgiveness first.
+    let accounting_builder = with_default_settlement(accounting_builder, params.bandwidth);
+
     #[cfg(feature = "swap")]
     let accounting = match swap_provider {
         Some(provider) => accounting_builder
@@ -503,7 +536,10 @@ impl SwarmLaunchConfig for ClientConfig {
     }
 }
 
-/// Build a client node. `cache == None` builds the default in-memory cache, no
+/// Build a client node, optionally overriding the cache through a builder seam.
+///
+/// `cache == None` reproduces the default cache: a byte-bounded in-memory
+/// [`vertex_swarm_localstore::ChunkStore`] sized from the local-store config, no
 /// reserve, so every pushsync relays and the opened database handle is ignored.
 pub(crate) async fn build_client(
     config: ClientConfig,
@@ -540,8 +576,12 @@ pub(crate) async fn build_client(
     Ok((parts.task, providers))
 }
 
-/// Resolve a client cache seam into the internal store factory. A client never
-/// has a reserve, so the reserve view is always `None`.
+/// Resolve a client cache seam into the internal store factory.
+///
+/// With no seam the factory builds the default in-memory cache sized from the
+/// config; a `Ready` seam returns the supplied cache verbatim; a `Factory` seam
+/// is invoked at build time with the opened shared database. A client never has a
+/// reserve, so the reserve view is always `None`.
 fn client_store_factory(
     cache: Option<CacheSeam>,
     cache_budget_bytes: u64,
@@ -569,7 +609,8 @@ fn client_store_factory(
     }
 }
 
-/// The default client cache: a byte-bounded in-memory LRU sized from the config.
+/// The default client cache: a byte-bounded in-memory LRU sized from the
+/// local-store config, erased to the local-store trait.
 fn default_cache(
     cache_budget_bytes: u64,
     soc_cache_ttl: u64,
@@ -597,16 +638,22 @@ impl SwarmLaunchConfig for StorerConfig {
     }
 }
 
-/// Shared return type for the seam-aware entrypoint and the trait impl.
+/// The storer providers, named so the seam-aware entrypoint and the trait impl
+/// share one return type.
 type StorerProviders = StorerComponents<
     TopologyHandle<Arc<Identity>>,
     VerifiedChunkProvider,
     Arc<dyn vertex_swarm_api::SwarmLocalStore>,
 >;
 
-/// Build a storer node. Both `None` uses the default admission-gated [`DbReserve`]
-/// as both reserve and local store; a reserve seam replaces the reserve, a cache
-/// seam replaces only the local-store view.
+/// Build a storer node, optionally overriding the cache and reserve through
+/// builder seams.
+///
+/// Both `None` reproduces the default: the admission-gated [`DbReserve`] over the
+/// shared database serves as both the reserve (pushsync ingest) and the local
+/// store (retrieval and components). A reserve seam replaces that reserve; a
+/// cache seam replaces only the local-store view, leaving the reserve view to the
+/// supplied or default reserve.
 pub(crate) async fn build_storer(
     config: StorerConfig,
     ctx: &dyn InfrastructureContext,
@@ -644,8 +691,10 @@ pub(crate) async fn build_storer(
 }
 
 /// Resolve a storer's cache and reserve seams into the internal store factory.
-/// The resolved reserve is the local store unless a cache seam supplies a
-/// separate local-store view.
+///
+/// With no reserve seam the default admission-gated reserve is built over the
+/// shared database. The resolved reserve is the local store unless a cache seam
+/// supplies a separate local-store view.
 fn storer_store_factory(
     cache: Option<CacheSeam>,
     reserve: Option<ReserveSeam>,
@@ -653,11 +702,14 @@ fn storer_store_factory(
     capacity: u64,
 ) -> StoreFactory<'static> {
     Box::new(move |db| {
+        // Resolve the reserve view, then the local-store view. With no cache
+        // seam the reserve is the local store, so the default path reuses the
+        // single `DbReserve` that `build_storer_reserve` erases to both views.
         let reserve: Arc<dyn vertex_swarm_api::ReserveStore> = match reserve {
             None => {
                 let store = build_storer_reserve(db.clone(), &identity, capacity)?;
-                // With no cache seam the reserve is already the local store, so
-                // return the paired views as-is.
+                // No cache seam: the reserve is already the local store, so return
+                // the paired views as-is without splitting them back apart.
                 if cache.is_none() {
                     return Ok(store);
                 }
@@ -668,6 +720,8 @@ fn storer_store_factory(
             Some(ReserveSeam::Ready(reserve)) => reserve,
             Some(ReserveSeam::Factory(factory)) => factory(db.clone())?,
         };
+        // A cache seam overrides the local-store view; otherwise the reserve is
+        // the local store.
         let local: Arc<dyn vertex_swarm_api::SwarmLocalStore> = match cache {
             None => Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
             Some(CacheSeam::Ready(local)) => local,
@@ -921,6 +975,49 @@ mod tests {
         assert!(after < baseline, "violation must lower the score");
     }
 
+    /// Client and storer both get a pseudosettle provider; a `None` mode wires none.
+    #[test]
+    fn default_settlement_wires_pseudosettle_per_node_type() {
+        let identity = test_identity_arc();
+
+        let build = |node_type| {
+            let bandwidth = DefaultBandwidthConfig::for_node_type(node_type);
+            let builder = AccountingBuilder::new(bandwidth.clone())
+                .with_pricer_from_config(identity.spec().clone());
+            with_default_settlement(builder, &bandwidth)
+                .build(&identity)
+                .bandwidth()
+                .provider_names()
+                .iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+        };
+
+        // Both carry pseudosettle; swap is wired separately and not exercised here.
+        assert_eq!(
+            build(SwarmNodeType::Client),
+            vec!["pseudosettle".to_string()]
+        );
+        assert_eq!(
+            build(SwarmNodeType::Storer),
+            vec!["pseudosettle".to_string()]
+        );
+
+        // A `None` mode wires no settlement provider at all.
+        let none_bandwidth = DefaultBandwidthConfig::for_node_type(SwarmNodeType::Bootnode);
+        assert_eq!(none_bandwidth.mode(), vertex_swarm_api::BandwidthMode::None);
+        let none_builder = AccountingBuilder::new(none_bandwidth.clone())
+            .with_pricer_from_config(identity.spec().clone());
+        assert!(
+            with_default_settlement(none_builder, &none_bandwidth)
+                .build(&identity)
+                .bandwidth()
+                .provider_names()
+                .is_empty(),
+            "a None mode must wire no settlement provider"
+        );
+    }
+
     /// The storer factory builds the admission-gated reserve, not the cache-only
     /// client store: a put for an unknown batch is rejected, proving admission is
     /// wired. The full admissible-put path is covered by the reserve crate.
@@ -981,6 +1078,8 @@ mod tests {
         );
     }
 
+    /// With no seam the client factory builds the default in-memory cache sized
+    /// from the supplied budget, accepts a content chunk, and exposes no reserve.
     #[test]
     fn client_factory_default_builds_a_working_cache() {
         use nectar_primitives::{AnyChunk, ContentChunk};
@@ -1007,6 +1106,8 @@ mod tests {
         );
     }
 
+    /// A `with_cache` seam is used verbatim: the same `Arc` reaches the node
+    /// store, no default cache is built.
     #[test]
     fn client_factory_honors_a_ready_cache_seam() {
         let cache: Arc<dyn vertex_swarm_api::SwarmLocalStore> = Arc::new(
@@ -1021,9 +1122,12 @@ mod tests {
         assert!(node_store.reserve.is_none());
     }
 
+    /// A `with_reserve` seam is used as both the reserve and, with no cache seam,
+    /// the local-store view.
     #[test]
     fn storer_factory_honors_a_ready_reserve_seam() {
         let identity = test_identity_arc();
+        // Build a real reserve to use as the seam value.
         let seam_reserve = build_storer_reserve(None, &identity, 1 << 12)
             .expect("reserve builds")
             .reserve
@@ -1041,8 +1145,9 @@ mod tests {
             Arc::ptr_eq(&seam_reserve, &reserve),
             "the supplied reserve must reach the node store unchanged"
         );
-        // With no cache seam reserve and local share one allocation: the count is
-        // reserve + local + the seam handle still held here.
+        // With no cache seam the reserve is the local store: both views point at
+        // the one allocation, so the strong count counts reserve, local, and the
+        // seam handle still held here.
         assert_eq!(
             Arc::strong_count(&reserve),
             3,
@@ -1050,5 +1155,6 @@ mod tests {
         );
     }
 
+    /// Test SOC cache TTL: any non-zero value works for the cache-shape tests.
     const DEFAULT_SOC_CACHE_TTL_NS_TEST: u64 = vertex_swarm_localstore::DEFAULT_SOC_CACHE_TTL_NS;
 }

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -50,9 +50,11 @@ impl ProtocolConfig {
         self.identity.identity(spec, network_dir, self.node_type)
     }
 
-    /// Create validated bandwidth accounting configuration.
+    /// Create validated bandwidth accounting configuration. Mode is seeded from
+    /// the resolved node type unless `--bandwidth.mode` is set; assumes the CLI
+    /// has already applied [`override_node_type`](Self::override_node_type).
     pub fn bandwidth_config(&self) -> Result<DefaultBandwidthConfig, BandwidthConfigError> {
-        DefaultBandwidthConfig::try_from(&self.bandwidth)
+        DefaultBandwidthConfig::try_from((self.node_type, &self.bandwidth))
     }
 
     /// Create local store configuration.
@@ -101,5 +103,33 @@ impl NodeProtocolConfig for ProtocolConfig {
         self.redistribution = args.redistribution.clone();
         self.chain = args.chain.clone();
         self.swap = args.swap.clone();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vertex_swarm_api::SwarmAccountingConfig;
+    use vertex_swarm_primitives::BandwidthMode;
+
+    use super::*;
+
+    #[test]
+    fn bandwidth_config_seeds_mode_from_node_type() {
+        for (node_type, expected) in [
+            (SwarmNodeType::Bootnode, BandwidthMode::None),
+            (SwarmNodeType::Client, BandwidthMode::Pseudosettle),
+            (SwarmNodeType::Storer, BandwidthMode::Both),
+        ] {
+            let config = ProtocolConfig {
+                node_type,
+                ..ProtocolConfig::default()
+            };
+            let bandwidth = config.bandwidth_config().expect("default args validate");
+            assert_eq!(
+                SwarmAccountingConfig::mode(&bandwidth),
+                expected,
+                "node type {node_type:?}"
+            );
+        }
     }
 }

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -467,6 +467,22 @@ mod tests {
     }
 
     #[test]
+    fn bandwidth_mode_default_by_node_type() {
+        assert_eq!(
+            BandwidthMode::default_for(SwarmNodeType::Bootnode),
+            BandwidthMode::None
+        );
+        assert_eq!(
+            BandwidthMode::default_for(SwarmNodeType::Client),
+            BandwidthMode::Pseudosettle
+        );
+        assert_eq!(
+            BandwidthMode::default_for(SwarmNodeType::Storer),
+            BandwidthMode::Both
+        );
+    }
+
+    #[test]
     fn connection_profile_string_round_trip() {
         use std::str::FromStr;
 
@@ -501,6 +517,16 @@ pub enum BandwidthMode {
 }
 
 impl BandwidthMode {
+    /// The default accounting mode for a node type: a bootnode does no accounting,
+    /// a client pseudosettles, a storer runs both pseudosettle and swap.
+    pub const fn default_for(node_type: SwarmNodeType) -> Self {
+        match node_type {
+            SwarmNodeType::Bootnode => BandwidthMode::None,
+            SwarmNodeType::Client => BandwidthMode::Pseudosettle,
+            SwarmNodeType::Storer => BandwidthMode::Both,
+        }
+    }
+
     pub fn pseudosettle_enabled(self) -> bool {
         matches!(self, BandwidthMode::Pseudosettle | BandwidthMode::Both)
     }


### PR DESCRIPTION
Closes #416. Stack 4/8 (base: #3).

Fixes two default-correctness bugs: the light client now wires `PseudosettleProvider` whenever the mode enables it (was an empty provider list), and the bandwidth mode is seeded from node type via `default_for` with an `Option<BandwidthMode>` override (was hardcoded Pseudosettle for all). Bootnode None, client Pseudosettle, storer Both. 3 must-fix applied.

Part of the node-type API stack (RFC: `docs/design/node-type-api.md`, PR #414). Built by a gated workflow: implemented, then QA + red-team reviewed, fixes applied, committed only when green (compiles default + all-features, clippy -D warnings, affected tests).

---

AI Assistance: Claude Code (Claude Opus) used for the implementation, tests, commit messages, and this PR description. Each component was reviewed by an automated QA and red-team pass before commit; I have reviewed the result and can explain it.