### PR TITLE
feat(swarm-puller): add the neighbourhood pull-sync service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9400,6 +9400,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "vertex-swarm-puller"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "auto_impl",
+ "libp2p",
+ "nectar-postage",
+ "nectar-primitives",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vertex-swarm-api",
+ "vertex-swarm-primitives",
+ "vertex-swarm-storer-behaviour",
+ "vertex-tasks",
+]
+
+[[package]]
 name = "vertex-swarm-redistribution"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ members = [
     # Storer (chunk storage and staking)
     "crates/swarm/storer",
 
+    # Puller (neighbourhood pull-sync service)
+    "crates/swarm/puller",
+
     # Postage (batch store + on-chain event ingest seam)
     "crates/swarm/postage",
 
@@ -246,6 +249,9 @@ vertex-swarm-redistribution = { path = "crates/swarm/redistribution" }
 
 # storer (chunk storage and staking)
 vertex-swarm-storer = { path = "crates/swarm/storer" }
+
+# puller (neighbourhood pull-sync service)
+vertex-swarm-puller = { path = "crates/swarm/puller" }
 
 # postage (batch store + on-chain event ingest seam)
 vertex-swarm-postage = { path = "crates/swarm/postage" }

--- a/crates/swarm/api/src/components/pullsync.rs
+++ b/crates/swarm/api/src/components/pullsync.rs
@@ -34,6 +34,14 @@ pub trait IntervalStore: Send + Sync {
 
     /// Record the last reserve epoch seen for `peer`.
     fn set_peer_epoch(&self, peer: &OverlayAddress, epoch: u64) -> SwarmResult<()>;
+
+    /// Clear every per-bin interval for `peer` and record `epoch`, atomically.
+    ///
+    /// The epoch is the commit barrier: a recorded epoch matching the advertised
+    /// one must never coexist with a stale interval, so the interval clear and the
+    /// epoch write commit together or not at all. No non-atomic default impl over
+    /// the per-field setters is permitted.
+    fn reset_peer(&self, peer: &OverlayAddress, epoch: u64) -> SwarmResult<()>;
 }
 
 /// Why a delivered chunk was refused admission to the reserve.

--- a/crates/swarm/puller/Cargo.toml
+++ b/crates/swarm/puller/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "vertex-swarm-puller"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Neighbourhood pull-sync service driving the storer reserve"
+
+[lints]
+workspace = true
+
+[dependencies]
+## vertex
+vertex-swarm-api.workspace = true
+vertex-swarm-primitives.workspace = true
+vertex-swarm-storer-behaviour.workspace = true
+vertex-tasks.workspace = true
+
+## p2p (PeerId only; no NetworkBehaviour or Swarm)
+libp2p.workspace = true
+
+## derive macros
+auto_impl.workspace = true
+
+## async
+tokio = { workspace = true, features = ["sync"] }
+
+## tracing & metrics
+tracing.workspace = true
+
+## error handling
+thiserror.workspace = true
+strum.workspace = true
+
+[dev-dependencies]
+alloy-primitives.workspace = true
+nectar-postage.workspace = true
+nectar-primitives.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "test-util"] }

--- a/crates/swarm/puller/src/lib.rs
+++ b/crates/swarm/puller/src/lib.rs
@@ -1,0 +1,24 @@
+//! Neighbourhood pull-sync service.
+//!
+//! The [`Puller`] is the readiness-gated background driver that pulls the
+//! storer's neighbourhood into its reserve. It is decoupled from the node swarm
+//! loop through the seams in [`seams`]: a [`PullsyncControl`] command surface, a
+//! [`PullsyncEvent`] receiver, a [`ReadinessGate`], a [`NeighbourSource`], and a
+//! [`ReserveAdmit`] put seam. A later integration step bridges these to the live
+//! `PullsyncBehaviour`; this crate wires no node.
+//!
+//! libp2p enters only through `PeerId` in the command and event surfaces; there
+//! is no `Swarm` or `NetworkBehaviour` here.
+
+mod seams;
+mod service;
+mod verifier;
+
+pub use seams::{
+    NeighbourSource, PullsyncControl, PullsyncEvent, ReadinessGate, ReserveAdmit, SyncTarget,
+};
+pub use service::{
+    BuiltPuller, DEFAULT_EVENT_CAPACITY, DEFAULT_PEER_RESPONSE_TIMEOUT, DEFAULT_TAIL_BACKOFF,
+    Puller, PullerConfig, PullerHandle, PullerSeams, build_puller, spawn_puller,
+};
+pub use verifier::SignatureVerifier;

