### PR TITLE
feat(swarm-builder): with_swap that derives the bandwidth mode

### DIFF
--- a/crates/swarm/builder/src/node.rs
+++ b/crates/swarm/builder/src/node.rs
@@ -98,6 +98,8 @@ where
             verify: ChunkVerifyConfig::default(),
             chain: ChainConfig::default(),
             swap: SwapConfig::default(),
+            #[cfg(feature = "swap")]
+            bandwidth_mode_override: None,
             cache: None,
             reserve: None,
         }
@@ -117,10 +119,17 @@ where
     verify: ChunkVerifyConfig,
     chain: ChainConfig,
     swap: SwapConfig,
-    /// `None` builds the default in-memory cache sized from `local_store`.
+    /// Effective bandwidth mode override recorded by `with_swap` when a chequebook is supplied;
+    /// `None` leaves the node-type-seeded mode untouched, `Some` is applied at build time through
+    /// `BandwidthConfig::with_mode_override` and is effective only for the default builders.
+    #[cfg(feature = "swap")]
+    bandwidth_mode_override: Option<vertex_swarm_api::BandwidthMode>,
+    /// Optional cache override. `None` builds the default in-memory cache sized
+    /// from `local_store`. The reserve seam rides on the client builder so a
+    /// `StorerNodeBuilder` (which wraps a `ClientNodeBuilder`) can carry it
+    /// before the storage transition.
     cache: Option<CacheSeam>,
-    /// Carried here so a wrapping storer builder keeps it across the storage
-    /// transition; consumed only by the storer build path.
+    /// Optional reserve override, consumed only by the storer build path.
     reserve: Option<ReserveSeam>,
 }
 
@@ -155,27 +164,58 @@ where
     }
 
     /// Set the SWAP settlement configuration (chequebook, beneficiary, deploy).
+    ///
+    /// Under the `swap` feature, supplying a chequebook address folds the effective bandwidth mode
+    /// toward swap-enabled (`Pseudosettle` becomes `Both`, disabled becomes `Swap`) via
+    /// [`BandwidthMode::with_swap`](vertex_swarm_api::BandwidthMode::with_swap). Without a chequebook
+    /// no settlement provider is wired, so the mode is left untouched rather than metering debt the
+    /// node can never settle. This diverges from the CLI/config path, where SWAP is selected solely
+    /// by `--bandwidth.mode`; the fold applies only to the default builders.
     pub fn with_swap(mut self, swap: SwapConfig) -> Self {
+        #[cfg(feature = "swap")]
+        // No chequebook means no settlement provider is wired, so do not commit the mode to swap.
+        if swap.chequebook.is_some() {
+            let base = self
+                .bandwidth_mode_override
+                .unwrap_or_else(|| SwarmAccountingConfig::mode(&self.accounting));
+            self.bandwidth_mode_override = Some(base.with_swap());
+        }
         self.swap = swap;
         self
     }
 
-    /// Cache sizing for the default in-memory cache; ignored when a cache seam
-    /// is set.
+    /// Record the chequebook config without touching the effective bandwidth mode, used by the
+    /// config round-trip where the CLI has already resolved the mode and SWAP stays selected solely
+    /// by the bandwidth mode (unlike the fluent [`with_swap`](Self::with_swap) seam).
+    fn set_swap(mut self, swap: SwapConfig) -> Self {
+        self.swap = swap;
+        self
+    }
+
+    /// Set the cache sizing for the default in-memory client cache.
+    ///
+    /// Ignored when a cache is supplied through [`with_cache`](Self::with_cache)
+    /// or [`with_cache_factory`](Self::with_cache_factory).
     pub fn with_local_store(mut self, local_store: LocalStoreConfig) -> Self {
         self.local_store = local_store;
         self
     }
 
