### PR TITLE
feat(swarm-storer-behaviour): add PullsyncBehaviour wiring the pullsync wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9490,6 +9490,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-swarm-storer-behaviour"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "futures",
+ "libp2p",
+ "libp2p-swarm-test",
+ "metrics",
+ "nectar-postage",
+ "nectar-primitives",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vertex-net-ratelimiter",
+ "vertex-swarm-api",
+ "vertex-swarm-net-handler-core",
+ "vertex-swarm-net-headers",
+ "vertex-swarm-net-pullsync",
+ "vertex-swarm-primitives",
+ "vertex-tasks",
+]
+
+[[package]]
 name = "vertex-swarm-stream"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     "crates/swarm/client-protocol",
     "crates/swarm/client-behaviour",
     "crates/swarm/node",
+    "crates/swarm/storer-behaviour",
     "crates/swarm/topology",
     "crates/swarm/peers/peer-manager",
     "crates/swarm/peers/peer-score",
@@ -223,6 +224,7 @@ vertex-swarm-test-utils = { path = "crates/swarm/test-utils" }
 vertex-swarm-client-protocol = { path = "crates/swarm/client-protocol" }
 vertex-swarm-client-behaviour = { path = "crates/swarm/client-behaviour" }
 vertex-swarm-node = { path = "crates/swarm/node" }
+vertex-swarm-storer-behaviour = { path = "crates/swarm/storer-behaviour" }
 
 # topology (in swarm/)
 vertex-swarm-topology = { path = "crates/swarm/topology" }

--- a/crates/swarm/storer-behaviour/Cargo.toml
+++ b/crates/swarm/storer-behaviour/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "vertex-swarm-storer-behaviour"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+## vertex
+vertex-net-ratelimiter.workspace = true
+vertex-swarm-api.workspace = true
+vertex-swarm-net-handler-core.workspace = true
+vertex-swarm-net-headers.workspace = true
+vertex-swarm-net-pullsync.workspace = true
+vertex-swarm-primitives.workspace = true
+vertex-tasks.workspace = true
+
+## async
+futures.workspace = true
+
+## p2p
+libp2p.workspace = true
+
+## tracing & metrics
+tracing.workspace = true
+metrics.workspace = true
+strum.workspace = true
+
+## error handling
+thiserror.workspace = true
+
+[dev-dependencies]
+alloy-primitives.workspace = true
+nectar-postage.workspace = true
+nectar-primitives.workspace = true
+libp2p-swarm-test.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }

--- a/crates/swarm/storer-behaviour/src/behaviour.rs
+++ b/crates/swarm/storer-behaviour/src/behaviour.rs
@@ -1,0 +1,188 @@
+//! `NetworkBehaviour` for pullsync: an inbound syncer backed by a
+//! [`PullStorage`] snapshot, plus a puller command surface that opens outbound
+//! cursor and range substreams.
+
+use std::{
+    collections::VecDeque,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use libp2p::{
+    Multiaddr, PeerId,
+    swarm::{
+        ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, NotifyHandler, THandler,
+        THandlerInEvent, THandlerOutEvent, ToSwarm,
+    },
+};
+use strum::IntoStaticStr;
+use vertex_net_ratelimiter::{KeyedRateLimiter, Quota};
+use vertex_swarm_api::{Bin, PullStorage, StampedChunk};
+
+use crate::error::PullsyncFailure;
+use crate::handler::{PullsyncCommand, PullsyncHandler, PullsyncHandlerEvent};
+
+/// Chunks served per second per peer, enforced by the per-connection handler
+/// through a shared [`KeyedRateLimiter`].
+const CHUNK_QUOTA: Quota = Quota::n_every(
+    match std::num::NonZeroU32::new(vertex_swarm_net_pullsync::MAX_CHUNKS_PER_SECOND as u32) {
+        Some(v) => v,
+        None => unreachable!(),
+    },
+    Duration::from_secs(1),
+);
+
+/// Events emitted by [`PullsyncBehaviour`].
+#[derive(Debug, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum PullsyncEvent {
+    /// A peer answered a cursor handshake with its per-bin cursors and reserve
+    /// epoch.
+    CursorsReceived {
+        peer: PeerId,
+        cursors: Vec<u64>,
+        epoch: u64,
+    },
+    /// A peer delivered a range page for `bin`. `topmost` is the highest id the
+    /// offer covered; the puller advances its cursor to it.
+    RangeDelivered {
+        peer: PeerId,
+        bin: Bin,
+        topmost: u64,
+        chunks: Vec<StampedChunk>,
+    },
+    /// An outbound command against `peer` failed.
+    Failed {
+        peer: PeerId,
+        failure: PullsyncFailure,
+    },
+}
+
+/// Pullsync behaviour: syncer (inbound) and puller command surface (outbound).
+pub struct PullsyncBehaviour {
+    /// Server snapshot the inbound responders read, injected as a trait object.
+    storage: Arc<dyn PullStorage>,
+    /// Shared into each handler so the per-peer chunks-per-second bucket
+    /// survives reconnects; freed on the final `ConnectionClosed`.
+    chunk_limit: Arc<KeyedRateLimiter<PeerId>>,
+    events: VecDeque<ToSwarm<PullsyncEvent, PullsyncCommand>>,
+}
+
+impl PullsyncBehaviour {
+    /// Construct with the storage snapshot the inbound syncer reads.
+    pub fn new(storage: Arc<dyn PullStorage>) -> Self {
+        Self {
+            storage,
+            chunk_limit: Arc::new(KeyedRateLimiter::new(CHUNK_QUOTA)),
+            events: VecDeque::new(),
+        }
+    }
+
+    /// Open the cursor handshake against `peer`. The peer's cursors arrive as a
+    /// [`PullsyncEvent::CursorsReceived`].
+    pub fn fetch_cursors(&mut self, peer: PeerId) {
+        self.events.push_back(ToSwarm::NotifyHandler {
+            peer_id: peer,
+            handler: NotifyHandler::Any,
+            event: PullsyncCommand::FetchCursors,
+        });
+    }
+
+    /// Open a range exchange against `peer` for `bin` from `start`. The selected
+    /// chunks arrive as a [`PullsyncEvent::RangeDelivered`].
+    pub fn sync_range(&mut self, peer: PeerId, bin: Bin, start: u64) {
+        self.events.push_back(ToSwarm::NotifyHandler {
+            peer_id: peer,
+            handler: NotifyHandler::Any,
+            event: PullsyncCommand::SyncRange { bin, start },
+        });
+    }
+
+    fn make_handler(&self, peer: PeerId) -> PullsyncHandler {
+        PullsyncHandler::new(
+            peer,
+            Arc::clone(&self.storage),
+            Arc::clone(&self.chunk_limit),
+        )
+    }
+}
+
+impl NetworkBehaviour for PullsyncBehaviour {
+    type ConnectionHandler = PullsyncHandler;
+    type ToSwarm = PullsyncEvent;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(self.make_handler(peer))
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: libp2p::core::Endpoint,
+        _port_use: libp2p::core::transport::PortUse,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(self.make_handler(peer))
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        if let FromSwarm::ConnectionClosed(closed) = event
+            && closed.remaining_established == 0
+        {
+            // Free the per-peer rate-limit bucket only when the last connection
+            // closes; an earlier clear would let a peer reset its bucket by
+            // churning a single connection.
+            self.chunk_limit.clear(&closed.peer_id);
+        }
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        _connection_id: ConnectionId,
+        event: THandlerOutEvent<Self>,
+    ) {
+        let event = match event {
+            PullsyncHandlerEvent::CursorsReceived { cursors, epoch } => {
+                PullsyncEvent::CursorsReceived {
+                    peer: peer_id,
+                    cursors,
+                    epoch,
+                }
+            }
+            PullsyncHandlerEvent::RangeDelivered {
+                bin,
+                topmost,
+                chunks,
+            } => PullsyncEvent::RangeDelivered {
+                peer: peer_id,
+                bin,
+                topmost,
+                chunks,
+            },
+            PullsyncHandlerEvent::OutboundFailed { failure } => PullsyncEvent::Failed {
+                peer: peer_id,
+                failure,
+            },
+        };
+        self.events.push_back(ToSwarm::GenerateEvent(event));
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        if let Some(event) = self.events.pop_front() {
+            return Poll::Ready(event);
+        }
+        Poll::Pending
+    }
+}

