### PR TITLE
feat(swarm-rpc): StorerComponents HasReserve and native ReserveService

### DIFF
--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -134,25 +134,31 @@ impl<T: Send + Sync, C: Send + Sync> HasChunkClient for ClientComponents<T, C> {
     }
 }
 
-/// Storer components (client + local store).
+/// Storer components (client + local store + reserve).
 ///
-/// Construction is builder-exclusive; see [`construct`].
+/// `S` is the retrieval-serve view ([`HasStore`]); `R` is the proximity-ordered
+/// reserve ([`HasReserve`]). Both stay generic so this crate names no concrete
+/// backend. Construction is builder-exclusive; see [`construct`].
 #[derive(Debug)]
-pub struct StorerComponents<T, C, S> {
+pub struct StorerComponents<T, C, S, R> {
     client: ClientComponents<T, C>,
     store: S,
+    reserve: R,
 }
 
-impl<T, C, S> StorerComponents<T, C, S> {
-    pub(crate) fn new(topology: T, chunk_client: C, store: S) -> Self {
+impl<T, C, S, R> StorerComponents<T, C, S, R> {
+    pub(crate) fn new(topology: T, chunk_client: C, store: S, reserve: R) -> Self {
         Self {
             client: ClientComponents::new(topology, chunk_client),
             store,
+            reserve,
         }
     }
 }
 
-impl<T: Send + Sync, C: Send + Sync, S: Send + Sync> HasTopology for StorerComponents<T, C, S> {
+impl<T: Send + Sync, C: Send + Sync, S: Send + Sync, R: Send + Sync> HasTopology
+    for StorerComponents<T, C, S, R>
+{
     type Topology = T;
 
     fn topology(&self) -> &T {
@@ -160,7 +166,9 @@ impl<T: Send + Sync, C: Send + Sync, S: Send + Sync> HasTopology for StorerCompo
     }
 }
 
-impl<T: Send + Sync, C: Send + Sync, S: Send + Sync> HasChunkClient for StorerComponents<T, C, S> {
+impl<T: Send + Sync, C: Send + Sync, S: Send + Sync, R: Send + Sync> HasChunkClient
+    for StorerComponents<T, C, S, R>
+{
     type ChunkClient = C;
 
     fn chunk_client(&self) -> &C {
@@ -168,11 +176,23 @@ impl<T: Send + Sync, C: Send + Sync, S: Send + Sync> HasChunkClient for StorerCo
     }
 }
 
-impl<T: Send + Sync, C: Send + Sync, S: Send + Sync> HasStore for StorerComponents<T, C, S> {
+impl<T: Send + Sync, C: Send + Sync, S: Send + Sync, R: Send + Sync> HasStore
+    for StorerComponents<T, C, S, R>
+{
     type Store = S;
 
     fn store(&self) -> &S {
         &self.store
+    }
+}
+
+impl<T: Send + Sync, C: Send + Sync, S: Send + Sync, R: BinCursorStore> HasReserve
+    for StorerComponents<T, C, S, R>
+{
+    type Reserve = R;
+
+    fn reserve(&self) -> &R {
+        &self.reserve
     }
 }
 
@@ -194,7 +214,12 @@ pub mod construct {
         ClientComponents::new(topology, chunk_client)
     }
 
-    pub fn storer<T, C, S>(topology: T, chunk_client: C, store: S) -> StorerComponents<T, C, S> {
-        StorerComponents::new(topology, chunk_client, store)
+    pub fn storer<T, C, S, R>(
+        topology: T,
+        chunk_client: C,
+        store: S,
+        reserve: R,
+    ) -> StorerComponents<T, C, S, R> {
+        StorerComponents::new(topology, chunk_client, store, reserve)
     }
 }

--- a/crates/swarm/api/src/components/reserve.rs
+++ b/crates/swarm/api/src/components/reserve.rs
@@ -101,6 +101,7 @@ pub struct BinScanItem {
 /// bin keeps a monotonic cursor; entries can be replayed from an arbitrary
 /// sequence, so redistribution and sync stream "what landed since cursor C"
 /// without scanning the whole reserve.
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait BinCursorStore: ReserveStore {
     /// Highest sequence assigned in `bin` so far (`0` if empty).
     fn bin_cursor(&self, bin: Bin) -> SwarmResult<u64>;

--- a/crates/swarm/builder/src/handle.rs
+++ b/crates/swarm/builder/src/handle.rs
@@ -3,7 +3,8 @@
 use std::sync::Arc;
 
 use vertex_swarm_api::{
-    BootnodeComponents, ClientComponents, HasTopology, StorerComponents, SwarmLocalStore,
+    BinCursorStore, BootnodeComponents, ClientComponents, HasTopology, StorerComponents,
+    SwarmLocalStore,
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_topology::TopologyHandle;
@@ -62,13 +63,15 @@ pub type BuiltBootnode = BuiltNode<BootnodeComponents<TopologyHandle<Arc<Identit
 pub type BuiltClient =
     BuiltNode<ClientComponents<TopologyHandle<Arc<Identity>>, VerifiedChunkProvider>>;
 
-/// Built storer node (topology + chunks + persisting reserve as the local
-/// store). The store is erased to `Arc<dyn SwarmLocalStore>` so one handle is
-/// shared for serve-on-retrieval while the launch path keeps the concrete reserve.
+/// Built storer node (topology + chunks + retrieval-serve store + reserve).
+///
+/// Store and reserve axes are erased to `Arc<dyn SwarmLocalStore>` and
+/// `Arc<dyn BinCursorStore>` so one handle each is shared with the run loop.
 pub type BuiltStorer = BuiltNode<
     StorerComponents<
         TopologyHandle<Arc<Identity>>,
         VerifiedChunkProvider,
         Arc<dyn SwarmLocalStore>,
+        Arc<dyn BinCursorStore>,
     >,
 >;

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -222,15 +222,21 @@ define_launch_types!(
 type StoreFactory<'a> =
     Box<dyn FnOnce(Option<Arc<RedbDatabase>>) -> Result<NodeStore, SwarmNodeError> + Send + 'a>;
 
+/// Guard message: a storer with no reserve is an internal wiring bug, not config.
+const STORER_RESERVE_MISSING: &str = "storer reserve missing";
+
 /// The node's local store, plus the storer reserve view when the node is a storer.
 ///
 /// `local` is the retrieval-serve view: a client's in-memory cache, or a storer's
 /// [`composite::CacheThenReserve`] layering the cache over the reserve (reserve
-/// wins on overlap). `reserve` is the separate pushsync-ingest view, carried only
-/// for a storer. A client leaves `reserve` `None`.
+/// wins on overlap). `reserve` is the separate storer reserve view, erased to
+/// [`BinCursorStore`](vertex_swarm_api::BinCursorStore) and carried only for a
+/// storer; it feeds pushsync ingest (upcast to `Arc<dyn ReserveStore>` at the
+/// `enable_storage` call site) and the served reserve capabilities. A client
+/// leaves `reserve` `None`.
 struct NodeStore {
     local: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
-    reserve: Option<Arc<dyn vertex_swarm_api::ReserveStore>>,
+    reserve: Option<Arc<dyn vertex_swarm_api::BinCursorStore>>,
 }
 
 /// A cache override supplied through the builder. With no seam the launch path
@@ -248,7 +254,7 @@ pub(crate) enum CacheSeam {
 /// database.
 pub(crate) enum ReserveSeam {
     /// A pre-built reserve, used as-is.
-    Ready(Arc<dyn vertex_swarm_api::ReserveStore>),
+    Ready(Arc<dyn vertex_swarm_api::BinCursorStore>),
     /// A factory invoked at build time with the opened shared database.
     Factory(ReserveFactory),
 }
@@ -265,7 +271,7 @@ pub(crate) type CacheFactory = Box<
 pub(crate) type ReserveFactory = Box<
     dyn FnOnce(
             Option<Arc<RedbDatabase>>,
-        ) -> Result<Arc<dyn vertex_swarm_api::ReserveStore>, SwarmNodeError>
+        ) -> Result<Arc<dyn vertex_swarm_api::BinCursorStore>, SwarmNodeError>
         + Send,
 >;
 
@@ -295,6 +301,10 @@ struct ClientNodeParts {
     /// The node's local store, erased to the trait; the storer wires this same
     /// instance into its components so retrieval and storage share one store.
     store: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
+    /// The storer reserve, erased to [`BinCursorStore`]; `None` for a client. The
+    /// storer wires this same instance so its components and the run loop share
+    /// one reserve.
+    reserve: Option<Arc<dyn vertex_swarm_api::BinCursorStore>>,
 }
 
 /// Shared launch path for the client- and storer-backed node types.
@@ -404,9 +414,11 @@ async fn build_client_backed_node(
 
     // Storer ingest: the inbound pushsync path gets the reserve so a delivery the
     // node is responsible for is stored and acknowledged with a signed receipt
-    // instead of relayed. A client has no reserve and keeps the verbatim relay.
-    if let Some(reserve) = reserve {
-        node.enable_storage(reserve);
+    // instead of relayed. A client has no reserve and keeps the verbatim relay. The
+    // same reserve is carried out through `ClientNodeParts` for the served reserve
+    // capabilities.
+    if let Some(reserve) = reserve.clone() {
+        node.enable_storage(reserve as Arc<dyn vertex_swarm_api::ReserveStore>);
     }
 
     let selector = Arc::new(PeerSelector::new(
@@ -467,6 +479,7 @@ async fn build_client_backed_node(
         topology,
         chunks,
         store,
+        reserve,
     })
 }
 
@@ -604,6 +617,7 @@ impl SwarmLaunchConfig for StorerConfig {
         TopologyHandle<Arc<Identity>>,
         VerifiedChunkProvider,
         Arc<dyn vertex_swarm_api::SwarmLocalStore>,
+        Arc<dyn vertex_swarm_api::BinCursorStore>,
     >;
     type Error = SwarmNodeError;
 
@@ -620,6 +634,7 @@ type StorerProviders = StorerComponents<
     TopologyHandle<Arc<Identity>>,
     VerifiedChunkProvider,
     Arc<dyn vertex_swarm_api::SwarmLocalStore>,
+    Arc<dyn vertex_swarm_api::BinCursorStore>,
 >;
 
 /// Build a storer node, optionally overriding the cache and reserve through
@@ -670,7 +685,11 @@ pub(crate) async fn build_storer(
     )
     .await?;
 
-    let providers = construct::storer(parts.topology, parts.chunks, parts.store);
+    // A missing reserve is a wiring bug: the launch path builds the default.
+    let reserve = parts
+        .reserve
+        .ok_or_else(|| SwarmNodeError::Build(STORER_RESERVE_MISSING.into()))?;
+    let providers = construct::storer(parts.topology, parts.chunks, parts.store, reserve);
     Ok((parts.task, providers))
 }
 
@@ -689,10 +708,10 @@ fn storer_store_factory(
     soc_cache_ttl: u64,
 ) -> StoreFactory<'static> {
     Box::new(move |db| {
-        let reserve: Arc<dyn vertex_swarm_api::ReserveStore> = match reserve {
+        let reserve: Arc<dyn vertex_swarm_api::BinCursorStore> = match reserve {
             None => build_storer_reserve(db.clone(), &identity, capacity)?
                 .reserve
-                .ok_or_else(|| SwarmNodeError::Build("storer reserve missing".into()))?,
+                .ok_or_else(|| SwarmNodeError::Build(STORER_RESERVE_MISSING.into()))?,
             Some(ReserveSeam::Ready(reserve)) => reserve,
             Some(ReserveSeam::Factory(factory)) => factory(db.clone())?,
         };
@@ -765,10 +784,10 @@ fn build_storer_reserve(
         .map_err(|e| SwarmNodeError::Build(e.into()))?,
     );
     // One `DbReserve`, two trait-object views: local-store (node and components)
-    // and reserve (pushsync ingest).
+    // and reserve (pushsync ingest plus the served reserve capabilities).
     Ok(NodeStore {
         local: Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
-        reserve: Some(reserve as Arc<dyn vertex_swarm_api::ReserveStore>),
+        reserve: Some(reserve as Arc<dyn vertex_swarm_api::BinCursorStore>),
     })
 }
 

--- a/crates/swarm/builder/src/node.rs
+++ b/crates/swarm/builder/src/node.rs
@@ -9,7 +9,7 @@ use vertex_node_api::InfrastructureContext;
 use vertex_storage_redb::RedbDatabase;
 use vertex_swarm_accounting::DefaultBandwidthConfig;
 use vertex_swarm_api::{
-    ReserveStore, SwarmAccountingConfig, SwarmIdentity, SwarmLaunchConfig, SwarmLocalStore,
+    BinCursorStore, SwarmAccountingConfig, SwarmIdentity, SwarmLaunchConfig, SwarmLocalStore,
     SwarmLocalStoreConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmPricingConfig,
     SwarmRoutingConfig, SwarmStorageConfig,
 };
@@ -197,18 +197,25 @@ where
         self
     }
 
-    /// Override the storer reserve with a pre-built store; consumed only by the
-    /// storer build path.
-    pub fn with_reserve(mut self, reserve: Arc<dyn ReserveStore>) -> Self {
+    /// Override the storer reserve with a pre-built store.
+    ///
+    /// Carried on the client builder so it survives the storage transition;
+    /// consumed only by the storer build path. A client never wires a reserve.
+    /// The reserve must implement [`BinCursorStore`] so the served reserve
+    /// capabilities can query per-bin counts and insertion cursors.
+    pub fn with_reserve(mut self, reserve: Arc<dyn BinCursorStore>) -> Self {
         self.reserve = Some(ReserveSeam::Ready(reserve));
         self
     }
 
-    /// Override the storer reserve with a factory invoked at build time with the
-    /// opened shared database (`None` in-memory).
+    /// Override the storer reserve with a factory invoked at build time.
+    ///
+    /// The factory receives the opened shared database (`None` in-memory). The
+    /// reserve must implement [`BinCursorStore`] so the served reserve
+    /// capabilities can query per-bin counts and insertion cursors.
     pub fn with_reserve_factory<F>(mut self, factory: F) -> Self
     where
-        F: FnOnce(Option<Arc<RedbDatabase>>) -> Result<Arc<dyn ReserveStore>, SwarmNodeError>
+        F: FnOnce(Option<Arc<RedbDatabase>>) -> Result<Arc<dyn BinCursorStore>, SwarmNodeError>
             + Send
             + 'static,
     {
@@ -291,7 +298,7 @@ where
 
     /// Override the reserve with a pre-built store. See
     /// [`ClientNodeBuilder::with_reserve`].
-    pub fn with_reserve(mut self, reserve: Arc<dyn ReserveStore>) -> Self {
+    pub fn with_reserve(mut self, reserve: Arc<dyn BinCursorStore>) -> Self {
         self.client = self.client.with_reserve(reserve);
         self
     }
@@ -300,7 +307,7 @@ where
     /// [`ClientNodeBuilder::with_reserve_factory`].
     pub fn with_reserve_factory<F>(mut self, factory: F) -> Self
     where
-        F: FnOnce(Option<Arc<RedbDatabase>>) -> Result<Arc<dyn ReserveStore>, SwarmNodeError>
+        F: FnOnce(Option<Arc<RedbDatabase>>) -> Result<Arc<dyn BinCursorStore>, SwarmNodeError>
             + Send
             + 'static,
     {

--- a/crates/swarm/rpc/build.rs
+++ b/crates/swarm/rpc/build.rs
@@ -8,7 +8,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(false)
         .file_descriptor_set_path(out_dir.join("swarm_descriptor.bin"))
-        .compile_protos(&["proto/node.proto", "proto/chunk.proto"], &["proto"])?;
+        .compile_protos(
+            &[
+                "proto/node.proto",
+                "proto/chunk.proto",
+                "proto/reserve.proto",
+            ],
+            &["proto"],
+        )?;
 
     Ok(())
 }

--- a/crates/swarm/rpc/proto/reserve.proto
+++ b/crates/swarm/rpc/proto/reserve.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+package vertex.swarm.reserve.v1;
+
+// Reserve service exposes the storer's proximity-ordered, always-stamped local
+// chunk reserve: its storage-responsibility radius, fill against capacity, and
+// per-bin counts and insertion cursors.
+service Reserve {
+  // GetReserveState returns the reserve's radius, current count, and capacity.
+  rpc GetReserveState(GetReserveStateRequest) returns (GetReserveStateResponse);
+
+  // GetReserveBins returns per-bin chunk counts and insertion cursors for every
+  // bin within the node's area of responsibility, i.e. from the current storage
+  // radius up to and including the maximum proximity order. These are the bins
+  // that hold reserve chunks and whose cursors drive redistribution and sync.
+  rpc GetReserveBins(GetReserveBinsRequest) returns (GetReserveBinsResponse);
+}
+
+message GetReserveStateRequest {}
+
+message GetReserveStateResponse {
+  // Current storage-responsibility radius (0-31). Chunks at or beyond it are
+  // within the node's area of responsibility.
+  uint32 storage_radius = 1;
+
+  // Total chunks currently held in the reserve.
+  uint64 count = 2;
+
+  // Maximum number of chunks the reserve will hold.
+  uint64 capacity = 3;
+}
+
+message GetReserveBinsRequest {}
+
+message GetReserveBinsResponse {
+  // Current storage-responsibility radius (0-31), echoed so the caller can
+  // correlate the bin slice with the radius it was taken at.
+  uint32 storage_radius = 1;
+
+  // One entry per bin within the area of responsibility, from the storage
+  // radius up to and including the maximum proximity order, ascending. The
+  // per-bin counts sum to the total reported by GetReserveState.
+  repeated ReserveBin bins = 2;
+}
+
+message ReserveBin {
+  // Proximity order of the bin relative to the local overlay (0-31).
+  uint32 proximity_order = 1;
+
+  // Chunks held at this proximity order.
+  uint64 count = 2;
+
+  // Highest insertion sequence assigned in this bin so far (0 if empty).
+  uint64 cursor = 3;
+}

--- a/crates/swarm/rpc/src/adapter.rs
+++ b/crates/swarm/rpc/src/adapter.rs
@@ -8,12 +8,12 @@
 
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
 use vertex_swarm_api::{
-    BootnodeComponents, ClientComponents, HasChunkClient, HasTopology, StorerComponents,
-    SwarmTopologyPeers, SwarmTopologyState, SwarmTopologyStats,
+    BinCursorStore, BootnodeComponents, ClientComponents, HasChunkClient, HasReserve, HasStore,
+    HasTopology, StorerComponents, SwarmTopologyPeers, SwarmTopologyState, SwarmTopologyStats,
 };
 use vertex_swarm_stream::ChunkClient;
 
-use crate::{ChunkService, NodeService, proto};
+use crate::{ChunkService, NodeService, ReserveService, proto};
 
 /// gRPC adapter over an api component container `C`; capability accessors
 /// delegate to `C`.
@@ -52,6 +52,22 @@ impl<C: HasChunkClient> HasChunkClient for GrpcAdapter<C> {
     }
 }
 
+impl<C: HasStore> HasStore for GrpcAdapter<C> {
+    type Store = C::Store;
+
+    fn store(&self) -> &Self::Store {
+        self.components.store()
+    }
+}
+
+impl<C: HasReserve> HasReserve for GrpcAdapter<C> {
+    type Reserve = C::Reserve;
+
+    fn reserve(&self) -> &Self::Reserve {
+        self.components.reserve()
+    }
+}
+
 impl<C> GrpcAdapter<C> {
     /// Register the node status service and the shared reflection descriptor.
     pub fn register_node(&self, registry: &mut GrpcRegistry)
@@ -81,6 +97,17 @@ impl<C> GrpcAdapter<C> {
         let chunk_server = proto::chunk::chunk_server::ChunkServer::new(chunk_service);
         registry.add_service(chunk_server);
     }
+
+    /// Register the storer reserve service.
+    pub fn register_reserve(&self, registry: &mut GrpcRegistry)
+    where
+        C: HasReserve,
+        C::Reserve: BinCursorStore + Clone + 'static,
+    {
+        let reserve_service = ReserveService::new(self.components.reserve().clone());
+        let reserve_server = proto::reserve::reserve_server::ReserveServer::new(reserve_service);
+        registry.add_service(reserve_server);
+    }
 }
 
 /// Bootnodes register the node status service only.
@@ -105,19 +132,18 @@ where
     }
 }
 
-/// Storer nodes register the node status service and the chunk service; the
-/// store axis (`S`) carries no served capability yet.
-impl<T, C, S> RegistersGrpcServices for GrpcAdapter<StorerComponents<T, C, S>>
+/// Storer nodes register the node status service, the chunk service, and the
+/// reserve service over the `R` reserve axis.
+impl<T, C, S, R> RegistersGrpcServices for GrpcAdapter<StorerComponents<T, C, S, R>>
 where
     T: SwarmTopologyState + SwarmTopologyStats + SwarmTopologyPeers + Clone + Send + Sync + 'static,
     C: ChunkClient + Send + Sync,
     S: Send + Sync,
+    R: BinCursorStore + Clone + 'static,
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
         self.register_node(registry);
         self.register_chunk(registry);
-
-        // TODO: Add storer-specific RPC services (reserve, redistribution) once
-        // they exist; gate them on `HasReserve`.
+        self.register_reserve(registry);
     }
 }

--- a/crates/swarm/rpc/src/grpc/mod.rs
+++ b/crates/swarm/rpc/src/grpc/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod chunk;
 pub mod node;
+pub mod reserve;

--- a/crates/swarm/rpc/src/grpc/reserve.rs
+++ b/crates/swarm/rpc/src/grpc/reserve.rs
@@ -1,0 +1,301 @@
+//! Reserve service: storer reserve state, radius, capacity, and per-bin order.
+
+use tonic::{Request, Response, Status};
+use vertex_swarm_api::BinCursorStore;
+use vertex_swarm_primitives::ProximityOrder;
+
+use crate::proto::reserve::{
+    GetReserveBinsRequest, GetReserveBinsResponse, GetReserveStateRequest, GetReserveStateResponse,
+    ReserveBin, reserve_server::Reserve,
+};
+
+/// Reserve service implementation.
+pub struct ReserveService<R> {
+    reserve: R,
+}
+
+impl<R> ReserveService<R> {
+    pub fn new(reserve: R) -> Self {
+        Self { reserve }
+    }
+}
+
+#[tonic::async_trait]
+impl<R: BinCursorStore + Send + Sync + 'static> Reserve for ReserveService<R> {
+    async fn get_reserve_state(
+        &self,
+        _request: Request<GetReserveStateRequest>,
+    ) -> Result<Response<GetReserveStateResponse>, Status> {
+        let count = self
+            .reserve
+            .count()
+            .map_err(|e| Status::internal(format!("reserve count failed: {e}")))?;
+
+        Ok(Response::new(GetReserveStateResponse {
+            storage_radius: u32::from(self.reserve.storage_radius().get()),
+            count,
+            capacity: self.reserve.capacity(),
+        }))
+    }
+
+    async fn get_reserve_bins(
+        &self,
+        _request: Request<GetReserveBinsRequest>,
+    ) -> Result<Response<GetReserveBinsResponse>, Status> {
+        let radius = self.reserve.storage_radius();
+
+        // The area of responsibility is `radius..=MAX_PO`: the bins that hold
+        // reserve chunks (shallower bins are shed as the radius grows), so their
+        // per-bin counts sum to the total reported by GetReserveState.
+        let max_po = ProximityOrder::MAX.get();
+        let mut bins = Vec::with_capacity(usize::from(max_po - radius.get()) + 1);
+        for po_raw in radius.get()..=max_po {
+            // `po_raw` is a valid proximity order by construction; fall back to the
+            // deepest bin rather than surfacing an impossible error.
+            let po = ProximityOrder::new(po_raw).unwrap_or(ProximityOrder::MAX);
+            let count = self
+                .reserve
+                .count_in(po)
+                .map_err(|e| Status::internal(format!("reserve bin count failed: {e}")))?;
+            let cursor = self
+                .reserve
+                .bin_cursor(po.into())
+                .map_err(|e| Status::internal(format!("reserve bin cursor failed: {e}")))?;
+            bins.push(ReserveBin {
+                proximity_order: u32::from(po_raw),
+                count,
+                cursor,
+            });
+        }
+
+        Ok(Response::new(GetReserveBinsResponse {
+            storage_radius: u32::from(radius.get()),
+            bins,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vertex_swarm_api::{
+        BatchId, BinScanItem, ChunkAddress, ReserveStore, SettableRadius, StorageRadius,
+        SwarmLocalStore, SwarmResult,
+    };
+    use vertex_swarm_primitives::{Bin, CachedChunk, ProximityOrder};
+
+    use super::*;
+
+    /// Fixed-shape reserve: a known radius and capacity, with per-proximity-order
+    /// counts from `bin_counts`. `count()` sums `bin_counts`.
+    struct FixedReserve {
+        radius: StorageRadius,
+        bin_counts: Vec<u64>,
+        capacity: u64,
+    }
+
+    impl FixedReserve {
+        fn count_at(&self, po: u8) -> u64 {
+            self.bin_counts
+                .get(usize::from(po))
+                .copied()
+                .unwrap_or_default()
+        }
+    }
+
+    impl SwarmLocalStore for FixedReserve {
+        fn put(&self, _chunk: CachedChunk) -> SwarmResult<()> {
+            Ok(())
+        }
+        fn get(&self, _address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
+            Ok(None)
+        }
+        fn contains(&self, _address: &ChunkAddress) -> bool {
+            false
+        }
+        fn remove(&self, _address: &ChunkAddress) -> SwarmResult<()> {
+            Ok(())
+        }
+    }
+
+    impl ReserveStore for FixedReserve {
+        fn storage_radius(&self) -> StorageRadius {
+            self.radius
+        }
+        fn is_responsible_for(&self, _address: &ChunkAddress) -> bool {
+            true
+        }
+        fn count(&self) -> SwarmResult<u64> {
+            Ok(self.bin_counts.iter().sum())
+        }
+        fn capacity(&self) -> u64 {
+            self.capacity
+        }
+        fn count_in(&self, po: ProximityOrder) -> SwarmResult<u64> {
+            Ok(self.count_at(po.get()))
+        }
+        fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>> {
+            Ok(None)
+        }
+        fn evict_from_bin(&self, _bin: Bin, _max: u64) -> SwarmResult<u64> {
+            Ok(0)
+        }
+        fn evict_batch(
+            &self,
+            _batch: BatchId,
+            _up_to_bin: Option<Bin>,
+            _max: u64,
+        ) -> SwarmResult<u64> {
+            Ok(0)
+        }
+    }
+
+    impl SettableRadius for FixedReserve {
+        fn set_storage_radius(&self, _radius: StorageRadius) {}
+    }
+
+    impl BinCursorStore for FixedReserve {
+        // Cursor is a thousands-scaled bin index, distinct from the count.
+        fn bin_cursor(&self, bin: Bin) -> SwarmResult<u64> {
+            Ok(u64::from(bin.get()) * 1000)
+        }
+        fn scan_bin_from<'a>(
+            &'a self,
+            _bin: Bin,
+            _start_seq: u64,
+        ) -> SwarmResult<Box<dyn Iterator<Item = SwarmResult<BinScanItem>> + Send + 'a>> {
+            Ok(Box::new(std::iter::empty()))
+        }
+    }
+
+    fn service(
+        radius: u8,
+        bin_counts: Vec<u64>,
+        capacity: u64,
+    ) -> ReserveService<Arc<FixedReserve>> {
+        ReserveService::new(Arc::new(FixedReserve {
+            radius: StorageRadius::new(Bin::new(radius).expect("valid radius")),
+            bin_counts,
+            capacity,
+        }))
+    }
+
+    /// The maximum proximity order, mirroring the service's own upper bound.
+    const MAX_PO: u8 = ProximityOrder::MAX.get();
+
+    #[tokio::test]
+    async fn reserve_state_reports_radius_count_capacity() {
+        // Total is the sum of the populated bins: 2 + 40 = 42.
+        let svc = service(7, vec![0, 0, 2, 0, 0, 0, 0, 0, 40], 1 << 20);
+        let resp = svc
+            .get_reserve_state(Request::new(GetReserveStateRequest {}))
+            .await
+            .expect("state succeeds")
+            .into_inner();
+
+        assert_eq!(resp.storage_radius, 7);
+        assert_eq!(resp.count, 42);
+        assert_eq!(resp.capacity, 1 << 20);
+    }
+
+    #[tokio::test]
+    async fn reserve_bins_cover_radius_through_max_po_inclusive() {
+        let radius = 3u8;
+        let svc = service(radius, vec![0; usize::from(MAX_PO) + 1], 1 << 20);
+        let resp = svc
+            .get_reserve_bins(Request::new(GetReserveBinsRequest {}))
+            .await
+            .expect("bins succeed")
+            .into_inner();
+
+        assert_eq!(resp.storage_radius, u32::from(radius));
+        // Bins radius..=MAX_PO inclusive: the area of responsibility, never the
+        // shallow complement below the radius.
+        assert_eq!(resp.bins.len(), usize::from(MAX_PO - radius) + 1);
+        for (idx, bin) in resp.bins.iter().enumerate() {
+            let po = radius + idx as u8;
+            assert_eq!(bin.proximity_order, u32::from(po));
+            assert_eq!(bin.cursor, u64::from(po) * 1000);
+        }
+        // The shallow bins below the radius are absent.
+        assert!(
+            resp.bins
+                .iter()
+                .all(|b| b.proximity_order >= u32::from(radius))
+        );
+    }
+
+    /// A non-zero radius with only deep bins populated: the populated bins appear
+    /// and the per-bin counts sum to the in-responsibility total.
+    #[tokio::test]
+    async fn reserve_bins_report_populated_deep_bins_summing_to_count() {
+        let radius = 8u8;
+        // Populate a few deep bins (within the AoR) and a shallow bin (below the
+        // radius) that must be excluded from the per-bin sum.
+        let mut bin_counts = vec![0u64; usize::from(MAX_PO) + 1];
+        bin_counts[2] = 99; // below the radius: shed, must not be reported.
+        bin_counts[8] = 5; // at the radius.
+        bin_counts[15] = 7;
+        bin_counts[usize::from(MAX_PO)] = 3; // deepest bin.
+
+        let svc = service(radius, bin_counts, 1 << 20);
+
+        let state = svc
+            .get_reserve_state(Request::new(GetReserveStateRequest {}))
+            .await
+            .expect("state succeeds")
+            .into_inner();
+        // GetReserveState.count is the whole reserve (including the stale shallow
+        // bin, which the radius will shed): 99 + 5 + 7 + 3 = 114.
+        assert_eq!(state.count, 114);
+
+        let bins = svc
+            .get_reserve_bins(Request::new(GetReserveBinsRequest {}))
+            .await
+            .expect("bins succeed")
+            .into_inner();
+
+        assert_eq!(bins.storage_radius, u32::from(radius));
+        // Every reported bin is within the area of responsibility.
+        assert!(
+            bins.bins
+                .iter()
+                .all(|b| b.proximity_order >= u32::from(radius))
+        );
+        // The populated deep bins are present with their exact counts.
+        let by_po = |po: u32| {
+            bins.bins
+                .iter()
+                .find(|b| b.proximity_order == po)
+                .map(|b| b.count)
+                .unwrap_or_default()
+        };
+        assert_eq!(by_po(8), 5);
+        assert_eq!(by_po(15), 7);
+        assert_eq!(by_po(u32::from(MAX_PO)), 3);
+        // The shallow bin below the radius is absent.
+        assert!(!bins.bins.iter().any(|b| b.proximity_order == 2));
+
+        // The per-bin counts within the AoR sum to count minus the shed shallow
+        // bins, i.e. the in-responsibility reserve (5 + 7 + 3 = 15).
+        let aor_sum: u64 = bins.bins.iter().map(|b| b.count).sum();
+        assert_eq!(aor_sum, 15);
+        assert_eq!(aor_sum, state.count - 99);
+    }
+
+    #[tokio::test]
+    async fn reserve_bins_at_max_radius_yields_one_bin() {
+        let svc = service(MAX_PO, vec![0; usize::from(MAX_PO) + 1], 1 << 20);
+        let resp = svc
+            .get_reserve_bins(Request::new(GetReserveBinsRequest {}))
+            .await
+            .expect("bins succeed")
+            .into_inner();
+
+        assert_eq!(resp.storage_radius, u32::from(MAX_PO));
+        // At the deepest radius the AoR is the single bin MAX_PO.
+        assert_eq!(resp.bins.len(), 1);
+        assert_eq!(resp.bins[0].proximity_order, u32::from(MAX_PO));
+    }
+}

--- a/crates/swarm/rpc/src/lib.rs
+++ b/crates/swarm/rpc/src/lib.rs
@@ -8,6 +8,7 @@ mod grpc;
 pub use adapter::GrpcAdapter;
 pub use grpc::chunk::{ChunkService, StampValidation};
 pub use grpc::node::NodeService;
+pub use grpc::reserve::ReserveService;
 
 pub mod proto {
     pub mod node {
@@ -16,6 +17,10 @@ pub mod proto {
 
     pub mod chunk {
         tonic::include_proto!("vertex.swarm.chunk.v1");
+    }
+
+    pub mod reserve {
+        tonic::include_proto!("vertex.swarm.reserve.v1");
     }
 
     /// File descriptor set for gRPC reflection.


### PR DESCRIPTION
Closes #422. Stack 8/8 (base: #7).

Carries the reserve as a type parameter in `StorerComponents` so it impls `HasReserve` (api crate stays wasm-clean), and adds the native-only gRPC `ReserveService`, closing the adapter TODO. 1 must-fix applied.

Part of the node-type API stack (RFC: `docs/design/node-type-api.md`, PR #414). Built by a gated workflow: implemented, then QA + red-team reviewed, fixes applied, committed only when green (compiles default + all-features, clippy -D warnings, affected tests).

---

AI Assistance: Claude Code (Claude Opus) used for the implementation, tests, commit messages, and this PR description. Each component was reviewed by an automated QA and red-team pass before commit; I have reviewed the result and can explain it.