### PR TITLE
feat(storer): evict the furthest chunks to keep the reserve within capacity

### DIFF
--- a/crates/swarm/storer/src/db_reserve/consensus_spec.rs
+++ b/crates/swarm/storer/src/db_reserve/consensus_spec.rs
@@ -61,6 +61,22 @@ fn content_chunk_in_bucket0(seed: u64) -> (nectar_primitives::AnyChunk, ChunkAdd
     panic!("no bucket-0 content chunk found within the search bound");
 }
 
+/// A content chunk whose address has exactly `target_po` leading bits clear, so
+/// its proximity order to the zero overlay is `target_po`. Lets a test place
+/// chunks at chosen distances to assert furthest-first eviction.
+fn content_chunk_at_po(seed: u64, target_po: u8) -> (nectar_primitives::AnyChunk, ChunkAddress) {
+    let overlay = ChunkAddress::with_first_byte(0x00);
+    for n in 0..1_000_000u64 {
+        let payload = format!("vertex reserve po fixture {seed}/{target_po}/{n}").into_bytes();
+        let chunk = ContentChunk::new(payload).expect("valid content chunk");
+        let addr = *chunk.address();
+        if addr.proximity(&overlay).get() == target_po {
+            return (chunk.into(), addr);
+        }
+    }
+    panic!("no content chunk at proximity order {target_po} within the search bound");
+}
+
 /// Bucket is derived from the address so `validate_bucket` passes.
 fn signed_stamp(
     signer: &PrivateKeySigner,
@@ -98,6 +114,12 @@ impl Fixture {
 
     /// All batches are owned by the shared signer, with the live context persisted.
     fn with_batches(batch_ids: &[B256]) -> Self {
+        Self::with_capacity(batch_ids, 10_000)
+    }
+
+    /// As [`with_batches`](Self::with_batches), at a chosen reserve capacity so the
+    /// furthest-eviction trigger can be exercised at a small bound.
+    fn with_capacity(batch_ids: &[B256], capacity: u64) -> Self {
         let db = RedbDatabase::in_memory().unwrap().into_arc();
         let batches = DbBatchStore::new(Arc::clone(&db)).unwrap();
         let signer = signer();
@@ -115,7 +137,7 @@ impl Fixture {
             &identity,
             reserve_batches,
             AdmissionValidator::new(THRESHOLD),
-            10_000,
+            capacity,
             EvictionStrategy::NoEviction,
             StorageRadius::ZERO,
         )
@@ -680,4 +702,153 @@ fn expired_event_does_not_acknowledge_when_eviction_fails_is_skipped() {
     // retries the store removal, which a later `run` backstop also catches.
     assert_eq!(fx.reserve.count().unwrap(), 0, "eviction already applied");
     assert_eq!(fx.payload_refcnt(&addr), None);
+}
+
+// --- furthest-eviction to capacity -----------------------------------
+
+#[test]
+fn evict_to_capacity_drops_the_furthest_entries_first() {
+    // Capacity 2, three entries at distinct proximity orders. The two furthest
+    // (lowest proximity) are evicted; the closest survives.
+    let id = B256::repeat_byte(0x11);
+    let fx = Fixture::with_capacity(&[id], 2);
+    let batch_id = fx.batch_id();
+
+    let (far_chunk, far_addr) = content_chunk_at_po(1, 0); // furthest
+    let (mid_chunk, mid_addr) = content_chunk_at_po(2, 3); // middle
+    let (near_chunk, near_addr) = content_chunk_at_po(3, 9); // closest
+
+    // Distinct stamp indices so the per-bucket arbiter slots never collide.
+    fx.put(&far_chunk, &far_addr, batch_id, 0, 100).unwrap();
+    fx.put(&mid_chunk, &mid_addr, batch_id, 1, 100).unwrap();
+    fx.put(&near_chunk, &near_addr, batch_id, 2, 100).unwrap();
+    assert_eq!(
+        fx.reserve.count().unwrap(),
+        3,
+        "three entries, over capacity"
+    );
+
+    let removed = fx.reserve.evict_to_capacity().unwrap();
+    assert_eq!(removed, 1, "one entry over capacity is shed");
+    assert_eq!(fx.reserve.count().unwrap(), 2, "back within capacity");
+
+    assert!(
+        !fx.reserve.contains(&far_addr),
+        "the furthest entry is evicted"
+    );
+    assert!(
+        fx.reserve.contains(&mid_addr),
+        "the middle entry is retained"
+    );
+    assert!(
+        fx.reserve.contains(&near_addr),
+        "the closest entry is retained"
+    );
+
+    // Idempotent at capacity.
+    assert_eq!(
+        fx.reserve.evict_to_capacity().unwrap(),
+        0,
+        "no eviction when already within capacity"
+    );
+}
+
+#[test]
+fn evict_to_capacity_does_not_rewind_bin_cursors() {
+    // A bin's monotonic insertion cursor must survive eviction so a pull-sync
+    // resume point stays valid: a scan from a sequence past the evicted entry
+    // still resolves the survivor.
+    let id = B256::repeat_byte(0x11);
+    let fx = Fixture::with_capacity(&[id], 1);
+    let batch_id = fx.batch_id();
+
+    // Two entries in the same bin (same proximity order to the zero overlay), so
+    // their insertion sequences are 1 and 2 in that bin.
+    let (first_chunk, first_addr) = content_chunk_at_po(1, 5);
+    let (second_chunk, second_addr) = content_chunk_at_po(2, 5);
+    let bin = first_addr.bin(&fx.overlay);
+    assert_eq!(bin, second_addr.bin(&fx.overlay), "fixtures share a bin");
+
+    fx.put(&first_chunk, &first_addr, batch_id, 0, 100).unwrap();
+    fx.put(&second_chunk, &second_addr, batch_id, 1, 100)
+        .unwrap();
+    let cursor_before = fx.reserve.bin_cursor(bin).unwrap();
+    assert_eq!(
+        cursor_before, 2,
+        "two insertions advance the bin cursor to 2"
+    );
+
+    // Over capacity by one: the furthest (here the first by tie order) is shed.
+    let removed = fx.reserve.evict_to_capacity().unwrap();
+    assert_eq!(removed, 1);
+
+    let cursor_after = fx.reserve.bin_cursor(bin).unwrap();
+    assert_eq!(
+        cursor_after, cursor_before,
+        "the monotonic bin cursor is never rewound on eviction"
+    );
+
+    // The evicted entry's Replay row is compacted away, leaving exactly the
+    // survivor; its sequence is one of the two originally assigned (1 or 2),
+    // never renumbered, so a resume point computed before eviction stays valid.
+    let items: Vec<_> = fx
+        .reserve
+        .scan_bin_from(bin, 0)
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(items.len(), 1, "exactly the survivor's Replay row remains");
+    assert!(
+        items[0].seq == 1 || items[0].seq == 2,
+        "the survivor keeps its original sequence; no renumbering"
+    );
+    // Resuming from one past the cursor yields nothing (no new inserts), proving
+    // the cursor was not rewound below the survivor.
+    let tail: Vec<_> = fx
+        .reserve
+        .scan_bin_from(bin, cursor_after + 1)
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert!(tail.is_empty(), "no entries beyond the unchanged cursor");
+}
+
+#[test]
+fn evict_to_capacity_frees_the_body_only_on_the_last_reference() {
+    // One content address under two batches: the shared payload survives the
+    // first entry's eviction (refcnt 2 -> 1) and is freed only when the last
+    // referencing entry goes.
+    let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
+    let fx = Fixture::with_capacity(&ids, 1);
+    let (chunk, addr) = content_chunk_at_po(1, 4);
+
+    fx.put(&chunk, &addr, ids[0], 0, 100).unwrap();
+    fx.put(&chunk, &addr, ids[1], 0, 100).unwrap();
+    assert_eq!(
+        fx.reserve.count().unwrap(),
+        2,
+        "two stamped entries share a body"
+    );
+    assert_eq!(fx.payload_refcnt(&addr), Some(2));
+
+    // Capacity 1, so one of the two entries is shed; the body remains refcounted.
+    let removed = fx.reserve.evict_to_capacity().unwrap();
+    assert_eq!(removed, 1, "one entry over capacity is shed");
+    assert_eq!(fx.reserve.count().unwrap(), 1);
+    assert_eq!(
+        fx.payload_refcnt(&addr),
+        Some(1),
+        "shared body survives while another entry references it"
+    );
+    assert!(fx.reserve.contains(&addr), "body still present");
+
+    // Drop the reserve to capacity 0 by evicting the last entry directly; the
+    // body is freed only now.
+    fx.reserve.evict_furthest().unwrap();
+    assert_eq!(fx.reserve.count().unwrap(), 0);
+    assert_eq!(
+        fx.payload_refcnt(&addr),
+        None,
+        "body freed only when the last referencing entry is evicted"
+    );
 }

--- a/crates/swarm/storer/src/db_reserve/store.rs
+++ b/crates/swarm/storer/src/db_reserve/store.rs
@@ -165,6 +165,48 @@ impl<DB: Database, BS: BatchStore> DbReserve<DB, BS> {
         self.reserve.on_removed_n(removed);
         Ok(removed)
     }
+
+    /// Evict the furthest entries until the reserve is within capacity, returning
+    /// the number removed. The [`Entry`] table is proximity-major, so the furthest
+    /// entries (smallest proximity order) are its leading keys: walk forward from
+    /// the front collecting the overflow, then delete that batch atomically.
+    ///
+    /// `BinCounter` is never touched, so a pull-sync cursor resumes correctly
+    /// across the eviction.
+    pub fn evict_to_capacity(&self) -> SwarmResult<u64> {
+        let capacity = self.reserve.capacity();
+        let count = self.reserve.count();
+        let Some(overflow) = count.checked_sub(capacity).filter(|n| *n > 0) else {
+            return Ok(0);
+        };
+
+        let mut targets: Vec<EvictTarget> = Vec::with_capacity(overflow as usize);
+        {
+            let tx = self.db.tx().map_err(storage_err)?;
+            let mut cursor = tx.cursor::<Entry>().map_err(storage_err)?;
+            let mut row = cursor.first().map_err(storage_err)?;
+            while let Some((key, _)) = row {
+                targets.push(EvictTarget {
+                    batch: key.batch,
+                    stamp_hash: key.stamp_hash,
+                    addr: key.addr,
+                });
+                if targets.len() as u64 >= overflow {
+                    break;
+                }
+                row = cursor.next().map_err(storage_err)?;
+            }
+        }
+        if targets.is_empty() {
+            return Ok(0);
+        }
+        debug!(
+            overflow,
+            collected = targets.len(),
+            "evicting the furthest entries to keep the reserve within capacity"
+        );
+        self.evict_entries(&targets)
+    }
 }
 
 /// Batch-store reads on the synchronous `put` path. The typed

--- a/crates/swarm/storer/src/reserve.rs
+++ b/crates/swarm/storer/src/reserve.rs
@@ -3,6 +3,7 @@
 //! The [`Reserve`] tracks storage capacity and handles eviction
 //! when the store is full.
 
+use nectar_primitives::{ChunkAddress, ProximityOrder};
 use parking_lot::RwLock;
 use tracing::{debug, warn};
 use vertex_swarm_api::SwarmIdentity;
@@ -118,11 +119,15 @@ impl Reserve {
                 })
             }
             EvictionStrategy::EvictOldest => self.evict_oldest(store),