--- a/crates/swarm/puller/src/seams.rs
+++ b/crates/swarm/puller/src/seams.rs
@@ -1,0 +1,79 @@
+//! Decoupling seams between the [`Puller`](crate::Puller) and the live node.
+//!
+//! The puller drives an abstract [`PullsyncControl`] (bridged to the live
+//! `PullsyncBehaviour` by the node) and consumes [`PullsyncEvent`]s off an mpsc
+//! receiver, gates on a [`ReadinessGate`], selects neighbours through a
+//! [`NeighbourSource`], and admits chunks through a [`ReserveAdmit`] put seam.
+
+use std::future::Future;
+
+use libp2p::PeerId;
+use vertex_swarm_api::SwarmResult;
+use vertex_swarm_primitives::{Bin, OverlayAddress, StampedChunk};
+
+pub use vertex_swarm_storer_behaviour::PullsyncEvent;
+
+/// Outbound command surface the puller drives, bridged to `PullsyncBehaviour`.
+///
+/// Each call opens an outbound substream against `peer`; its result arrives as a
+/// [`PullsyncEvent`] on the puller's event receiver.
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait PullsyncControl: Send + Sync {
+    /// Open the cursor handshake against `peer`.
+    fn fetch_cursors(&self, peer: PeerId);
+
+    /// Open a range exchange against `peer` for `bin` from `start`.
+    fn sync_range(&self, peer: PeerId, bin: Bin, start: u64);
+}
+
+/// Readiness gate the puller awaits before each sync pass.
+///
+/// Bridged to `TopologyHandle::wait_until_neighborhood_ready`; abstracted so the
+/// loop is testable without a live topology.
+pub trait ReadinessGate: Send + Sync {
+    /// Resolve once the neighbourhood is ready for pull-syncing.
+    fn wait_ready(&self) -> impl Future<Output = ()> + Send;
+}
+
+/// A neighbour to pull-sync from, with the bins in scope for it.
+#[derive(Debug, Clone)]
+pub struct SyncTarget {
+    /// libp2p identity for the [`PullsyncControl`] commands.
+    pub peer: PeerId,
+    /// Overlay identity keying the persisted intervals.
+    pub overlay: OverlayAddress,
+    /// Neighbourhood bins to sync, shallowest first.
+    pub bins: Vec<Bin>,
+}
+
+/// Source of the neighbours and bins to sync on each pass.
+///
+/// Bridged to the topology handle (depth, neighbourhood bins, connected
+/// neighbours and their peer ids).
+#[auto_impl::auto_impl(&, Arc, Box)]
+pub trait NeighbourSource: Send + Sync {
+    /// The current set of sync targets.
+    fn targets(&self) -> Vec<SyncTarget>;
+}
+
+/// Reserve admission put seam.
+///
+/// A blanket impl bridges any [`SwarmLocalStore`] (the storer reserve), so the
+/// puller crate depends on no storer backend.
+///
+/// [`SwarmLocalStore`]: vertex_swarm_api::SwarmLocalStore
+pub trait ReserveAdmit: Send + Sync {
+    /// Admit a verified, stamped chunk to the reserve.
+    fn admit(&self, chunk: StampedChunk) -> SwarmResult<()>;
+}
+
+/// Bridge any [`SwarmLocalStore`] to the put seam, converting the chunk to the
+/// always-stamped [`CachedChunk`] the reserve expects.
+///
+/// [`SwarmLocalStore`]: vertex_swarm_api::SwarmLocalStore
+/// [`CachedChunk`]: vertex_swarm_primitives::CachedChunk
+impl<S: vertex_swarm_api::SwarmLocalStore> ReserveAdmit for S {
+    fn admit(&self, chunk: StampedChunk) -> SwarmResult<()> {
+        self.put(vertex_swarm_primitives::CachedChunk::from(chunk))
+    }
+}

