### PR TITLE
refactor(accounting): drop BandwidthMode, make pseudosettle default and swap opt-in

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -64,8 +64,8 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
 
     /// Create a new accounting instance with the given settlement providers.
     ///
-    /// Providers are called in order during settlement operations.
-    /// For `BandwidthMode::Both`, pseudosettle should come before swap.
+    /// Providers are called in order during settlement operations; pseudosettle
+    /// should come before swap.
     pub fn with_providers(
         config: C,
         identity: I,
@@ -580,10 +580,6 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SwarmSettlementProvider for FixedAdjustProvider {
-        fn supported_mode(&self) -> vertex_swarm_api::BandwidthMode {
-            vertex_swarm_api::BandwidthMode::None
-        }
-
         fn pre_allow(
             &self,
             _peer: OverlayAddress,
@@ -646,7 +642,6 @@ mod tests {
     /// disconnect threshold is 1250.
     fn small_config() -> BandwidthConfig {
         BandwidthConfig::new(
-            vertex_swarm_api::BandwidthMode::Pseudosettle,
             1000,
             25,
             0,

--- a/crates/swarm/accounting/core/src/args.rs
+++ b/crates/swarm/accounting/core/src/args.rs
@@ -2,50 +2,10 @@
 
 use clap::Args;
 use serde::{Deserialize, Serialize};
-use vertex_swarm_primitives::BandwidthMode;
 
 pub use vertex_swarm_accounting_pricing::FixedPricingArgs;
 
 use crate::constants::*;
-
-/// CLI wrapper for [`BandwidthMode`] with clap integration.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Default,
-    clap::ValueEnum,
-    strum::FromRepr,
-    Serialize,
-    Deserialize,
-)]
-#[serde(rename_all = "lowercase")]
-#[repr(u8)]
-pub enum BandwidthModeArg {
-    /// No bandwidth accounting (dev only).
-    None = 0,
-    /// Soft accounting without real payments (default).
-    #[default]
-    Pseudosettle = 1,
-    /// Real payment channels with chequebook.
-    Swap = 2,
-    /// Both pseudosettle and SWAP.
-    Both = 3,
-}
-
-impl From<BandwidthModeArg> for BandwidthMode {
-    fn from(arg: BandwidthModeArg) -> Self {
-        BandwidthMode::from_repr(arg as u8).expect("matching repr")
-    }
-}
-
-impl From<BandwidthMode> for BandwidthModeArg {
-    fn from(mode: BandwidthMode) -> Self {
-        BandwidthModeArg::from_repr(mode as u8).expect("matching repr")
-    }
-}
 
 /// Bandwidth accounting CLI arguments.
 ///
@@ -55,10 +15,6 @@ impl From<BandwidthMode> for BandwidthModeArg {
 #[command(next_help_heading = "Bandwidth Accounting")]
 #[serde(default)]
 pub struct BandwidthArgs {
-    /// Bandwidth accounting mode.
-    #[arg(long = "bandwidth.mode", value_enum, default_value_t = BandwidthModeArg::Pseudosettle)]
-    pub mode: BandwidthModeArg,
-
     /// Payment threshold (triggers settlement when exceeded).
     #[arg(long = "bandwidth.threshold", default_value_t = DEFAULT_PAYMENT_THRESHOLD)]
     pub payment_threshold: u64,
@@ -93,7 +49,6 @@ pub struct BandwidthArgs {
 impl Default for BandwidthArgs {
     fn default() -> Self {
         Self {
-            mode: BandwidthModeArg::default(),
             payment_threshold: DEFAULT_PAYMENT_THRESHOLD,
             payment_tolerance_percent: DEFAULT_PAYMENT_TOLERANCE_PERCENT,
             refresh_rate: DEFAULT_REFRESH_RATE,

--- a/crates/swarm/accounting/core/src/builder.rs
+++ b/crates/swarm/accounting/core/src/builder.rs
@@ -64,8 +64,8 @@ impl<C, P> AccountingBuilder<C, P> {
 
     /// Add a settlement provider.
     ///
-    /// Multiple providers can be added. They are called in order during settlement.
-    /// For `BandwidthMode::Both`, add pseudosettle before swap.
+    /// Multiple providers can be added. They are called in order during
+    /// settlement; add pseudosettle before swap.
     pub fn with_settlement(mut self, provider: impl SwarmSettlementProvider + 'static) -> Self {
         self.providers.push(Box::new(provider));
         self

--- a/crates/swarm/accounting/core/src/config.rs
+++ b/crates/swarm/accounting/core/src/config.rs
@@ -1,21 +1,15 @@
 //! Validated bandwidth accounting configuration.
 
 use vertex_swarm_accounting_pricing::FixedPricingConfig;
-use vertex_swarm_api::{Au, BandwidthMode, SwarmAccountingConfig, SwarmPricingConfig};
+use vertex_swarm_api::{Au, SwarmAccountingConfig, SwarmPricingConfig};
 
-use crate::args::{BandwidthArgs, BandwidthModeArg};
+use crate::args::BandwidthArgs;
 use crate::constants::*;
 
 /// Error during bandwidth configuration validation.
 #[derive(Debug, Clone, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum BandwidthConfigError {
-    #[error("bandwidth options have no effect when mode is 'none'")]
-    OptionsWithDisabledMode,
-    #[error("early-percent only applies to 'swap' or 'both' modes")]
-    EarlyPercentWithoutSwap,
-    #[error("refresh-rate only applies to 'pseudosettle' or 'both' modes")]
-    RefreshRateWithoutPseudosettle,
     #[error("throttle-allowance-percent must be in 1..=100")]
     ThrottleAllowancePercentOutOfRange,
 }
@@ -26,7 +20,6 @@ pub enum BandwidthConfigError {
 /// for the standard CLI-produced configuration with fixed pricing.
 #[derive(Debug, Clone)]
 pub struct BandwidthConfig<P = FixedPricingConfig> {
-    mode: BandwidthMode,
     payment_threshold: u64,
     payment_tolerance_percent: u64,
     refresh_rate: u64,
@@ -43,7 +36,6 @@ impl<P> BandwidthConfig<P> {
     /// Create with explicit values.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        mode: BandwidthMode,
         payment_threshold: u64,
         payment_tolerance_percent: u64,
         refresh_rate: u64,
@@ -53,7 +45,6 @@ impl<P> BandwidthConfig<P> {
         pricing: P,
     ) -> Self {
         Self {
-            mode,
             payment_threshold,
             payment_tolerance_percent,
             refresh_rate,
@@ -81,38 +72,11 @@ impl TryFrom<&BandwidthArgs> for BandwidthConfig<FixedPricingConfig> {
     type Error = BandwidthConfigError;
 
     fn try_from(args: &BandwidthArgs) -> Result<Self, Self::Error> {
-        let default = BandwidthArgs::default();
-
-        match args.mode {
-            BandwidthModeArg::None => {
-                let has_non_default = args.refresh_rate != default.refresh_rate
-                    || args.payment_threshold != default.payment_threshold
-                    || args.payment_tolerance_percent != default.payment_tolerance_percent
-                    || args.early_payment_percent != default.early_payment_percent
-                    || args.client_only_factor != default.client_only_factor;
-                if has_non_default {
-                    return Err(BandwidthConfigError::OptionsWithDisabledMode);
-                }
-            }
-            BandwidthModeArg::Pseudosettle => {
-                if args.early_payment_percent != default.early_payment_percent {
-                    return Err(BandwidthConfigError::EarlyPercentWithoutSwap);
-                }
-            }
-            BandwidthModeArg::Swap => {
-                if args.refresh_rate != default.refresh_rate {
-                    return Err(BandwidthConfigError::RefreshRateWithoutPseudosettle);
-                }
-            }
-            BandwidthModeArg::Both => {}
-        }
-
         if !(1..=100).contains(&args.throttle_allowance_percent) {
             return Err(BandwidthConfigError::ThrottleAllowancePercentOutOfRange);
         }
 
         Ok(Self {
-            mode: args.mode.into(),
             payment_threshold: args.payment_threshold,
             payment_tolerance_percent: args.payment_tolerance_percent,
             refresh_rate: args.refresh_rate,
@@ -127,7 +91,6 @@ impl TryFrom<&BandwidthArgs> for BandwidthConfig<FixedPricingConfig> {
 impl Default for BandwidthConfig<FixedPricingConfig> {
     fn default() -> Self {
         Self {
-            mode: BandwidthMode::Pseudosettle,
             payment_threshold: DEFAULT_PAYMENT_THRESHOLD,
             payment_tolerance_percent: DEFAULT_PAYMENT_TOLERANCE_PERCENT,
             refresh_rate: DEFAULT_REFRESH_RATE,
@@ -143,10 +106,6 @@ impl<P> SwarmAccountingConfig for BandwidthConfig<P>
 where
     P: Send + Sync,
 {
-    fn mode(&self) -> BandwidthMode {
-        self.mode
-    }
-
     fn payment_threshold(&self) -> Au {
         Au::from_amount(self.payment_threshold)
     }

--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -35,7 +35,7 @@ pub use accounting::{
     Accounting, AccountingAction, AccountingError, AccountingPeerHandle, PeerState,
     PeerStateSnapshot, ProvideAction, ReceiveAction,
 };
-pub use args::{BandwidthArgs, BandwidthModeArg};
+pub use args::BandwidthArgs;
 pub use builder::{AccountingBuilder, NoAccountingBuilder};
 pub use client_accounting::ClientAccounting;
 pub use config::{BandwidthConfig, BandwidthConfigError, DefaultBandwidthConfig};

--- a/crates/swarm/accounting/core/src/settlement.rs
+++ b/crates/swarm/accounting/core/src/settlement.rs
@@ -1,6 +1,6 @@
-//! No-op settlement provider for `BandwidthMode::None`.
+//! No-op settlement provider.
 
-use vertex_swarm_api::{Au, BandwidthMode, SwarmPeerState, SwarmResult, SwarmSettlementProvider};
+use vertex_swarm_api::{Au, SwarmPeerState, SwarmResult, SwarmSettlementProvider};
 use vertex_swarm_primitives::OverlayAddress;
 
 /// No-op settlement provider (always returns 0, never settles).
@@ -9,10 +9,6 @@ pub struct NoSettlement;
 
 #[async_trait::async_trait]
 impl SwarmSettlementProvider for NoSettlement {
-    fn supported_mode(&self) -> BandwidthMode {
-        BandwidthMode::None
-    }
-
     fn pre_allow(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> Au {
         Au::ZERO
     }
@@ -39,6 +35,5 @@ mod tests {
 
         assert_eq!(provider.pre_allow(test_peer(), &state), Au::ZERO);
         assert_eq!(provider.name(), "none");
-        assert_eq!(provider.supported_mode(), BandwidthMode::None);
     }
 }

--- a/crates/swarm/accounting/pseudosettle/src/lib.rs
+++ b/crates/swarm/accounting/pseudosettle/src/lib.rs
@@ -24,8 +24,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use vertex_swarm_accounting::Accounting;
 use vertex_swarm_api::{
-    Au, BandwidthMode, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmError, SwarmIdentity,
-    SwarmPeerState, SwarmResult, SwarmSettlementProvider,
+    Au, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmError, SwarmIdentity, SwarmPeerState,
+    SwarmResult, SwarmSettlementProvider,
 };
 use vertex_swarm_node::ClientCommand;
 use vertex_swarm_primitives::OverlayAddress;
@@ -81,10 +81,6 @@ impl<C: SwarmAccountingConfig> PseudosettleProvider<C> {
 
 #[async_trait::async_trait]
 impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for PseudosettleProvider<C> {
-    fn supported_mode(&self) -> BandwidthMode {
-        BandwidthMode::Pseudosettle
-    }
-
     fn pre_allow(&self, _peer: OverlayAddress, state: &dyn SwarmPeerState) -> Au {
         refresh_allowance(state, self.config.refresh_rate())
     }

--- a/crates/swarm/accounting/swap/src/lib.rs
+++ b/crates/swarm/accounting/swap/src/lib.rs
@@ -7,9 +7,9 @@
 //! optional `swap-chequebook` feature adds an on-chain client for redeeming
 //! received cheques.
 //!
-//! Swap is one of the pluggable [`SwarmSettlementProvider`]s selected by
-//! [`BandwidthMode`], alongside pseudosettle. The two compose: pseudosettle
-//! forgives debt up to a time-based allowance, swap pays the remainder.
+//! Swap is one of the pluggable [`SwarmSettlementProvider`]s, alongside
+//! pseudosettle. The two compose: pseudosettle forgives debt up to a time-based
+//! allowance, swap pays the remainder.
 //!
 //! # Usage
 //!
@@ -36,8 +36,8 @@ use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use tokio::sync::mpsc;
 use vertex_swarm_api::{
-    Au, BandwidthMode, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmError, SwarmPeerState,
-    SwarmResult, SwarmSettlementProvider,
+    Au, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmError, SwarmPeerState, SwarmResult,
+    SwarmSettlementProvider,
 };
 use vertex_swarm_node::ClientCommand;
 use vertex_swarm_primitives::OverlayAddress;
@@ -52,7 +52,7 @@ pub use vertex_swarm_node::SwapEvent;
 /// On `settle()`, when the peer's debt crosses the payment threshold the
 /// provider delegates to the service, which issues and sends a signed cheque.
 /// Without a handle it is inert (it never issues cheques on its own), so it
-/// composes safely with pseudosettle in [`BandwidthMode::Both`].
+/// composes safely alongside pseudosettle.
 pub struct SwapProvider<C> {
     config: C,
     /// Optional handle for delegating to the service.
@@ -98,10 +98,6 @@ impl<C: SwarmAccountingConfig> SwapProvider<C> {
 
 #[async_trait::async_trait]
 impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for SwapProvider<C> {
-    fn supported_mode(&self) -> BandwidthMode {
-        BandwidthMode::Swap
-    }
-
     fn pre_allow(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> Au {
         // SWAP does not modify the balance during the allow check; payment is
         // driven by `settle()` once debt crosses the threshold.
@@ -184,17 +180,13 @@ mod tests {
     use alloy_primitives::{Address, U256};
     use alloy_signer_local::PrivateKeySigner;
     use vertex_swarm_accounting_chequebook::{Cheque, ChequeExt, SignedCheque};
-    use vertex_swarm_api::{BandwidthMode, SwarmAccountingConfig};
+    use vertex_swarm_api::SwarmAccountingConfig;
 
     const CHAIN: NamedChain = NamedChain::Gnosis;
 
     struct SwapTestConfig;
 
     impl SwarmAccountingConfig for SwapTestConfig {
-        fn mode(&self) -> BandwidthMode {
-            BandwidthMode::Swap
-        }
-
         fn payment_threshold(&self) -> Au {
             Au::from_amount(13_500_000)
         }

--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -8,8 +8,6 @@
 //! Settlement is handled by pluggable [`SwarmSettlementProvider`] implementations:
 //! - **Pseudosettle**: Time-based debt forgiveness (soft accounting)
 //! - **Swap**: Chequebook-based real payments
-//!
-//! Providers are configured via [`SwarmAccountingConfig`] which specifies the [`BandwidthMode`].
 
 use core::future::Future;
 use std::vec::Vec;
@@ -18,8 +16,6 @@ use nectar_primitives::ChunkAddress;
 use vertex_swarm_primitives::OverlayAddress;
 
 use crate::{Au, SwarmIdentity, SwarmPricing, SwarmResult};
-
-pub use vertex_swarm_primitives::BandwidthMode;
 
 /// Direction of data transfer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,9 +61,6 @@ pub trait SwarmPeerState: Send + Sync {
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait SwarmSettlementProvider: Send + Sync + 'static {
-    /// The bandwidth mode this provider supports.
-    fn supported_mode(&self) -> BandwidthMode;
-
     /// Called before checking if a transfer is allowed.
     /// Returns the amount of balance adjustment (positive = credit added).
     fn pre_allow(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> Au;
@@ -83,21 +76,6 @@ pub trait SwarmSettlementProvider: Send + Sync + 'static {
 /// Configuration for bandwidth accounting.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait SwarmAccountingConfig: Send + Sync {
-    /// The bandwidth accounting mode.
-    fn mode(&self) -> BandwidthMode;
-
-    /// Check if a settlement provider is enabled for this configuration.
-    fn provider_enabled(&self, provider: &dyn SwarmSettlementProvider) -> bool {
-        let mode = self.mode();
-        let supported = provider.supported_mode();
-        match supported {
-            BandwidthMode::Pseudosettle => mode.pseudosettle_enabled(),
-            BandwidthMode::Swap => mode.swap_enabled(),
-            BandwidthMode::Both => mode.pseudosettle_enabled() || mode.swap_enabled(),
-            BandwidthMode::None => true, // No-op provider always works
-        }
-    }
-
     /// Payment threshold in AU (triggers settlement when peer debt exceeds this).
     fn payment_threshold(&self) -> Au;
 
@@ -124,11 +102,6 @@ pub trait SwarmAccountingConfig: Send + Sync {
             .checked_scale(100 + self.payment_tolerance_percent())
             .unwrap_or(Au::from_amount(u64::MAX));
         Au::from_amount(scaled.as_amount() / 100)
-    }
-
-    /// Check if bandwidth accounting is enabled.
-    fn is_enabled(&self) -> bool {
-        self.mode().is_enabled()
     }
 }
 

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -8,7 +8,7 @@ mod reserve;
 mod topology;
 
 pub use self::bandwidth::{
-    AccountingAction, BandwidthMode, Direction, SwarmAccountingConfig, SwarmBandwidthAccounting,
+    AccountingAction, Direction, SwarmAccountingConfig, SwarmBandwidthAccounting,
     SwarmClientAccounting, SwarmPeerBandwidth, SwarmPeerState, SwarmSettlementProvider,
 };
 pub use self::localstore::{SwarmLocalStore, SwarmLocalStoreConfig};

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -37,14 +37,13 @@ mod types;
 
 pub use self::accounting::{Au, AuConversionError};
 pub use self::components::{
-    AccountingAction, BandwidthMode, BinCursorStore, BinScanItem, BootnodeComponents,
-    ClientComponents, Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology,
-    ReserveStore, SettableRadius, StorerComponents, SwarmAccountingConfig,
-    SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig,
-    SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder,
-    SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins,
-    SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting,
-    SwarmTopologyState, SwarmTopologyStats, construct,
+    AccountingAction, BinCursorStore, BinScanItem, BootnodeComponents, ClientComponents, Direction,
+    HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology, ReserveStore, SettableRadius,
+    StorerComponents, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting,
+    SwarmLocalStore, SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState,
+    SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
+    SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting,
+    SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats, construct,
 };
 pub use self::config::{
     DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN,

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -12,12 +12,12 @@ use vertex_storage_redb::RedbDatabase;
 use vertex_swarm_accounting::{
     Accounting, AccountingBuilder, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
 };
+#[cfg(feature = "chain")]
+use vertex_swarm_api::SwarmSpec;
 use vertex_swarm_api::{
     BootnodeComponents, ClientComponents, PeerReporter, StorerComponents, SwarmClientAccounting,
     SwarmLaunchConfig, SwarmNodeType, construct,
 };
-#[cfg(feature = "chain")]
-use vertex_swarm_api::{SwarmAccountingConfig, SwarmSpec};
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::args::NetworkConfig;
 use vertex_swarm_node::{AccountingSettlement, BootNode, ClientNode, PeerSelector, SelfThrottle};
@@ -368,10 +368,13 @@ async fn build_client_backed_node(
         .spawn_service("swarm.client_service", client_service);
 
     // A storer always needs a chain (staking, oracle, settlement); a client
-    // needs one only when SWAP settlement is enabled.
+    // needs one only when SWAP settlement is enabled via `--swap`.
     #[cfg(feature = "chain")]
     let chain_provider = {
-        let swap_enabled = SwarmAccountingConfig::mode(params.bandwidth).swap_enabled();
+        #[cfg(feature = "swap")]
+        let swap_enabled = params.swap.enable;
+        #[cfg(not(feature = "swap"))]
+        let swap_enabled = false;
         build_node_chain_provider(
             params.spec,
             params.identity,

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -276,6 +276,13 @@ async fn build_client_backed_node(
     } = (params.make_store)(db.clone())?;
     let node_store = Arc::clone(&store);
 
+    // SWAP defaults on for storers (maximum support) and off for clients; an
+    // explicit --swap overrides. Resolved once and shared with the chain check.
+    #[cfg(feature = "swap")]
+    let swap_enabled = params.swap.enable.unwrap_or(node_type.swap_default());
+    #[cfg(all(not(feature = "swap"), feature = "chain"))]
+    let swap_enabled = false;
+
     // SWAP settlement is prepared first: the provider embeds in the accounting
     // and the swap event sink routes at node build time.
     #[cfg(feature = "swap")]
@@ -284,6 +291,7 @@ async fn build_client_backed_node(
         params.identity,
         params.bandwidth,
         params.swap,
+        swap_enabled,
     )
     .unzip();
 
@@ -368,22 +376,16 @@ async fn build_client_backed_node(
         .spawn_service("swarm.client_service", client_service);
 
     // A storer always needs a chain (staking, oracle, settlement); a client
-    // needs one only when SWAP settlement is enabled via `--swap`.
+    // needs one only when SWAP is enabled.
     #[cfg(feature = "chain")]
-    let chain_provider = {
-        #[cfg(feature = "swap")]
-        let swap_enabled = params.swap.enable;
-        #[cfg(not(feature = "swap"))]
-        let swap_enabled = false;
-        build_node_chain_provider(
-            params.spec,
-            params.identity,
-            node_type,
-            swap_enabled,
-            params.chain,
-        )
-        .await?
-    };
+    let chain_provider = build_node_chain_provider(
+        params.spec,
+        params.identity,
+        node_type,
+        swap_enabled,
+        params.chain,
+    )
+    .await?;
 
     // SWAP settlement service over the shared accounting: forwards cheque
     // commands to the node and cashes received cheques on chain when a provider

--- a/crates/swarm/builder/src/swap.rs
+++ b/crates/swarm/builder/src/swap.rs
@@ -68,11 +68,12 @@ impl SwapWiring {
         identity: &Arc<Identity>,
         config: &C,
         swap_config: &SwapConfig,
+        swap_enabled: bool,
     ) -> Option<(SwapProvider<C>, Self)>
     where
         C: SwarmAccountingConfig + Clone + 'static,
     {
-        if !swap_config.enable {
+        if !swap_enabled {
             return None;
         }
 

--- a/crates/swarm/builder/src/swap.rs
+++ b/crates/swarm/builder/src/swap.rs
@@ -1,8 +1,8 @@
 //! SWAP settlement wiring for the client launch path.
 //!
 //! Ties three pieces together behind the `swap` feature: a [`SwapProvider`]
-//! registered with the accounting builder so [`BandwidthMode`] selection drives
-//! cheque issuance, the [`SwapService`] actor that owns the cheque-exchange state
+//! registered with the accounting builder when `--swap` is set, the
+//! [`SwapService`] actor that owns the cheque-exchange state
 //! machine, and the wire plumbing that routes swap events from the node into the
 //! service and the service's `SendCheque` commands back to the node.
 //!
@@ -58,11 +58,11 @@ pub(crate) struct SwapWiring {
 impl SwapWiring {
     /// Build the swap handle and provider when SWAP settlement is enabled.
     ///
-    /// Returns `None` (and leaves accounting swap-free) when the bandwidth mode
-    /// does not enable SWAP, or when SWAP is requested but the required chequebook
-    /// address and settlement chain cannot be resolved. The returned provider is
-    /// registered with the accounting builder; the returned wiring is later handed
-    /// to [`SwapWiring::spawn`].
+    /// Returns `None` (and leaves accounting swap-free) when `--swap` is not set,
+    /// or when SWAP is requested but the required chequebook address and
+    /// settlement chain cannot be resolved. The returned provider is registered
+    /// with the accounting builder; the returned wiring is later handed to
+    /// [`SwapWiring::spawn`].
     pub(crate) fn prepare<C>(
         spec: &Arc<Spec>,
         identity: &Arc<Identity>,
@@ -72,14 +72,7 @@ impl SwapWiring {
     where
         C: SwarmAccountingConfig + Clone + 'static,
     {
-        let mode = config.mode();
-        if !mode.swap_enabled() {
-            if swap_config.enable {
-                warn!(
-                    ?mode,
-                    "--swap set but bandwidth mode does not enable SWAP; settlement not wired"
-                );
-            }
+        if !swap_config.enable {
             return None;
         }
 

--- a/crates/swarm/node/src/args/swap.rs
+++ b/crates/swarm/node/src/args/swap.rs
@@ -4,8 +4,8 @@
 //! a deploy toggle) that exist in every build. The arguments name no chain types,
 //! so the surface is identical whether or not the binary is compiled with the
 //! optional `swap` feature; a build without the feature simply ignores them. The
-//! builder reads these only under the `swap` feature, and only when the bandwidth
-//! mode enables SWAP. The settlement chain and contract addresses come from the
+//! builder reads these only under the `swap` feature, and only when SWAP is
+//! enabled. The settlement chain and contract addresses come from the
 //! network spec; the RPC endpoint is the shared `--chain.rpc-url`.
 
 use alloy_primitives::Address;
@@ -17,12 +17,11 @@ use serde::{Deserialize, Serialize};
 #[command(next_help_heading = "Swap")]
 #[serde(default)]
 pub struct SwapArgs {
-    /// Enable SWAP settlement (chequebook payments). Equivalent to selecting a
-    /// SWAP-capable bandwidth mode. Has no effect unless the binary was built with
-    /// the `swap` feature.
-    #[arg(long = "swap")]
+    /// Enable or disable SWAP settlement. Unset defaults on for storers and off
+    /// for clients. No effect unless built with the `swap` feature.
+    #[arg(long = "swap", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     #[serde(default)]
-    pub enable: bool,
+    pub enable: Option<bool>,
 
     /// This node's chequebook contract address (the drawer of cheques we issue).
     /// Required to issue cheques when SWAP is enabled and a chequebook is not
@@ -43,10 +42,6 @@ pub struct SwapArgs {
     pub deploy: bool,
 
     /// Per-peer cap on uncashed cheque exposure, in cumulative-payout units.
-    /// A received cheque settles debt on structural validation while on-chain
-    /// cashing is stubbed for v1, so this bounds how much uncashed value can buy
-    /// real service before crediting for the peer stops. Defaults to ten times
-    /// the default payment threshold.
     #[arg(long = "swap.bounce-limit", default_value_t = DEFAULT_BOUNCE_LIMIT)]
     #[serde(default = "default_bounce_limit")]
     pub bounce_limit: u128,
@@ -63,7 +58,7 @@ fn default_bounce_limit() -> u128 {
 impl Default for SwapArgs {
     fn default() -> Self {
         Self {
-            enable: false,
+            enable: None,
             chequebook: None,
             beneficiary: None,
             deploy: false,
@@ -92,8 +87,9 @@ impl SwapArgs {
 /// inert.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SwapConfig {
-    /// Whether SWAP settlement is requested via the dedicated flag.
-    pub enable: bool,
+    /// SWAP request: `Some(true)`/`Some(false)` force it on or off, `None` takes
+    /// the node-type default (on for storers, off for clients).
+    pub enable: Option<bool>,
 
     /// This node's chequebook contract address, if configured.
     pub chequebook: Option<Address>,
@@ -122,7 +118,7 @@ mod tests {
     #[test]
     fn defaults_when_unset() {
         let cfg = SwapArgs::default().swap_config();
-        assert!(!cfg.enable);
+        assert_eq!(cfg.enable, None);
         assert_eq!(cfg.chequebook, None);
         assert_eq!(cfg.beneficiary, None);
         assert!(!cfg.deploy);
@@ -134,14 +130,14 @@ mod tests {
         let chequebook = Address::repeat_byte(0x11);
         let beneficiary = Address::repeat_byte(0x22);
         let args = SwapArgs {
-            enable: true,
+            enable: Some(true),
             chequebook: Some(chequebook),
             beneficiary: Some(beneficiary),
             deploy: true,
             bounce_limit: 42,
         };
         let cfg = args.swap_config();
-        assert!(cfg.enable);
+        assert_eq!(cfg.enable, Some(true));
         assert_eq!(cfg.chequebook, Some(chequebook));
         assert_eq!(cfg.beneficiary, Some(beneficiary));
         assert!(cfg.deploy);

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -704,8 +704,8 @@ mod tests {
         DefaultBandwidthConfig, NoAccounting, NoPeerBandwidth, NoProvideAction, NoReceiveAction,
     };
     use vertex_swarm_api::{
-        Au, BandwidthMode, PeerAffordability, SwarmBandwidthAccounting, SwarmClientAccounting,
-        SwarmPricing, SwarmResult,
+        Au, PeerAffordability, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmPricing,
+        SwarmResult,
     };
     use vertex_swarm_test_utils::MockIdentity;
 
@@ -796,16 +796,7 @@ mod tests {
         };
         // Only refresh_rate (1 AU/sec) and throttle_allowance_percent (100) are
         // read; the rest are placeholders.
-        let config = DefaultBandwidthConfig::new(
-            BandwidthMode::Pseudosettle,
-            0,
-            0,
-            1,
-            0,
-            1,
-            100,
-            Default::default(),
-        );
+        let config = DefaultBandwidthConfig::new(0, 0, 1, 0, 1, 100, Default::default());
         let throttle = Arc::new(SelfThrottle::new(&accounting, &config));
         (ClientHandle::new(tx).with_throttle(throttle), rx)
     }

--- a/crates/swarm/node/src/throttle.rs
+++ b/crates/swarm/node/src/throttle.rs
@@ -471,7 +471,6 @@ mod tests {
         // config; the remaining fields are placeholders that the throttle never
         // touches.
         let config = DefaultBandwidthConfig::new(
-            vertex_swarm_api::BandwidthMode::Pseudosettle,
             0,
             0,
             refresh_rate,

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -245,6 +245,12 @@ impl SwarmNodeType {
         matches!(self, SwarmNodeType::Storer)
     }
 
+    /// Whether SWAP settlement defaults on for this node type. Storers settle
+    /// monetarily by default to provide maximum support; clients are opt-in.
+    pub fn swap_default(&self) -> bool {
+        matches!(self, SwarmNodeType::Storer)
+    }
+
     /// Whether this node type requires a persistent (keystore-backed) signing
     /// key. Bootnodes need a stable overlay address across restarts so peers
     /// can reach them via their well-known overlay. Storers need a stable key

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -481,35 +481,3 @@ mod tests {
         assert!(ConnectionProfile::from_str("turbo").is_err());
     }
 }
-
-/// Bandwidth accounting mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, strum::Display, strum::FromRepr)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[strum(serialize_all = "lowercase")]
-#[repr(u8)]
-pub enum BandwidthMode {
-    /// No bandwidth accounting (dev/testing only).
-    None = 0,
-    /// Soft accounting without real payments (default).
-    #[default]
-    Pseudosettle = 1,
-    /// Real payment channels with chequebook.
-    Swap = 2,
-    /// Both pseudosettle and SWAP.
-    Both = 3,
-}
-
-impl BandwidthMode {
-    pub fn pseudosettle_enabled(self) -> bool {
-        matches!(self, BandwidthMode::Pseudosettle | BandwidthMode::Both)
-    }
-
-    pub fn swap_enabled(self) -> bool {
-        matches!(self, BandwidthMode::Swap | BandwidthMode::Both)
-    }
-
-    pub fn is_enabled(self) -> bool {
-        !matches!(self, BandwidthMode::None)
-    }
-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ Internal design documents for planned changes.
 
 - [**Chunk Size Const Generic**](design/chunk-size-const-generic.md) - Making chunk body size a compile-time const generic
 - [**Chain Service**](design/chain-service.md) - Node-wide chain access built on a shared alloy provider, with a thin chain crate for config, errors, and provider extensions
+- [**Accounting and Settlement**](design/accounting-settlement.md) - Ledger, pseudosettle (always on) and SWAP (opt-in via `--swap`), wire conformance, and security invariants
 
 ### Development
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -26,7 +26,7 @@ flowchart LR
     C --> D["NodeConfig\n- mode\n- network\n- bandwidth\n- storage\n- identity"]
 ```
 
-The `SwarmSpec` provides network-level constants (network ID, bootnodes, contract addresses, default pricing parameters). CLI arguments provide node-level configuration (ports, capacity, mode selection, accounting mode) and can override network defaults where appropriate.
+The `SwarmSpec` provides network-level constants (network ID, bootnodes, contract addresses, default pricing parameters). CLI arguments provide node-level configuration (ports, capacity, node type, settlement selection) and can override network defaults where appropriate.
 
 ## Argument Groups
 
@@ -71,14 +71,9 @@ When both `--db.path` and `--db.persist` are given, the explicit path wins.
 
 What persistence covers: peer snapshots (the identity-only records described in [Peer Management](../networking/peer-management.md)), written periodically and on shutdown so a restarted node warm-starts its peer set. Peer scores, bans, and dial backoff are runtime-only and are never persisted in either mode. If the configured database cannot be opened, the node logs a warning and continues fully in-memory rather than aborting.
 
-## Bandwidth Modes
+## Bandwidth accounting
 
-| Mode | Description | Use Case |
-|------|-------------|----------|
-| **none** | No accounting | Bootnodes (set automatically) |
-| **pseudosettle** | Soft accounting without real payments | Default, testing, trusted networks |
-| **swap** | Payment channels with chequebook | Production with real payments |
-| **both** | Pseudosettle until threshold, then SWAP | Hybrid approach |
+Soft accounting (pseudosettle) is always on for client and storer nodes; it needs no flag. Monetary settlement (SWAP) is opt-in via `--swap` and selected purely by that flag plus the node type.
 
 ## Observability Flags
 

--- a/docs/design/accounting-settlement.md
+++ b/docs/design/accounting-settlement.md
@@ -8,7 +8,7 @@ The accounting layer separates the ledger, the settlement mechanisms, and how th
 
 ## Settlement
 
-Two roles on different debt bases, not a pipeline. Soft accounting forgives total debt over time at the configured refresh rate; it is always on for client and storer nodes, realised on the wire by the pseudosettle protocol. Monetary settlement (SWAP) is optional, settles only originated debt, and is opt-in via `--swap`. There is no runtime mode enum: pseudosettle is the default and SWAP is selected by the flag plus the node type.
+Two roles on different debt bases, not a pipeline. Soft accounting forgives total debt over time at the configured refresh rate; it is always on for client and storer nodes, realised on the wire by the pseudosettle protocol. Monetary settlement (SWAP) settles only originated debt and defaults on for storers, which provide maximum support, and off for clients; `--swap` overrides either way, so a client (including a wasm client) can opt in. There is no runtime mode enum. The SWAP cheque-exchange path is built to compile for wasm; only on-chain cashout is native.
 
 ## Wire conformance
 

--- a/docs/design/accounting-settlement.md
+++ b/docs/design/accounting-settlement.md
@@ -1,0 +1,23 @@
+# Accounting and settlement
+
+The accounting layer separates the ledger, the settlement mechanisms, and how they are selected.
+
+## Ledger
+
+`Accounting<C, I>` tracks per-peer balances in accounting units (`Au`, signed; positive means the peer owes us). It owns the reservation lifecycle (`prepare_receive`/`prepare_provide` reserve, commit on apply, release on drop), the payment and disconnect thresholds, affordability via `PeerAffordability`, and breach reporting through `PeerReporter`. It is mechanism-agnostic and generic only over its config and identity.
+
+## Settlement
+
+Two roles on different debt bases, not a pipeline. Soft accounting forgives total debt over time at the configured refresh rate; it is always on for client and storer nodes, realised on the wire by the pseudosettle protocol. Monetary settlement (SWAP) is optional, settles only originated debt, and is opt-in via `--swap`. There is no runtime mode enum: pseudosettle is the default and SWAP is selected by the flag plus the node type.
+
+## Wire conformance
+
+The dominant peer on the live network is the Go reference node, so these are interop-critical and carry conformance vectors. Pseudosettle `Payment`/`PaymentAck` carry the amount as minimal big-endian unsigned bytes; the ack echoes the accepted amount (which may be less than requested) and a server timestamp in seconds, and the payer credits the accepted amount. Pricing announces the payment threshold on every connection. SWAP cheques are EIP-712 signed (`Chequebook` domain, version 1.0, chain id 100) and travel as a JSON object inside a protobuf bytes field, with cumulative payout as a U256 decimal string; exchange rate and deduction ride as stream headers. The refresh allowance and overdraft maths cap elapsed at one second, matching the reference.
+
+## Security invariants
+
+The refresh allowance is bounded by genuine elapsed wall-clock since accounting began for a peer, never the absolute clock, and never resets to unbounded on reconnect. A peer is refused service once its debt to us crosses the payment threshold. Pseudosettle credits at most the offered amount. Balance arithmetic saturates rather than wrapping. Uncashed SWAP cheques are bounded per peer until on-chain cashing confirms.
+
+## Deferred
+
+On-chain SWAP cashout and deploy, persisted batched cheque cashing, dynamic payment-threshold growth, and the hardening backlog are tracked separately.


### PR DESCRIPTION
## What

Delete the closed `BandwidthMode` enum and make settlement selection a node-type plus `--swap` decision. Soft accounting (pseudosettle) is always on for client and storer nodes. SWAP defaults on for storers (to provide maximum support) and off for clients; `--swap` / `--swap=false` override either way, so a client, including a wasm client, can opt in.

Removes `BandwidthMode` (and its `Both` variant), `BandwidthModeArg`, the `--bandwidth.mode` flag, `SwarmAccountingConfig::{mode, provider_enabled, is_enabled}`, and `SwarmSettlementProvider::supported_mode`. `--swap` becomes a tri-state `Option<bool>` resolved against `SwarmNodeType::swap_default` in the launch path; the resolved value gates both the swap wiring and the chain requirement. Dead mode-conditional config validation is dropped; the throttle-percent check stays.

Adds the design note `docs/design/accounting-settlement.md` and updates the CLI docs.

## Why

`BandwidthMode` was a closed enum whose `Both` variant only worked because there were exactly two mechanisms, duplicated as `BandwidthModeArg`, with selection split between the mode and `--swap`. Selection is now a type and flag decision with opinionated per-node-type defaults. Part of the accounting and settlement reshape.

## Testing

`cargo clippy --workspace --all-features -- -D warnings` clean; `cargo test` across primitives, api, accounting core, pseudosettle, swap, builder, node (all-features) passes; the builder compiles in all four swap/chain feature combinations.

## AI Assistance

Claude Code (Opus 4.8) used for the change and verification, under human review.
