### PR TITLE
fix(accounting-swap): allow the wasm cashout task future to be !Send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8334,6 +8334,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
+ "getrandom 0.2.17",
  "nectar-contracts",
  "nectar-swarms",
  "strum 0.28.0",

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -34,5 +34,10 @@ alloy-contract = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 
+# alloy's signer stack pulls getrandom 0.2 transitively; on wasm32 its browser
+# backend needs the `js` feature. This direct dep only flips that feature on.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["js"] }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/swarm/accounting/pseudosettle/src/service.rs
+++ b/crates/swarm/accounting/pseudosettle/src/service.rs
@@ -14,7 +14,7 @@ use vertex_swarm_api::{
 use vertex_swarm_client_protocol::{ClientCommand, PseudosettleEvent};
 use vertex_swarm_net_pseudosettle::PaymentAck;
 use vertex_swarm_primitives::OverlayAddress;
-use vertex_tasks::{GracefulShutdown, SpawnableTask};
+use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask};
 
 use crate::error::PseudosettleSettlementError;
 
@@ -322,7 +322,7 @@ fn wire_from_au(amount: Au) -> U256 {
 }
 
 impl<A: SwarmBandwidthAccounting + 'static> SpawnableTask for PseudosettleService<A> {
-    fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + Send {
+    fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + MaybeSend {
         self.run(shutdown)
     }
 }

--- a/crates/swarm/accounting/swap/src/service.rs
+++ b/crates/swarm/accounting/swap/src/service.rs
@@ -22,7 +22,7 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_client_protocol::{ClientCommand, SwapEvent};
 use vertex_swarm_primitives::OverlayAddress;
-use vertex_tasks::{GracefulShutdown, SpawnableTask};
+use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask};
 
 use crate::error::SwapSettlementError;
 
@@ -434,7 +434,7 @@ where
     A: SwarmBandwidthAccounting + 'static,
     S: SignerSync + Send + Sync + 'static,
 {
-    fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + Send {
+    fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + MaybeSend {
         self.run(shutdown)
     }
 }

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -12,7 +12,7 @@ pub use vertex_swarm_client_protocol::{ChunkTransferError, RetrievalResult};
 use vertex_swarm_net_pseudosettle::PaymentAck;
 use vertex_swarm_net_pushsync::Receipt;
 use vertex_swarm_primitives::{CachedChunk, OverlayAddress, StampedChunk};
-use vertex_tasks::{GracefulShutdown, SpawnableTask};
+use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask};
 
 use crate::protocol::{ClientCommand, ClientEvent, FailureKind};
 use crate::throttle::{ProtocolKind, SelfThrottle};
@@ -499,7 +499,10 @@ impl Default for ClientService {
 }
 
 impl SpawnableTask for ClientService {
-    fn into_task(self, shutdown: GracefulShutdown) -> impl std::future::Future<Output = ()> + Send {
+    fn into_task(
+        self,
+        shutdown: GracefulShutdown,
+    ) -> impl std::future::Future<Output = ()> + MaybeSend {
         self.run(shutdown)
     }
 }

--- a/crates/swarm/stream/src/lib.rs
+++ b/crates/swarm/stream/src/lib.rs
@@ -29,10 +29,8 @@ use vertex_swarm_api::{
     OverlayAddress, PushReceipt, Stamp, StampedChunk, SwarmChunkProvider, SwarmChunkSender,
     SwarmError, SwarmResult,
 };
-// `MaybeSendBoxFuture` is `Send` on native (so the streams stay `Send` for
-// tonic) and `!Send` on wasm. The `MaybeSend*` markers below follow the same
-// split.
-use vertex_tasks::MaybeSendBoxFuture;
+// `Send` on native (so the streams stay `Send` for tonic), unbounded on wasm.
+use vertex_tasks::{MaybeSend, MaybeSendBoxFuture, MaybeSendIter, MaybeSendStream};
 
 /// A downloaded chunk proven to answer the address that requested it.
 ///
@@ -257,28 +255,6 @@ where
     }
 }
 
-/// `Send` bound on an address-source [`Stream`], native-only. Blanket-impl;
-/// callers never name it.
-#[cfg(not(target_arch = "wasm32"))]
-pub trait MaybeSendStream: Send {}
-#[cfg(not(target_arch = "wasm32"))]
-impl<T: Send> MaybeSendStream for T {}
-#[cfg(target_arch = "wasm32")]
-pub trait MaybeSendStream {}
-#[cfg(target_arch = "wasm32")]
-impl<T> MaybeSendStream for T {}
-
-/// `Send` bound on a [`ChunkClientExt`] return value, native-only. Blanket-impl;
-/// callers never name it.
-#[cfg(not(target_arch = "wasm32"))]
-pub trait MaybeSend: Send {}
-#[cfg(not(target_arch = "wasm32"))]
-impl<T: Send> MaybeSend for T {}
-#[cfg(target_arch = "wasm32")]
-pub trait MaybeSend {}
-#[cfg(target_arch = "wasm32")]
-impl<T> MaybeSend for T {}
-
 /// Capability alias for a lean chunk client: retrieves, sends, cloneable, and
 /// shareable across threads. Blanket-impl, so callers never name it.
 ///