--- a/crates/swarm/puller/src/service.rs
+++ b/crates/swarm/puller/src/service.rs
@@ -1,0 +1,398 @@
+//! The [`Puller`]: readiness-gated background driver that pull-syncs the
+//! neighbourhood into the reserve.
+//!
+//! Per pass it awaits neighbourhood readiness, then for each neighbour fetches
+//! cursors, resets that peer's intervals on a reserve-epoch change, and for each
+//! in-scope bin drives `sync_range` from the persisted interval upward,
+//! verifying and admitting each delivered chunk before advancing the interval.
+//! When caught up it backs off and re-passes (live tail).
+
+use std::time::Duration;
+
+use libp2p::PeerId;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+use vertex_swarm_api::{IntervalStore, PullChunkVerifier};
+use vertex_swarm_primitives::{Bin, OverlayAddress};
+use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask, time};
+
+use crate::seams::{
+    NeighbourSource, PullsyncControl, PullsyncEvent, ReadinessGate, ReserveAdmit, SyncTarget,
+};
+
+/// Backoff between sync passes once the neighbourhood is caught up.
+pub const DEFAULT_TAIL_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Ceiling on awaiting a single peer's cursor or range reply, above the wire
+/// handler's own outbound and read bounds so a slow exchange is not cut off.
+pub const DEFAULT_PEER_RESPONSE_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Tuning for the [`Puller`] loop.
+#[derive(Debug, Clone, Copy)]
+pub struct PullerConfig {
+    /// Backoff applied after a caught-up pass before tailing again.
+    pub tail_backoff: Duration,
+    /// Ceiling on awaiting one peer's reply before abandoning that target; a
+    /// never-connected or silent peer yields no `Failed` event, so without this
+    /// the per-peer await blocks the whole pass forever.
+    pub peer_response_timeout: Duration,
+}
+
+impl Default for PullerConfig {
+    fn default() -> Self {
+        Self {
+            tail_backoff: DEFAULT_TAIL_BACKOFF,
+            peer_response_timeout: DEFAULT_PEER_RESPONSE_TIMEOUT,
+        }
+    }
+}
+
+/// The decoupling seams the [`Puller`] drives, bundled so the loop and its
+/// constructors take one value rather than six.
+pub struct PullerSeams<C, S, V, A, G, N> {
+    /// Outbound command surface, bridged to `PullsyncBehaviour`.
+    pub control: C,
+    /// Per-peer interval and epoch persistence.
+    pub intervals: S,
+    /// Admission gate run before a chunk enters the reserve.
+    pub verifier: V,
+    /// Reserve put seam.
+    pub admit: A,
+    /// Neighbourhood readiness gate.
+    pub readiness: G,
+    /// Source of neighbours and in-scope bins.
+    pub neighbours: N,
+}
+
+/// Neighbourhood pull-sync service.
+///
+/// Generic over the decoupling seams so it runs against the live node or test
+/// mocks unchanged. The reserve epoch is read from each peer's cursor handshake;
+/// a change resets that peer's persisted intervals so a wiped or recreated source
+/// reserve is re-synced from zero.
+pub struct Puller<C, E, S, V, A, G, N> {
+    control: C,
+    events: mpsc::Receiver<E>,
+    intervals: S,
+    verifier: V,
+    admit: A,
+    readiness: G,
+    neighbours: N,
+    config: PullerConfig,
+}
+
+impl<C, S, V, A, G, N> Puller<C, PullsyncEvent, S, V, A, G, N>
+where
+    C: PullsyncControl,
+    S: IntervalStore,
+    V: PullChunkVerifier,
+    A: ReserveAdmit,
+    G: ReadinessGate,
+    N: NeighbourSource,
+{
+    /// Construct a puller over the decoupling seams and its event receiver.
+    pub fn new(
+        seams: PullerSeams<C, S, V, A, G, N>,
+        events: mpsc::Receiver<PullsyncEvent>,
+        config: PullerConfig,
+    ) -> Self {
+        let PullerSeams {
+            control,
+            intervals,
+            verifier,
+            admit,
+            readiness,
+            neighbours,
+        } = seams;
+        Self {
+            control,
+            events,
+            intervals,
+            verifier,
+            admit,
+            readiness,
+            neighbours,
+            config,
+        }
+    }
+
+    /// Run the sync loop until `shutdown` fires.
+    pub async fn run(mut self, shutdown: GracefulShutdown) {
+        let mut shutdown = std::pin::pin!(shutdown);
+
+        loop {
+            tokio::select! {
+                guard = &mut shutdown => {
+                    debug!("puller received shutdown signal");
+                    drop(guard);
+                    break;
+                }
+                () = self.readiness.wait_ready() => {}
+            }
+
+            tokio::select! {
+                guard = &mut shutdown => {
+                    drop(guard);
+                    return;
+                }
+                () = self.sync_pass() => {}
+            }
+
+            tokio::select! {
+                guard = &mut shutdown => {
+                    drop(guard);
+                    break;
+                }
+                () = time::sleep(self.config.tail_backoff) => {}
+            }
+        }
+        debug!("puller shutdown complete");
+    }
+
+    /// One sync pass: fetch and sync every current neighbour target once.
+    ///
+    /// Public for deterministic testing; the live driver wraps it with the
+    /// readiness gate and tail backoff in [`run`](Self::run).
+    pub async fn sync_pass(&mut self) {
+        for target in self.neighbours.targets() {
+            self.sync_peer(&target).await;
+        }
+    }
+
+    /// Fetch a peer's cursors, reconcile its epoch, then sync each in-scope bin.
+    async fn sync_peer(&mut self, target: &SyncTarget) {
+        self.control.fetch_cursors(target.peer);
+
+        let epoch = match self.await_cursors(target.peer).await {
+            Some(epoch) => epoch,
+            None => return,
+        };
+
+        if let Err(e) = self.reconcile_epoch(&target.overlay, epoch) {
+            warn!(overlay = %target.overlay, error = %e, "puller epoch reconcile failed");
+            return;
+        }
+
+        for bin in &target.bins {
+            self.sync_bin(target, *bin).await;
+        }
+    }
+
+    /// Drain the event stream until this peer's cursor handshake answers,
+    /// returning its advertised reserve epoch. `None` abandons this peer: it
+    /// failed, the deadline elapsed, or the stream closed.
+    async fn await_cursors(&mut self, peer: PeerId) -> Option<u64> {
+        let ceiling = self.config.peer_response_timeout;
+        let events = &mut self.events;
+        let drained = async {
+            loop {
+                match events.recv().await? {
+                    PullsyncEvent::CursorsReceived { peer: p, epoch, .. } if p == peer => {
+                        return Some(epoch);
+                    }
+                    PullsyncEvent::Failed { peer: p, failure } if p == peer => {
+                        debug!(%peer, %failure, "puller cursor handshake failed");
+                        return None;
+                    }
+                    _ => continue,
+                }
+            }
+        };
+        match time::timeout(ceiling, drained).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                warn!(%peer, "puller cursor handshake timed out, abandoning peer");
+                None
+            }
+        }
+    }
+
+    /// Reset a peer's persisted intervals when its advertised epoch no longer
+    /// matches the last seen value, then record the new epoch.
+    fn reconcile_epoch(
+        &self,
+        overlay: &OverlayAddress,
+        epoch: u64,
+    ) -> vertex_swarm_api::SwarmResult<()> {
+        if self.intervals.peer_epoch(overlay)? == Some(epoch) {
+            return Ok(());
+        }
+        // A new epoch means the source reserve was recreated: every persisted
+        // cursor for this peer is stale. The clear and the epoch write must land
+        // together, or a crash between them could leave a matching epoch over stale
+        // intervals and silently skip data, so reset atomically.
+        self.intervals.reset_peer(overlay, epoch)
+    }
+
+    /// Drive one bin from its persisted interval upward until caught up.
+    async fn sync_bin(&mut self, target: &SyncTarget, bin: Bin) {
+        loop {
+            let start = match self.intervals.interval(&target.overlay, bin) {
+                Ok(start) => start,
+                Err(e) => {
+                    warn!(overlay = %target.overlay, error = %e, "puller interval read failed");
+                    return;
+                }
+            };
+
+            self.control.sync_range(target.peer, bin, start);
+
+            let (topmost, chunks) = match self.await_range(target.peer, bin).await {
+                Some(page) => page,
+                None => return,
+            };
+
+            let mut rejected = false;
+            for chunk in chunks {
+                match self.verifier.verify(&chunk) {
+                    Ok(()) => {
+                        if let Err(e) = self.admit.admit(chunk) {
+                            warn!(overlay = %target.overlay, error = %e, "puller reserve admit failed");
+                        }
+                    }
+                    Err(e) => {
+                        // A rejected chunk taints the whole offer: do not advance
+                        // past it, or the unverified span is skipped forever.
+                        rejected = true;
+                        debug!(overlay = %target.overlay, reason = <&'static str>::from(&e), "puller rejected chunk");
+                    }
+                }
+            }
+
+            // A tainted page does not advance the interval; stop tailing this bin
+            // so the same start is retried on a later pass rather than spun on now.
+            if rejected {
+                return;
+            }
+
+            // Caught up: the offer covered nothing past the resume point.
+            if topmost <= start {
+                return;
+            }
+
+            if let Err(e) = self.intervals.set_interval(&target.overlay, bin, topmost) {
+                warn!(overlay = %target.overlay, error = %e, "puller interval write failed");
+                return;
+            }
+        }
+    }
+
+    /// Drain the event stream until this peer's range page for `bin` answers,
+    /// returning `(topmost, chunks)`. `None` abandons this peer: it failed, the
+    /// deadline elapsed, or the stream closed.
+    async fn await_range(
+        &mut self,
+        peer: PeerId,
+        bin: Bin,
+    ) -> Option<(u64, Vec<vertex_swarm_primitives::StampedChunk>)> {
+        let ceiling = self.config.peer_response_timeout;
+        let events = &mut self.events;
+        let drained = async {
+            loop {
+                match events.recv().await? {
+                    PullsyncEvent::RangeDelivered {
+                        peer: p,
+                        bin: b,
+                        topmost,
+                        chunks,
+                    } if p == peer && b == bin => return Some((topmost, chunks)),
+                    PullsyncEvent::Failed { peer: p, failure } if p == peer => {
+                        debug!(%peer, %failure, "puller range exchange failed");
+                        return None;
+                    }
+                    _ => continue,
+                }
+            }
+        };
+        match time::timeout(ceiling, drained).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                warn!(%peer, %bin, "puller range exchange timed out, abandoning peer");
+                None
+            }
+        }
+    }
+}
+
+/// Cloneable handle to the puller's event sender, for the node bridge to feed
+/// [`PullsyncEvent`]s in.
+#[derive(Clone)]
+pub struct PullerHandle {
+    events: mpsc::Sender<PullsyncEvent>,
+}
+
+impl PullerHandle {
+    /// Forward a behaviour event into the running puller.
+    ///
+    /// `Err` carries the rejected event back (channel full or the puller gone),
+    /// boxed because the variant is large.
+    pub fn deliver(
+        &self,
+        event: PullsyncEvent,
+    ) -> Result<(), Box<mpsc::error::TrySendError<PullsyncEvent>>> {
+        self.events.try_send(event).map_err(Box::new)
+    }
+}
+
+/// Default event-channel capacity.
+pub const DEFAULT_EVENT_CAPACITY: usize = 256;
+
+impl<C, S, V, A, G, N> SpawnableTask for Puller<C, PullsyncEvent, S, V, A, G, N>
+where
+    C: PullsyncControl + 'static,
+    S: IntervalStore + 'static,
+    V: PullChunkVerifier + 'static,
+    A: ReserveAdmit + 'static,
+    G: ReadinessGate + Send + 'static,
+    N: NeighbourSource + 'static,
+{
+    fn into_task(
+        self,
+        shutdown: GracefulShutdown,
+    ) -> impl std::future::Future<Output = ()> + MaybeSend {
+        self.run(shutdown)
+    }
+}
+
+/// A constructed [`Puller`] paired with the handle the node bridge feeds events
+/// through.
+pub type BuiltPuller<C, S, V, A, G, N> = (Puller<C, PullsyncEvent, S, V, A, G, N>, PullerHandle);
+
+/// Build a puller plus its event handle, wiring an mpsc channel of the given
+/// capacity between the node bridge and the loop.
+pub fn build_puller<C, S, V, A, G, N>(
+    seams: PullerSeams<C, S, V, A, G, N>,
+    config: PullerConfig,
+    event_capacity: usize,
+) -> BuiltPuller<C, S, V, A, G, N>
+where
+    C: PullsyncControl,
+    S: IntervalStore,
+    V: PullChunkVerifier,
+    A: ReserveAdmit,
+    G: ReadinessGate,
+    N: NeighbourSource,
+{
+    let (events_tx, events_rx) = mpsc::channel(event_capacity);
+    let puller = Puller::new(seams, events_rx, config);
+    (puller, PullerHandle { events: events_tx })
+}
+
+/// Spawn the puller as a graceful-shutdown service, returning its event handle.
+pub fn spawn_puller<C, S, V, A, G, N>(
+    executor: &vertex_tasks::TaskExecutor,
+    seams: PullerSeams<C, S, V, A, G, N>,
+    config: PullerConfig,
+) -> PullerHandle
+where
+    C: PullsyncControl + 'static,
+    S: IntervalStore + 'static,
+    V: PullChunkVerifier + 'static,
+    A: ReserveAdmit + 'static,
+    G: ReadinessGate + Send + 'static,
+    N: NeighbourSource + 'static,
+{
+    let (puller, handle) = build_puller(seams, config, DEFAULT_EVENT_CAPACITY);
+    executor.spawn_service("swarm.puller", puller);
+    handle
+}