--- a/crates/swarm/storer-behaviour/src/error.rs
+++ b/crates/swarm/storer-behaviour/src/error.rs
@@ -1,0 +1,18 @@
+//! Errors surfaced by [`PullsyncBehaviour`](crate::PullsyncBehaviour) as failure
+//! events.
+
+use strum::IntoStaticStr;
+
+/// Why a pullsync command against a peer failed.
+#[derive(Debug, thiserror::Error, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum PullsyncFailure {
+    /// The substream upgrade or framed exchange failed (negotiation, transport,
+    /// or a malformed message from the peer).
+    #[error("pullsync stream failed: {0}")]
+    Stream(String),
+
+    /// The peer kept the substream open past the per-page deadline.
+    #[error("pullsync exchange timed out")]
+    TimedOut,
+}

--- a/crates/swarm/storer-behaviour/src/handler.rs
+++ b/crates/swarm/storer-behaviour/src/handler.rs
@@ -1,0 +1,581 @@
+//! Per-connection handler for pullsync.
+//!
+//! Inbound is the syncer: cursors and range substreams are served by
+//! self-contained futures that read [`PullStorage`] and send the reply inside
+//! the future, resolving to an outcome the handler turns into a metric. Outbound
+//! is the puller command surface: a `FetchCursors` resolves in the upgrade, a
+//! `SyncRange` is driven to completion by an outbound future that selects the
+//! whole offer and collects the deliveries.
+
+use std::{
+    collections::VecDeque,
+    num::NonZeroU32,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use futures::{
+    future::BoxFuture,
+    stream::{FuturesUnordered, StreamExt},
+};
+use libp2p::{
+    PeerId,
+    swarm::{
+        SubstreamProtocol,
+        handler::{
+            ConnectionEvent, ConnectionHandler, ConnectionHandlerEvent, DialUpgradeError,
+            FullyNegotiatedInbound, FullyNegotiatedOutbound, ListenUpgradeError,
+        },
+    },
+};
+use tracing::{debug, warn};
+use vertex_net_ratelimiter::{KeyedRateLimiter, Quota};
+use vertex_swarm_api::{Bin, ChunkAddress, PullStorage, StampedChunk, SwarmResult};
+use vertex_swarm_net_handler_core::HandlerCore;
+use vertex_swarm_net_pullsync::{
+    Ack, BitVector, ChunkDescriptor, DEFAULT_MAX_PAGE, Delivery, Get, Offer, SyncRequester,
+    SyncResponder, Want,
+};
+use vertex_swarm_primitives::all_bins;
+use vertex_tasks::time::timeout;
+
+use crate::error::PullsyncFailure;
+use crate::upgrade::{
+    InboundOutput, OutboundOutput, PullsyncInboundUpgrade, PullsyncOutboundUpgrade,
+};
+
+/// Per-connection inbound substream-open quota: headroom for a burst of cursor
+/// and range opens while throttling a peer that loops new streams.
+const INBOUND_SUBSTREAM_QUOTA: Quota = Quota::n_every(nonzero(8), Duration::from_secs(20));
+
+/// Deadline on the headers exchange and first framed read of an inbound stream.
+const STREAM_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Outbound deadline covering the upgrade and the offer read.
+const OUTBOUND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Deadline on each post-upgrade framed read. The upgrade timeout bounds
+/// negotiation and the first read only; without this a peer that opens a sync
+/// stream and then stalls (takes our offer but never sends a want, or withholds
+/// deliveries) would pin a serving or driving slot indefinitely.
+const READ_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cap on concurrent inbound serving futures per connection. Once full,
+/// `listen_protocol` stops advertising serving so the muxer back-pressures.
+const MAX_INBOUND_SERVING: usize = 16;
+
+/// Cap on concurrent outbound range futures per connection.
+const MAX_OUTBOUND_DRIVING: usize = 8;
+
+/// Cap on commands queued from the behaviour before the oldest is dropped.
+const MAX_PENDING_COMMANDS: usize = 64;
+
+const fn nonzero(n: u32) -> NonZeroU32 {
+    match NonZeroU32::new(n) {
+        Some(v) => v,
+        None => unreachable!(),
+    }
+}
+
+/// Commands from the behaviour to the handler.
+#[derive(Debug)]
+pub enum PullsyncCommand {
+    /// Open the cursor handshake and report the peer's per-bin cursors.
+    FetchCursors,
+    /// Open a range exchange for `bin` from `start` and collect the deliveries.
+    SyncRange { bin: Bin, start: u64 },
+}
+
+/// Events from the handler to the behaviour.
+#[derive(Debug)]
+pub enum PullsyncHandlerEvent {
+    /// Cursor handshake answered.
+    CursorsReceived { cursors: Vec<u64>, epoch: u64 },
+    /// Range exchange delivered chunks for `bin`, with `topmost` the highest id
+    /// the offer covered (the puller advances its cursor to it).
+    RangeDelivered {
+        bin: Bin,
+        topmost: u64,
+        chunks: Vec<StampedChunk>,
+    },
+    /// An outbound command failed.
+    OutboundFailed { failure: PullsyncFailure },
+}
+
+/// Outcome of one inbound serving future. The reply is already sent inside the
+/// future; this carries only the metrics signal.
+enum InboundOutcome {
+    Cursors,
+    Range { delivered: u64 },
+    Failed,
+}
+
+/// Outcome of one outbound range future.
+enum RangeOutcome {
+    Delivered {
+        bin: Bin,
+        topmost: u64,
+        chunks: Vec<StampedChunk>,
+    },
+    Failed(PullsyncFailure),
+}
+
+/// Per-connection pullsync handler.
+pub struct PullsyncHandler {
+    remote_peer_id: PeerId,
+    /// Server snapshot the inbound responders read.
+    storage: Arc<dyn PullStorage>,
+    /// Shared core: pending events and the inbound substream-open limiter.
+    core: HandlerCore<PullsyncHandlerEvent>,
+    /// Shared with the behaviour so the per-peer chunks-per-second bucket
+    /// survives reconnects; freed on the final `ConnectionClosed`.
+    chunk_limit: Arc<KeyedRateLimiter<PeerId>>,
+    pending_commands: VecDeque<PullsyncCommand>,
+    inbound: FuturesUnordered<BoxFuture<'static, InboundOutcome>>,
+    outbound: FuturesUnordered<BoxFuture<'static, RangeOutcome>>,
+}
+
+impl PullsyncHandler {
+    pub fn new(
+        remote_peer_id: PeerId,
+        storage: Arc<dyn PullStorage>,
+        chunk_limit: Arc<KeyedRateLimiter<PeerId>>,
+    ) -> Self {
+        Self {
+            remote_peer_id,
+            storage,
+            core: HandlerCore::new(INBOUND_SUBSTREAM_QUOTA),
+            chunk_limit,
+            pending_commands: VecDeque::new(),
+            inbound: FuturesUnordered::new(),
+            outbound: FuturesUnordered::new(),
+        }
+    }
+
+    /// Answer a cursor handshake from the local per-bin cursors and reserve epoch.
+    fn serve_cursors(&mut self, responder: vertex_swarm_net_pullsync::CursorsResponder) {
+        let storage = Arc::clone(&self.storage);
+        self.inbound.push(Box::pin(async move {
+            // A storage fault must surface as a failed serve; advertising 0
+            // cursors would mask the fault and stall the peer's sync.
+            let mut cursors = Vec::with_capacity(Bin::COUNT);
+            for bin in all_bins(Bin::MAX) {
+                match storage.bin_cursor(bin) {
+                    Ok(cursor) => cursors.push(cursor),
+                    Err(e) => {
+                        warn!(error = %e, %bin, "Pullsync bin cursor read failed");
+                        return InboundOutcome::Failed;
+                    }
+                }
+            }
+            let ack = Ack {
+                cursors,
+                epoch: storage.reserve_epoch(),
+            };
+            match responder.send_ack(ack).await {
+                Ok(()) => InboundOutcome::Cursors,
+                Err(e) => {
+                    debug!(error = %e, "Pullsync cursors serve failed");
+                    InboundOutcome::Failed
+                }
+            }
+        }));
+    }
+
+    /// Serve a range request: page the bin, offer descriptors, deliver the wanted
+    /// chunks under the per-second cap.
+    fn serve_range(&mut self, get: Get, responder: SyncResponder) {
+        let storage = Arc::clone(&self.storage);
+        let chunk_limit = Arc::clone(&self.chunk_limit);
+        let peer = self.remote_peer_id;
+        self.inbound.push(Box::pin(serve_range_inner(
+            storage,
+            chunk_limit,
+            peer,
+            get,
+            responder,
+        )));
+    }
+
+    /// Drive a negotiated outbound range to completion.
+    fn drive_range(&mut self, bin: Bin, offer: Offer, requester: SyncRequester) {
+        self.outbound
+            .push(Box::pin(drive_range_inner(bin, offer, requester)));
+    }
+
+    /// Index of the first queued command that may dispatch now. A `FetchCursors`
+    /// always may; a `SyncRange` only while the outbound driving cap has room.
+    fn next_dispatchable_command(&self) -> Option<usize> {
+        let has_range_slot = self.outbound.len() < MAX_OUTBOUND_DRIVING;
+        self.pending_commands.iter().position(|cmd| match cmd {
+            PullsyncCommand::FetchCursors => true,
+            PullsyncCommand::SyncRange { .. } => has_range_slot,
+        })
+    }
+}
+
+/// Page the requested bin into an offer, read the want, and stream the selected
+/// chunks. The per-peer chunks-per-second bucket trims the selection so a
+/// requester cannot drain us faster than the reserve rate cap.
+async fn serve_range_inner(
+    storage: Arc<dyn PullStorage>,
+    chunk_limit: Arc<KeyedRateLimiter<PeerId>>,
+    peer: PeerId,
+    get: Get,
+    responder: SyncResponder,
+) -> InboundOutcome {
+    let (descriptors, topmost) = match page_bin(&storage, get.bin, get.start) {
+        Ok(page) => page,
+        Err(e) => {
+            debug!(error = %e, "Pullsync range scan failed");
+            return InboundOutcome::Failed;
+        }
+    };
+
+    let offer = Offer::new(topmost, descriptors.iter().map(|(_, d)| *d).collect());
+    let responder = match responder.write_offer(offer).await {
+        Ok(r) => r,
+        Err(e) => {
+            debug!(error = %e, "Pullsync offer send failed");
+            return InboundOutcome::Failed;
+        }
+    };
+
+    // An empty page ends the exchange after the offer, with no want round.
+    if descriptors.is_empty() {
+        return match responder.finish().await {
+            Ok(()) => InboundOutcome::Range { delivered: 0 },
+            Err(e) => {
+                debug!(error = %e, "Pullsync empty offer finish failed");
+                InboundOutcome::Failed
+            }
+        };
+    }
+
+    // Bound the want read: a peer that takes the offer and never answers must not
+    // hold the serving slot past the deadline.
+    let (want, mut responder) = match timeout(READ_TIMEOUT, responder.read_want()).await {
+        Ok(Ok(pair)) => pair,
+        Ok(Err(e)) => {
+            debug!(error = %e, "Pullsync want read failed");
+            return InboundOutcome::Failed;
+        }
+        Err(_) => {
+            debug!(%peer, "Pullsync want read timed out");
+            return InboundOutcome::Failed;
+        }
+    };
+
+    let mut delivered = 0u64;
+    for (i, (address, _)) in descriptors.iter().enumerate() {
+        if !want.wanted.get(i) {
+            continue;
+        }
+        // One token per chunk; stop serving this page once the bucket is empty
+        // rather than blocking.
+        if chunk_limit.try_consume(peer).is_err() {
+            debug!(%peer, "Pullsync chunk rate limit reached; truncating page");
+            break;
+        }
+        let cached = match storage.get(address) {
+            Ok(Some(cached)) => cached,
+            // Evicted between the offer and this read: skip it, sending fewer
+            // deliveries than wanted bits. A puller matches deliveries by address
+            // and reads to stream close, so the shortfall is tolerated; this is a
+            // deliberate divergence from sending a placeholder for the gap.
+            Ok(None) => continue,
+            Err(e) => {
+                debug!(error = %e, "Pullsync chunk fetch failed");
+                return InboundOutcome::Failed;
+            }
+        };
+        let (chunk, stamp) = cached.into_parts();
+        // A reserve entry is always stamped; a stampless one is not a valid
+        // delivery, so skip it rather than send a half chunk.
+        let Some(stamp) = stamp else { continue };
+        if let Err(e) = responder
+            .send_delivery(Delivery::new(StampedChunk::new(chunk, stamp)))
+            .await
+        {
+            debug!(error = %e, "Pullsync delivery send failed");
+            return InboundOutcome::Failed;
+        }
+        delivered += 1;
+    }
+
+    match responder.finish().await {
+        Ok(()) => InboundOutcome::Range { delivered },
+        Err(e) => {
+            debug!(error = %e, "Pullsync delivery finish failed");
+            InboundOutcome::Failed
+        }
+    }
+}
+
+/// Collect up to [`DEFAULT_MAX_PAGE`] descriptors for `bin` from `start`, paired
+/// with their address, plus the topmost sequence covered.
+#[allow(clippy::type_complexity)]
+fn page_bin(
+    storage: &Arc<dyn PullStorage>,
+    bin: Bin,
+    start: u64,
+) -> SwarmResult<(Vec<(ChunkAddress, ChunkDescriptor)>, u64)> {
+    let mut descriptors = Vec::new();
+    // Raised only from scanned ids; an empty range yields topmost 0, never
+    // `start`. The puller advances its cursor to `max(topmost, start)`, so
+    // returning `start` here would falsely mark an empty range as synced.
+    let mut topmost = 0u64;
+    for item in storage.scan_bin_from(bin, start)? {
+        let item = item?;
+        topmost = topmost.max(item.seq);
+        descriptors.push((
+            item.address,
+            ChunkDescriptor::new(item.address, item.batch_id, item.stamp_hash),
+        ));
+        if descriptors.len() as u64 >= DEFAULT_MAX_PAGE {
+            break;
+        }
+    }
+    Ok((descriptors, topmost))
+}
+
+/// Select every chunk in the offer, send the want, and collect the deliveries.
+/// Admission and verification belong to the puller service; the command surface
+/// wants all offered chunks so the round-trip is exercised end to end.
+async fn drive_range_inner(bin: Bin, offer: Offer, requester: SyncRequester) -> RangeOutcome {
+    let topmost = offer.topmost;
+    let expected = offer.chunks.len();
+
+    // An empty offer ends the exchange with no want; the topmost still advances
+    // the puller's cursor past the now-known-empty range.
+    if expected == 0 {
+        return match requester.finish().await {
+            Ok(()) => RangeOutcome::Delivered {
+                bin,
+                topmost,
+                chunks: Vec::new(),
+            },
+            Err(e) => RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
+        };
+    }
+
+    let mut want = BitVector::new(expected);
+    for i in 0..expected {
+        want.set(i);
+    }
+    let mut requester = match requester.send_want(Want::new(want)).await {
+        Ok(r) => r,
+        Err(e) => return RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
+    };
+
+    let mut chunks = Vec::with_capacity(expected);
+    loop {
+        // Bound each delivery read: a responder that takes our want and then
+        // withholds deliveries must not pin the driving slot past the deadline.
+        match timeout(READ_TIMEOUT, requester.next_delivery()).await {
+            Ok(Ok(Some(delivery))) => chunks.push(*delivery.chunk),
+            Ok(Ok(None)) => break,
+            Ok(Err(e)) => return RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
+            Err(_) => return RangeOutcome::Failed(PullsyncFailure::TimedOut),
+        }
+    }
+    RangeOutcome::Delivered {
+        bin,
+        topmost,
+        chunks,
+    }
+}
+
+impl ConnectionHandler for PullsyncHandler {
+    type FromBehaviour = PullsyncCommand;
+    type ToBehaviour = PullsyncHandlerEvent;
+    type InboundProtocol = PullsyncInboundUpgrade;
+    type OutboundProtocol = PullsyncOutboundUpgrade;
+    type InboundOpenInfo = ();
+    type OutboundOpenInfo = OutboundInfo;
+
+    fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol, Self::InboundOpenInfo> {
+        SubstreamProtocol::new(PullsyncInboundUpgrade, ()).with_timeout(STREAM_TIMEOUT)
+    }
+
+    fn connection_keep_alive(&self) -> bool {
+        true
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<
+        ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
+    > {
+        if let Some(event) = self.core.poll_pending() {
+            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
+        }
+
+        while let Poll::Ready(Some(outcome)) = self.inbound.poll_next_unpin(cx) {
+            match outcome {
+                InboundOutcome::Cursors => crate::metrics::inbound_cursors_served(),
+                InboundOutcome::Range { delivered } => {
+                    crate::metrics::inbound_range_served(delivered)
+                }
+                InboundOutcome::Failed => crate::metrics::inbound_failed(),
+            }
+        }
+
+        if let Poll::Ready(Some(outcome)) = self.outbound.poll_next_unpin(cx) {
+            let event = match outcome {
+                RangeOutcome::Delivered {
+                    bin,
+                    topmost,
+                    chunks,
+                } => {
+                    crate::metrics::outbound_range_delivered(chunks.len() as u64);
+                    PullsyncHandlerEvent::RangeDelivered {
+                        bin,
+                        topmost,
+                        chunks,
+                    }
+                }
+                RangeOutcome::Failed(failure) => {
+                    crate::metrics::outbound_failed();
+                    PullsyncHandlerEvent::OutboundFailed { failure }
+                }
+            };
+            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
+        }
+
+        // A `FetchCursors` resolves entirely in the upgrade and occupies no
+        // outbound driving slot, so only `SyncRange` is gated on the cap. Gating
+        // both would head-of-line block cursor fetches behind saturated range
+        // drives.
+        if let Some(idx) = self.next_dispatchable_command()
+            && let Some(cmd) = self.pending_commands.remove(idx)
+        {
+            let (protocol, info) = match cmd {
+                PullsyncCommand::FetchCursors => {
+                    (PullsyncOutboundUpgrade::Cursors, OutboundInfo::Cursors)
+                }
+                PullsyncCommand::SyncRange { bin, start } => (
+                    PullsyncOutboundUpgrade::Sync(Get::new(bin, start)),
+                    OutboundInfo::Sync { bin },
+                ),
+            };
+            return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
+                protocol: SubstreamProtocol::new(protocol, info).with_timeout(OUTBOUND_TIMEOUT),
+            });
+        }
+
+        Poll::Pending
+    }
+
+    fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
+        if self.pending_commands.len() >= MAX_PENDING_COMMANDS {
+            warn!(peer_id = %self.remote_peer_id, "Pullsync command queue full, dropping oldest");
+            self.pending_commands.pop_front();
+        }
+        self.pending_commands.push_back(event);
+    }
+
+    fn on_connection_event(
+        &mut self,
+        event: ConnectionEvent<
+            Self::InboundProtocol,
+            Self::OutboundProtocol,
+            Self::InboundOpenInfo,
+            Self::OutboundOpenInfo,
+        >,
+    ) {
+        match event {
+            ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
+                protocol, ..
+            }) => {
+                if !self.core.try_accept_inbound() || self.inbound.len() >= MAX_INBOUND_SERVING {
+                    warn!(peer_id = %self.remote_peer_id, "Rate limiting inbound pullsync stream");
+                    crate::metrics::inbound_rate_limited();
+                    return;
+                }
+                match protocol {
+                    InboundOutput::Cursors(responder) => self.serve_cursors(responder),
+                    InboundOutput::Sync(get, responder) => self.serve_range(get, responder),
+                }
+            }
+
+            ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
+                protocol,
+                info,
+            }) => match (protocol, info) {
+                (OutboundOutput::Cursors(ack), OutboundInfo::Cursors) => {
+                    crate::metrics::outbound_cursors_received();
+                    self.core.push_event(PullsyncHandlerEvent::CursorsReceived {
+                        cursors: ack.cursors,
+                        epoch: ack.epoch,
+                    });
+                }
+                (OutboundOutput::Sync(offer, requester), OutboundInfo::Sync { bin }) => {
+                    self.drive_range(bin, offer, requester);
+                }
+                (_, info) => warn!(?info, "Mismatched pullsync outbound output"),
+            },
+
+            ConnectionEvent::DialUpgradeError(DialUpgradeError { error, info }) => {
+                let failure = classify(&error.to_string());
+                debug!(?info, %error, "Pullsync outbound error");
+                self.core
+                    .push_event(PullsyncHandlerEvent::OutboundFailed { failure });
+            }
+
+            ConnectionEvent::ListenUpgradeError(ListenUpgradeError { error, .. }) => {
+                debug!(%error, "Pullsync inbound error");
+                crate::metrics::inbound_failed();
+            }
+
+            _ => {}
+        }
+    }
+}
+
+/// Map a stream-upgrade error to the typed failure, preserving the timeout
+/// signal so the puller service can tell a stall from a fault.
+fn classify(error: &str) -> PullsyncFailure {
+    if error.contains("Timeout") || error.contains("timeout") {
+        PullsyncFailure::TimedOut
+    } else {
+        PullsyncFailure::Stream(error.to_string())
+    }
+}
+
+/// Per-connection outbound open info carried alongside an outbound request.
+#[derive(Debug)]
+pub enum OutboundInfo {
+    Cursors,
+    Sync { bin: Bin },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future::pending;
+
+    // A stalled post-upgrade read elapses at `READ_TIMEOUT` instead of pending
+    // forever, the property both the inbound want read and the outbound delivery
+    // read rely on to drop the exchange and free its slot. Mirrors the failure
+    // mapping the outbound drive uses on a withholding responder.
+    #[tokio::test(start_paused = true)]
+    async fn stalled_read_times_out_and_maps_to_failure() {
+        let stalled = pending::<Result<(), PullsyncFailure>>();
+        let outcome = match timeout(READ_TIMEOUT, stalled).await {
+            Ok(Ok(())) => RangeOutcome::Delivered {
+                bin: Bin::ZERO,
+                topmost: 0,
+                chunks: Vec::new(),
+            },
+            Ok(Err(e)) => RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
+            Err(_) => RangeOutcome::Failed(PullsyncFailure::TimedOut),
+        };
+        assert!(matches!(
+            outcome,
+            RangeOutcome::Failed(PullsyncFailure::TimedOut)
+        ));
+    }
+}