@@ -476,17 +452,6 @@ where
         limit: config.max_concurrency.max(1),
     }
 }
-
-/// `Send` bound on the pending-chunk iterator so [`PutStream`] stays `Send`,
-/// native-only. Blanket-impl; callers never name it.
-#[cfg(not(target_arch = "wasm32"))]
-pub trait MaybeSendIter: Send {}
-#[cfg(not(target_arch = "wasm32"))]
-impl<T: Send> MaybeSendIter for T {}
-#[cfg(target_arch = "wasm32")]
-pub trait MaybeSendIter {}
-#[cfg(target_arch = "wasm32")]
-impl<T> MaybeSendIter for T {}
 
 /// Boxed pending-chunk feed, `Send` on native so [`PutStream`] stays `Send`.
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -61,6 +61,32 @@ pub type MaybeSendBoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 #[cfg(target_arch = "wasm32")]
 pub type MaybeSendBoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
+/// Marker for a `Send` bound that follows the platform executor: `Send` on
+/// native (multi-thread tokio), no bound on `wasm32` (the browser event loop
+/// runs `!Send` timer and fetch futures). Blanket-impl; callers never name it.
+///
+/// This is the unboxed sibling of [`MaybeSendBoxFuture`]; use it as the return
+/// bound on an `impl Future` an `async fn` produces, which cannot be a boxed
+/// alias. The single canonical home for the divergence; crates must not define
+/// per-crate cfg-gated siblings.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSend: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send + ?Sized> MaybeSend for T {}
+
+/// Marker for a `Send` bound that follows the platform executor: `Send` on
+/// native (multi-thread tokio), no bound on `wasm32` (the browser event loop
+/// runs `!Send` timer and fetch futures). Blanket-impl; callers never name it.
+///
+/// This is the unboxed sibling of [`MaybeSendBoxFuture`]; use it as the return
+/// bound on an `impl Future` an `async fn` produces, which cannot be a boxed
+/// alias. The single canonical home for the divergence; crates must not define
+/// per-crate cfg-gated siblings.
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSend {}
+#[cfg(target_arch = "wasm32")]
+impl<T: ?Sized> MaybeSend for T {}
+
 /// A boxed future representing a node's main event loop.
 pub type NodeTask = Pin<Box<dyn Future<Output = ()> + Send>>;
 
@@ -78,7 +104,12 @@ pub trait SpawnableTask: Send + 'static {
     /// Consume self and return a future to run as a background task.
     ///
     /// The service should listen for the shutdown signal and exit gracefully when received.
-    fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + Send;
+    ///
+    /// The future is [`MaybeSend`]: `Send` on native, where the multi-thread
+    /// executor spawns it through the Send-bounded path; unbounded on wasm,
+    /// where an on-chain settlement future is `!Send` and the task runs on the
+    /// browser event loop.
+    fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + MaybeSend;
 }
 
 /// Global [`TaskExecutor`] instance that can be accessed from anywhere.
@@ -772,10 +803,22 @@ impl TaskExecutor {
     /// This is the preferred way to spawn long-running services that implement
     /// [`SpawnableTask`]. The service receives a [`GracefulShutdown`] signal and
     /// is monitored for panics.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn spawn_service<S: SpawnableTask>(&self, name: &'static str, service: S) -> TaskHandle {
         self.spawn_critical_with_graceful_shutdown_signal(name, |shutdown| {
             service.into_task(shutdown)
         })
+    }
+
+    /// Browser variant of [`Self::spawn_service`].
+    ///
+    /// A service task can own a `!Send` future on wasm (an on-chain settlement
+    /// future is `!Send` on the browser fetch transport), so it runs on the
+    /// browser event loop through the local spawner rather than the Send-bounded
+    /// critical one. There is no separate panic-monitoring pool in the browser.
+    #[cfg(target_arch = "wasm32")]
+    pub fn spawn_service<S: SpawnableTask>(&self, name: &'static str, service: S) -> TaskHandle {
+        self.spawn_local_with_graceful_shutdown_signal(name, |shutdown| service.into_task(shutdown))
     }
 
     /// Spawns a periodic background task with graceful shutdown support.

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -61,31 +61,36 @@ pub type MaybeSendBoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 #[cfg(target_arch = "wasm32")]
 pub type MaybeSendBoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
 
-/// Marker for a `Send` bound that follows the platform executor: `Send` on
-/// native (multi-thread tokio), no bound on `wasm32` (the browser event loop
-/// runs `!Send` timer and fetch futures). Blanket-impl; callers never name it.
-///
-/// This is the unboxed sibling of [`MaybeSendBoxFuture`]; use it as the return
-/// bound on an `impl Future` an `async fn` produces, which cannot be a boxed
-/// alias. The single canonical home for the divergence; crates must not define
-/// per-crate cfg-gated siblings.
+/// `Send` on native, unbounded on wasm32. Blanket-impl; the canonical home for
+/// the marker, so crates must not define per-crate siblings.
 #[cfg(not(target_arch = "wasm32"))]
 pub trait MaybeSend: Send {}
 #[cfg(not(target_arch = "wasm32"))]
 impl<T: Send + ?Sized> MaybeSend for T {}