--- a/crates/swarm/puller/src/verifier.rs
+++ b/crates/swarm/puller/src/verifier.rs
@@ -1,0 +1,53 @@
+//! Interim signature-only [`PullChunkVerifier`].
+//!
+//! Recovers the stamp signer over the chunk address, proving the stamp signature
+//! is well-formed and bound to the chunk. The full check also resolves the batch
+//! and confirms on-chain funding; that plugs in once the batch-store verifier
+//! lands. Until then this admits any structurally-sound, correctly-signed chunk.
+
+use vertex_swarm_api::{PullChunkVerifier, VerifyError};
+use vertex_swarm_primitives::StampedChunk;
+
+/// Signature-only verifier: recovers the stamp signer over the chunk address.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SignatureVerifier;
+
+impl PullChunkVerifier for SignatureVerifier {
+    fn verify(&self, chunk: &StampedChunk) -> Result<(), VerifyError> {
+        chunk
+            .stamp()
+            .recover_signer(chunk.address())
+            .map(|_| ())
+            .map_err(|_| VerifyError::InvalidSignature)
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions over known-bounds fixtures"
+)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+    use nectar_postage::Stamp;
+    use nectar_primitives::ContentChunk;
+    use vertex_swarm_primitives::StampedChunk;
+
+    /// A stamp whose signature does not recover to a valid signer (zeroed sig).
+    fn unsigned_chunk() -> StampedChunk {
+        let chunk = ContentChunk::new(&b"verify-test"[..]).unwrap();
+        let mut raw = [0u8; 65];
+        raw[64] = 27;
+        let sig = alloy_primitives::Signature::try_from(&raw[..]).unwrap();
+        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        StampedChunk::new(chunk.into(), stamp)
+    }
+
+    #[test]
+    fn malformed_signature_is_rejected() {
+        // A zero signature recovers no signer; the verifier rejects it.
+        let err = SignatureVerifier.verify(&unsigned_chunk()).unwrap_err();
+        assert!(matches!(err, VerifyError::InvalidSignature));
+    }
+}

