### PR TITLE
fix(swarm-bandwidth): refuse service past payment threshold and saturate balance arithmetic

### DIFF
--- a/crates/swarm/api/src/accounting.rs
+++ b/crates/swarm/api/src/accounting.rs
@@ -126,10 +126,13 @@ impl Au {
     }
 
     /// The absolute value as a non-negative amount.
+    ///
+    /// Saturates at [`i64::MAX`]: `|i64::MIN|` does not fit a positive `i64`, so
+    /// the raw cast would wrap it back to a negative value (M8).
     #[inline]
     #[must_use]
     pub const fn unsigned_abs(self) -> Au {
-        Self(self.0.unsigned_abs() as i64)
+        Self::from_amount(self.0.unsigned_abs())
     }
 
     /// Checked addition, `None` on overflow.
@@ -299,6 +302,16 @@ mod tests {
     fn as_amount_clamps_negatives() {
         assert_eq!(Au::new(-5).as_amount(), 0);
         assert_eq!(Au::new(5).as_amount(), 5);
+    }
+
+    #[test]
+    fn unsigned_abs_saturates_at_i64_min() {
+        // |i64::MIN| has no positive i64 representation; it must saturate to
+        // i64::MAX rather than wrap back to a negative value (M8).
+        assert_eq!(Au::new(i64::MIN).unsigned_abs(), Au::new(i64::MAX));
+        assert_eq!(Au::new(-5).unsigned_abs(), Au::new(5));
+        assert_eq!(Au::new(5).unsigned_abs(), Au::new(5));
+        assert_eq!(Au::ZERO.unsigned_abs(), Au::ZERO);
     }
 
     #[test]

--- a/crates/swarm/bandwidth/core/src/accounting/mod.rs
+++ b/crates/swarm/bandwidth/core/src/accounting/mod.rs
@@ -115,7 +115,9 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
 
         let current_balance = state.balance();
         let reserved = state.reserved_balance();
-        let projected = current_balance - price - reserved;
+        let projected = current_balance
+            .saturating_sub(price)
+            .saturating_sub(reserved);
 
         let disconnect_threshold = self.config.disconnect_threshold();
         let threshold = -disconnect_threshold;
@@ -148,12 +150,35 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
     }
 
     /// Prepare a provide action (we are providing service, balance increases).
+    ///
+    /// Hard serve-refuse (H3): refuse to serve once the peer's projected debt to
+    /// us (committed balance plus outstanding provides plus this price) would
+    /// cross the per-peer payment threshold, the point at which the peer is
+    /// expected to settle. Without this gate a peer could free-ride up to the
+    /// disconnect threshold per episode; the gate restores serve headroom only
+    /// once the peer settles. The receive side keeps its own
+    /// disconnect-threshold guard in [`Accounting::prepare_receive`].
     pub fn prepare_provide(
         &self,
         peer: OverlayAddress,
         price: Au,
     ) -> Result<ProvideAction, AccountingError> {
         let state = self.get_or_create_peer(peer);
+
+        let payment_threshold = state.payment_threshold();
+        // Projected debt the peer would owe us once this provide commits.
+        let projected = state
+            .balance()
+            .saturating_add(state.shadow_reserved_balance())
+            .saturating_add(price);
+        if projected > payment_threshold {
+            return Err(AccountingError::PaymentThreshold {
+                peer,
+                balance: projected,
+                threshold: payment_threshold,
+            });
+        }
+
         state.add_shadow_reserved(price);
         Ok(ProvideAction::new(state, price))
     }
