### PR TITLE
feat(swarm-api): add pullsync storage, interval, and chunk-verifier traits

### DIFF
--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -4,6 +4,7 @@ mod bandwidth;
 mod localstore;
 mod peers;
 mod pricing;
+mod pullsync;
 mod reserve;
 mod topology;
 
@@ -14,6 +15,7 @@ pub use self::bandwidth::{
 pub use self::localstore::{SwarmLocalStore, SwarmLocalStoreConfig};
 pub use self::peers::SwarmPeerResolver;
 pub use self::pricing::{SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig};
+pub use self::pullsync::{IntervalStore, PullChunkVerifier, PullStorage, VerifyError};
 pub use self::reserve::{BinCursorStore, BinScanItem, ReserveStore, SettableRadius};
 pub use self::topology::{
     SwarmTopology, SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers,

--- a/crates/swarm/api/src/components/pullsync.rs
+++ b/crates/swarm/api/src/components/pullsync.rs
@@ -1,0 +1,68 @@
+//! Pullsync trait surface: server snapshot, puller interval persistence, and the
+//! chunk-admission verifier seam.
+
+use nectar_primitives::Bin;
+use vertex_swarm_primitives::{OverlayAddress, StampedChunk};
+
+use crate::SwarmResult;
+
+use super::BinCursorStore;
+
+/// Server-side snapshot the cursor handshake and range responder read.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait PullStorage: BinCursorStore {
+    /// Reserve generation marker; changes only on reserve recreate, so a new
+    /// value tells a puller its persisted cursors are stale.
+    fn reserve_epoch(&self) -> u64;
+}
+
+/// Puller-side persistence of sync progress per `(peer, bin)`.
+///
+/// A stored `peer_epoch` that no longer matches the peer's advertised
+/// [`reserve_epoch`](PullStorage::reserve_epoch) means the puller must reset that
+/// peer's intervals to `0`.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait IntervalStore: Send + Sync {
+    /// Last synced insertion sequence for `peer` in `bin` (`0` if never synced).
+    fn interval(&self, peer: &OverlayAddress, bin: Bin) -> SwarmResult<u64>;
+
+    /// Record the last synced insertion sequence for `peer` in `bin`.
+    fn set_interval(&self, peer: &OverlayAddress, bin: Bin, binid: u64) -> SwarmResult<()>;
+
+    /// Last reserve epoch seen for `peer`, or `None` if never recorded.
+    fn peer_epoch(&self, peer: &OverlayAddress) -> SwarmResult<Option<u64>>;
+
+    /// Record the last reserve epoch seen for `peer`.
+    fn set_peer_epoch(&self, peer: &OverlayAddress, epoch: u64) -> SwarmResult<()>;
+}
+
+/// Why a delivered chunk was refused admission to the reserve.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum VerifyError {
+    /// The stamp signature does not recover to the batch owner.
+    #[error("invalid stamp signature")]
+    InvalidSignature,
+
+    /// The stamp references a batch that is expired or unknown to the node.
+    #[error("postage batch is expired or unknown")]
+    UnknownBatch,
+
+    /// The batch exists but no longer covers its cumulative payout.
+    #[error("postage batch funding is insufficient")]
+    InsufficientFunding,
+
+    /// The chunk or its stamp is structurally malformed.
+    #[error("chunk or stamp is malformed")]
+    Malformed,
+}
+
+/// Admission gate the puller runs before accepting a delivered chunk.
+///
+/// A pluggable seam: the full check is stamp signature recovery plus on-chain
+/// batch funding, so an interim signature-only impl is valid.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait PullChunkVerifier: Send + Sync {
+    /// Verify a delivered chunk before it enters the reserve.
+    fn verify(&self, chunk: &StampedChunk) -> Result<(), VerifyError>;
+}

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -38,12 +38,13 @@ mod types;
 pub use self::accounting::{Au, AuConversionError};
 pub use self::components::{
     AccountingAction, BinCursorStore, BinScanItem, BootnodeComponents, ClientComponents, Direction,
-    HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology, ReserveStore, SettableRadius,
-    StorerComponents, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting,
-    SwarmLocalStore, SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState,
-    SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
+    HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology, IntervalStore,
+    PullChunkVerifier, PullStorage, ReserveStore, SettableRadius, StorerComponents,
+    SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore,
+    SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing,
+    SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
     SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting,
-    SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats, construct,
+    SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats, VerifyError, construct,
 };
 pub use self::config::{
     DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN,


### PR DESCRIPTION
## What

Add the libp2p-free trait surface for pullsync: `PullStorage` (a `BinCursorStore` supertrait adding `reserve_epoch`, reusing `scan_bin_from`/`get`), `IntervalStore` (per-(peer,bin) cursor + per-peer epoch persistence), and the `PullChunkVerifier` admission seam with `VerifyError`.

## Why

Part of the pullsync protocol (#77). The verifier is a seam: full crypto + on-chain batch funding is the target, with the batch-funding arm satisfied by an injected verifier (the separately in-flight batch-store work); a signature-only impl is the interim. Keeps the `api` crate postage-free.

## Testing

`cargo test -p vertex-swarm-api`; clippy clean.

## AI Assistance

Claude Code (Opus 4.8) used for implementation and verification.