--- a/crates/swarm/puller/tests/loop.rs
+++ b/crates/swarm/puller/tests/loop.rs
@@ -1,0 +1,430 @@
+//! Deterministic unit tests for the puller loop against mock seams.
+//!
+//! No real time, topology, or network: the event channel is pre-seeded with the
+//! scripted behaviour responses and a single `sync_pass` is driven directly, so
+//! the readiness gate and tail backoff are out of scope.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use alloy_primitives::{B256, Signature};
+use libp2p::PeerId;
+use nectar_postage::Stamp;
+use nectar_primitives::ContentChunk;
+use tokio::sync::mpsc;
+use vertex_swarm_api::{IntervalStore, PullChunkVerifier, SwarmResult, VerifyError};
+use vertex_swarm_primitives::{Bin, OverlayAddress, StampedChunk};
+use vertex_swarm_puller::{
+    NeighbourSource, Puller, PullerConfig, PullerSeams, PullsyncControl, PullsyncEvent,
+    ReserveAdmit, SyncTarget,
+};
+
+// The readiness gate is exercised by `run`, not `sync_pass`; these tests drive
+// one deterministic pass directly, so a unit gate stands in.
+struct NoGate;
+impl vertex_swarm_puller::ReadinessGate for NoGate {
+    fn wait_ready(&self) -> impl std::future::Future<Output = ()> + Send {
+        std::future::ready(())
+    }
+}
+
+// ---- mock seams ----
+
+// Each mock is a `Clone` newtype over shared state, so the trait impl is on a
+// local type (no orphan-rule violation from impl-on-`Arc`).
+
+#[derive(Clone, Default)]
+struct MockControl {
+    fetched: Arc<Mutex<Vec<PeerId>>>,
+    ranges: Arc<Mutex<Vec<(PeerId, Bin, u64)>>>,
+}
+
+impl PullsyncControl for MockControl {
+    fn fetch_cursors(&self, peer: PeerId) {
+        self.fetched.lock().unwrap().push(peer);
+    }
+
+    fn sync_range(&self, peer: PeerId, bin: Bin, start: u64) {
+        self.ranges.lock().unwrap().push((peer, bin, start));
+    }
+}
+
+/// In-memory [`IntervalStore`].
+#[derive(Clone, Default)]
+struct MockIntervals {
+    intervals: Arc<Mutex<std::collections::HashMap<(OverlayAddress, u8), u64>>>,
+    epochs: Arc<Mutex<std::collections::HashMap<OverlayAddress, u64>>>,
+}
+
+impl IntervalStore for MockIntervals {
+    fn interval(&self, peer: &OverlayAddress, bin: Bin) -> SwarmResult<u64> {
+        Ok(self
+            .intervals
+            .lock()
+            .unwrap()
+            .get(&(*peer, bin.get()))
+            .copied()
+            .unwrap_or(0))
+    }
+
+    fn set_interval(&self, peer: &OverlayAddress, bin: Bin, binid: u64) -> SwarmResult<()> {
+        self.intervals
+            .lock()
+            .unwrap()
+            .insert((*peer, bin.get()), binid);
+        Ok(())
+    }
+
+    fn peer_epoch(&self, peer: &OverlayAddress) -> SwarmResult<Option<u64>> {
+        Ok(self.epochs.lock().unwrap().get(peer).copied())
+    }
+
+    fn set_peer_epoch(&self, peer: &OverlayAddress, epoch: u64) -> SwarmResult<()> {
+        self.epochs.lock().unwrap().insert(*peer, epoch);
+        Ok(())
+    }
+
+    fn reset_peer(&self, peer: &OverlayAddress, epoch: u64) -> SwarmResult<()> {
+        self.intervals.lock().unwrap().retain(|(p, _), _| p != peer);
+        self.epochs.lock().unwrap().insert(*peer, epoch);
+        Ok(())
+    }
+}
+
+/// Records every admitted chunk address.
+#[derive(Clone, Default)]
+struct MockAdmit {
+    admitted: Arc<Mutex<Vec<nectar_primitives::ChunkAddress>>>,
+}
+
+impl ReserveAdmit for MockAdmit {
+    fn admit(&self, chunk: StampedChunk) -> SwarmResult<()> {
+        self.admitted.lock().unwrap().push(*chunk.address());
+        Ok(())
+    }
+}
+
+/// Verifier with a fixed verdict for all chunks.
+#[derive(Clone, Copy)]
+struct FixedVerifier {
+    accept: bool,
+}
+
+impl PullChunkVerifier for FixedVerifier {
+    fn verify(&self, _chunk: &StampedChunk) -> Result<(), VerifyError> {
+        if self.accept {
+            Ok(())
+        } else {
+            Err(VerifyError::InvalidSignature)
+        }
+    }
+}
+
+struct OneTarget(SyncTarget);
+
+impl NeighbourSource for OneTarget {
+    fn targets(&self) -> Vec<SyncTarget> {
+        vec![self.0.clone()]
+    }
+}
+
+// ---- fixtures ----
+
+fn overlay(n: u8) -> OverlayAddress {
+    OverlayAddress::from([n; 32])
+}
+
+fn bin(n: u8) -> Bin {
+    Bin::new(n).unwrap()
+}
+
+fn stamped(seed: u8) -> StampedChunk {
+    let chunk = ContentChunk::new(vec![seed; 64]).unwrap();
+    let mut raw = [0u8; 65];
+    raw[..64].fill(1);
+    raw[64] = 27;
+    let sig = Signature::try_from(&raw[..]).unwrap();
+    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    StampedChunk::new(chunk.into(), stamp)
+}
+
+struct Harness {
+    control: MockControl,
+    intervals: MockIntervals,
+    admit: MockAdmit,
+    events_tx: mpsc::Sender<PullsyncEvent>,
+    peer: PeerId,
+    overlay: OverlayAddress,
+}
+
+/// Build a puller over the mocks and the scripted target, returning the puller
+/// (caller spawns it) and the harness handles to assert against.
+type TestPuller =
+    Puller<MockControl, PullsyncEvent, MockIntervals, FixedVerifier, MockAdmit, NoGate, OneTarget>;
+
+fn harness(accept: bool) -> (TestPuller, Harness) {
+    let control = MockControl::default();
+    let intervals = MockIntervals::default();
+    let admit = MockAdmit::default();
+    let peer = PeerId::random();
+    let ov = overlay(1);
+    let target = SyncTarget {
+        peer,
+        overlay: ov,
+        bins: vec![bin(2)],
+    };
+    let (events_tx, events_rx) = mpsc::channel(32);
+
+    let puller = Puller::new(
+        PullerSeams {
+            control: control.clone(),
+            intervals: intervals.clone(),
+            verifier: FixedVerifier { accept },
+            admit: admit.clone(),
+            readiness: NoGate,
+            neighbours: OneTarget(target),
+        },
+        events_rx,
+        PullerConfig::default(),
+    );
+
+    (
+        puller,
+        Harness {
+            control,
+            intervals,
+            admit,
+            events_tx,
+            peer,
+            overlay: ov,
+        },
+    )
+}
+
+/// Seed the scripted events, then drive exactly one pass. The final caught-up
+/// page makes the pass return without draining the channel dry.
+async fn run_pass(mut puller: TestPuller, h: &Harness, events: Vec<PullsyncEvent>) {
+    for e in events {
+        h.events_tx.send(e).await.unwrap();
+    }
+    puller.sync_pass().await;
+}
+
+// ---- tests ----
+
+#[tokio::test]
+async fn non_empty_range_syncs_verifies_admits_and_advances() {
+    let (puller, h) = harness(true);
+    let chunk = stamped(0xaa);
+    let addr = *chunk.address();
+
+    run_pass(
+        puller,
+        &h,
+        vec![
+            PullsyncEvent::CursorsReceived {
+                peer: h.peer,
+                cursors: vec![],
+                epoch: 1,
+            },
+            PullsyncEvent::RangeDelivered {
+                peer: h.peer,
+                bin: bin(2),
+                topmost: 10,
+                chunks: vec![chunk],
+            },
+            // Caught up: topmost unchanged at the new resume point.
+            PullsyncEvent::RangeDelivered {
+                peer: h.peer,
+                bin: bin(2),
+                topmost: 10,
+                chunks: vec![],
+            },
+        ],
+    )
+    .await;
+
+    assert_eq!(*h.control.fetched.lock().unwrap(), vec![h.peer]);
+    // First sync_range starts at 0, second at the advanced 10.
+    assert_eq!(
+        *h.control.ranges.lock().unwrap(),
+        vec![(h.peer, bin(2), 0), (h.peer, bin(2), 10)]
+    );
+    assert_eq!(*h.admit.admitted.lock().unwrap(), vec![addr]);
+    assert_eq!(h.intervals.interval(&h.overlay, bin(2)).unwrap(), 10);
+}
+
+#[tokio::test]
+async fn epoch_change_resets_intervals() {
+    let (puller, h) = harness(true);
+    // Pre-existing progress at a stale epoch.
+    h.intervals.set_interval(&h.overlay, bin(2), 99).unwrap();
+    h.intervals.set_peer_epoch(&h.overlay, 1).unwrap();
+
+    run_pass(
+        puller,
+        &h,
+        vec![
+            // New epoch 2 differs from the stored 1: reset before syncing.
+            PullsyncEvent::CursorsReceived {
+                peer: h.peer,
+                cursors: vec![],
+                epoch: 2,
+            },
+            // Empty page at the reset resume point: caught up immediately.
+            PullsyncEvent::RangeDelivered {
+                peer: h.peer,
+                bin: bin(2),
+                topmost: 0,
+                chunks: vec![],
+            },
+        ],
+    )
+    .await;
+
+    assert_eq!(h.intervals.peer_epoch(&h.overlay).unwrap(), Some(2));
+    // The stale interval was reset, and the first sync_range started at 0.
+    assert_eq!(h.intervals.interval(&h.overlay, bin(2)).unwrap(), 0);
+    assert_eq!(
+        h.control.ranges.lock().unwrap().first().copied(),
+        Some((h.peer, bin(2), 0))
+    );
+}
+
+#[tokio::test]
+async fn rejected_chunk_is_not_admitted_and_interval_not_advanced() {
+    let (puller, h) = harness(false);
+    let chunk = stamped(0xbb);
+
+    run_pass(
+        puller,
+        &h,
+        vec![
+            PullsyncEvent::CursorsReceived {
+                peer: h.peer,
+                cursors: vec![],
+                epoch: 1,
+            },
+            PullsyncEvent::RangeDelivered {
+                peer: h.peer,
+                bin: bin(2),
+                topmost: 10,
+                chunks: vec![chunk],
+            },
+        ],
+    )
+    .await;
+
+    // Verifier rejected: nothing admitted and the interval is not advanced, so
+    // the unverified span is retried on a later pass rather than skipped.
+    assert!(h.admit.admitted.lock().unwrap().is_empty());
+    assert_eq!(h.intervals.interval(&h.overlay, bin(2)).unwrap(), 0);
+    // Exactly one sync_range was issued (from 0); the tainted page stops the bin.
+    assert_eq!(*h.control.ranges.lock().unwrap(), vec![(h.peer, bin(2), 0)]);
+}
+
+struct TwoTargets(Vec<SyncTarget>);
+
+impl NeighbourSource for TwoTargets {
+    fn targets(&self) -> Vec<SyncTarget> {
+        self.0.clone()
+    }
+}
+
+// A silent peer (never-connected or wedged) emits no `Failed` event, so the
+// per-peer await would block the whole pass forever without the timeout. With
+// paused time tokio auto-advances to the deadline once the await parks, so the
+// pass abandons the silent first target and still processes the second.
+#[tokio::test(start_paused = true)]
+async fn silent_peer_is_abandoned_and_pass_proceeds() {
+    let control = MockControl::default();
+    let intervals = MockIntervals::default();
+    let admit = MockAdmit::default();
+
+    let silent = PeerId::random();
+    let silent_ov = overlay(1);
+    let live = PeerId::random();
+    let live_ov = overlay(2);
+
+    let targets = vec![
+        SyncTarget {
+            peer: silent,
+            overlay: silent_ov,
+            bins: vec![bin(2)],
+        },
+        SyncTarget {
+            peer: live,
+            overlay: live_ov,
+            bins: vec![bin(2)],
+        },
+    ];
+
+    let timeout = std::time::Duration::from_secs(45);
+    let (events_tx, events_rx) = mpsc::channel(32);
+    let puller = Puller::new(
+        PullerSeams {
+            control: control.clone(),
+            intervals: intervals.clone(),
+            verifier: FixedVerifier { accept: true },
+            admit: admit.clone(),
+            readiness: NoGate,
+            neighbours: TwoTargets(targets),
+        },
+        events_rx,
+        PullerConfig {
+            peer_response_timeout: timeout,
+            ..PullerConfig::default()
+        },
+    );
+
+    // The silent peer's await would discard any live-peer event already queued,
+    // so the live page is delivered only once that await has elapsed and the pass
+    // has advanced to the live peer. Driving the pass on a task lets the test body
+    // step the paused clock past the silent peer's deadline first.
+    let mut puller = puller;
+    let handle = tokio::spawn(async move {
+        puller.sync_pass().await;
+        puller
+    });
+
+    // Let the silent peer's await park, then elapse its deadline.
+    tokio::time::sleep(timeout + std::time::Duration::from_secs(1)).await;
+
+    // The pass is now awaiting the live peer; deliver its cursor and caught-up page.
+    events_tx
+        .send(PullsyncEvent::CursorsReceived {
+            peer: live,
+            cursors: vec![],
+            epoch: 1,
+        })
+        .await
+        .unwrap();
+    events_tx
+        .send(PullsyncEvent::RangeDelivered {
+            peer: live,
+            bin: bin(2),
+            topmost: 0,
+            chunks: vec![],
+        })
+        .await
+        .unwrap();
+
+    handle.await.unwrap();
+
+    // Both peers had cursors fetched: the pass did not wedge on the silent one.
+    assert_eq!(
+        *control.fetched.lock().unwrap(),
+        vec![silent, live],
+        "the pass must reach the second target after abandoning the first"
+    );
+    // The silent peer advanced no interval and issued no range; the live peer was
+    // synced through to its caught-up page.
+    assert_eq!(intervals.interval(&silent_ov, bin(2)).unwrap(), 0);
+    assert!(intervals.peer_epoch(&silent_ov).unwrap().is_none());
+    assert_eq!(
+        *control.ranges.lock().unwrap(),
+        vec![(live, bin(2), 0)],
+        "only the live peer drove a range exchange"
+    );
+}

