### PR TITLE
feat(accounting-chequebook): make on-chain cashout deps build for wasm32

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -129,6 +129,15 @@ jobs:
       # (`swap-chequebook`) is excluded; it lands in a later change.
       - name: Build chain-free swap path for wasm32
         run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node --features swap -p vertex-swarm-accounting-swap -p vertex-swarm-accounting-chequebook -p vertex-swarm-accounting-pseudosettle -p vertex-swarm-accounting-pricing -p vertex-swarm-accounting
+      # The on-chain cashout path: the chequebook client and the swap cashout
+      # logic are transport-generic, so with `swap-chequebook` selecting the
+      # browser fetch transport they build for wasm. `vertex-chain` is the shared
+      # provider crate they sit on.
+      - name: Build cashout path for wasm32
+        run: |
+          cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-accounting-chequebook --features swap-chequebook
+          cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-accounting-swap --features swap-chequebook
+          cargo +nightly build --target wasm32-unknown-unknown -p vertex-chain
 
   ci-success:
     name: ci success

--- a/crates/swarm/accounting/chequebook/Cargo.toml
+++ b/crates/swarm/accounting/chequebook/Cargo.toml
@@ -45,10 +45,6 @@ alloy-sol-types = { workspace = true }
 # `sol!` interfaces.
 vertex-chain = { workspace = true, optional = true }
 alloy-contract = { workspace = true, optional = true }
-alloy-provider = { workspace = true, optional = true, features = [
-    "reqwest",
-    "reqwest-native-tls",
-] }
 alloy-network = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
@@ -60,11 +56,22 @@ serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["base64"] }
 serde_json = { workspace = true }
 
+# Native uses the reqwest transport with native-tls (system OpenSSL).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+alloy-provider = { workspace = true, optional = true, features = [
+    "reqwest",
+    "reqwest-native-tls",
+] }
+
 # On wasm, the secp256k1 backend pulled in by `alloy-primitives/k256` reaches
 # `getrandom`, which needs its browser backend selected explicitly. This is a
 # transitive build requirement, not a direct API use.
+#
+# The reqwest transport on wasm uses the browser fetch backend, which does TLS
+# through the browser, so no `*-tls` feature is selected.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
+alloy-provider = { workspace = true, optional = true, features = ["reqwest"] }
 
 [dev-dependencies]
 alloy-signer = { workspace = true }


### PR DESCRIPTION
## What

Make the SWAP on-chain cashout dependencies build for `wasm32-unknown-unknown`. The `swap-chequebook` feature pulled `alloy-provider` with `reqwest-native-tls` (system OpenSSL), which breaks wasm. The dependency is now target-split in `vertex-swarm-accounting-chequebook`: native keeps `["reqwest", "reqwest-native-tls"]`, wasm uses `["reqwest"]` and relies on the browser fetch transport for TLS. The cashout logic was already transport-generic, so no logic changes were needed. The wasm CI job now builds the cashout crates (`accounting-chequebook`/`accounting-swap` with `swap-chequebook`, plus `vertex-chain`).

Stacked on the chain-free swap wasm PR.

## Why

Part of the accounting and settlement reshape (#441): a wasm client must be able to cash cheques on chain, not only exchange them. This proves the cashout deps and logic compile for the browser cone. The browser provider construction (host-supplied RPC URL) is a follow-up.

## Testing

Native builds and `cargo clippy --features swap-chequebook -- -D warnings` clean for the touched crates. Wasm is verified by the CI `wasm` job; the load-bearing check is that alloy's `reqwest` feature yields a TLS-free fetch transport on wasm.

## AI Assistance

Claude Code (Opus 4.8) used for the change and native verification, under human review.