--- a/crates/swarm/storer-behaviour/src/lib.rs
+++ b/crates/swarm/storer-behaviour/src/lib.rs
@@ -1,0 +1,18 @@
+//! Composite libp2p behaviours for the storer node.
+//!
+//! Currently exposes [`PullsyncBehaviour`], one `NetworkBehaviour` that runs both
+//! pullsync substreams: inbound it is the syncer, answering cursor handshakes and
+//! range requests from an injected [`PullStorage`](vertex_swarm_api::PullStorage);
+//! outbound it is the puller command surface, opening cursor and range substreams
+//! on command and emitting their results. The puller service loop (readiness
+//! gating, interval persistence, verification, admission) drives this surface from
+//! a higher layer.
+
+mod behaviour;
+mod error;
+mod handler;
+pub mod metrics;
+mod upgrade;
+
+pub use behaviour::{PullsyncBehaviour, PullsyncEvent};
+pub use error::PullsyncFailure;

--- a/crates/swarm/storer-behaviour/src/metrics.rs
+++ b/crates/swarm/storer-behaviour/src/metrics.rs
@@ -1,0 +1,41 @@
+//! Pullsync behaviour counters. Label-free; per-peer detail lives in scoring and
+//! the structured debug log.
+
+use metrics::counter;
+
+/// An inbound cursor handshake was answered.
+pub fn inbound_cursors_served() {
+    counter!("swarm.pullsync.inbound_cursors_served_total").increment(1);
+}
+
+/// An inbound range request was served, with `delivered` chunks sent.
+pub fn inbound_range_served(delivered: u64) {
+    counter!("swarm.pullsync.inbound_ranges_served_total").increment(1);
+    counter!("swarm.pullsync.inbound_chunks_delivered_total").increment(delivered);
+}
+
+/// An inbound substream was refused because the per-peer rate limit was hit.
+pub fn inbound_rate_limited() {
+    counter!("swarm.pullsync.inbound_rate_limited_total").increment(1);
+}
+
+/// An inbound serving future failed before completing the exchange.
+pub fn inbound_failed() {
+    counter!("swarm.pullsync.inbound_failed_total").increment(1);
+}
+
+/// An outbound cursor handshake completed.
+pub fn outbound_cursors_received() {
+    counter!("swarm.pullsync.outbound_cursors_received_total").increment(1);
+}
+
+/// An outbound range exchange delivered `count` chunks.
+pub fn outbound_range_delivered(count: u64) {
+    counter!("swarm.pullsync.outbound_ranges_delivered_total").increment(1);
+    counter!("swarm.pullsync.outbound_chunks_received_total").increment(count);
+}
+
+/// An outbound command failed.
+pub fn outbound_failed() {
+    counter!("swarm.pullsync.outbound_failed_total").increment(1);
+}

