### PR TITLE
feat(swarm-net-pullsync): add pullsync wire protocol crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9119,6 +9119,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-swarm-net-pullsync"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer-local",
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p",
+ "nectar-postage",
+ "nectar-primitives",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vertex-net-codec",
+ "vertex-swarm-net-headers",
+ "vertex-swarm-net-proto",
+ "vertex-swarm-primitives",
+]
+
+[[package]]
 name = "vertex-swarm-net-pushsync"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "crates/swarm/net/identify",
     "crates/swarm/net/pricing",
     "crates/swarm/net/pseudosettle",
+    "crates/swarm/net/pullsync",
     "crates/swarm/net/pushsync",
     "crates/swarm/net/retrieval",
     "crates/swarm/net/swap",
@@ -177,6 +178,7 @@ vertex-swarm-net-hive = { path = "crates/swarm/net/hive" }
 vertex-swarm-net-identify = { path = "crates/swarm/net/identify" }
 vertex-swarm-net-pricing = { path = "crates/swarm/net/pricing" }
 vertex-swarm-net-pseudosettle = { path = "crates/swarm/net/pseudosettle" }
+vertex-swarm-net-pullsync = { path = "crates/swarm/net/pullsync" }
 vertex-swarm-net-pushsync = { path = "crates/swarm/net/pushsync" }
 vertex-swarm-net-retrieval = { path = "crates/swarm/net/retrieval" }
 vertex-swarm-net-swap = { path = "crates/swarm/net/swap" }

--- a/crates/swarm/net/AGENTS.md
+++ b/crates/swarm/net/AGENTS.md
@@ -10,6 +10,7 @@ Root-level rules in `/AGENTS.md` apply here too. The notes below are the area-sp
 - `hive`: signed peer-record gossip for topology bootstrap.
 - `pricing`: `/swarm/pricing/1.0.0/pricing`. Payment threshold announcement.
 - `pseudosettle`: `/swarm/pseudosettle/1.0.0/pseudosettle`. Bandwidth micro-payments.
+- `pullsync`: `/swarm/pullsync/1.4.0/cursors` (Syn/Ack cursor handshake) and `/swarm/pullsync/1.4.0/pullsync` (Get/Offer/Want/Delivery range exchange). One protocol, two streams: the "one `PROTOCOL_NAME` per crate" rule bends here, exposed as `PROTOCOL_CURSORS` and `PROTOCOL_SYNC`.
 - `pushsync`: `/swarm/pushsync/1.3.1/pushsync`. Chunk push with receipts.
 - `retrieval`: `/swarm/retrieval/1.4.0/retrieval`. Chunk request and delivery.
 - `headers`: shared header frame used by request-response protocols, with trace-context propagation. W3C propagation over OpenTelemetry is native-only (`tracing.rs`); the wasm sibling (`tracing_wasm.rs`, Pattern C) is no-op inject/extract since a browser client has no OTLP backend. The on-wire `tracing-span-context` field is unaffected.

--- a/crates/swarm/net/pullsync/Cargo.toml
+++ b/crates/swarm/net/pullsync/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "vertex-swarm-net-pullsync"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Swarm pullsync protocol for storer range synchronisation"
+
+[dependencies]
+## vertex
+vertex-net-codec.workspace = true
+vertex-swarm-net-headers.workspace = true
+vertex-swarm-net-proto.workspace = true
+vertex-swarm-primitives.workspace = true
+nectar-primitives.workspace = true
+nectar-postage.workspace = true
+
+## alloy
+alloy-primitives.workspace = true
+
+## p2p
+libp2p.workspace = true
+asynchronous-codec.workspace = true
+
+## protobuf
+quick-protobuf.workspace = true
+quick-protobuf-codec.workspace = true
+
+## async
+futures.workspace = true
+
+## misc
+bytes.workspace = true
+strum.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+alloy-signer-local.workspace = true
+
+[lints]
+workspace = true

--- a/crates/swarm/net/pullsync/src/bitvector.rs
+++ b/crates/swarm/net/pullsync/src/bitvector.rs
@@ -1,8 +1,9 @@
-//! MSB-first selection bitvector for the pullsync `Want` reply: bit `i` selects
-//! `chunks[i]` of the preceding `Offer`. Byte length is `ceil(len / 8)`; trailing
-//! pad bits are zero.
+//! LSB-first selection bitvector for the pullsync `Want` reply: bit `i` selects
+//! `chunks[i]` of the preceding `Offer`. Bit `i` is `0x01 << (i % 8)` in byte
+//! `i / 8`; the byte length is `len / 8 + 1` (always one trailing byte, even
+//! when `len` is a multiple of 8), and trailing pad bits are zero.
 
-/// A fixed-length set of selection bits, packed MSB-first one bit per offered
+/// A fixed-length set of selection bits, packed LSB-first one bit per offered
 /// chunk.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BitVector {
@@ -10,12 +11,18 @@ pub struct BitVector {
     len: usize,
 }
 