--- a/crates/swarm/storer/src/db_intervals.rs
+++ b/crates/swarm/storer/src/db_intervals.rs
@@ -1,0 +1,222 @@
+//! Persisting [`IntervalStore`] for the pull-sync service over the
+//! vertex-storage `Database`.
+//!
+//! Two tables track per-peer sync progress: a `(peer, bin) -> binid` interval
+//! table and a `peer -> epoch` table. The compound interval key is big-endian
+//! `[peer: 32][bin: 1]`, so a peer's bins are a contiguous, bin-ascending range.
+
+use std::sync::Arc;
+
+use nectar_primitives::Bin;
+use vertex_storage::{Database, DatabaseError, DbTx, DbTxMut, Decode, Encode, Table, table};
+use vertex_swarm_api::{IntervalStore, SwarmError, SwarmResult};
+use vertex_swarm_primitives::OverlayAddress;
+
+// Per-(peer, bin) interval cursor: the last synced insertion sequence.
+table!(pub(crate) Interval, "puller_interval", PeerBinKey, u64, compressed = false);
+
+// Per-peer reserve epoch last seen, to detect a reserve wipe at the source.
+table!(pub(crate) PeerEpoch, "puller_peer_epoch", OverlayAddress, u64, compressed = false);
+
+/// Compound key `(peer, bin)` for [`Interval`].
+///
+/// Big-endian `[peer: 32][bin: 1]` (33 bytes): a peer's bins are contiguous and
+/// ascending by bin.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+pub(crate) struct PeerBinKey {
+    pub(crate) peer: OverlayAddress,
+    pub(crate) bin: u8,
+}
+
+impl PeerBinKey {
+    fn new(peer: OverlayAddress, bin: Bin) -> Self {
+        Self {
+            peer,
+            bin: bin.get(),
+        }
+    }
+}
+
+impl Encode for PeerBinKey {
+    type Encoded = [u8; 33];
+
+    fn encode(self) -> Self::Encoded {
+        let mut out = [0u8; 33];
+        out[..32].copy_from_slice(self.peer.as_slice());
+        out[32] = self.bin;
+        out
+    }
+}
+
+impl Decode for PeerBinKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        let bytes: [u8; 33] = value.try_into().map_err(|_| DatabaseError::Decode)?;
+        let peer: [u8; 32] = bytes[..32].try_into().map_err(|_| DatabaseError::Decode)?;
+        Ok(Self {
+            peer: OverlayAddress::from(peer),
+            bin: bytes[32],
+        })
+    }
+}
+
+/// Persisting interval store backing the pull-sync resume point.
+pub struct DbIntervalStore<DB: Database> {
+    db: Arc<DB>,
+}
+
+impl<DB: Database> DbIntervalStore<DB> {
+    /// Open the interval store, ensuring both tables exist.
+    pub fn new(db: Arc<DB>) -> Result<Self, DatabaseError> {
+        db.update(|tx| {
+            tx.ensure_table(Interval::NAME)?;
+            tx.ensure_table(PeerEpoch::NAME)
+        })?;
+        Ok(Self { db })
+    }
+}
+
+fn storage_err(err: DatabaseError) -> SwarmError {
+    SwarmError::storage(err)
+}
+
+impl<DB: Database> IntervalStore for DbIntervalStore<DB> {
+    fn interval(&self, peer: &OverlayAddress, bin: Bin) -> SwarmResult<u64> {
+        Ok(self
+            .db
+            .view(|tx| tx.get::<Interval>(PeerBinKey::new(*peer, bin)))
+            .map_err(storage_err)?
+            .unwrap_or(0))
+    }
+
+    fn set_interval(&self, peer: &OverlayAddress, bin: Bin, binid: u64) -> SwarmResult<()> {
+        self.db
+            .update(|tx| tx.put::<Interval>(PeerBinKey::new(*peer, bin), binid))
+            .map_err(storage_err)
+    }
+
+    fn peer_epoch(&self, peer: &OverlayAddress) -> SwarmResult<Option<u64>> {
+        self.db
+            .view(|tx| tx.get::<PeerEpoch>(*peer))
+            .map_err(storage_err)
+    }
+
+    fn set_peer_epoch(&self, peer: &OverlayAddress, epoch: u64) -> SwarmResult<()> {
+        self.db
+            .update(|tx| tx.put::<PeerEpoch>(*peer, epoch))
+            .map_err(storage_err)
+    }
+
+    fn reset_peer(&self, peer: &OverlayAddress, epoch: u64) -> SwarmResult<()> {
+        self.db
+            .update(|tx| {
+                // The `[peer: 32][bin: 1]` key makes this peer's bins the contiguous
+                // run `[peer][0x00..=0xFF]`, so deleting that range clears exactly
+                // its intervals and never bleeds into an adjacent peer. Absent keys
+                // already read as 0, so a delete is equivalent to zeroing.
+                for bin in 0u8..=u8::MAX {
+                    tx.delete::<Interval>(PeerBinKey { peer: *peer, bin })?;
+                }
+                // Epoch last and in the same tx: it is the commit barrier the puller
+                // checks, so it must never become visible before the interval clear.
+                tx.put::<PeerEpoch>(*peer, epoch)
+            })
+            .map_err(storage_err)
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test assertions over known-bounds fixtures"
+)]
+mod tests {
+    use super::*;
+    use vertex_storage_redb::RedbDatabase;
+
+    fn peer(n: u8) -> OverlayAddress {
+        OverlayAddress::from([n; 32])
+    }
+
+    fn bin(n: u8) -> Bin {
+        Bin::new(n).unwrap()
+    }
+
+    fn store() -> DbIntervalStore<RedbDatabase> {
+        DbIntervalStore::new(RedbDatabase::in_memory().unwrap().into_arc()).unwrap()
+    }
+
+    #[test]
+    fn unseen_interval_is_zero() {
+        let s = store();
+        assert_eq!(s.interval(&peer(1), bin(3)).unwrap(), 0);
+    }
+
+    #[test]
+    fn interval_round_trips_per_peer_and_bin() {
+        let s = store();
+        s.set_interval(&peer(1), bin(3), 42).unwrap();
+        s.set_interval(&peer(1), bin(4), 7).unwrap();
+        s.set_interval(&peer(2), bin(3), 99).unwrap();
+
+        assert_eq!(s.interval(&peer(1), bin(3)).unwrap(), 42);
+        assert_eq!(s.interval(&peer(1), bin(4)).unwrap(), 7);
+        assert_eq!(s.interval(&peer(2), bin(3)).unwrap(), 99);
+        // A bin never written stays at zero for that peer.
+        assert_eq!(s.interval(&peer(2), bin(4)).unwrap(), 0);
+    }
+
+    #[test]
+    fn peer_epoch_round_trips() {
+        let s = store();
+        assert_eq!(s.peer_epoch(&peer(1)).unwrap(), None);
+        s.set_peer_epoch(&peer(1), 5).unwrap();
+        assert_eq!(s.peer_epoch(&peer(1)).unwrap(), Some(5));
+        s.set_peer_epoch(&peer(1), 6).unwrap();
+        assert_eq!(s.peer_epoch(&peer(1)).unwrap(), Some(6));
+    }
+
+    #[test]
+    fn intervals_survive_reopen() {
+        let db = RedbDatabase::in_memory().unwrap().into_arc();
+        DbIntervalStore::new(Arc::clone(&db))
+            .unwrap()
+            .set_interval(&peer(1), bin(3), 42)
+            .unwrap();
+        let reopened = DbIntervalStore::new(db).unwrap();
+        assert_eq!(reopened.interval(&peer(1), bin(3)).unwrap(), 42);
+    }
+
+    #[test]
+    fn reset_peer_clears_all_bins_sets_epoch_and_spares_neighbours() {
+        let s = store();
+
+        // Two peers whose 32-byte overlays are adjacent (differ only in the last
+        // byte), so their `[peer][bin]` key ranges immediately abut: a range
+        // delete that bled past the 32-byte boundary would corrupt the neighbour.
+        let target = OverlayAddress::from([0u8; 32]);
+        let mut neighbour_bytes = [0u8; 32];
+        neighbour_bytes[31] = 1;
+        let neighbour = OverlayAddress::from(neighbour_bytes);
+
+        for b in [bin(0), bin(3), bin(31)] {
+            s.set_interval(&target, b, 100).unwrap();
+            s.set_interval(&neighbour, b, 200).unwrap();
+        }
+        s.set_peer_epoch(&target, 5).unwrap();
+
+        s.reset_peer(&target, 9).unwrap();
+
+        // Every bin for the target is back to zero and the new epoch is recorded.
+        for b in [bin(0), bin(3), bin(31)] {
+            assert_eq!(s.interval(&target, b).unwrap(), 0);
+        }
+        assert_eq!(s.peer_epoch(&target).unwrap(), Some(9));
+
+        // The boundary-adjacent neighbour is untouched.
+        for b in [bin(0), bin(3), bin(31)] {
+            assert_eq!(s.interval(&neighbour, b).unwrap(), 200);
+        }
+    }
+}