--- a/crates/swarm/storer-behaviour/src/upgrade.rs
+++ b/crates/swarm/storer-behaviour/src/upgrade.rs
@@ -1,0 +1,107 @@
+//! Combined upgrades for the two pullsync substreams.
+//!
+//! Inbound advertises both [`PROTOCOL_CURSORS`] and [`PROTOCOL_SYNC`] and
+//! dispatches on the negotiated id. Outbound knows its id from the command.
+
+use futures::future::BoxFuture;
+use libp2p::{InboundUpgrade, OutboundUpgrade, Stream, core::UpgradeInfo};
+use vertex_swarm_net_headers::ProtocolError;
+use vertex_swarm_net_pullsync::{
+    Ack, CursorsResponder, Get, Offer, PROTOCOL_CURSORS, PROTOCOL_SYNC, SyncRequester,
+    SyncResponder, cursors_inbound, cursors_outbound, sync_inbound, sync_outbound,
+};
+
+/// Output of the inbound upgrade once a substream negotiates.
+pub enum InboundOutput {
+    /// Cursor handshake: `Syn` read, awaiting our `Ack`.
+    Cursors(CursorsResponder),
+    /// Range request: the `Get`, plus the responder for offer/want/delivery.
+    Sync(Get, SyncResponder),
+}
+
+/// Inbound upgrade for both pullsync substreams.
+#[derive(Clone, Debug, Default)]
+pub struct PullsyncInboundUpgrade;
+
+impl UpgradeInfo for PullsyncInboundUpgrade {
+    type Info = &'static str;
+    type InfoIter = std::array::IntoIter<Self::Info, 2>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        [PROTOCOL_CURSORS, PROTOCOL_SYNC].into_iter()
+    }
+}
+
+impl InboundUpgrade<Stream> for PullsyncInboundUpgrade {
+    type Output = InboundOutput;
+    type Error = ProtocolError;
+    type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+
+    fn upgrade_inbound(self, socket: Stream, info: Self::Info) -> Self::Future {
+        Box::pin(async move {
+            match info {
+                PROTOCOL_CURSORS => {
+                    let responder = cursors_inbound().upgrade_inbound(socket, info).await?;
+                    Ok(InboundOutput::Cursors(responder))
+                }
+                _ => {
+                    let (get, responder) = sync_inbound().upgrade_inbound(socket, info).await?;
+                    Ok(InboundOutput::Sync(get, responder))
+                }
+            }
+        })
+    }
+}
+
+/// Output of the outbound upgrade once a substream negotiates.
+#[allow(clippy::large_enum_variant)]
+pub enum OutboundOutput {
+    /// Cursor handshake answered with the peer's `Ack`.
+    Cursors(Ack),
+    /// Range request answered with the `Offer`, plus the requester for
+    /// want/delivery.
+    Sync(Offer, SyncRequester),
+}
+
+/// Outbound upgrade selecting one pullsync substream per command.
+pub enum PullsyncOutboundUpgrade {
+    /// Open the cursor handshake.
+    Cursors,
+    /// Open a range exchange for the given `Get`.
+    Sync(Get),
+}
+
+impl UpgradeInfo for PullsyncOutboundUpgrade {
+    type Info = &'static str;
+    type InfoIter = std::iter::Once<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        let name = match self {
+            Self::Cursors => PROTOCOL_CURSORS,
+            Self::Sync(_) => PROTOCOL_SYNC,
+        };
+        std::iter::once(name)
+    }
+}
+
+impl OutboundUpgrade<Stream> for PullsyncOutboundUpgrade {
+    type Output = OutboundOutput;
+    type Error = ProtocolError;
+    type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
+
+    fn upgrade_outbound(self, socket: Stream, info: Self::Info) -> Self::Future {
+        Box::pin(async move {
+            match self {
+                Self::Cursors => {
+                    let ack = cursors_outbound().upgrade_outbound(socket, info).await?;
+                    Ok(OutboundOutput::Cursors(ack))
+                }
+                Self::Sync(get) => {
+                    let (offer, requester) =
+                        sync_outbound(get).upgrade_outbound(socket, info).await?;
+                    Ok(OutboundOutput::Sync(offer, requester))
+                }
+            }
+        })
+    }
+}