@@ -370,7 +395,8 @@ impl SwarmPeerBandwidth for AccountingPeerHandle {
     fn record(&self, amount: Au, direction: Direction) {
         match direction {
             Direction::Upload => self.state.add_balance(amount),
-            Direction::Download => self.state.add_balance(-amount),
+            // Saturating negation: `-amount` would wrap on `i64::MIN` (M8).
+            Direction::Download => self.state.add_balance(Au::ZERO.saturating_sub(amount)),
         }
     }
 
@@ -381,7 +407,7 @@ impl SwarmPeerBandwidth for AccountingPeerHandle {
         // Check threshold
         let balance = self.state.balance();
         let reserved = self.state.reserved_balance();
-        let projected = balance - amount - reserved;
+        let projected = balance.saturating_sub(amount).saturating_sub(reserved);
 
         projected >= -self.disconnect_threshold
     }
@@ -744,6 +770,59 @@ mod tests {
             accounting.allowance_remaining(&peer),
             SMALL_DISCONNECT_THRESHOLD
         );
+    }
+
+    #[test]
+    fn test_provide_refused_past_payment_threshold_until_settled() {
+        // Payment threshold 1000, disconnect 1250.
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+        let handle = accounting.for_peer(peer);
+
+        // Serving up to the payment threshold is allowed.
+        let provide = accounting
+            .prepare_provide(peer, au(1000))
+            .expect("at payment threshold is allowed");
+        provide.apply();
+        assert_eq!(handle.balance(), au(1000));
+
+        // The peer now owes us exactly the payment threshold. Any further
+        // service is refused: it would push the projected debt over the
+        // threshold (H3 free-ride stop), even though the disconnect threshold
+        // (1250) has not been reached.
+        assert!(matches!(
+            accounting.prepare_provide(peer, au(1)),
+            Err(AccountingError::PaymentThreshold { .. })
+        ));
+
+        // The peer settles (we forgive/receive its debt), restoring headroom.
+        handle.record(au(600), Direction::Download);
+        assert_eq!(handle.balance(), au(400));
+
+        // Service resumes within the recovered headroom.
+        let provide = accounting
+            .prepare_provide(peer, au(600))
+            .expect("settled peer is served again");
+        provide.apply();
+        assert_eq!(handle.balance(), au(1000));
+    }
+
+    #[test]
+    fn test_provide_refusal_counts_outstanding_reservations() {
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+
+        // An outstanding (un-applied) provide reserves shadow balance, so a
+        // second provide that together crosses the threshold is refused.
+        let _outstanding = accounting
+            .prepare_provide(peer, au(900))
+            .expect("first provide reserved");
+        assert!(matches!(
+            accounting.prepare_provide(peer, au(200)),
+            Err(AccountingError::PaymentThreshold { .. })
+        ));
+        // A smaller provide that stays under the threshold still succeeds.
+        assert!(accounting.prepare_provide(peer, au(100)).is_ok());
     }
 
     #[test]

--- a/crates/swarm/bandwidth/core/src/accounting/peer.rs
+++ b/crates/swarm/bandwidth/core/src/accounting/peer.rs
@@ -5,6 +5,21 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use serde::{Deserialize, Serialize};
 use vertex_swarm_api::{Au, SwarmPeerState};
 