-            EvictionStrategy::EvictFurthest => {
-                // TODO: rank by proximity to self.overlay; for now fall back.
-                warn!("EvictFurthest not implemented, falling back to EvictOldest");
-                self.evict_oldest(store)
-            }
+            EvictionStrategy::EvictFurthest => match self.overlay {
+                Some(overlay) => self.evict_furthest(store, &overlay),
+                None => {
+                    // Furthest ranking is undefined without our overlay; fall back
+                    // to oldest rather than evict on a meaningless metric.
+                    warn!("EvictFurthest needs an overlay; falling back to EvictOldest");
+                    self.evict_oldest(store)
+                }
+            },
         }
     }
 
@@ -152,6 +157,37 @@ impl Reserve {
 
         if let Some(addr) = to_evict {
             debug!(%addr, "Evicting chunk");
+            store.delete(&addr)?;
+            self.on_removed();
+            Ok(())
+        } else {
+            // Empty but reported full; should not happen.
+            Err(StorerError::StorageFull {
+                capacity: self.capacity,
+                used: 0,
+            })
+        }
+    }
+
+    /// Evict the chunk with the lowest proximity order to `overlay`, i.e. the one
+    /// furthest from us. Ties broken by iteration order.
+    fn evict_furthest<S: ChunkStore>(
+        &self,
+        store: &S,
+        overlay: &OverlayAddress,
+    ) -> StorerResult<()> {
+        let mut furthest: Option<(ProximityOrder, ChunkAddress)> = None;
+
+        store.for_each(|addr| {
+            let po = addr.proximity(overlay);
+            if furthest.is_none_or(|(best, _)| po < best) {
+                furthest = Some((po, *addr));
+            }
+            true
+        })?;
+
+        if let Some((_, addr)) = furthest {
+            debug!(%addr, "Evicting furthest chunk");
             store.delete(&addr)?;
             self.on_removed();
             Ok(())
@@ -265,5 +301,31 @@ mod tests {
         reserve.try_reserve(&store).unwrap();
         assert!(reserve.has_room());
         assert_eq!(store.count().unwrap(), 1);
+    }
+
+    #[test]
+    fn evict_furthest_drops_the_lowest_proximity_chunk() {
+        use vertex_swarm_test_utils::MockIdentity;
+
+        // Overlay is all-zero, so 0x00.. is closest and 0x80.. (top bit set) is
+        // furthest. Furthest eviction must drop the 0x80 address and keep 0x00.
+        let identity = MockIdentity::with_first_byte(0x00);
+        let reserve =
+            Reserve::with_strategy(2, EvictionStrategy::EvictFurthest).with_identity(&identity);
+        let store = MemoryChunkStore::new();
+
+        let near = test_address(0x00);
+        let far = test_address(0x80);
+        store.put(&near, b"data").unwrap();
+        store.put(&far, b"data").unwrap();
+        reserve.on_added();
+        reserve.on_added();
+
+        assert!(!reserve.has_room());
+        reserve.try_reserve(&store).unwrap();
+
+        assert!(reserve.has_room());
+        assert!(store.contains(&near).unwrap(), "closest chunk retained");
+        assert!(!store.contains(&far).unwrap(), "furthest chunk evicted");
     }
 }


### PR DESCRIPTION
## What

Add `DbReserve::evict_to_capacity`: when the reserve exceeds capacity it walks the proximity-major `Entry` table from the front and evicts the furthest (lowest proximity order) entries until back within capacity, in one atomic transaction through the existing per-entry eviction primitive (which compacts every index row, clears the arbiter slot, and decrements the shared payload refcount). Also completes the in-memory `Reserve::EvictFurthest` strategy (rank by typed `ProximityOrder` against the node overlay, drop the lowest).

`BinCounter` is never rewound by eviction, so pull-sync cursors stay valid across eviction (hard invariant, tested).

## Why

A storer must bound its reserve; furthest-from-us chunks are the right ones to shed (part of the storer node, #75). Scope is furthest-eviction only; the redistribution/storage-incentive game is deferred.

## Testing

`cargo test -p vertex-swarm-storer`: furthest-first eviction, BinCounter-not-rewound, body-freed-only-on-last-reference, and the in-memory EvictFurthest strategy. clippy/fmt clean.

## AI Assistance

Claude Code (Opus 4.8) used for implementation and verification.