+/// Byte length for a vector selecting over `len` chunks: `len / 8 + 1`, always
+/// one trailing byte.
+const fn byte_len(len: usize) -> usize {
+    len / 8 + 1
+}
+
 impl BitVector {
     /// An all-clear vector sized for `len` chunks.
     #[must_use]
     pub fn new(len: usize) -> Self {
         Self {
-            bytes: vec![0u8; len.div_ceil(8)],
+            bytes: vec![0u8; byte_len(len)],
             len,
         }
     }
@@ -29,9 +36,9 @@ impl BitVector {
     }
 
     /// Wrap raw wire bytes selecting over `len` chunks; `bytes` must be exactly
-    /// `ceil(len / 8)` long.
+    /// `len / 8 + 1` long.
     pub fn from_bytes(bytes: Vec<u8>, len: usize) -> Result<Self, BitVectorError> {
-        let expected = len.div_ceil(8);
+        let expected = byte_len(len);
         if bytes.len() != expected {
             return Err(BitVectorError {
                 expected,
@@ -61,7 +68,7 @@ impl BitVector {
         }
         self.bytes
             .get(i / 8)
-            .is_some_and(|byte| byte & (0x80 >> (i % 8)) != 0)
+            .is_some_and(|byte| byte & (0x01 << (i % 8)) != 0)
     }
 
     /// Mark `chunks[i]` as wanted. No-op for `i >= len`.
@@ -69,7 +76,7 @@ impl BitVector {
         if i < self.len
             && let Some(byte) = self.bytes.get_mut(i / 8)
         {
-            *byte |= 0x80 >> (i % 8);
+            *byte |= 0x01 << (i % 8);
         }
     }
 
@@ -96,7 +103,7 @@ impl BitVector {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("bitvector length mismatch: expected {expected} bytes, got {got}")]
 pub struct BitVectorError {
-    /// Bytes required for the offer (`ceil(len / 8)`).
+    /// Bytes required for the offer (`len / 8 + 1`).
     pub expected: usize,
     /// Bytes actually received.
     pub got: usize,
@@ -107,35 +114,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bit_i_is_msb_first_within_each_byte() {
+    fn bit_i_is_lsb_first_within_each_byte() {
         let mut bv = BitVector::new(16);
         bv.set(0);
-        bv.set(7);
+        bv.set(1);
         bv.set(8);
-        bv.set(15);
-        // Byte 0: bits 0 and 7 -> 0b1000_0001 = 0x81.
-        // Byte 1: bits 8 and 15 -> 0b1000_0001 = 0x81.
-        assert_eq!(bv.as_bytes(), &[0x81, 0x81]);
+        // Byte 0: bits 0 and 1 -> 0b0000_0011 = 0x03.
+        // Byte 1: bit 8 -> 0b0000_0001 = 0x01.
+        // Byte 2: trailing len/8+1 pad byte -> 0x00.
+        assert_eq!(bv.as_bytes(), &[0x03, 0x01, 0x00]);
         assert!(bv.get(0));
-        assert!(bv.get(7));
+        assert!(bv.get(1));
         assert!(bv.get(8));
-        assert!(bv.get(15));
-        assert!(!bv.get(1));
+        assert!(!bv.get(2));
+        assert!(!bv.get(7));
         assert!(!bv.get(9));
     }
 
     #[test]
-    fn single_high_bit_is_0x80() {
+    fn single_bit_one_is_0x02_not_0x40() {
         let mut bv = BitVector::new(8);
-        bv.set(0);
-        assert_eq!(bv.as_bytes(), &[0x80]);
+        bv.set(1);
+        // LSB-first: bit 1 is 0x02. MSB-first would be 0x40.
+        assert_eq!(bv.as_bytes(), &[0x02, 0x00]);
     }
 
     #[test]
-    fn byte_length_is_ceil_div_eight() {
-        assert_eq!(BitVector::new(0).as_bytes().len(), 0);
+    fn byte_length_is_len_div_eight_plus_one() {
+        assert_eq!(BitVector::new(0).as_bytes().len(), 1);
         assert_eq!(BitVector::new(1).as_bytes().len(), 1);
-        assert_eq!(BitVector::new(8).as_bytes().len(), 1);
+        assert_eq!(BitVector::new(8).as_bytes().len(), 2);
         assert_eq!(BitVector::new(9).as_bytes().len(), 2);
         assert_eq!(BitVector::new(250).as_bytes().len(), 32);
     }
@@ -159,9 +167,9 @@ mod tests {
 
     #[test]
     fn from_bytes_rejects_wrong_length() {
-        assert!(BitVector::from_bytes(vec![0u8; 2], 16).is_ok());
+        assert!(BitVector::from_bytes(vec![0u8; 3], 16).is_ok());
         let err = BitVector::from_bytes(vec![0u8; 1], 16).expect_err("too short");
-        assert_eq!(err.expected, 2);
+        assert_eq!(err.expected, 3);
         assert_eq!(err.got, 1);
     }
 

--- a/crates/swarm/net/pullsync/src/bitvector.rs
+++ b/crates/swarm/net/pullsync/src/bitvector.rs
@@ -1,0 +1,177 @@
+//! MSB-first selection bitvector for the pullsync `Want` reply: bit `i` selects
+//! `chunks[i]` of the preceding `Offer`. Byte length is `ceil(len / 8)`; trailing
+//! pad bits are zero.
+
+/// A fixed-length set of selection bits, packed MSB-first one bit per offered
+/// chunk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BitVector {
+    bytes: Vec<u8>,
+    len: usize,
+}
+
+impl BitVector {
+    /// An all-clear vector sized for `len` chunks.
+    #[must_use]
+    pub fn new(len: usize) -> Self {
+        Self {
+            bytes: vec![0u8; len.div_ceil(8)],
+            len,
+        }
+    }
+
+    /// Wrap raw wire bytes, sizing the selection at `8 * bytes.len()`. The `Want`
+    /// frame carries no explicit chunk count, so byte length is the only signal.
+    #[must_use]
+    pub fn from_wire_bytes(bytes: Vec<u8>) -> Self {
+        let len = bytes.len() * 8;
+        Self { bytes, len }
+    }
+
+    /// Wrap raw wire bytes selecting over `len` chunks; `bytes` must be exactly
+    /// `ceil(len / 8)` long.
+    pub fn from_bytes(bytes: Vec<u8>, len: usize) -> Result<Self, BitVectorError> {
+        let expected = len.div_ceil(8);
+        if bytes.len() != expected {
+            return Err(BitVectorError {
+                expected,
+                got: bytes.len(),
+            });
+        }
+        Ok(Self { bytes, len })
+    }
+
+    /// The number of chunks this vector selects over.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether this vector selects over no chunks.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Whether `chunks[i]` is wanted. `false` for any `i >= len`.
+    #[must_use]
+    pub fn get(&self, i: usize) -> bool {
+        if i >= self.len {
+            return false;
+        }
+        self.bytes
+            .get(i / 8)
+            .is_some_and(|byte| byte & (0x80 >> (i % 8)) != 0)
+    }
+
+    /// Mark `chunks[i]` as wanted. No-op for `i >= len`.
+    pub fn set(&mut self, i: usize) {
+        if i < self.len
+            && let Some(byte) = self.bytes.get_mut(i / 8)
+        {
+            *byte |= 0x80 >> (i % 8);
+        }
+    }
+
+    /// The count of set bits, i.e. how many deliveries the offer answers with.
+    #[must_use]
+    pub fn count_ones(&self) -> usize {
+        (0..self.len).filter(|&i| self.get(i)).count()
+    }
+
+    /// The packed wire bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Consume into the packed wire bytes.
+    #[must_use]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+/// The `Want` bitvector byte length did not match the offer it answers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("bitvector length mismatch: expected {expected} bytes, got {got}")]
+pub struct BitVectorError {
+    /// Bytes required for the offer (`ceil(len / 8)`).
+    pub expected: usize,
+    /// Bytes actually received.
+    pub got: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bit_i_is_msb_first_within_each_byte() {
+        let mut bv = BitVector::new(16);
+        bv.set(0);
+        bv.set(7);
+        bv.set(8);
+        bv.set(15);
+        // Byte 0: bits 0 and 7 -> 0b1000_0001 = 0x81.
+        // Byte 1: bits 8 and 15 -> 0b1000_0001 = 0x81.
+        assert_eq!(bv.as_bytes(), &[0x81, 0x81]);
+        assert!(bv.get(0));
+        assert!(bv.get(7));
+        assert!(bv.get(8));
+        assert!(bv.get(15));
+        assert!(!bv.get(1));
+        assert!(!bv.get(9));
+    }
+
+    #[test]
+    fn single_high_bit_is_0x80() {
+        let mut bv = BitVector::new(8);
+        bv.set(0);
+        assert_eq!(bv.as_bytes(), &[0x80]);
+    }
+
+    #[test]
+    fn byte_length_is_ceil_div_eight() {
+        assert_eq!(BitVector::new(0).as_bytes().len(), 0);
+        assert_eq!(BitVector::new(1).as_bytes().len(), 1);
+        assert_eq!(BitVector::new(8).as_bytes().len(), 1);
+        assert_eq!(BitVector::new(9).as_bytes().len(), 2);
+        assert_eq!(BitVector::new(250).as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn count_ones_counts_selected_chunks() {
+        let mut bv = BitVector::new(10);
+        bv.set(1);
+        bv.set(3);
+        bv.set(9);
+        assert_eq!(bv.count_ones(), 3);
+    }
+
+    #[test]
+    fn out_of_range_index_is_clear_and_set_is_noop() {
+        let mut bv = BitVector::new(3);
+        bv.set(5);
+        assert!(!bv.get(5));
+        assert_eq!(bv.count_ones(), 0);
+    }
+
+    #[test]
+    fn from_bytes_rejects_wrong_length() {
+        assert!(BitVector::from_bytes(vec![0u8; 2], 16).is_ok());
+        let err = BitVector::from_bytes(vec![0u8; 1], 16).expect_err("too short");
+        assert_eq!(err.expected, 2);
+        assert_eq!(err.got, 1);
+    }
+
+    #[test]
+    fn round_trips_through_wire_bytes() {
+        let mut bv = BitVector::new(20);
+        bv.set(2);
+        bv.set(17);
+        let len = bv.len();
+        let restored = BitVector::from_bytes(bv.clone().into_bytes(), len).expect("valid bytes");
+        assert_eq!(restored, bv);
+    }
+}

--- a/crates/swarm/net/pullsync/src/codec.rs
+++ b/crates/swarm/net/pullsync/src/codec.rs
@@ -1,0 +1,405 @@
+//! Codec for pullsync protocol messages.
+//!
+//! Every domain type here converts to and from a `vertex_swarm_net_proto::pullsync`
+//! message at the [`ProtoMessage`] boundary; the protobuf type never escapes
+//! this module.
+
+use alloy_primitives::B256;
+use bytes::Bytes;
+use nectar_primitives::ChunkAddress;
+use vertex_net_codec::{Codec, ProtoMessage};
+use vertex_swarm_primitives::{BatchId, Bin, StampedChunk};
+
+use crate::bitvector::BitVector;
+use crate::error::PullsyncError;
+
+pub(crate) type SynCodec = Codec<Syn, PullsyncError>;
+pub(crate) type AckCodec = Codec<Ack, PullsyncError>;
+pub(crate) type GetCodec = Codec<Get, PullsyncError>;
+pub(crate) type OfferCodec = Codec<Offer, PullsyncError>;
+pub(crate) type WantCodec = Codec<Want, PullsyncError>;
+pub(crate) type DeliveryCodec = Codec<Delivery, PullsyncError>;
+
+/// Open the cursor handshake. Carries no payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Syn;
+
+impl ProtoMessage for Syn {
+    type Proto = vertex_swarm_net_proto::pullsync::Syn;
+    type EncodeError = std::convert::Infallible;
+    type DecodeError = PullsyncError;
+
+    fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
+        Ok(vertex_swarm_net_proto::pullsync::Syn {})
+    }
+
+    fn from_proto(_proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        Ok(Self)
+    }
+}
+
+/// Cursor handshake reply. `cursors[bin]` is the topmost id the responder holds
+/// for that bin (`0` when empty); `epoch` is its reserve generation marker, so a
+/// requester can detect a reserve reset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ack {
+    pub cursors: Vec<u64>,
+    pub epoch: u64,
+}
+
+impl ProtoMessage for Ack {
+    type Proto = vertex_swarm_net_proto::pullsync::Ack;
+    type EncodeError = std::convert::Infallible;
+    type DecodeError = PullsyncError;
+
+    fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
+        Ok(vertex_swarm_net_proto::pullsync::Ack {
+            cursors: self.cursors,
+            epoch: self.epoch,
+        })
+    }
+
+    fn from_proto(proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        Ok(Self {
+            cursors: proto.cursors,
+            epoch: proto.epoch,
+        })
+    }
+}
+
+/// Request the chunks in `bin` from bin id `start` (inclusive) upward. The wire
+/// `bin` field is `int32`; a value outside `0..=MAX_PO` is a decode error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Get {
+    pub bin: Bin,
+    pub start: u64,
+}
+
+impl Get {
+    pub fn new(bin: Bin, start: u64) -> Self {
+        Self { bin, start }
+    }
+}
+
+impl ProtoMessage for Get {
+    type Proto = vertex_swarm_net_proto::pullsync::Get;
+    type EncodeError = std::convert::Infallible;
+    type DecodeError = PullsyncError;
+
+    fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
+        Ok(vertex_swarm_net_proto::pullsync::Get {
+            bin: i32::from(self.bin.get()),
+            start: self.start,
+        })
+    }
+
+    fn from_proto(proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        let raw = u8::try_from(proto.bin).map_err(|_| PullsyncError::InvalidBin(proto.bin))?;
+        let bin = Bin::new(raw).map_err(|_| PullsyncError::InvalidBin(proto.bin))?;
+        Ok(Self {
+            bin,
+            start: proto.start,
+        })
+    }
+}
+
+/// One chunk advertised in an [`Offer`]: 32B address, 32B batch id, 32B stamp
+/// hash. No chunk data, only the identity a requester needs to want it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkDescriptor {
+    pub address: ChunkAddress,
+    pub batch_id: BatchId,
+    pub stamp_hash: B256,
+}
+
+impl ChunkDescriptor {
+    pub fn new(address: ChunkAddress, batch_id: BatchId, stamp_hash: B256) -> Self {
+        Self {
+            address,
+            batch_id,
+            stamp_hash,
+        }
+    }
+
+    fn into_proto(self) -> vertex_swarm_net_proto::pullsync::Chunk {
+        vertex_swarm_net_proto::pullsync::Chunk {
+            address: self.address.to_vec(),
+            batch_id: self.batch_id.to_vec(),
+            stamp_hash: self.stamp_hash.to_vec(),
+        }
+    }
+
+    fn from_proto(proto: vertex_swarm_net_proto::pullsync::Chunk) -> Result<Self, PullsyncError> {
+        let address = ChunkAddress::from_slice(&proto.address)?;
+        let batch_id = b256_from_slice(&proto.batch_id, "batch_id")?;
+        let stamp_hash = b256_from_slice(&proto.stamp_hash, "stamp_hash")?;
+        Ok(Self {
+            address,
+            batch_id,
+            stamp_hash,
+        })
+    }
+}
+
+/// Decode a 32-byte field, reporting which field was the wrong length.
+fn b256_from_slice(slice: &[u8], field: &'static str) -> Result<B256, PullsyncError> {
+    B256::try_from(slice).map_err(|_| PullsyncError::InvalidFieldLength {
+        field,
+        len: slice.len(),
+    })
+}
+
+/// The responder's answer to a [`Get`]: descriptors for the range, up to
+/// [`DEFAULT_MAX_PAGE`](crate::DEFAULT_MAX_PAGE) per page. `topmost` is the
+/// highest bin id covered, so the requester advances its cursor even when it
+/// wants none of the offered chunks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Offer {
+    pub topmost: u64,
+    pub chunks: Vec<ChunkDescriptor>,
+}
+
+impl Offer {
+    pub fn new(topmost: u64, chunks: Vec<ChunkDescriptor>) -> Self {
+        Self { topmost, chunks }
+    }
+}
+
+impl ProtoMessage for Offer {
+    type Proto = vertex_swarm_net_proto::pullsync::Offer;
+    type EncodeError = std::convert::Infallible;
+    type DecodeError = PullsyncError;
+
+    fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
+        Ok(vertex_swarm_net_proto::pullsync::Offer {
+            topmost: self.topmost,
+            chunks: self
+                .chunks
+                .into_iter()
+                .map(ChunkDescriptor::into_proto)
+                .collect(),
+        })
+    }
+
+    fn from_proto(proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        let chunks = proto
+            .chunks
+            .into_iter()
+            .map(ChunkDescriptor::from_proto)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            topmost: proto.topmost,
+            chunks,
+        })
+    }
+}
+
+/// Selection reply to an [`Offer`]: bit `i` set means the requester wants
+/// `chunks[i]`. The responder then sends one [`Delivery`] per set bit, in offer
+/// order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Want {
+    pub wanted: BitVector,
+}
+
+impl Want {
+    pub fn new(wanted: BitVector) -> Self {
+        Self { wanted }
+    }
+
+    /// The number of deliveries this want asks for.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.wanted.count_ones()
+    }
+}
+
+impl ProtoMessage for Want {
+    type Proto = vertex_swarm_net_proto::pullsync::Want;
+    type EncodeError = std::convert::Infallible;
+    type DecodeError = PullsyncError;
+
+    fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
+        Ok(vertex_swarm_net_proto::pullsync::Want {
+            bit_vector: self.wanted.into_bytes(),
+        })
+    }
+
+    fn from_proto(proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        Ok(Self {
+            wanted: BitVector::from_wire_bytes(proto.bit_vector),
+        })
+    }
+}
+
+/// A single wanted chunk: a full [`StampedChunk`], validated against its own
+/// address on decode. Boxed to keep the enclosing message types small.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Delivery {
+    pub chunk: Box<StampedChunk>,
+}
+
+impl Delivery {
+    pub fn new(chunk: StampedChunk) -> Self {
+        Self {
+            chunk: Box::new(chunk),
+        }
+    }
+}
+
+impl ProtoMessage for Delivery {
+    type Proto = vertex_swarm_net_proto::pullsync::Delivery;
+    type EncodeError = std::convert::Infallible;
+    type DecodeError = PullsyncError;
+
+    fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
+        let address = *self.chunk.address();
+        let (chunk, stamp) = (*self.chunk).into_parts();
+        Ok(vertex_swarm_net_proto::pullsync::Delivery {
+            address: address.to_vec(),
+            data: chunk.into_bytes().to_vec(),
+            stamp: stamp.to_bytes().to_vec(),
+        })
+    }
+
+    fn from_proto(proto: Self::Proto) -> Result<Self, Self::DecodeError> {
+        if proto.address.len() != 32 {
+            return Err(PullsyncError::InvalidFieldLength {
+                field: "address",
+                len: proto.address.len(),
+            });
+        }
+        let address = ChunkAddress::from_slice(&proto.address)?;
+        let stamp = nectar_postage::Stamp::try_from_slice(&proto.stamp)?;
+        let chunk = StampedChunk::reconstruct(address, Bytes::from(proto.data), stamp)
+            .map_err(|e| PullsyncError::InvalidChunk(e.to_string()))?;
+        Ok(Self::new(chunk))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Signature;
+    use nectar_postage::Stamp;
+    use nectar_primitives::{AnyChunk, ContentChunk};
+    use vertex_net_codec::assert_proto_roundtrip;
+
+    fn test_stamp() -> Stamp {
+        let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+    }
+
+    fn test_stamped_chunk() -> StampedChunk {
+        let chunk: AnyChunk = ContentChunk::new(&b"pullsync payload"[..])
+            .expect("valid content chunk")
+            .into();
+        StampedChunk::new(chunk, test_stamp())
+    }
+
+    fn descriptor() -> ChunkDescriptor {
+        ChunkDescriptor::new(
+            ChunkAddress::new([0x11; 32]),
+            B256::repeat_byte(0x22),
+            B256::repeat_byte(0x33),
+        )
+    }
+
+    #[test]
+    fn syn_roundtrip() {
+        assert_proto_roundtrip!(Syn);
+    }
+
+    #[test]
+    fn ack_roundtrip() {
+        assert_proto_roundtrip!(Ack {
+            cursors: vec![0, 5, 0, 9, 100],
+            epoch: 7,
+        });
+    }
+
+    #[test]
+    fn get_roundtrip() {
+        assert_proto_roundtrip!(Get::new(Bin::new(11).expect("valid bin"), 42));
+    }
+
+    #[test]
+    fn get_rejects_out_of_range_bin() {
+        let proto = vertex_swarm_net_proto::pullsync::Get { bin: 99, start: 0 };
+        let err = Get::from_proto(proto).expect_err("bin 99 exceeds MAX_PO");
+        assert!(matches!(err, PullsyncError::InvalidBin(99)));
+    }
+
+    #[test]
+    fn get_rejects_negative_bin() {
+        let proto = vertex_swarm_net_proto::pullsync::Get { bin: -1, start: 0 };
+        let err = Get::from_proto(proto).expect_err("a negative bin is invalid");
+        assert!(matches!(err, PullsyncError::InvalidBin(-1)));
+    }
+
+    #[test]
+    fn offer_roundtrip() {
+        assert_proto_roundtrip!(Offer::new(250, vec![descriptor(), descriptor()]));
+    }
+
+    #[test]
+    fn offer_rejects_short_descriptor_field() {
+        let proto = vertex_swarm_net_proto::pullsync::Offer {
+            topmost: 1,
+            chunks: vec![vertex_swarm_net_proto::pullsync::Chunk {
+                address: vec![0u8; 32],
+                batch_id: vec![0u8; 31],
+                stamp_hash: vec![0u8; 32],
+            }],
+        };
+        let err = Offer::from_proto(proto).expect_err("short batch_id rejected");
+        assert!(matches!(
+            err,
+            PullsyncError::InvalidFieldLength {
+                field: "batch_id",
+                len: 31
+            }
+        ));
+    }
+
+    #[test]
+    fn want_roundtrip_preserves_selection() {
+        // The offer length is not on the wire, so a decoded `Want` is sized to a
+        // whole number of bytes; the selected bits and the packed bytes are what
+        // round-trip, not the original `len`.
+        let mut bv = BitVector::new(10);
+        bv.set(1);
+        bv.set(9);
+        let want = Want::new(bv);
+        let decoded = Want::from_proto(want.clone().into_proto().unwrap()).unwrap();
+        assert_eq!(decoded.wanted.as_bytes(), want.wanted.as_bytes());
+        assert!(decoded.wanted.get(1));
+        assert!(decoded.wanted.get(9));
+        assert_eq!(decoded.count(), 2);
+    }
+
+    #[test]
+    fn want_count_matches_set_bits() {
+        let mut bv = BitVector::new(16);
+        bv.set(0);
+        bv.set(8);
+        bv.set(15);
+        assert_eq!(Want::new(bv).count(), 3);
+    }
+
+    #[test]
+    fn delivery_roundtrip() {
+        assert_proto_roundtrip!(Delivery::new(test_stamped_chunk()));
+    }
+
+    #[test]
+    fn delivery_wire_data_is_chunk_identity() {
+        let stamped = test_stamped_chunk();
+        let address = *stamped.address();
+        let wire_data = stamped.chunk().clone().into_bytes();
+        let proto = Delivery::new(stamped).into_proto().unwrap();
+        assert_eq!(Bytes::from(proto.data.clone()), wire_data);
+        let decoded = Delivery::from_proto(proto).unwrap();
+        assert_eq!(*decoded.chunk.address(), address);
+    }
+}