-
-/// Marker for a `Send` bound that follows the platform executor: `Send` on
-/// native (multi-thread tokio), no bound on `wasm32` (the browser event loop
-/// runs `!Send` timer and fetch futures). Blanket-impl; callers never name it.
-///
-/// This is the unboxed sibling of [`MaybeSendBoxFuture`]; use it as the return
-/// bound on an `impl Future` an `async fn` produces, which cannot be a boxed
-/// alias. The single canonical home for the divergence; crates must not define
-/// per-crate cfg-gated siblings.
 #[cfg(target_arch = "wasm32")]
 pub trait MaybeSend {}
 #[cfg(target_arch = "wasm32")]
 impl<T: ?Sized> MaybeSend for T {}
+
+/// `Send` on native, unbounded on wasm32, for a `Stream`. Blanket-impl.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSendStream: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> MaybeSendStream for T {}
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSendStream {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSendStream for T {}
+
+/// `Send` on native, unbounded on wasm32, for an `Iterator`. Blanket-impl.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait MaybeSendIter: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> MaybeSendIter for T {}
+#[cfg(target_arch = "wasm32")]
+pub trait MaybeSendIter {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSendIter for T {}
 
 /// A boxed future representing a node's main event loop.
 pub type NodeTask = Pin<Box<dyn Future<Output = ()> + Send>>;
@@ -105,10 +110,8 @@ pub trait SpawnableTask: Send + 'static {
     ///
     /// The service should listen for the shutdown signal and exit gracefully when received.
     ///
-    /// The future is [`MaybeSend`]: `Send` on native, where the multi-thread
-    /// executor spawns it through the Send-bounded path; unbounded on wasm,
-    /// where an on-chain settlement future is `!Send` and the task runs on the
-    /// browser event loop.
+    /// The future is [`MaybeSend`]: `Send` on native, unbounded on wasm (where a
+    /// settlement future is `!Send` and runs on the browser event loop).
     fn into_task(self, shutdown: GracefulShutdown) -> impl Future<Output = ()> + MaybeSend;
 }
 
@@ -810,12 +813,8 @@ impl TaskExecutor {
         })
     }
 
-    /// Browser variant of [`Self::spawn_service`].
-    ///
-    /// A service task can own a `!Send` future on wasm (an on-chain settlement
-    /// future is `!Send` on the browser fetch transport), so it runs on the
-    /// browser event loop through the local spawner rather than the Send-bounded
-    /// critical one. There is no separate panic-monitoring pool in the browser.
+    /// Browser variant of [`Self::spawn_service`]: the task future may be `!Send`,
+    /// so it runs on the local spawner (no panic-monitoring pool in the browser).
     #[cfg(target_arch = "wasm32")]
     pub fn spawn_service<S: SpawnableTask>(&self, name: &'static str, service: S) -> TaskHandle {
         self.spawn_local_with_graceful_shutdown_signal(name, |shutdown| service.into_task(shutdown))


### PR DESCRIPTION
## What

Relax `SpawnableTask::into_task`'s returned-future bound from `+ Send` to a new `vertex_tasks::MaybeSend` marker (Send on native, unbounded on wasm32), and cfg-split `TaskExecutor::spawn_service` so native still spawns through the Send-bounded critical path while wasm routes through `spawn_local`. The three impls (`SwapService`, `PseudosettleService`, `ClientService`) move to `MaybeSend`.

## Why

main CI `wasm` job went red after #431 squash-merged. Feature unification now pulls the `swap-chequebook` cashout path into the wasm client cone, where the swap service's `run` future awaits alloy's `PendingTransactionBuilder` (`!Send` on the single-threaded browser fetch transport). The unconditional `+ Send` bound then fails with E0277. Each of #431 and #451 was green alone; the combination was never CI-tested pre-merge.

The service value stays `Send` on both targets (the `SpawnableTask: Send` supertrait is unchanged); only the spawned future is allowed to be `!Send` on wasm, matching how the native multi-thread executor and the wasm `spawn_local` executor actually differ.

## Testing

Native, no Send regression: `cargo clippy -p vertex-tasks -p vertex-swarm-accounting-swap -p vertex-swarm-accounting-pseudosettle -p vertex-swarm-node -p vertex-swarm-builder --all-targets --all-features -- -D warnings` clean; `cargo test -p vertex-swarm-accounting-swap` and `-p vertex-tasks` pass.

wasm32 (pinned stable via `nix develop`): the full `wasm` job builds, including the previously failing `cargo build --target wasm32-unknown-unknown -p vertex-swarm-accounting-swap --features swap-chequebook`.

## AI Assistance

Claude Code (Opus 4.8) used for diagnosis, the MaybeSend fix, and verification.