-    /// Override the cache with a pre-built local store, ignoring the shared
-    /// database handle.
+    /// Override the cache with a pre-built local store.
+    ///
+    /// Replaces the default in-memory [`ChunkStore`]. The opened shared database
+    /// handle is not offered; use [`with_cache_factory`](Self::with_cache_factory)
+    /// to back the cache onto it.
     pub fn with_cache(mut self, cache: Arc<dyn SwarmLocalStore>) -> Self {
         self.cache = Some(CacheSeam::Ready(cache));
         self
     }
 
-    /// Override the cache with a factory invoked at build time with the opened
-    /// shared database (`None` in-memory).
+    /// Override the cache with a factory invoked at build time.
+    ///
+    /// The factory receives the opened shared database (`None` in-memory) so the
+    /// cache can size or back itself from the same handle the rest of the node
+    /// uses.
     pub fn with_cache_factory<F>(mut self, factory: F) -> Self
     where
         F: FnOnce(Option<Arc<RedbDatabase>>) -> Result<Arc<dyn SwarmLocalStore>, SwarmNodeError>
@@ -186,15 +226,18 @@ where
         self
     }
 
-    /// Override the storer reserve with a pre-built store; consumed only by the
-    /// storer build path.
+    /// Override the storer reserve with a pre-built store.
+    ///
+    /// Carried on the client builder so it survives the storage transition;
+    /// consumed only by the storer build path. A client never wires a reserve.
     pub fn with_reserve(mut self, reserve: Arc<dyn ReserveStore>) -> Self {
         self.reserve = Some(ReserveSeam::Ready(reserve));
         self
     }
 
-    /// Override the storer reserve with a factory invoked at build time with the
-    /// opened shared database (`None` in-memory).
+    /// Override the storer reserve with a factory invoked at build time.
+    ///
+    /// The factory receives the opened shared database (`None` in-memory).
     pub fn with_reserve_factory<F>(mut self, factory: F) -> Self
     where
         F: FnOnce(Option<Arc<RedbDatabase>>) -> Result<Arc<dyn ReserveStore>, SwarmNodeError>
@@ -257,6 +300,19 @@ where
 {
     pub fn spec(&self) -> &Arc<Spec> {
         self.client.spec()
+    }
+
+    /// Set the chain configuration. See [`ClientNodeBuilder::with_chain`].
+    pub fn with_chain(mut self, chain: ChainConfig) -> Self {
+        self.client = self.client.with_chain(chain);
+        self
+    }
+
+    /// Set the SWAP settlement configuration. See [`ClientNodeBuilder::with_swap`]. A storer runs
+    /// swap by node-type default, so the mode fold is a no-op and this supplies the chequebook config.
+    pub fn with_swap(mut self, swap: SwapConfig) -> Self {
+        self.client = self.client.with_swap(swap);
+        self
     }
 
     /// Override the cache with a pre-built local store. See
@@ -362,11 +418,15 @@ impl DefaultClientBuilder {
         )
         .with_local_store(config.local_store().clone())
         .with_chain(config.chain().clone())
-        .with_swap(config.swap().clone())
+        .set_swap(config.swap().clone())
     }
 