--- a/crates/swarm/net/pullsync/src/error.rs
+++ b/crates/swarm/net/pullsync/src/error.rs
@@ -1,0 +1,71 @@
+//! Error types for pullsync protocol.
+
+vertex_net_codec::protocol_error! {
+    /// Pullsync protocol errors.
+    pub enum PullsyncError {
+        /// Bin index on a `Get` was outside `0..=MAX_PO`.
+        #[error("invalid bin: {0}")]
+        InvalidBin(i32),
+
+        /// A descriptor field was not exactly 32 bytes. `field` names the
+        /// offending field, `len` is the length received.
+        #[error("invalid {field} length: expected 32, got {len}")]
+        InvalidFieldLength {
+            field: &'static str,
+            len: usize,
+        },
+
+        /// Invalid chunk address encoding.
+        #[error("invalid chunk address: {0}")]
+        InvalidAddress(#[from] nectar_primitives::PrimitivesError),
+
+        /// Malformed postage stamp in a delivery.
+        #[error("invalid stamp: {0}")]
+        InvalidStamp(#[from] nectar_postage::StampError),
+
+        /// Chunk bytes did not match the delivery's address.
+        ///
+        /// Carries a string rather than a source error because the underlying
+        /// `PrimitivesError` is already claimed by `InvalidAddress` via `#[from]`.
+        #[error("invalid chunk: {0}")]
+        InvalidChunk(String),
+    }
+}
+
+impl PullsyncError {
+    /// True for malformed chunk or descriptor signals attributable to the
+    /// sending peer, which warrant an adverse score; false for transport or
+    /// negotiation failures.
+    #[must_use]
+    pub fn is_invalid_chunk(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidChunk(_)
+                | Self::InvalidStamp(_)
+                | Self::InvalidAddress(_)
+                | Self::InvalidFieldLength { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_descriptor_signals_are_invalid_chunk() {
+        assert!(
+            PullsyncError::InvalidFieldLength {
+                field: "address",
+                len: 7
+            }
+            .is_invalid_chunk()
+        );
+    }
+
+    #[test]
+    fn transport_errors_are_not_invalid_chunk() {
+        assert!(!PullsyncError::ConnectionClosed.is_invalid_chunk());
+        assert!(!PullsyncError::InvalidBin(99).is_invalid_chunk());
+    }
+}

--- a/crates/swarm/net/pullsync/src/lib.rs
+++ b/crates/swarm/net/pullsync/src/lib.rs
@@ -1,0 +1,43 @@
+//! Pullsync protocol for Swarm storer range synchronisation, over two streams:
+//! [`PROTOCOL_CURSORS`] to learn a peer's per-bin cursors, then [`PROTOCOL_SYNC`]
+//! per bin to pull missing chunks.
+//!
+//! Wire invariants: `Ack.cursors[bin]` is the topmost id held for that bin (`0`
+//! when empty); in the range exchange `Want` bit `i` selects `chunks[i]` of the
+//! preceding `Offer` (MSB-first), answered by one `Delivery` per set bit in offer
+//! order.
+
+mod bitvector;
+pub use bitvector::{BitVector, BitVectorError};
+
+mod codec;
+pub use codec::{Ack, ChunkDescriptor, Delivery, Get, Offer, Syn, Want};
+
+mod error;
+pub use error::PullsyncError;
+
+pub mod metrics;
+
+mod protocol;
+pub use protocol::{
+    CursorsInboundProtocol, CursorsOutboundProtocol, CursorsResponder, SyncInboundProtocol,
+    SyncOutboundProtocol, SyncRequester, SyncResponder, cursors_inbound, cursors_outbound,
+    sync_inbound, sync_outbound,
+};
+
+/// Cursor-handshake stream: `Syn` to `Ack`.
+pub const PROTOCOL_CURSORS: &str = "/swarm/pullsync/1.4.0/cursors";
+
+/// Range-exchange stream: `Get` to `Offer` to `Want` to `Delivery`.
+pub const PROTOCOL_SYNC: &str = "/swarm/pullsync/1.4.0/pullsync";
+
+/// Maximum chunk descriptors a responder offers in one `Offer` page.
+pub const DEFAULT_MAX_PAGE: u64 = 250;
+
+/// Responder rate cap on chunks served per second. Enforced by the behaviour
+/// layer, not the codec.
+pub const MAX_CHUNKS_PER_SECOND: u64 = 250;
+
+/// Time a responder waits to fill one page before sending it. Enforced by the
+/// behaviour layer.
+pub const PAGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);

--- a/crates/swarm/net/pullsync/src/lib.rs
+++ b/crates/swarm/net/pullsync/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! Wire invariants: `Ack.cursors[bin]` is the topmost id held for that bin (`0`
 //! when empty); in the range exchange `Want` bit `i` selects `chunks[i]` of the
-//! preceding `Offer` (MSB-first), answered by one `Delivery` per set bit in offer
-//! order.
+//! preceding `Offer` (LSB-first), answered by one `Delivery` per set bit in offer
+//! order. An empty `Offer` ends the exchange with no `Want`.
 
 mod bitvector;
 pub use bitvector::{BitVector, BitVectorError};

--- a/crates/swarm/net/pullsync/src/metrics.rs
+++ b/crates/swarm/net/pullsync/src/metrics.rs
@@ -1,0 +1,15 @@
+//! Metric names for pullsync's range-exchange volume counters and per-page
+//! latency histogram. Exchange-level success and error counts come from the
+//! headered-stream layer.
+
+/// Total chunk descriptors offered across all pages.
+pub const CHUNKS_OFFERED_TOTAL: &str = "swarm.pullsync.chunks_offered_total";
+
+/// Total chunks selected by `Want` replies.
+pub const CHUNKS_WANTED_TOTAL: &str = "swarm.pullsync.chunks_wanted_total";
+
+/// Total chunks delivered in answer to `Want` replies.
+pub const CHUNKS_DELIVERED_TOTAL: &str = "swarm.pullsync.chunks_delivered_total";
+
+/// Latency of a single offer-to-deliveries page exchange.
+pub const PAGE_DURATION: &str = "swarm.pullsync.page_duration";

--- a/crates/swarm/net/pullsync/src/protocol.rs
+++ b/crates/swarm/net/pullsync/src/protocol.rs
@@ -50,7 +50,7 @@ const MAX_GET_SIZE: usize = 8 + 8 + PROTOBUF_FRAMING;
 const MAX_OFFER_SIZE: usize = DEFAULT_MAX_PAGE as usize * DESCRIPTOR_SIZE + 8 + PROTOBUF_FRAMING;
 
 /// Accept-limit for a `Want`: one selection bit per offered chunk, packed into
-/// `ceil(DEFAULT_MAX_PAGE / 8)` bytes.
+/// `DEFAULT_MAX_PAGE / 8 + 1` bytes.
 const MAX_WANT_SIZE: usize = DEFAULT_MAX_PAGE as usize / 8 + 1 + PROTOBUF_FRAMING;
 
 /// Accept-limit for a `Delivery`: the largest chunk payload, its address, and a
@@ -179,16 +179,21 @@ pub enum SyncResponder {
     Offering {
         framed: Framed<libp2p::Stream, OfferCodec>,
     },
-    /// Offer sent and want received; delivering the wanted chunks.
+    /// Offer sent; awaiting the want, or finishing if the offer was empty.
+    Offered {
+        framed: Framed<libp2p::Stream, WantCodec>,
+    },
+    /// Want received; delivering the wanted chunks.
     Delivering {
         framed: Framed<libp2p::Stream, DeliveryCodec>,
     },
 }
 
 impl SyncResponder {
-    /// Send the offer, read the requester's `Want`, and enter the delivery
-    /// phase. Returns the want so the caller knows which descriptors to deliver.
-    pub async fn send_offer(self, offer: Offer) -> Result<(Want, Self), PullsyncError> {
+    /// Send the offer and enter the `Offered` phase. An empty offer ends the
+    /// exchange with [`finish`](Self::finish) and no want round; a non-empty
+    /// offer continues with [`read_want`](Self::read_want).
+    pub async fn write_offer(self, offer: Offer) -> Result<Self, PullsyncError> {
         let SyncResponder::Offering { mut framed } = self else {
             return Err(PullsyncError::ConnectionClosed);
         };
@@ -198,7 +203,16 @@ impl SyncResponder {
             "Pullsync sync: sending offer"
         );
         framed.send(offer).await?;
-        let mut framed = reframe(framed, WantCodec::new(MAX_WANT_SIZE));
+        let framed = reframe(framed, WantCodec::new(MAX_WANT_SIZE));
+        Ok(SyncResponder::Offered { framed })
+    }
+
+    /// Read the requester's `Want` and enter the delivery phase. Call only after
+    /// a non-empty offer; an empty offer is terminated by [`finish`](Self::finish).
+    pub async fn read_want(self) -> Result<(Want, Self), PullsyncError> {
+        let SyncResponder::Offered { mut framed } = self else {
+            return Err(PullsyncError::ConnectionClosed);
+        };
         debug!("Pullsync sync: reading want");
         let want = framed
             .try_next()
@@ -217,13 +231,20 @@ impl SyncResponder {
         framed.send(delivery).await
     }
 
-    /// Flush and close the delivery stream after the last `send_delivery`.
+    /// Flush and close the stream, ending the exchange. Valid after an empty
+    /// offer (from `Offered`, no want read) or after the last delivery.
     pub async fn finish(self) -> Result<(), PullsyncError> {
-        let SyncResponder::Delivering { mut framed } = self else {
-            return Err(PullsyncError::ConnectionClosed);
-        };
-        framed.close().await?;
-        Ok(())
+        match self {
+            SyncResponder::Offered { mut framed } => {
+                framed.close().await?;
+                Ok(())
+            }
+            SyncResponder::Delivering { mut framed } => {
+                framed.close().await?;
+                Ok(())
+            }
+            SyncResponder::Offering { .. } => Err(PullsyncError::ConnectionClosed),
+        }
     }
 }
 
@@ -269,10 +290,11 @@ impl HeaderedOutbound for SyncOutboundInner {
 }
 
 /// Client-side driver for the range exchange after the offer arrives. After
-/// [`accept_want`](Self::accept_want) the caller reads exactly
-/// [`Want::count`](crate::Want::count) deliveries.
+/// [`send_want`](Self::send_want) the caller reads exactly
+/// [`Want::count`](crate::Want::count) deliveries. An empty offer is terminated
+/// by [`finish`](Self::finish) with no want.
 pub enum SyncRequester {
-    /// Offer received; awaiting the want to send.
+    /// Offer received; awaiting the want to send, or finishing if empty.
     Wanting {
         framed: Framed<libp2p::Stream, WantCodec>,
     },
@@ -283,8 +305,9 @@ pub enum SyncRequester {
 }
 
 impl SyncRequester {
-    /// Send the selection and enter the receive phase.
-    pub async fn accept_want(self, want: Want) -> Result<Self, PullsyncError> {
+    /// Send the selection and enter the receive phase. Call only for a non-empty
+    /// offer; an empty offer is terminated by [`finish`](Self::finish).
+    pub async fn send_want(self, want: Want) -> Result<Self, PullsyncError> {
         let SyncRequester::Wanting { mut framed } = self else {
             return Err(PullsyncError::ConnectionClosed);
         };
@@ -300,6 +323,16 @@ impl SyncRequester {
             return Err(PullsyncError::ConnectionClosed);
         };
         framed.try_next().await
+    }
+
+    /// Close the stream from the `Wanting` phase, ending the exchange with no
+    /// want. Used when the offer was empty.
+    pub async fn finish(self) -> Result<(), PullsyncError> {
+        let SyncRequester::Wanting { mut framed } = self else {
+            return Err(PullsyncError::ConnectionClosed);
+        };
+        framed.close().await?;
+        Ok(())
     }
 }
 
@@ -322,4 +355,36 @@ pub fn sync_inbound() -> SyncInboundProtocol {
 
 pub fn sync_outbound(get: Get) -> SyncOutboundProtocol {
     Outbound::new(SyncOutboundInner::new(get))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use nectar_primitives::ChunkAddress;
+
+    use crate::ChunkDescriptor;
+
+    use super::*;
+
+    // The empty-offer flow keys on `Offer::chunks.is_empty()`: an empty offer is
+    // finished with no want on both sides, a non-empty offer proceeds to the want
+    // round. The stream drivers wrap an opaque `libp2p::Stream` and so cannot be
+    // exercised without a live transport; the phase-typed enums make the
+    // sequencing a compile-time contract, and the gate below is the runtime seam
+    // the behaviour layer branches on.
+    #[test]
+    fn empty_offer_is_the_no_want_gate() {
+        let empty = Offer::new(7, vec![]);
+        assert!(empty.chunks.is_empty(), "empty offer ends with no want");
+
+        let one = Offer::new(
+            7,
+            vec![ChunkDescriptor::new(
+                ChunkAddress::new([0; 32]),
+                B256::ZERO,
+                B256::ZERO,
+            )],
+        );
+        assert!(!one.chunks.is_empty(), "non-empty offer proceeds to want");
+    }
 }

--- a/crates/swarm/net/pullsync/src/protocol.rs
+++ b/crates/swarm/net/pullsync/src/protocol.rs
@@ -1,0 +1,325 @@
+//! Protocol upgrades for pullsync's two headered streams.
+//!
+//! - **Cursors** ([`PROTOCOL_CURSORS`]): `Syn` then `Ack`.
+//! - **Sync** ([`PROTOCOL_SYNC`]): `Get`, `Offer`, `Want`, then one `Delivery`
+//!   per set bit, all on one stream. Each phase swaps the codec via [`reframe`],
+//!   preserving any bytes already buffered.
+
+use asynchronous_codec::{Decoder, Encoder, Framed};
+use futures::{SinkExt, TryStreamExt, future::BoxFuture};
+use nectar_postage::STAMP_SIZE;
+use nectar_primitives::bmt::{DEFAULT_BODY_SIZE, HASH_SIZE, SPAN_SIZE};
+use tracing::debug;
+use vertex_swarm_net_headers::{
+    HeaderedInbound, HeaderedOutbound, HeaderedStream, Inbound, Outbound,
+};
+
+use crate::{
+    DEFAULT_MAX_PAGE, PROTOCOL_CURSORS, PROTOCOL_SYNC,
+    codec::{
+        Ack, AckCodec, Delivery, DeliveryCodec, Get, GetCodec, Offer, OfferCodec, Syn, SynCodec,
+        Want, WantCodec,
+    },
+    error::PullsyncError,
+};
+
+/// One chunk descriptor on the wire: three 32-byte fields plus per-field
+/// protobuf framing.
+const DESCRIPTOR_SIZE: usize = 3 * HASH_SIZE + 16;
+
+/// Protobuf framing allowance across a message's fields, rounded up generously.
+const PROTOBUF_FRAMING: usize = 64;
+
+/// Recoverable-signature size carried inside a single-owner chunk's `data`.
+const SOC_SIGNATURE_SIZE: usize = 65;
+
+/// Largest legitimate chunk `data` payload: a single-owner chunk (span, owner
+/// id, signature, body), the biggest chunk variant on the wire.
+const MAX_CHUNK_DATA_SIZE: usize = SPAN_SIZE + HASH_SIZE + SOC_SIGNATURE_SIZE + DEFAULT_BODY_SIZE;
+
+/// Accept-limit for the cursor handshake messages (`Syn`, `Ack`). `Ack` carries
+/// one `u64` per bin plus the epoch; a generous fixed bound covers the full bin
+/// space and framing.
+const MAX_HANDSHAKE_SIZE: usize = 8 * (nectar_primitives::Bin::COUNT + 1) + PROTOBUF_FRAMING;
+
+/// Accept-limit for a `Get`: a bin and a start cursor.
+const MAX_GET_SIZE: usize = 8 + 8 + PROTOBUF_FRAMING;
+
+/// Accept-limit for an `Offer` page: a full page of descriptors plus the
+/// `topmost` cursor and framing. A local DoS guard, not wire-visible.
+const MAX_OFFER_SIZE: usize = DEFAULT_MAX_PAGE as usize * DESCRIPTOR_SIZE + 8 + PROTOBUF_FRAMING;
+
+/// Accept-limit for a `Want`: one selection bit per offered chunk, packed into
+/// `ceil(DEFAULT_MAX_PAGE / 8)` bytes.
+const MAX_WANT_SIZE: usize = DEFAULT_MAX_PAGE as usize / 8 + 1 + PROTOBUF_FRAMING;
+
+/// Accept-limit for a `Delivery`: the largest chunk payload, its address, and a
+/// full stamp.
+const MAX_DELIVERY_SIZE: usize = HASH_SIZE + MAX_CHUNK_DATA_SIZE + STAMP_SIZE + PROTOBUF_FRAMING;
+
+/// Re-frame an existing stream with a new codec, preserving the bytes already
+/// read into or queued for the stream across the phase switch.
+fn reframe<C1, C2>(framed: Framed<libp2p::Stream, C1>, codec: C2) -> Framed<libp2p::Stream, C2>
+where
+    C1: Encoder + Decoder,
+    C2: Encoder + Decoder,
+{
+    Framed::from_parts(framed.into_parts().map_codec(|_| codec))
+}
+
+// ---------------------------------------------------------------------------
+// Cursor handshake
+// ---------------------------------------------------------------------------
+
+/// Cursors inbound: read `Syn`, answer with `Ack`.
+#[derive(Debug, Clone)]
+pub struct CursorsInboundInner;
+
+impl HeaderedInbound for CursorsInboundInner {
+    type Output = CursorsResponder;
+    type Error = PullsyncError;
+
+    fn protocol_name(&self) -> &'static str {
+        PROTOCOL_CURSORS
+    }
+
+    fn read(self, stream: HeaderedStream) -> BoxFuture<'static, Result<Self::Output, Self::Error>> {
+        Box::pin(async move {
+            let mut framed = Framed::new(stream.into_inner(), SynCodec::new(MAX_HANDSHAKE_SIZE));
+            debug!("Pullsync cursors: reading syn");
+            framed
+                .try_next()
+                .await?
+                .ok_or(PullsyncError::ConnectionClosed)?;
+            let framed = reframe(framed, AckCodec::new(MAX_HANDSHAKE_SIZE));
+            Ok(CursorsResponder { framed })
+        })
+    }
+}
+
+/// Handle for replying to a cursor handshake with the local cursors.
+pub struct CursorsResponder {
+    framed: Framed<libp2p::Stream, AckCodec>,
+}
+
+impl CursorsResponder {
+    /// Send the per-bin cursors and epoch, closing the handshake.
+    pub async fn send_ack(mut self, ack: Ack) -> Result<(), PullsyncError> {
+        debug!(epoch = ack.epoch, "Pullsync cursors: sending ack");
+        self.framed.send(ack).await
+    }
+}
+
+/// Cursors outbound: send `Syn`, read `Ack`.
+#[derive(Debug, Clone, Default)]
+pub struct CursorsOutboundInner;
+
+impl HeaderedOutbound for CursorsOutboundInner {
+    type Output = Ack;
+    type Error = PullsyncError;
+
+    fn protocol_name(&self) -> &'static str {
+        PROTOCOL_CURSORS
+    }
+
+    fn write(
+        self,
+        stream: HeaderedStream,
+    ) -> BoxFuture<'static, Result<Self::Output, Self::Error>> {
+        Box::pin(async move {
+            let mut framed = Framed::new(stream.into_inner(), SynCodec::new(MAX_HANDSHAKE_SIZE));
+            debug!("Pullsync cursors: sending syn");
+            framed.send(Syn).await?;
+            let mut framed = reframe(framed, AckCodec::new(MAX_HANDSHAKE_SIZE));
+            debug!("Pullsync cursors: reading ack");
+            framed
+                .try_next()
+                .await?
+                .ok_or(PullsyncError::ConnectionClosed)
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Range exchange
+// ---------------------------------------------------------------------------
+
+/// Sync inbound: read `Get`, return a responder for the offer/want/delivery
+/// phases.
+#[derive(Debug, Clone)]
+pub struct SyncInboundInner;
+
+impl HeaderedInbound for SyncInboundInner {
+    type Output = (Get, SyncResponder);
+    type Error = PullsyncError;
+
+    fn protocol_name(&self) -> &'static str {
+        PROTOCOL_SYNC
+    }
+
+    fn read(self, stream: HeaderedStream) -> BoxFuture<'static, Result<Self::Output, Self::Error>> {
+        Box::pin(async move {
+            let mut framed = Framed::new(stream.into_inner(), GetCodec::new(MAX_GET_SIZE));
+            debug!("Pullsync sync: reading get");
+            let get = framed
+                .try_next()
+                .await?
+                .ok_or(PullsyncError::ConnectionClosed)?;
+            debug!(bin = %get.bin, start = get.start, "Pullsync sync: received get");
+            let framed = reframe(framed, OfferCodec::new(MAX_OFFER_SIZE));
+            Ok((get, SyncResponder::Offering { framed }))
+        })
+    }
+}
+
+/// Server-side driver for the range exchange. The variant encodes the phase, so
+/// calling a method out of phase is a compile error.
+pub enum SyncResponder {
+    /// Awaiting the offer for the requested range.
+    Offering {
+        framed: Framed<libp2p::Stream, OfferCodec>,
+    },
+    /// Offer sent and want received; delivering the wanted chunks.
+    Delivering {
+        framed: Framed<libp2p::Stream, DeliveryCodec>,
+    },
+}
+
+impl SyncResponder {
+    /// Send the offer, read the requester's `Want`, and enter the delivery
+    /// phase. Returns the want so the caller knows which descriptors to deliver.
+    pub async fn send_offer(self, offer: Offer) -> Result<(Want, Self), PullsyncError> {
+        let SyncResponder::Offering { mut framed } = self else {
+            return Err(PullsyncError::ConnectionClosed);
+        };
+        debug!(
+            topmost = offer.topmost,
+            chunks = offer.chunks.len(),
+            "Pullsync sync: sending offer"
+        );
+        framed.send(offer).await?;
+        let mut framed = reframe(framed, WantCodec::new(MAX_WANT_SIZE));
+        debug!("Pullsync sync: reading want");
+        let want = framed
+            .try_next()
+            .await?
+            .ok_or(PullsyncError::ConnectionClosed)?;
+        let framed = reframe(framed, DeliveryCodec::new(MAX_DELIVERY_SIZE));
+        Ok((want, SyncResponder::Delivering { framed }))
+    }
+
+    /// Send one wanted chunk. Call once per set bit in the `Want`, in offer
+    /// order.
+    pub async fn send_delivery(&mut self, delivery: Delivery) -> Result<(), PullsyncError> {
+        let SyncResponder::Delivering { framed } = self else {
+            return Err(PullsyncError::ConnectionClosed);
+        };
+        framed.send(delivery).await
+    }
+
+    /// Flush and close the delivery stream after the last `send_delivery`.
+    pub async fn finish(self) -> Result<(), PullsyncError> {
+        let SyncResponder::Delivering { mut framed } = self else {
+            return Err(PullsyncError::ConnectionClosed);
+        };
+        framed.close().await?;
+        Ok(())
+    }
+}
+
+/// Sync outbound: send `Get`, read `Offer`, return a driver for the want and
+/// delivery phases.
+#[derive(Debug, Clone)]
+pub struct SyncOutboundInner {
+    get: Get,
+}
+
+impl SyncOutboundInner {
+    pub fn new(get: Get) -> Self {
+        Self { get }
+    }
+}
+
+impl HeaderedOutbound for SyncOutboundInner {
+    type Output = (Offer, SyncRequester);
+    type Error = PullsyncError;
+
+    fn protocol_name(&self) -> &'static str {
+        PROTOCOL_SYNC
+    }
+
+    fn write(
+        self,
+        stream: HeaderedStream,
+    ) -> BoxFuture<'static, Result<Self::Output, Self::Error>> {
+        Box::pin(async move {
+            let mut framed = Framed::new(stream.into_inner(), GetCodec::new(MAX_GET_SIZE));
+            debug!(bin = %self.get.bin, start = self.get.start, "Pullsync sync: sending get");
+            framed.send(self.get).await?;
+            let mut framed = reframe(framed, OfferCodec::new(MAX_OFFER_SIZE));
+            debug!("Pullsync sync: reading offer");
+            let offer = framed
+                .try_next()
+                .await?
+                .ok_or(PullsyncError::ConnectionClosed)?;
+            let framed = reframe(framed, WantCodec::new(MAX_WANT_SIZE));
+            Ok((offer, SyncRequester::Wanting { framed }))
+        })
+    }
+}
+
+/// Client-side driver for the range exchange after the offer arrives. After
+/// [`accept_want`](Self::accept_want) the caller reads exactly
+/// [`Want::count`](crate::Want::count) deliveries.
+pub enum SyncRequester {
+    /// Offer received; awaiting the want to send.
+    Wanting {
+        framed: Framed<libp2p::Stream, WantCodec>,
+    },
+    /// Want sent; receiving the selected deliveries.
+    Receiving {
+        framed: Framed<libp2p::Stream, DeliveryCodec>,
+    },
+}
+
+impl SyncRequester {
+    /// Send the selection and enter the receive phase.
+    pub async fn accept_want(self, want: Want) -> Result<Self, PullsyncError> {
+        let SyncRequester::Wanting { mut framed } = self else {
+            return Err(PullsyncError::ConnectionClosed);
+        };
+        debug!(wanted = want.count(), "Pullsync sync: sending want");
+        framed.send(want).await?;
+        let framed = reframe(framed, DeliveryCodec::new(MAX_DELIVERY_SIZE));
+        Ok(SyncRequester::Receiving { framed })
+    }
+
+    /// Read the next delivery, or `None` when the responder closes the stream.
+    pub async fn next_delivery(&mut self) -> Result<Option<Delivery>, PullsyncError> {
+        let SyncRequester::Receiving { framed } = self else {
+            return Err(PullsyncError::ConnectionClosed);
+        };
+        framed.try_next().await
+    }
+}
+
+pub type CursorsInboundProtocol = Inbound<CursorsInboundInner>;
+pub type CursorsOutboundProtocol = Outbound<CursorsOutboundInner>;
+pub type SyncInboundProtocol = Inbound<SyncInboundInner>;
+pub type SyncOutboundProtocol = Outbound<SyncOutboundInner>;
+
+pub fn cursors_inbound() -> CursorsInboundProtocol {
+    Inbound::new(CursorsInboundInner)
+}
+
+pub fn cursors_outbound() -> CursorsOutboundProtocol {
+    Outbound::new(CursorsOutboundInner)
+}
+
+pub fn sync_inbound() -> SyncInboundProtocol {
+    Inbound::new(SyncInboundInner)
+}
+
+pub fn sync_outbound(get: Get) -> SyncOutboundProtocol {
+    Outbound::new(SyncOutboundInner::new(get))
+}

--- a/crates/swarm/net/pullsync/tests/interop.rs
+++ b/crates/swarm/net/pullsync/tests/interop.rs
@@ -1,0 +1,188 @@
+//! Wire-conformance vectors for the pullsync 1.4.0 messages.
+//!
+//! These pin the protobuf byte layout every conforming peer must produce. Each
+//! domain type is exercised through the public `ProtoMessage` API, never a
+//! private reimplementation of the byte layout, and the serialized protobuf
+//! bytes are asserted against fixed vectors. A single byte of drift in a field
+//! tag, ordering, or the MSB-first `Want` bitvector surfaces as a mismatch.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "conformance fixtures: panicking on malformed test inputs is intended"
+)]
+
+use alloy_primitives::{B256, Signature};
+use nectar_postage::Stamp;
+use nectar_primitives::{AnyChunk, ChunkAddress, ContentChunk};
+use quick_protobuf::Writer;
+use vertex_net_codec::ProtoMessage;
+use vertex_swarm_primitives::{Bin, StampedChunk};
+
+use vertex_swarm_net_pullsync::{Ack, BitVector, ChunkDescriptor, Delivery, Get, Offer, Syn, Want};
+
+/// Serialize a domain message to its raw protobuf bytes (no length framing).
+fn proto_bytes<M>(msg: M) -> Vec<u8>
+where
+    M: ProtoMessage,
+    M::EncodeError: std::fmt::Debug,
+{
+    let proto = msg.into_proto().expect("encode");
+    let mut out = Vec::new();
+    let mut writer = Writer::new(&mut out);
+    quick_protobuf::MessageWrite::write_message(&proto, &mut writer).expect("write");
+    out
+}
+
+fn descriptor(addr: u8, batch: u8, hash: u8) -> ChunkDescriptor {
+    ChunkDescriptor::new(
+        ChunkAddress::new([addr; 32]),
+        B256::repeat_byte(batch),
+        B256::repeat_byte(hash),
+    )
+}
+
+#[test]
+fn syn_encodes_to_empty_message() {
+    assert_eq!(proto_bytes(Syn), Vec::<u8>::new());
+}
+
+#[test]
+fn ack_roundtrips_through_proto() {
+    let ack = Ack {
+        cursors: vec![0, 5, 0, 9],
+        epoch: 42,
+    };
+    let decoded = Ack::from_proto(ack.clone().into_proto().unwrap()).unwrap();
+    assert_eq!(decoded, ack);
+}
+
+/// A `Get` with the deepest bin must encode `bin = MAX_PO` (31) and decode back
+/// to the same typed bin.
+#[test]
+fn get_high_bin_roundtrips() {
+    let get = Get::new(Bin::MAX, 1_000_000);
+    let bytes = proto_bytes(get);
+    // field 1 (bin), varint: tag 0x08, value 31 (0x1f).
+    // field 2 (start), varint: tag 0x10, value 1_000_000.
+    assert_eq!(&bytes[..2], &[0x08, 0x1f]);
+    let decoded = Get::from_proto(get.into_proto().unwrap()).unwrap();
+    assert_eq!(decoded.bin, Bin::MAX);
+    assert_eq!(decoded.start, 1_000_000);
+}
+
+/// An offer of two descriptors pins the repeated-`Chunk` layout: each chunk is a
+/// length-delimited submessage carrying three 32-byte fields in field order.
+#[test]
+fn offer_two_descriptors_fixed_bytes() {
+    let offer = Offer::new(
+        7,
+        vec![descriptor(0x11, 0x22, 0x33), descriptor(0x44, 0x55, 0x66)],
+    );
+    let bytes = proto_bytes(offer.clone());
+
+    // One descriptor's submessage body: field 1 (address) + field 2 (batch_id)
+    // + field 3 (stamp_hash), each a 32-byte length-delimited bytes field.
+    let chunk_body = |addr: u8, batch: u8, hash: u8| {
+        let mut v = Vec::new();
+        v.extend_from_slice(&[0x0a, 0x20]); // field 1, len 32
+        v.extend_from_slice(&[addr; 32]);
+        v.extend_from_slice(&[0x12, 0x20]); // field 2, len 32
+        v.extend_from_slice(&[batch; 32]);
+        v.extend_from_slice(&[0x1a, 0x20]); // field 3, len 32
+        v.extend_from_slice(&[hash; 32]);
+        v
+    };
+
+    let mut expected = Vec::new();
+    // field 1 (topmost), varint 7.
+    expected.extend_from_slice(&[0x08, 0x07]);
+    // field 2 (chunks), repeated submessage. Each body is 3*(2+32) = 102 = 0x66.
+    let first = chunk_body(0x11, 0x22, 0x33);
+    let second = chunk_body(0x44, 0x55, 0x66);
+    expected.extend_from_slice(&[0x12, first.len() as u8]);
+    expected.extend_from_slice(&first);
+    expected.extend_from_slice(&[0x12, second.len() as u8]);
+    expected.extend_from_slice(&second);
+
+    assert_eq!(bytes, expected, "offer wire layout drifted");
+
+    // And it decodes back to the same descriptors.
+    let decoded = Offer::from_proto(offer.clone().into_proto().unwrap()).unwrap();
+    assert_eq!(decoded, offer);
+}
+
+/// The `Want` bitvector is MSB-first: bit `i` is the high bit of byte `i / 8`.
+/// Wanting chunks 0, 7, 8, and 15 of a 16-chunk offer encodes the literal bytes
+/// `0x81 0x81` on field 1.
+#[test]
+fn want_bitvector_is_msb_first_fixed_bytes() {
+    let mut bv = BitVector::new(16);
+    bv.set(0);
+    bv.set(7);
+    bv.set(8);
+    bv.set(15);
+    assert_eq!(bv.as_bytes(), &[0x81, 0x81]);
+
+    let bytes = proto_bytes(Want::new(bv.clone()));
+    // field 1 (bit_vector), length-delimited: tag 0x0a, len 2, then 0x81 0x81.
+    assert_eq!(bytes, vec![0x0a, 0x02, 0x81, 0x81]);
+
+    // The selection survives a round-trip and counts four wanted chunks.
+    let want = Want::new(bv);
+    let decoded = Want::from_proto(want.clone().into_proto().unwrap()).unwrap();
+    assert_eq!(decoded.count(), 4);
+    assert!(decoded.wanted.get(0));
+    assert!(decoded.wanted.get(7));
+    assert!(decoded.wanted.get(8));
+    assert!(decoded.wanted.get(15));
+    assert!(!decoded.wanted.get(1));
+}
+
+/// A delivery pins the field order `address(1)`, `data(2)`, `stamp(3)` and
+/// reconstructs byte-identically against the chunk's own address.
+#[test]
+fn delivery_fixed_bytes_and_roundtrip() {
+    let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    let chunk: AnyChunk = ContentChunk::new(&b"pullsync payload"[..])
+        .expect("valid content chunk")
+        .into();
+    let address = *chunk.address();
+    let wire_data = chunk.clone().into_bytes();
+    let stamped = StampedChunk::new(chunk, stamp.clone());
+
+    let bytes = proto_bytes(Delivery::new(stamped));
+
+    // Hand-build the expected protobuf: field 1 address (32 bytes), field 2 data,
+    // field 3 stamp (113 bytes).
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&[0x0a, 0x20]);
+    expected.extend_from_slice(address.as_bytes());
+    expected.push(0x12);
+    push_len(&mut expected, wire_data.len());
+    expected.extend_from_slice(&wire_data);
+    expected.push(0x1a);
+    push_len(&mut expected, 113);
+    expected.extend_from_slice(&stamp.to_bytes());
+    assert_eq!(bytes, expected, "delivery wire layout drifted");
+
+    // Reconstructs to the requested address.
+    let proto = vertex_swarm_net_proto::pullsync::Delivery {
+        address: address.to_vec(),
+        data: wire_data.to_vec(),
+        stamp: stamp.to_bytes().to_vec(),
+    };
+    let decoded = Delivery::from_proto(proto).expect("valid delivery");
+    assert_eq!(*decoded.chunk.address(), address);
+}
+
+/// Encode a protobuf length as a base-128 varint.
+fn push_len(buf: &mut Vec<u8>, mut len: usize) {
+    while len >= 0x80 {
+        buf.push((len as u8 & 0x7f) | 0x80);
+        len >>= 7;
+    }
+    buf.push(len as u8);
+}

--- a/crates/swarm/net/pullsync/tests/interop.rs
+++ b/crates/swarm/net/pullsync/tests/interop.rs
@@ -4,7 +4,7 @@
 //! domain type is exercised through the public `ProtoMessage` API, never a
 //! private reimplementation of the byte layout, and the serialized protobuf
 //! bytes are asserted against fixed vectors. A single byte of drift in a field
-//! tag, ordering, or the MSB-first `Want` bitvector surfaces as a mismatch.
+//! tag, ordering, or the LSB-first `Want` bitvector surfaces as a mismatch.
 
 #![allow(
     clippy::expect_used,
@@ -113,31 +113,33 @@ fn offer_two_descriptors_fixed_bytes() {
     assert_eq!(decoded, offer);
 }
 
-/// The `Want` bitvector is MSB-first: bit `i` is the high bit of byte `i / 8`.
-/// Wanting chunks 0, 7, 8, and 15 of a 16-chunk offer encodes the literal bytes
-/// `0x81 0x81` on field 1.
+/// The `Want` bitvector is LSB-first: bit `i` is `0x01 << (i % 8)` in byte
+/// `i / 8`, and the byte length is `len / 8 + 1`. Wanting chunks 0, 1, and 8 of
+/// a 16-chunk offer encodes the literal bytes `0x03 0x01 0x00` on field 1; the
+/// asymmetric bit 1 (`0x02`, not `0x40`) pins the ordering, and the third byte
+/// is the `len / 8 + 1` trailing byte.
 #[test]
-fn want_bitvector_is_msb_first_fixed_bytes() {
+fn want_bitvector_is_lsb_first_fixed_bytes() {
     let mut bv = BitVector::new(16);
     bv.set(0);
-    bv.set(7);
+    bv.set(1);
     bv.set(8);
-    bv.set(15);
-    assert_eq!(bv.as_bytes(), &[0x81, 0x81]);
+    // Byte 0: bits 0,1 -> 0x03. Byte 1: bit 8 -> 0x01. Byte 2: len/8+1 pad -> 0x00.
+    assert_eq!(bv.as_bytes(), &[0x03, 0x01, 0x00]);
 
     let bytes = proto_bytes(Want::new(bv.clone()));
-    // field 1 (bit_vector), length-delimited: tag 0x0a, len 2, then 0x81 0x81.
-    assert_eq!(bytes, vec![0x0a, 0x02, 0x81, 0x81]);
+    // field 1 (bit_vector), length-delimited: tag 0x0a, len 3, then 0x03 0x01 0x00.
+    assert_eq!(bytes, vec![0x0a, 0x03, 0x03, 0x01, 0x00]);
 
-    // The selection survives a round-trip and counts four wanted chunks.
+    // The selection survives a round-trip and counts three wanted chunks.
     let want = Want::new(bv);
     let decoded = Want::from_proto(want.clone().into_proto().unwrap()).unwrap();
-    assert_eq!(decoded.count(), 4);
+    assert_eq!(decoded.count(), 3);
     assert!(decoded.wanted.get(0));
-    assert!(decoded.wanted.get(7));
+    assert!(decoded.wanted.get(1));
     assert!(decoded.wanted.get(8));
-    assert!(decoded.wanted.get(15));
-    assert!(!decoded.wanted.get(1));
+    assert!(!decoded.wanted.get(2));
+    assert!(!decoded.wanted.get(7));
 }
 
 /// A delivery pins the field order `address(1)`, `data(2)`, `stamp(3)` and


### PR DESCRIPTION
## What

Add `vertex-swarm-net-pullsync`, the pullsync wire protocol: one protocol with two streams (`/swarm/pullsync/1.4.0/cursors` for Syn/Ack, `/swarm/pullsync/1.4.0/pullsync` for the Get/Offer/Want/Delivery range exchange), domain codecs behind the `ProtoMessage` boundary, an MSB-first selection bitvector, the multi-phase responder/requester drivers, and fixed-byte conformance vectors.

## Why

Part of the pullsync protocol (#77). Wire-conformant with the live network (protocol id, page/rate limits, bitvector bit-order, and the 96-byte chunk descriptor are pinned to the reference). Foundation crate consumed by the storer behaviour and puller.

## Testing

`cargo test -p vertex-swarm-net-pullsync` (20 unit + 6 interop conformance vectors); clippy clean.

## AI Assistance

Claude Code (Opus 4.8) used for implementation and verification.