--- a/crates/swarm/storer/src/lib.rs
+++ b/crates/swarm/storer/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod cache;
+mod db_intervals;
 mod db_reserve;
 mod db_store;
 mod error;
@@ -17,6 +18,7 @@ mod reserve;
 mod traits;
 
 pub use cache::ChunkCache;
+pub use db_intervals::DbIntervalStore;
 pub use db_reserve::DbReserve;
 pub use db_store::DbChunkStore;
 pub use error::StorerError;


### PR DESCRIPTION
## What

Add `vertex-swarm-puller`: the readiness-gated background service that pull-syncs the neighbourhood into the storer reserve. The loop fetches a neighbour's cursors, resets that peer's intervals on a reserve-epoch change, drives `sync_range` from the persisted interval upward, verifies each delivered chunk, admits accepted chunks to the reserve, and advances the persisted interval; it live-tails with a bounded backoff once caught up.

It is decoupled from the node swarm loop via seams (`PullsyncControl`, a `PullsyncEvent` receiver, `ReserveAdmit`, `ReadinessGate`, `NeighbourSource`) that a later integration step bridges to `PullsyncBehaviour` and `TopologyHandle`. Also adds the DB-backed `DbIntervalStore` (in `vertex-swarm-storer`) and an interim signature-only `PullChunkVerifier` (on-chain batch funding plugs into the seam later).

## Why

The storer fills its reserve by pulling from neighbours (#77). A verifier rejection taints the page (nothing admitted, interval not advanced) so an unverified span is retried rather than trusted.

## Testing

`cargo test -p vertex-swarm-puller -p vertex-swarm-storer`: deterministic loop tests (sync-verify-admit-advance, epoch-change resets intervals, rejected chunk not admitted and interval not advanced), plus the `DbIntervalStore` table tests. clippy/fmt clean.

## AI Assistance

Claude Code (Opus 4.8) used for implementation; adversarial QA in progress.