-    /// Convert to config for building. Drops any store seam, since [`ClientConfig`]
-    /// is `Clone`; prefer [`build`](Self::build), which consumes the seam directly.
+    /// Convert to config for building.
+    ///
+    /// Drops any store seam: a [`ClientConfig`] is `Clone` and carries neither the
+    /// `FnOnce` factory variants nor a pre-built `Ready` cache. [`build`](Self::build)
+    /// consumes the seam directly, so prefer it over `into_config().build()`
+    /// whenever any seam (cache or reserve, `Ready` or `Factory`) is set.
     pub fn into_config(self) -> ClientConfig {
         ClientConfig::new(
             self.base.spec,
@@ -386,6 +446,12 @@ impl DefaultClientBuilder {
         ctx: &dyn InfrastructureContext,
     ) -> Result<BuiltClient, SwarmNodeError> {
         let cache = self.cache.take();
+        #[cfg(feature = "swap")]
+        {
+            self.accounting = self
+                .accounting
+                .with_mode_override(self.bandwidth_mode_override);
+        }
         let config = self.into_config();
         let (task, providers) = crate::launch::build_client(config, ctx, cache).await?;
         Ok(BuiltNode::new(task, providers))
@@ -420,7 +486,7 @@ impl DefaultStorerBuilder {
             config.storage().clone(),
             config.verify(),
         );
-        builder.client = builder.client.with_chain(chain).with_swap(swap);
+        builder.client = builder.client.with_chain(chain).set_swap(swap);
         builder
     }
 
@@ -447,6 +513,13 @@ impl DefaultStorerBuilder {
     ) -> Result<BuiltStorer, SwarmNodeError> {
         let cache = self.client.cache.take();
         let reserve = self.client.reserve.take();
+        #[cfg(feature = "swap")]
+        {
+            self.client.accounting = self
+                .client
+                .accounting
+                .with_mode_override(self.client.bandwidth_mode_override);
+        }
         let config = self.into_config();
         let (task, providers) = crate::launch::build_storer(config, ctx, cache, reserve).await?;
         Ok(BuiltNode::new(task, providers))
@@ -468,5 +541,126 @@ impl From<ClientConfig> for DefaultClientBuilder {
 impl From<StorerConfig> for DefaultStorerBuilder {
     fn from(config: StorerConfig) -> Self {
         Self::from_config(config)
+    }
+}
+
+#[cfg(all(test, feature = "swap"))]
+mod swap_tests {
+    use vertex_swarm_api::{BandwidthMode, SwarmAccountingConfig, SwarmNodeType};
+    use vertex_swarm_node::args::{NetworkArgs, SwapConfig};
+    use vertex_swarm_test_utils::test_identity_arc;
+
+    use super::*;
+
+    fn test_network() -> NetworkConfig<KademliaConfig> {
+        let args = NetworkArgs {
+            port: 0,
+            mdns: false,
+            disable_discovery: true,
+            ..Default::default()
+        };
+        NetworkConfig::try_from(&args).expect("test network args are valid")
+    }
+
+    fn client_builder(node_type: SwarmNodeType) -> DefaultClientBuilder {
+        let identity = test_identity_arc();
+        DefaultClientBuilder::from_parts(
+            identity.spec().clone(),
+            identity,
+            test_network(),
+            DefaultBandwidthConfig::for_node_type(node_type),
+            ChunkVerifyConfig::default(),
+        )
+    }
+
+    /// A swap config carrying a chequebook, the path that selects swap through the fluent seam.
+    fn swap_with_chequebook() -> SwapConfig {
+        SwapConfig {
+            chequebook: Some(alloy_primitives::Address::repeat_byte(0x11)),
+            ..SwapConfig::default()
+        }
+    }
+
+    /// The effective mode the build path would apply: seeded config mode plus the recorded override.
+    fn effective_mode(builder: &DefaultClientBuilder) -> BandwidthMode {
+        SwarmAccountingConfig::mode(
+            &builder
+                .accounting
+                .clone()
+                .with_mode_override(builder.bandwidth_mode_override),
+        )
+    }
+
+    #[test]
+    fn with_swap_drives_a_client_to_both() {
+        // Client is seeded Pseudosettle; the chequebook folds swap in, preserving the leg.
+        let builder = client_builder(SwarmNodeType::Client).with_swap(swap_with_chequebook());
+        assert_eq!(effective_mode(&builder), BandwidthMode::Both);
+    }
+
+    #[test]
+    fn with_swap_enables_swap_from_a_disabled_mode() {
+        let builder = client_builder(SwarmNodeType::Bootnode).with_swap(swap_with_chequebook());
+        assert_eq!(effective_mode(&builder), BandwidthMode::Swap);
+    }
+
+    #[test]
+    fn with_swap_without_a_chequebook_leaves_the_mode_untouched() {
+        let builder = client_builder(SwarmNodeType::Client).with_swap(SwapConfig::default());
+        assert!(
+            builder.bandwidth_mode_override.is_none(),
+            "without a chequebook the swap fold must not fire"
+        );
+        assert_eq!(effective_mode(&builder), BandwidthMode::Pseudosettle);
+    }
+
+    #[test]
+    fn with_swap_is_idempotent() {
+        let builder = client_builder(SwarmNodeType::Client)
+            .with_swap(swap_with_chequebook())
+            .with_swap(swap_with_chequebook());
+        assert_eq!(effective_mode(&builder), BandwidthMode::Both);
+    }
+
+    #[test]
+    fn from_config_does_not_fold_the_mode() {
+        // The config round-trip records the chequebook but leaves SWAP selection to the mode.
+        let identity = test_identity_arc();
+        let config = ClientConfig::new(
+            identity.spec().clone(),
+            identity,
+            test_network(),
+            DefaultBandwidthConfig::for_node_type(SwarmNodeType::Client),
+            LocalStoreConfig::default(),
+            ChunkVerifyConfig::default(),
+            ChainConfig::default(),
+            SwapConfig {
+                chequebook: Some(alloy_primitives::Address::repeat_byte(0x11)),
+                ..SwapConfig::default()
+            },
+        );
+        let builder = DefaultClientBuilder::from_config(config);
+        assert!(
+            builder.bandwidth_mode_override.is_none(),
+            "from_config must not fold swap into the mode"
+        );
+        assert_eq!(effective_mode(&builder), BandwidthMode::Pseudosettle);
+    }
+
+    #[test]
+    fn storer_with_swap_stays_both() {
+        // Storer is seeded Both; the fold is a no-op.
+        let identity = test_identity_arc();
+        let builder = DefaultStorerBuilder::from_parts(
+            identity.spec().clone(),
+            identity,
+            test_network(),
+            DefaultBandwidthConfig::for_node_type(SwarmNodeType::Storer),
+            LocalStoreConfig::default(),
+            StorageConfig::new(false),
+            ChunkVerifyConfig::default(),
+        )
+        .with_swap(SwapConfig::default());
+        assert_eq!(effective_mode(&builder.client), BandwidthMode::Both);
     }
 }

--- a/crates/swarm/node/src/args/swap.rs
+++ b/crates/swarm/node/src/args/swap.rs
@@ -1,9 +1,10 @@
 //! SWAP settlement CLI arguments and validated configuration.
 //!
-//! Plain knobs that exist in every build and name no chain types. SWAP is
-//! selected by `--bandwidth.mode`; these only parameterise it, and the builder
-//! reads them only under the `swap` feature. The settlement chain and contract
-//! addresses come from the network spec; the RPC endpoint is `--chain.rpc-url`.
+//! Plain knobs (chequebook, beneficiary, deploy toggle) present in every build; read by the builder
+//! only under the `swap` feature when the bandwidth mode enables SWAP. On the CLI/config path SWAP
+//! is selected solely by `--bandwidth.mode`; these only parameterise it. (The `with_swap` embedder
+//! seam diverges and selects swap by chequebook presence; that is documented on the method.) Chain
+//! and contract addresses come from the spec; the RPC endpoint is the shared `--chain.rpc-url`.
 
 use alloy_primitives::Address;
 use clap::Args;
@@ -14,17 +15,22 @@ use serde::{Deserialize, Serialize};
 #[command(next_help_heading = "Swap")]
 #[serde(default)]
 pub struct SwapArgs {
-    /// This node's chequebook contract address, the drawer of cheques we issue.
+    /// This node's chequebook contract address (the drawer of cheques we issue).
+    /// Required to issue cheques when SWAP is enabled and a chequebook is not
+    /// being deployed. Select a swap-capable `--bandwidth.mode` to enable SWAP.
     #[arg(long = "swap.chequebook")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chequebook: Option<Address>,
 
-    /// Payout address cheques sent to this node must name; defaults to the node Ethereum address.
+    /// Payout address that cheques sent to this node must name (where received
+    /// funds are paid). Defaults to the node Ethereum address when unset. Select
+    /// a swap-capable `--bandwidth.mode` to enable SWAP.
     #[arg(long = "swap.beneficiary")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub beneficiary: Option<Address>,
 
     /// Deploy a new chequebook on startup instead of using an existing one.
+    /// Select a swap-capable `--bandwidth.mode` to enable SWAP.
     #[arg(long = "swap.deploy")]
     #[serde(default)]
     pub deploy: bool,
@@ -43,13 +49,16 @@ impl SwapArgs {
 
 /// Validated SWAP configuration carried on the node configs.
 ///
-/// Plain data with no chain-crate types; the builder reads it only under the `swap` feature.
+/// Plain data with no chain-crate types so it compiles in every build. The
+/// builder reads these fields only under the `swap` feature; without it they are
+/// inert.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SwapConfig {
     /// This node's chequebook contract address, if configured.
     pub chequebook: Option<Address>,
 
-    /// Payout address cheques sent to us must name; `None` falls back to the node Ethereum address.
+    /// Payout address cheques sent to us must name. `None` falls back to the node
+    /// Ethereum address.
     pub beneficiary: Option<Address>,
 
     /// Whether to deploy a fresh chequebook on startup.

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -483,6 +483,14 @@ mod tests {
     }
 
     #[test]
+    fn bandwidth_mode_with_swap_folds_in_swap() {
+        assert_eq!(BandwidthMode::None.with_swap(), BandwidthMode::Swap);
+        assert_eq!(BandwidthMode::Pseudosettle.with_swap(), BandwidthMode::Both);
+        assert_eq!(BandwidthMode::Swap.with_swap(), BandwidthMode::Swap);
+        assert_eq!(BandwidthMode::Both.with_swap(), BandwidthMode::Both);
+    }
+
+    #[test]
     fn connection_profile_string_round_trip() {
         use std::str::FromStr;
 
@@ -517,8 +525,16 @@ pub enum BandwidthMode {
 }
 
 impl BandwidthMode {
-    /// The default accounting mode for a node type: a bootnode does no accounting,
-    /// a client pseudosettles, a storer runs both pseudosettle and swap.
+    /// The default accounting mode for a node type.
+    ///
+    /// A bootnode does no bandwidth accounting, a client forgives debt over
+    /// time but issues no cheques ([`BandwidthMode::Pseudosettle`]), and a storer
+    /// runs both providers ([`BandwidthMode::Both`]): pseudosettle for light peers
+    /// that cannot pay and swap with the peers it settles against.
+    ///
+    /// This seeds the `BandwidthConfig::for_node_type` constructor; an operator
+    /// override is carried separately as `Option<BandwidthMode>` (`None` means
+    /// use this default), never inferred from value equality.
     pub const fn default_for(node_type: SwarmNodeType) -> Self {
         match node_type {
             SwarmNodeType::Bootnode => BandwidthMode::None,
@@ -533,6 +549,14 @@ impl BandwidthMode {
 
     pub fn swap_enabled(self) -> bool {
         matches!(self, BandwidthMode::Swap | BandwidthMode::Both)
+    }
+
+    /// Return this mode with SWAP folded in, preserving any pseudosettle leg.
+    pub const fn with_swap(self) -> Self {
+        match self {
+            BandwidthMode::None | BandwidthMode::Swap => BandwidthMode::Swap,
+            BandwidthMode::Pseudosettle | BandwidthMode::Both => BandwidthMode::Both,
+        }
     }
 
     pub fn is_enabled(self) -> bool {


### PR DESCRIPTION
Closes #420. Stack 5/8 (base: #4).

Adds `ClientNodeBuilder::with_swap(SwapConfig)` (feature-gated) that derives the effective mode toward swap-enabled and marks chain needed (the CDN client path). 2 must-fix applied.

Part of the node-type API stack (RFC: `docs/design/node-type-api.md`, PR #414). Built by a gated workflow: implemented, then QA + red-team reviewed, fixes applied, committed only when green (compiles default + all-features, clippy -D warnings, affected tests).

---

AI Assistance: Claude Code (Claude Opus) used for the implementation, tests, commit messages, and this PR description. Each component was reviewed by an automated QA and red-team pass before commit; I have reviewed the result and can explain it.