+/// Add `delta` to an atomic balance, saturating at the [`i64`] bounds.
+///
+/// Plain `fetch_add` wraps on overflow, which could flip a balance's sign and
+/// invert owed/owes (M8). A compare-exchange loop applies saturating addition.
+fn saturating_fetch_add(atomic: &AtomicI64, delta: i64) {
+    let mut current = atomic.load(Ordering::Relaxed);
+    loop {
+        let next = current.saturating_add(delta);
+        match atomic.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => return,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
 /// Atomic per-peer balance state (serializable for persistence).
 ///
 /// - Positive balance: peer owes us (we provided service)
@@ -54,9 +69,12 @@ impl PeerState {
         Au::new(self.balance.load(Ordering::Relaxed))
     }
 
-    /// Add to the balance atomically.
+    /// Add to the balance atomically, saturating at the [`i64`] bounds.
+    ///
+    /// Saturating (M8): an adversarial price or settlement sequence must not
+    /// wrap the balance and flip owed/owes.
     pub fn add_balance(&self, amount: Au) {
-        self.balance.fetch_add(amount.get(), Ordering::Relaxed);
+        saturating_fetch_add(&self.balance, amount.get());
     }
 
     /// Set the balance atomically.
@@ -103,10 +121,9 @@ impl PeerState {
         Au::new(self.surplus_balance.load(Ordering::Relaxed))
     }
 
-    /// Add to surplus balance.
+    /// Add to surplus balance, saturating at the [`i64`] bounds.
     pub fn add_surplus(&self, amount: Au) {
-        self.surplus_balance
-            .fetch_add(amount.get(), Ordering::Relaxed);
+        saturating_fetch_add(&self.surplus_balance, amount.get());
     }
 
     /// Get the payment threshold in AU.
@@ -149,7 +166,7 @@ impl SwarmPeerState for PeerState {
     }
 
     fn add_balance(&self, amount: Au) {
-        self.balance.fetch_add(amount.get(), Ordering::Relaxed);
+        saturating_fetch_add(&self.balance, amount.get());
     }
 
     fn last_refresh(&self) -> u64 {
@@ -231,6 +248,22 @@ mod tests {
 
         state.set_balance(au(200));
         assert_eq!(state.balance(), au(200));
+    }
+
+    #[test]
+    fn test_add_balance_saturates_instead_of_wrapping() {
+        let state = PeerState::new(au(1000), au(10000));
+
+        // Adding into the positive bound saturates rather than wrapping to a
+        // negative balance (which would flip owed/owes).
+        state.set_balance(Au::new(i64::MAX));
+        state.add_balance(au(1000));
+        assert_eq!(state.balance(), Au::new(i64::MAX));
+
+        // The negative bound saturates too.
+        state.set_balance(Au::new(i64::MIN));
+        state.add_balance(au(-1000));
+        assert_eq!(state.balance(), Au::new(i64::MIN));
     }
 
     #[test]


### PR DESCRIPTION
## What

Refuse to serve a peer once its debt to us would cross the per-peer payment threshold, and make balance arithmetic saturate instead of wrapping.

`Accounting::prepare_provide` now rejects a provide when projected debt (`balance + shadow_reserved + price`) would exceed the payment threshold, returning the existing `AccountingError::PaymentThreshold`. Previously the serve path was gated only at the disconnect threshold, so a debtor peer could consume real service up to disconnect per episode with only a score penalty. `Au::unsigned_abs` now saturates at `i64::MAX` (was wrapping `i64::MIN` back to negative); `add_balance`/`add_surplus` use a saturating CAS; `record`'s download leg and the `prepare_receive`/`allow` projections use saturating AU ops.

## Why

Closes #436. Without a hard serve-stop at the payment threshold, every peer gets a disconnect-threshold worth of free service per reconnect (H3), and unchecked `i64` arithmetic could in principle wrap a balance and flip owed into owes (M8). Pre-existing, found in the accounting and settlement red-team. Gates a mainnet-safe v1.

## Interop

Local serve policy only; no wire bytes change. The refusal aligns us with the reference implementation's provide-reserve check (`balance + shadowReserved` against the payment threshold) rather than diverging. A peer that settles via pseudosettle or swap is unaffected, since settlement restores headroom. A peer that stops settling is cut off at the payment threshold rather than the disconnect threshold, which is the intended free-ride stop.

## Testing

`cargo test -p vertex-swarm-api -p vertex-swarm-bandwidth` (34 + 18 pass). `cargo clippy -p vertex-swarm-api -p vertex-swarm-bandwidth --all-targets -- -D warnings` clean. Consumer sanity: `cargo test -p vertex-swarm-node` (83 pass). New tests cover serve-refusal-until-settled, reservation-counted refusal, saturating balance, and `unsigned_abs(i64::MIN)`.

## AI Assistance

Claude Code (Opus 4.8) used for the red-team analysis that found the bugs and for implementing the fixes and tests, under human review.
