### PR TITLE
ci(wasm): build the chain-free swap path for wasm32 and fix native-only comments

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -123,6 +123,12 @@ jobs:
       # browser client node.
       - name: Build client cone for wasm32
         run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node
+      # The chain-free SWAP path: cheque exchange (sign, send, validate, credit)
+      # needs no chain, so the accounting stack and `vertex-swarm-node/swap`
+      # build for wasm with default features. The on-chain cashout path
+      # (`swap-chequebook`) is excluded; it lands in a later change.
+      - name: Build chain-free swap path for wasm32
+        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node --features swap -p vertex-swarm-accounting-swap -p vertex-swarm-accounting-chequebook -p vertex-swarm-accounting-pseudosettle -p vertex-swarm-accounting-pricing -p vertex-swarm-accounting
 
   ci-success:
     name: ci success

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = []
 # Enable on-chain SWAP settlement for the embedded client. Forwards to the
-# builder's chain feature; native-only and off by default so the FFI client
-# stays chain-free unless the host opts in.
+# builder's chain feature; off by default so the FFI client stays chain-free
+# unless the host opts in.
 chain = ["vertex-swarm-builder/chain"]
 
 [dependencies]

--- a/crates/swarm/builder/Cargo.toml
+++ b/crates/swarm/builder/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 [features]
 default = []
 # Construct a shared Ethereum alloy provider for chain-needing node types
-# (storer, and a client with SWAP enabled). Native-only: pulls the alloy RPC
-# stack (HTTP transport via reqwest) and the on-chain chequebook client. Off by
-# default so the client node and the wasm build stay completely chain-free; the
-# cone guard (`just check-cone`) enforces this.
+# (storer, and a client with SWAP enabled). Pulls the alloy RPC stack and the
+# on-chain chequebook client. Off by default to keep the default client cone
+# lean. The alloy transport stack is target-split (native TLS vs browser fetch),
+# so the chain code itself can build for wasm when its features are selected.
 chain = [
     "dep:vertex-chain",
     "vertex-swarm-accounting-chequebook/swap-chequebook",
@@ -74,7 +74,7 @@ vertex-swarm-net-pushsync.workspace = true
 vertex-swarm-identity.workspace = true
 vertex-swarm-spec.workspace = true
 
-# vertex - chain (optional, native-only, behind the `chain` feature)
+# vertex - chain (optional, behind the `chain` feature)
 vertex-chain = { workspace = true, optional = true }
 # The on-chain chequebook client. Pure cheque codec by default; the builder's
 # `chain` feature enables `swap-chequebook` on it to construct the SWAP


### PR DESCRIPTION
## What

Build the chain-free SWAP path for `wasm32-unknown-unknown` in CI, and correct two inaccurate comments that claimed chain code is native-only.

The wasm job now also builds `vertex-swarm-node --features swap` plus the accounting crates (`-swap`, `-chequebook`, `-pseudosettle`, `-pricing`, core) with default features, proving the cheque-exchange path (sign, send, validate, credit) compiles for the browser cone. The on-chain cashout path (behind the chain/`swap-chequebook` features) is a later change.

The `builder` and `ffi` Cargo.toml comments wrongly said the `chain` feature is native-only and that `just check-cone` enforces a chain-free wasm cone. Per `docs/agents/wasm.md`, chain code is wasm-compatible with the right alloy features, and `check-cone` only checks `vertex-ffi` for two observability crates. The comments now reflect that the chain feature is off by default to keep the default client cone lean and that the alloy transport stack is target-split.

## Why

Part of the accounting and settlement reshape (#441): a wasm client must be able to run SWAP. This first step verifies the chain-free half on wasm and removes the misleading guidance.

## Testing

Native: `cargo build`/`cargo clippy --features swap -- -D warnings` clean for the touched crates. Wasm is verified by the CI `wasm` job (no local wasm toolchain).

## AI Assistance

Claude Code (Opus 4.8) used for the change and native verification, under human review.
