### PR TITLE
feat(swarm-builder): storer cache-then-reserve composite served store

### DIFF
--- a/crates/swarm/builder/Cargo.toml
+++ b/crates/swarm/builder/Cargo.toml
@@ -56,6 +56,8 @@ vertex-swarm-accounting.workspace = true
 vertex-swarm-accounting-pricing.workspace = true
 vertex-swarm-accounting-pseudosettle.workspace = true
 vertex-swarm-localstore.workspace = true
+# The `CachedChunk` value the cache-then-reserve serve view passes through.
+vertex-swarm-primitives.workspace = true
 vertex-swarm-peer-manager.workspace = true
 vertex-swarm-peer-score.workspace = true
 vertex-net-peer-store.workspace = true
@@ -121,9 +123,6 @@ nectar-postage.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
 vertex-swarm-test-utils.workspace = true
-# The `CachedChunk` value the storer reserve stores and serves, exercised by the
-# store-factory test.
-vertex-swarm-primitives.workspace = true
 
 # Client upload/download examples. They build a client through the public builder
 # and drive the chunk sender/provider directly, the way an FFI or gRPC embedder

--- a/crates/swarm/builder/src/composite.rs
+++ b/crates/swarm/builder/src/composite.rs
@@ -1,0 +1,178 @@
+//! The storer retrieval-serve view: a forwarding cache layered over the reserve.
+//!
+//! Reads hit either backend, reserve first so an admission-validated in-AoR copy
+//! wins on the rare overlap. Writes go to the cache only; reserve admission is the
+//! reserve's own concern, reached through its own handle (pushsync ingest).
+
+use std::sync::Arc;
+
+use nectar_primitives::ChunkAddress;
+use vertex_swarm_api::{SwarmLocalStore, SwarmResult};
+use vertex_swarm_primitives::CachedChunk;
+
+/// A forwarding cache layered over a reserve: reads from either, writes to the cache.
+pub(crate) struct CacheThenReserve {
+    /// Forwarding cache of out-of-AoR chunks; the write target.
+    cache: Arc<dyn SwarmLocalStore>,
+    /// Admission-validated in-AoR copies; read-only through this view.
+    reserve: Arc<dyn SwarmLocalStore>,
+}
+
+impl CacheThenReserve {
+    pub(crate) fn new(cache: Arc<dyn SwarmLocalStore>, reserve: Arc<dyn SwarmLocalStore>) -> Self {
+        Self { cache, reserve }
+    }
+}
+
+impl SwarmLocalStore for CacheThenReserve {
+    fn put(&self, chunk: CachedChunk) -> SwarmResult<()> {
+        self.cache.put(chunk)
+    }
+
+    fn get(&self, address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
+        // Reserve first so an in-AoR copy wins over a cached one on overlap.
+        if let Some(chunk) = self.reserve.get(address)? {
+            return Ok(Some(chunk));
+        }
+        self.cache.get(address)
+    }
+
+    fn contains(&self, address: &ChunkAddress) -> bool {
+        self.reserve.contains(address) || self.cache.contains(address)
+    }
+
+    fn remove(&self, address: &ChunkAddress) -> SwarmResult<()> {
+        self.cache.remove(address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use alloy_primitives::{B256, Signature};
+    use alloy_signer_local::PrivateKeySigner;
+    use nectar_postage::Stamp;
+    use nectar_primitives::{AnyChunk, ContentChunk, SingleOwnerChunk};
+    use vertex_swarm_localstore::{ChunkStore, Clock};
+
+    /// Fixed at the epoch so a stamped SOC stays within the cache TTL.
+    struct EpochClock;
+
+    impl Clock for EpochClock {
+        fn now_ns(&self) -> i64 {
+            0
+        }
+    }
+
+    fn store() -> Arc<dyn SwarmLocalStore> {
+        Arc::new(ChunkStore::with_budget_and_clock(
+            1 << 20,
+            1_000_000_000,
+            EpochClock,
+        ))
+    }
+
+    fn stamp_at(timestamp: u64) -> Stamp {
+        let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+        Stamp::new(B256::repeat_byte(0xaa), 3, 7, timestamp, sig)
+    }
+
+    fn content(payload: &'static [u8]) -> CachedChunk {
+        let chunk: AnyChunk = ContentChunk::new(payload)
+            .expect("valid content chunk")
+            .into();
+        CachedChunk::new(chunk, None)
+    }
+
+    fn soc(id: u8, payload: &'static [u8], stamp_ns: u64) -> CachedChunk {
+        let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("signer");
+        let chunk: AnyChunk = SingleOwnerChunk::new(B256::repeat_byte(id), payload, &signer)
+            .expect("valid soc")
+            .into();
+        CachedChunk::new(chunk, Some(stamp_at(stamp_ns)))
+    }
+
+    #[test]
+    fn serves_from_either_backend_reserve_first_on_overlap() {
+        let cache = store();
+        let reserve = store();
+
+        let cache_only = content(b"only in the cache");
+        let cache_addr = *cache_only.address();
+        cache.put(cache_only.clone()).expect("cache put");
+
+        let reserve_only = content(b"only in the reserve");
+        let reserve_addr = *reserve_only.address();
+        reserve.put(reserve_only.clone()).expect("reserve put");
+
+        // Same address in both backends, reserve carrying the OLDER stamp, so a win
+        // for the reserve copy can only be positional (reserve consulted first).
+        let overlap_cache = soc(0x22, b"cache revision", 200);
+        let overlap_reserve = soc(0x22, b"reserve revision", 100);
+        let overlap_addr = *overlap_cache.address();
+        assert_eq!(
+            overlap_addr,
+            *overlap_reserve.address(),
+            "same owner+id is the same address"
+        );
+        cache.put(overlap_cache).expect("cache overlap put");
+        reserve
+            .put(overlap_reserve.clone())
+            .expect("reserve overlap put");
+
+        let composite = CacheThenReserve::new(Arc::clone(&cache), Arc::clone(&reserve));
+
+        assert_eq!(
+            composite.get(&cache_addr).expect("get cache-only"),
+            Some(cache_only),
+            "a chunk only in the cache is served"
+        );
+        assert!(composite.contains(&cache_addr));
+        assert_eq!(
+            composite.get(&reserve_addr).expect("get reserve-only"),
+            Some(reserve_only),
+            "a chunk only in the reserve is served"
+        );
+        assert!(composite.contains(&reserve_addr));
+
+        assert_eq!(
+            composite.get(&overlap_addr).expect("get overlap"),
+            Some(overlap_reserve),
+            "the reserve copy wins on an overlapping address regardless of stamp age"
+        );
+    }
+
+    #[test]
+    fn writes_route_to_the_cache_only() {
+        let cache = store();
+        let reserve = store();
+        let composite = CacheThenReserve::new(Arc::clone(&cache), Arc::clone(&reserve));
+
+        let chunk = content(b"forwarded out-of-aor chunk");
+        let address = *chunk.address();
+        composite.put(chunk.clone()).expect("composite put");
+
+        assert!(
+            cache.contains(&address),
+            "the put lands in the forwarding cache"
+        );
+        assert!(
+            !reserve.contains(&address),
+            "the put must not reach the reserve"
+        );
+
+        // Remove through the composite must not touch the reserve.
+        let reserved = content(b"admitted in-aor chunk");
+        let reserved_addr = *reserved.address();
+        reserve.put(reserved).expect("seed reserve");
+        composite.remove(&reserved_addr).expect("composite remove");
+        assert!(
+            reserve.contains(&reserved_addr),
+            "remove must not touch the reserve"
+        );
+
+        composite.remove(&address).expect("remove cached");
+        assert!(!cache.contains(&address), "remove clears the cache entry");
+    }
+}

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -218,9 +218,10 @@ type StoreFactory<'a> =
 
 /// The node's local store, plus the storer reserve view when the node is a storer.
 ///
-/// A storer's local store *is* its reserve: both views point at the one
-/// `DbReserve` so it is reused without rebuilding (`local` for retrieval and
-/// components, `reserve` for pushsync ingest). A client leaves `reserve` `None`.
+/// `local` is the retrieval-serve view: a client's in-memory cache, or a storer's
+/// [`composite::CacheThenReserve`] layering the cache over the reserve (reserve
+/// wins on overlap). `reserve` is the separate pushsync-ingest view, carried only
+/// for a storer. A client leaves `reserve` `None`.
 struct NodeStore {
     local: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
     reserve: Option<Arc<dyn vertex_swarm_api::ReserveStore>>,
@@ -609,9 +610,13 @@ type StorerProviders = StorerComponents<
     Arc<dyn vertex_swarm_api::SwarmLocalStore>,
 >;
 
-/// Build a storer node. Both `None` uses the default admission-gated [`DbReserve`]
-/// as both reserve and local store; a reserve seam replaces the reserve, a cache
-/// seam replaces only the local-store view.
+/// Build a storer node, optionally overriding the cache and reserve through
+/// builder seams.
+///
+/// Both `None` reproduces the default: the admission-gated [`DbReserve`] is the
+/// pushsync-ingest reserve, layered under a default in-memory forwarding cache for
+/// the retrieval-serve view. A reserve seam replaces the reserve; a cache seam
+/// replaces the forwarding cache.
 pub(crate) async fn build_storer(
     config: StorerConfig,
     ctx: &dyn InfrastructureContext,
@@ -625,6 +630,8 @@ pub(crate) async fn build_storer(
     let _redistribution_enabled = config.storage().redistribution_enabled();
     let capacity = config.spec().reserve_capacity;
     let identity = config.identity().clone();
+    let cache_budget = config.local_store().cache_budget_bytes();
+    let soc_ttl = config.local_store().soc_cache_ttl();
 
     let parts = build_client_backed_node(
         ctx,
@@ -635,7 +642,14 @@ pub(crate) async fn build_storer(
             network: config.network(),
             bandwidth: config.bandwidth(),
             verify: config.verify(),
-            make_store: storer_store_factory(cache, reserve, identity, capacity),
+            make_store: storer_store_factory(
+                cache,
+                reserve,
+                identity,
+                capacity,
+                cache_budget,
+                soc_ttl,
+            ),
             #[cfg(feature = "chain")]
             chain: config.chain(),
             #[cfg(feature = "swap")]
@@ -649,35 +663,38 @@ pub(crate) async fn build_storer(
 }
 
 /// Resolve a storer's cache and reserve seams into the internal store factory.
-/// The resolved reserve is the local store unless a cache seam supplies a
-/// separate local-store view.
+///
+/// The reserve (pushsync ingest) is carried separately while the retrieval-serve
+/// view is a [`CacheThenReserve`] over both backends (reserve wins on overlap).
+/// Defaults: the admission-gated [`DbReserve`] and an in-memory
+/// [`vertex_swarm_localstore::ChunkStore`] cache sized from the local-store config.
 fn storer_store_factory(
     cache: Option<CacheSeam>,
     reserve: Option<ReserveSeam>,
     identity: Arc<Identity>,
     capacity: u64,
+    cache_budget_bytes: u64,
+    soc_cache_ttl: u64,
 ) -> StoreFactory<'static> {
     Box::new(move |db| {
         let reserve: Arc<dyn vertex_swarm_api::ReserveStore> = match reserve {
-            None => {
-                let store = build_storer_reserve(db.clone(), &identity, capacity)?;
-                // With no cache seam the reserve is already the local store, so
-                // return the paired views as-is.
-                if cache.is_none() {
-                    return Ok(store);
-                }
-                store
-                    .reserve
-                    .ok_or_else(|| SwarmNodeError::Build("storer reserve missing".into()))?
-            }
+            None => build_storer_reserve(db.clone(), &identity, capacity)?
+                .reserve
+                .ok_or_else(|| SwarmNodeError::Build("storer reserve missing".into()))?,
             Some(ReserveSeam::Ready(reserve)) => reserve,
             Some(ReserveSeam::Factory(factory)) => factory(db.clone())?,
         };
-        let local: Arc<dyn vertex_swarm_api::SwarmLocalStore> = match cache {
-            None => Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
-            Some(CacheSeam::Ready(local)) => local,
+        let cache: Arc<dyn vertex_swarm_api::SwarmLocalStore> = match cache {
+            None => default_cache(cache_budget_bytes, soc_cache_ttl),
+            Some(CacheSeam::Ready(cache)) => cache,
             Some(CacheSeam::Factory(factory)) => factory(db)?,
         };
+        // The reserve upcasts to the local-store read side; writes land in the cache.
+        let local: Arc<dyn vertex_swarm_api::SwarmLocalStore> =
+            Arc::new(crate::composite::CacheThenReserve::new(
+                cache,
+                Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
+            ));
         Ok(NodeStore {
             local,
             reserve: Some(reserve),
@@ -1028,6 +1045,9 @@ mod tests {
 
     #[test]
     fn storer_factory_honors_a_ready_reserve_seam() {
+        use nectar_primitives::{AnyChunk, ContentChunk};
+        use vertex_swarm_primitives::CachedChunk;
+
         let identity = test_identity_arc();
         let seam_reserve = build_storer_reserve(None, &identity, 1 << 12)
             .expect("reserve builds")
@@ -1039,21 +1059,75 @@ mod tests {
             Some(ReserveSeam::Ready(Arc::clone(&seam_reserve))),
             identity,
             1 << 12,
+            1 << 20,
+            DEFAULT_SOC_CACHE_TTL_NS_TEST,
         );
         let node_store = factory(None).expect("seam reserve is used");
         let reserve = node_store.reserve.expect("storer always has a reserve");
         assert!(
             Arc::ptr_eq(&seam_reserve, &reserve),
-            "the supplied reserve must reach the node store unchanged"
+            "the supplied reserve must reach the node store as the ingest view"
         );
-        // With no cache seam reserve and local share one allocation: the count is
-        // reserve + local + the seam handle still held here.
-        assert_eq!(
-            Arc::strong_count(&reserve),
-            3,
-            "the reserve and the local-store view share one allocation"
+
+        // A put through the serve view lands in the cache, never the reserve.
+        let chunk: AnyChunk = ContentChunk::new(b"forwarded out-of-aor".to_vec())
+            .expect("valid content chunk")
+            .into();
+        let address = *chunk.address();
+        node_store
+            .local
+            .put(CachedChunk::new(chunk, None))
+            .expect("the forwarding cache accepts a content chunk");
+        assert!(
+            node_store.local.contains(&address),
+            "the retrieval-serve view serves the cached chunk"
+        );
+        assert!(
+            !reserve.contains(&address),
+            "a put through the serve view must not reach the reserve"
         );
     }
 
+    /// The default storer path (`None`, `None`) layers the default cache over the
+    /// built reserve, with serve-view writes reaching the cache only.
+    #[test]
+    fn storer_factory_default_layers_cache_over_built_reserve() {
+        use nectar_primitives::{AnyChunk, ContentChunk};
+        use vertex_swarm_primitives::CachedChunk;
+
+        let identity = test_identity_arc();
+        let factory = storer_store_factory(
+            None,
+            None,
+            identity,
+            1 << 12,
+            1 << 20,
+            DEFAULT_SOC_CACHE_TTL_NS_TEST,
+        );
+        let node_store = factory(None).expect("default storer store builds");
+        let reserve = node_store
+            .reserve
+            .expect("the default storer factory yields a reserve view");
+
+        // A put through the serve view lands in the default cache, never the reserve.
+        let chunk: AnyChunk = ContentChunk::new(b"forwarded out-of-aor default".to_vec())
+            .expect("valid content chunk")
+            .into();
+        let address = *chunk.address();
+        node_store
+            .local
+            .put(CachedChunk::new(chunk, None))
+            .expect("the default forwarding cache accepts a content chunk");
+        assert!(
+            node_store.local.contains(&address),
+            "the retrieval-serve view serves the cached chunk"
+        );
+        assert!(
+            !reserve.contains(&address),
+            "a put through the serve view must not reach the built reserve"
+        );
+    }
+
+    /// Any non-zero TTL works for the cache-shape tests.
     const DEFAULT_SOC_CACHE_TTL_NS_TEST: u64 = vertex_swarm_localstore::DEFAULT_SOC_CACHE_TTL_NS;
 }

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -35,6 +35,7 @@
 
 #[cfg(feature = "chain")]
 mod chain;
+mod composite;
 pub mod config;
 mod error;
 mod handle;

--- a/crates/swarm/builder/src/node.rs
+++ b/crates/swarm/builder/src/node.rs
@@ -167,15 +167,26 @@ where
         self
     }
 
-    /// Override the cache with a pre-built local store, ignoring the shared
-    /// database handle.
+    /// Override the cache with a pre-built local store.
+    ///
+    /// Replaces the default in-memory [`ChunkStore`]. The opened shared database
+    /// handle is not offered; use [`with_cache_factory`](Self::with_cache_factory)
+    /// to back the cache onto it.
+    ///
+    /// On a client this is the full retrieval-serve view; on a storer only the
+    /// forwarding-cache layer of the cache-then-reserve view (read after the reserve,
+    /// written for out-of-AoR chunks, never for reserve admission).
     pub fn with_cache(mut self, cache: Arc<dyn SwarmLocalStore>) -> Self {
         self.cache = Some(CacheSeam::Ready(cache));
         self
     }
 
-    /// Override the cache with a factory invoked at build time with the opened
-    /// shared database (`None` in-memory).
+    /// Override the cache with a factory invoked at build time.
+    ///
+    /// The factory receives the opened shared database (`None` in-memory) so the
+    /// cache can size or back itself from the same handle the rest of the node
+    /// uses. The client-versus-storer seam meaning of [`with_cache`](Self::with_cache)
+    /// applies: on a storer the built store is only the forwarding-cache layer.
     pub fn with_cache_factory<F>(mut self, factory: F) -> Self
     where
         F: FnOnce(Option<Arc<RedbDatabase>>) -> Result<Arc<dyn SwarmLocalStore>, SwarmNodeError>


### PR DESCRIPTION
Closes #419. Stack 6/8 (base: #5).

Adds the `CacheThenReserve` composite `SwarmLocalStore` (reserve-first read, cache fallback) as the storer retrieval-serve view, so a storer also serves chunks it forwards outside its area of responsibility. The reserve stays injected separately for pushsync ingest; the six reserve tables are not collapsed.

Part of the node-type API stack (RFC: `docs/design/node-type-api.md`, PR #414). Built by a gated workflow: implemented, then QA + red-team reviewed, fixes applied, committed only when green (compiles default + all-features, clippy -D warnings, affected tests).

---

AI Assistance: Claude Code (Claude Opus) used for the implementation, tests, commit messages, and this PR description. Each component was reviewed by an automated QA and red-team pass before commit; I have reviewed the result and can explain it.