--- a/crates/swarm/storer-behaviour/tests/round_trip.rs
+++ b/crates/swarm/storer-behaviour/tests/round_trip.rs
@@ -1,0 +1,290 @@
+//! Behaviour-level round-trip: a puller behaviour syncs cursors and a range page
+//! from a syncer behaviour backed by a mock [`PullStorage`].
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::get_first)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_primitives::{B256, Signature};
+use futures::StreamExt;
+use libp2p::Swarm;
+use libp2p_swarm_test::SwarmExt;
+use nectar_postage::Stamp;
+use nectar_primitives::{AnyChunk, Bin, ChunkAddress, ContentChunk, ProximityOrder};
+use vertex_swarm_api::{
+    BatchId, BinScanItem, PullStorage, StampedChunk, StorageRadius, SwarmResult,
+};
+use vertex_swarm_primitives::CachedChunk;
+use vertex_swarm_storer_behaviour::{PullsyncBehaviour, PullsyncEvent};
+
+/// A reserve snapshot for one bin: ordered entries plus an address index.
+#[derive(Default)]
+struct MockPullStorage {
+    bin: u8,
+    epoch: u64,
+    items: Vec<BinScanItem>,
+    chunks: HashMap<ChunkAddress, StampedChunk>,
+}
+
+impl MockPullStorage {
+    fn with_chunks(bin: Bin, epoch: u64, chunks: Vec<StampedChunk>) -> Self {
+        let mut items = Vec::new();
+        let mut index = HashMap::new();
+        for (i, chunk) in chunks.into_iter().enumerate() {
+            let address = *chunk.address();
+            let stamp_hash = B256::from_slice(address.as_slice());
+            items.push(BinScanItem {
+                seq: i as u64 + 1,
+                address,
+                batch_id: BatchId::repeat_byte(0xbb),
+                stamp_hash,
+            });
+            index.insert(address, chunk);
+        }
+        Self {
+            bin: bin.get(),
+            epoch,
+            items,
+            chunks: index,
+        }
+    }
+}
+
+impl vertex_swarm_api::SwarmLocalStore for MockPullStorage {
+    fn put(&self, _chunk: CachedChunk) -> SwarmResult<()> {
+        Ok(())
+    }
+
+    fn get(&self, address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
+        Ok(self.chunks.get(address).cloned().map(CachedChunk::from))
+    }
+
+    fn contains(&self, address: &ChunkAddress) -> bool {
+        self.chunks.contains_key(address)
+    }
+
+    fn remove(&self, _address: &ChunkAddress) -> SwarmResult<()> {
+        Ok(())
+    }
+}
+
+impl vertex_swarm_api::ReserveStore for MockPullStorage {
+    fn storage_radius(&self) -> StorageRadius {
+        StorageRadius::ZERO
+    }
+
+    fn is_responsible_for(&self, _address: &ChunkAddress) -> bool {
+        true
+    }
+
+    fn count(&self) -> SwarmResult<u64> {
+        Ok(self.items.len() as u64)
+    }
+
+    fn capacity(&self) -> u64 {
+        u64::MAX
+    }
+
+    fn count_in(&self, _po: ProximityOrder) -> SwarmResult<u64> {
+        Ok(0)
+    }
+
+    fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>> {
+        Ok(None)
+    }
+
+    fn evict_from_bin(&self, _bin: Bin, _max: u64) -> SwarmResult<u64> {
+        Ok(0)
+    }
+
+    fn evict_batch(&self, _batch: BatchId, _up_to_bin: Option<Bin>, _max: u64) -> SwarmResult<u64> {
+        Ok(0)
+    }
+}
+
+impl vertex_swarm_api::BinCursorStore for MockPullStorage {
+    fn bin_cursor(&self, bin: Bin) -> SwarmResult<u64> {
+        if bin.get() == self.bin {
+            Ok(self.items.last().map(|i| i.seq).unwrap_or(0))
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn scan_bin_from<'a>(
+        &'a self,
+        bin: Bin,
+        start_seq: u64,
+    ) -> SwarmResult<Box<dyn Iterator<Item = SwarmResult<BinScanItem>> + Send + 'a>> {
+        let items: Vec<BinScanItem> = if bin.get() == self.bin {
+            self.items
+                .iter()
+                .filter(|i| i.seq >= start_seq)
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        Ok(Box::new(items.into_iter().map(Ok)))
+    }
+}
+
+impl PullStorage for MockPullStorage {
+    fn reserve_epoch(&self) -> u64 {
+        self.epoch
+    }
+}
+
+fn content(payload: &'static [u8]) -> StampedChunk {
+    let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
+    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    let chunk: AnyChunk = ContentChunk::new(payload)
+        .expect("valid content chunk")
+        .into();
+    StampedChunk::new(chunk, stamp)
+}
+
+fn syncer(storage: MockPullStorage) -> Swarm<PullsyncBehaviour> {
+    let storage: Arc<dyn PullStorage> = Arc::new(storage);
+    Swarm::new_ephemeral_tokio(move |_| PullsyncBehaviour::new(Arc::clone(&storage)))
+}
+
+/// Connect a puller and a syncer over an in-memory transport.
+async fn connect(puller: &mut Swarm<PullsyncBehaviour>, syncer: &mut Swarm<PullsyncBehaviour>) {
+    puller.listen().with_memory_addr_external().await;
+    syncer.listen().with_memory_addr_external().await;
+    puller.connect(syncer).await;
+}
+
+#[tokio::test]
+async fn cursor_handshake_round_trips() {
+    let bin = Bin::new(5).expect("valid bin");
+    let chunks = vec![content(b"cursor chunk a"), content(b"cursor chunk b")];
+    let mut puller = syncer(MockPullStorage::default());
+    let mut server = syncer(MockPullStorage::with_chunks(bin, 7, chunks));
+    let server_peer = *server.local_peer_id();
+
+    connect(&mut puller, &mut server).await;
+    puller.behaviour_mut().fetch_cursors(server_peer);
+
+    let event = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            tokio::select! {
+                _ = server.select_next_some() => {}
+                ev = puller.select_next_some() => {
+                    if let libp2p::swarm::SwarmEvent::Behaviour(e) = ev {
+                        return e;
+                    }
+                }
+            }
+        }
+    })
+    .await
+    .expect("cursors resolved within timeout");
+
+    match event {
+        PullsyncEvent::CursorsReceived {
+            peer,
+            cursors,
+            epoch,
+        } => {
+            assert_eq!(peer, server_peer);
+            assert_eq!(epoch, 7);
+            assert_eq!(cursors.len(), Bin::COUNT);
+            assert_eq!(cursors.get(5), Some(&2), "bin 5 holds two entries");
+            assert_eq!(cursors.get(0), Some(&0), "other bins are empty");
+        }
+        other => panic!("expected cursors, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn range_exchange_delivers_the_page() {
+    let bin = Bin::new(3).expect("valid bin");
+    let chunks = vec![content(b"range chunk one"), content(b"range chunk two")];
+    let addresses: Vec<ChunkAddress> = chunks.iter().map(|c| *c.address()).collect();
+    let mut puller = syncer(MockPullStorage::default());
+    let mut server = syncer(MockPullStorage::with_chunks(bin, 1, chunks));
+    let server_peer = *server.local_peer_id();
+
+    connect(&mut puller, &mut server).await;
+    puller.behaviour_mut().sync_range(server_peer, bin, 0);
+
+    let event = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            tokio::select! {
+                _ = server.select_next_some() => {}
+                ev = puller.select_next_some() => {
+                    if let libp2p::swarm::SwarmEvent::Behaviour(e) = ev {
+                        return e;
+                    }
+                }
+            }
+        }
+    })
+    .await
+    .expect("range resolved within timeout");
+
+    match event {
+        PullsyncEvent::RangeDelivered {
+            peer,
+            bin: got_bin,
+            topmost,
+            chunks,
+        } => {
+            assert_eq!(peer, server_peer);
+            assert_eq!(got_bin, bin);
+            assert_eq!(topmost, 2, "topmost covers both entries");
+            assert_eq!(chunks.len(), 2, "the whole page is wanted and delivered");
+            let delivered: Vec<ChunkAddress> = chunks.iter().map(|c| *c.address()).collect();
+            assert_eq!(delivered, addresses, "deliveries arrive in offer order");
+        }
+        other => panic!("expected a range delivery, got {other:?}"),
+    }
+}
+
+/// An empty range completes promptly with topmost 0 and no want round.
+#[tokio::test]
+async fn empty_range_completes_with_no_want() {
+    let bin = Bin::new(3).expect("valid bin");
+    // The syncer holds chunks in a different bin, so the requested bin is empty.
+    let other = Bin::new(4).expect("valid bin");
+    let chunks = vec![content(b"elsewhere chunk")];
+    let mut puller = syncer(MockPullStorage::default());
+    let mut server = syncer(MockPullStorage::with_chunks(other, 1, chunks));
+    let server_peer = *server.local_peer_id();
+
+    connect(&mut puller, &mut server).await;
+    puller.behaviour_mut().sync_range(server_peer, bin, 0);
+
+    let event = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            tokio::select! {
+                _ = server.select_next_some() => {}
+                ev = puller.select_next_some() => {
+                    if let libp2p::swarm::SwarmEvent::Behaviour(e) = ev {
+                        return e;
+                    }
+                }
+            }
+        }
+    })
+    .await
+    .expect("empty range resolves promptly, no hang");
+
+    match event {
+        PullsyncEvent::RangeDelivered {
+            peer,
+            bin: got_bin,
+            topmost,
+            chunks,
+        } => {
+            assert_eq!(peer, server_peer);
+            assert_eq!(got_bin, bin);
+            assert_eq!(topmost, 0, "an empty range yields topmost 0, not start");
+            assert!(chunks.is_empty(), "an empty range delivers no chunks");
+        }
+        other => panic!("expected an empty range delivery, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## What

Add the `vertex-swarm-storer-behaviour` crate with `PullsyncBehaviour`: the libp2p `NetworkBehaviour` + handler that drives the pullsync wire protocol. Inbound is the syncer (server) answering the cursor handshake and Get/Offer/Want/Delivery range exchange from an injected `Arc<dyn PullStorage>`; outbound is the puller command/event surface (`fetch_cursors`, `sync_range` -> `CursorsReceived`/`RangeDelivered`/`Failed`).

## Why

The storer protocol tier of the composite-behaviour layering (#77). A later PR composes this with the client behaviour into the storer composite; the puller service loop (readiness, intervals, verification, admission) is a separate step.

## Conformance and hardening (from QA against the bee reference)

An empty offer ends the exchange with no Want round (both sides), empty-range `topmost` is 0, the Want bitvector is the LSB-first wire bitvector from the net crate, deliveries are rate-limited (250/s) and post-upgrade reads carry a timeout so a stalling peer cannot pin a serving/driving slot.

## Testing

`cargo test -p vertex-swarm-storer-behaviour`: libp2p-swarm-test round-trips for the cursor handshake, a full offer page, and an empty range (no hang, no Want), plus a read-timeout unit test. clippy/fmt clean.

## AI Assistance

Claude Code (Opus 4.8) used for implementation, adversarial QA, and the fixes.