### PR TITLE
fix(swarm-puller): correlate pullsync events by request id and fail fast on unconnected neighbours

### DIFF
--- a/crates/swarm/builder/src/pullsync.rs
+++ b/crates/swarm/builder/src/pullsync.rs
@@ -45,7 +45,9 @@ impl TopologyNeighbours {
 impl NeighbourSource for TopologyNeighbours {
     fn targets(&self) -> Vec<SyncTarget> {
         let depth = self.topology.depth();
-        let bins: Vec<Bin> = neighborhood_bins(depth, Bin::MAX).collect();
+        // Scope to the routing table's deepest bin, matching `neighbors(depth)`;
+        // bins above it hold no peers, so driving ranges there wastes a pass.
+        let bins: Vec<Bin> = neighborhood_bins(depth, self.topology.max_bin()).collect();
         self.topology
             .neighbors(depth)
             .into_iter()

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -47,8 +47,16 @@ use crate::{ClientHandle, ClientService};
 /// sub-behaviour. Mirrors the `ClientCommand` path: the puller's
 /// [`PullsyncControl`] enqueues these and the swarm loop drains them.
 enum PullsyncCommand {
-    FetchCursors { peer: PeerId },
-    SyncRange { peer: PeerId, bin: Bin, start: u64 },
+    FetchCursors {
+        peer: PeerId,
+        request_id: u64,
+    },
+    SyncRange {
+        peer: PeerId,
+        request_id: u64,
+        bin: Bin,
+        start: u64,
+    },
 }
 
 /// [`PullsyncControl`] bridge: the puller's outbound command surface, sending
@@ -59,20 +67,25 @@ pub struct StorerPullsyncControl {
 }
 
 impl PullsyncControl for StorerPullsyncControl {
-    fn fetch_cursors(&self, peer: PeerId) {
+    fn fetch_cursors(&self, peer: PeerId, request_id: u64) {
         if self
             .command_tx
-            .try_send(PullsyncCommand::FetchCursors { peer })
+            .try_send(PullsyncCommand::FetchCursors { peer, request_id })
             .is_err()
         {
             metrics::counter!("swarm.pullsync.commands_dropped").increment(1);
         }
     }
 
-    fn sync_range(&self, peer: PeerId, bin: Bin, start: u64) {
+    fn sync_range(&self, peer: PeerId, request_id: u64, bin: Bin, start: u64) {
         if self
             .command_tx
-            .try_send(PullsyncCommand::SyncRange { peer, bin, start })
+            .try_send(PullsyncCommand::SyncRange {
+                peer,
+                request_id,
+                bin,
+                start,
+            })
             .is_err()
         {
             metrics::counter!("swarm.pullsync.commands_dropped").increment(1);
@@ -451,12 +464,38 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
     }
 
     fn handle_pullsync_command(&mut self, command: PullsyncCommand) {
+        let (peer, request_id) = match &command {
+            PullsyncCommand::FetchCursors { peer, request_id }
+            | PullsyncCommand::SyncRange {
+                peer, request_id, ..
+            } => (*peer, *request_id),
+        };
+
+        // A `NotifyHandler` for an unconnected peer is dropped silently, leaving
+        // the puller to wait out its full response timeout. Synthesize the
+        // failure so it abandons the target at once.
+        if !self.base.swarm.is_connected(&peer) {
+            self.route_pullsync_event(PullsyncEvent::Failed {
+                peer,
+                request_id,
+                failure: vertex_swarm_storer_behaviour::PullsyncFailure::Stream(
+                    "peer not connected".into(),
+                ),
+            });
+            return;
+        }
+
         let pullsync = &mut self.base.swarm.behaviour_mut().storer.pullsync;
         match command {
-            PullsyncCommand::FetchCursors { peer } => pullsync.fetch_cursors(peer),
-            PullsyncCommand::SyncRange { peer, bin, start } => {
-                pullsync.sync_range(peer, bin, start)
+            PullsyncCommand::FetchCursors { peer, request_id } => {
+                pullsync.fetch_cursors(peer, request_id)
             }
+            PullsyncCommand::SyncRange {
+                peer,
+                request_id,
+                bin,
+                start,
+            } => pullsync.sync_range(peer, request_id, bin, start),
         }
     }
 

--- a/crates/swarm/puller/src/seams.rs
+++ b/crates/swarm/puller/src/seams.rs
@@ -16,14 +16,15 @@ pub use vertex_swarm_storer_behaviour::PullsyncEvent;
 /// Outbound command surface the puller drives, bridged to `PullsyncBehaviour`.
 ///
 /// Each call opens an outbound substream against `peer`; its result arrives as a
-/// [`PullsyncEvent`] on the puller's event receiver.
+/// [`PullsyncEvent`] on the puller's event receiver, echoing `request_id` so the
+/// puller can discard a stale reply from a prior, timed-out command.
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait PullsyncControl: Send + Sync {
     /// Open the cursor handshake against `peer`.
-    fn fetch_cursors(&self, peer: PeerId);
+    fn fetch_cursors(&self, peer: PeerId, request_id: u64);
 
     /// Open a range exchange against `peer` for `bin` from `start`.
-    fn sync_range(&self, peer: PeerId, bin: Bin, start: u64);
+    fn sync_range(&self, peer: PeerId, request_id: u64, bin: Bin, start: u64);
 }
 
 /// Readiness gate the puller awaits before each sync pass.

--- a/crates/swarm/puller/src/service.rs
+++ b/crates/swarm/puller/src/service.rs
@@ -79,6 +79,10 @@ pub struct Puller<C, E, S, V, A, G, N> {
     readiness: G,
     neighbours: N,
     config: PullerConfig,
+    /// Monotonic id stamped on each outbound command so a late reply from a
+    /// timed-out command cannot be matched to the next command for the same
+    /// peer and bin. Local to the in-process surface; never on the wire.
+    next_request_id: u64,
 }
 
 impl<C, S, V, A, G, N> Puller<C, PullsyncEvent, S, V, A, G, N>
@@ -113,7 +117,16 @@ where
             readiness,
             neighbours,
             config,
+            next_request_id: 0,
         }
+    }
+
+    /// Next outbound command id; wraps after `u64::MAX` commands, which the
+    /// await never confuses for a stale in-flight reply.
+    fn next_request_id(&mut self) -> u64 {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1);
+        id
     }
 
     /// Run the sync loop until `shutdown` fires.
@@ -161,9 +174,10 @@ where
 
     /// Fetch a peer's cursors, reconcile its epoch, then sync each in-scope bin.
     async fn sync_peer(&mut self, target: &SyncTarget) {
-        self.control.fetch_cursors(target.peer);
+        let request_id = self.next_request_id();
+        self.control.fetch_cursors(target.peer, request_id);
 
-        let epoch = match self.await_cursors(target.peer).await {
+        let epoch = match self.await_cursors(target.peer, request_id).await {
             Some(epoch) => epoch,
             None => return,
         };
@@ -178,19 +192,29 @@ where
         }
     }
 
-    /// Drain the event stream until this peer's cursor handshake answers,
-    /// returning its advertised reserve epoch. `None` abandons this peer: it
-    /// failed, the deadline elapsed, or the stream closed.
-    async fn await_cursors(&mut self, peer: PeerId) -> Option<u64> {
+    /// Drain the event stream until this command's cursor handshake answers,
+    /// returning its advertised reserve epoch. Matching is keyed on `request_id`
+    /// so a stale reply from a prior timed-out command is discarded rather than
+    /// taken for this one. `None` abandons this peer: it failed, the deadline
+    /// elapsed, or the stream closed.
+    async fn await_cursors(&mut self, peer: PeerId, request_id: u64) -> Option<u64> {
         let ceiling = self.config.peer_response_timeout;
         let events = &mut self.events;
         let drained = async {
             loop {
                 match events.recv().await? {
-                    PullsyncEvent::CursorsReceived { peer: p, epoch, .. } if p == peer => {
+                    PullsyncEvent::CursorsReceived {
+                        request_id: id,
+                        epoch,
+                        ..
+                    } if id == request_id => {
                         return Some(epoch);
                     }
-                    PullsyncEvent::Failed { peer: p, failure } if p == peer => {
+                    PullsyncEvent::Failed {
+                        request_id: id,
+                        failure,
+                        ..
+                    } if id == request_id => {
                         debug!(%peer, %failure, "puller cursor handshake failed");
                         return None;
                     }
@@ -235,9 +259,10 @@ where
                 }
             };
 
-            self.control.sync_range(target.peer, bin, start);
+            let request_id = self.next_request_id();
+            self.control.sync_range(target.peer, request_id, bin, start);
 
-            let (topmost, chunks) = match self.await_range(target.peer, bin).await {
+            let (topmost, chunks) = match self.await_range(target.peer, request_id, bin).await {
                 Some(page) => page,
                 None => return,
             };
@@ -277,12 +302,16 @@ where
         }
     }
 
-    /// Drain the event stream until this peer's range page for `bin` answers,
-    /// returning `(topmost, chunks)`. `None` abandons this peer: it failed, the
-    /// deadline elapsed, or the stream closed.
+    /// Drain the event stream until this command's range page answers,
+    /// returning `(topmost, chunks)`. Matching is keyed on `request_id` so a
+    /// stale reply buffered from a prior timed-out command for the same peer and
+    /// bin is discarded rather than advancing the interval past undelivered
+    /// data. `None` abandons this peer: it failed, the deadline elapsed, or the
+    /// stream closed.
     async fn await_range(
         &mut self,
         peer: PeerId,
+        request_id: u64,
         bin: Bin,
     ) -> Option<(u64, Vec<vertex_swarm_primitives::StampedChunk>)> {
         let ceiling = self.config.peer_response_timeout;
@@ -291,12 +320,16 @@ where
             loop {
                 match events.recv().await? {
                     PullsyncEvent::RangeDelivered {
-                        peer: p,
-                        bin: b,
+                        request_id: id,
                         topmost,
                         chunks,
-                    } if p == peer && b == bin => return Some((topmost, chunks)),
-                    PullsyncEvent::Failed { peer: p, failure } if p == peer => {
+                        ..
+                    } if id == request_id => return Some((topmost, chunks)),
+                    PullsyncEvent::Failed {
+                        request_id: id,
+                        failure,
+                        ..
+                    } if id == request_id => {
                         debug!(%peer, %failure, "puller range exchange failed");
                         return None;
                     }

--- a/crates/swarm/puller/tests/loop.rs
+++ b/crates/swarm/puller/tests/loop.rs
@@ -38,15 +38,19 @@ impl vertex_swarm_puller::ReadinessGate for NoGate {
 struct MockControl {
     fetched: Arc<Mutex<Vec<PeerId>>>,
     ranges: Arc<Mutex<Vec<(PeerId, Bin, u64)>>>,
+    /// Request ids stamped on each `sync_range`, in issue order, so a test can
+    /// reply with the live id rather than guessing it.
+    range_ids: Arc<Mutex<Vec<u64>>>,
 }
 
 impl PullsyncControl for MockControl {
-    fn fetch_cursors(&self, peer: PeerId) {
+    fn fetch_cursors(&self, peer: PeerId, _request_id: u64) {
         self.fetched.lock().unwrap().push(peer);
     }
 
-    fn sync_range(&self, peer: PeerId, bin: Bin, start: u64) {
+    fn sync_range(&self, peer: PeerId, request_id: u64, bin: Bin, start: u64) {
         self.ranges.lock().unwrap().push((peer, bin, start));
+        self.range_ids.lock().unwrap().push(request_id);
     }
 }
 
@@ -223,13 +227,16 @@ async fn non_empty_range_syncs_verifies_admits_and_advances() {
         puller,
         &h,
         vec![
+            // Cursors take request id 0, the first command of the pass.
             PullsyncEvent::CursorsReceived {
                 peer: h.peer,
+                request_id: 0,
                 cursors: vec![],
                 epoch: 1,
             },
             PullsyncEvent::RangeDelivered {
                 peer: h.peer,
+                request_id: 1,
                 bin: bin(2),
                 topmost: 10,
                 chunks: vec![chunk],
@@ -237,6 +244,7 @@ async fn non_empty_range_syncs_verifies_admits_and_advances() {
             // Caught up: topmost unchanged at the new resume point.
             PullsyncEvent::RangeDelivered {
                 peer: h.peer,
+                request_id: 2,
                 bin: bin(2),
                 topmost: 10,
                 chunks: vec![],
@@ -269,12 +277,14 @@ async fn epoch_change_resets_intervals() {
             // New epoch 2 differs from the stored 1: reset before syncing.
             PullsyncEvent::CursorsReceived {
                 peer: h.peer,
+                request_id: 0,
                 cursors: vec![],
                 epoch: 2,
             },
             // Empty page at the reset resume point: caught up immediately.
             PullsyncEvent::RangeDelivered {
                 peer: h.peer,
+                request_id: 1,
                 bin: bin(2),
                 topmost: 0,
                 chunks: vec![],
@@ -303,11 +313,13 @@ async fn rejected_chunk_is_not_admitted_and_interval_not_advanced() {
         vec![
             PullsyncEvent::CursorsReceived {
                 peer: h.peer,
+                request_id: 0,
                 cursors: vec![],
                 epoch: 1,
             },
             PullsyncEvent::RangeDelivered {
                 peer: h.peer,
+                request_id: 1,
                 bin: bin(2),
                 topmost: 10,
                 chunks: vec![chunk],
@@ -322,6 +334,72 @@ async fn rejected_chunk_is_not_admitted_and_interval_not_advanced() {
     assert_eq!(h.intervals.interval(&h.overlay, bin(2)).unwrap(), 0);
     // Exactly one sync_range was issued (from 0); the tainted page stops the bin.
     assert_eq!(*h.control.ranges.lock().unwrap(), vec![(h.peer, bin(2), 0)]);
+}
+
+// A late reply from a prior timed-out command stays buffered in the channel. It
+// carries that command's (now stale) request id, so the next command's await
+// must skip it rather than take it for its own delivery and advance the interval
+// past data the new command has not yet received.
+#[tokio::test]
+async fn stale_range_reply_is_ignored() {
+    let (puller, h) = harness(true);
+    let chunk = stamped(0xcc);
+    let addr = *chunk.address();
+
+    run_pass(
+        puller,
+        &h,
+        vec![
+            PullsyncEvent::CursorsReceived {
+                peer: h.peer,
+                request_id: 0,
+                cursors: vec![],
+                epoch: 1,
+            },
+            // Buffered before the real reply: a stale page from a request id the
+            // current `sync_range` (id 1) never issued. Its high topmost would
+            // wrongly skip to 500 if matched on peer and bin alone.
+            PullsyncEvent::RangeDelivered {
+                peer: h.peer,
+                request_id: 99,
+                bin: bin(2),
+                topmost: 500,
+                chunks: vec![],
+            },
+            // The current command's own delivery.
+            PullsyncEvent::RangeDelivered {
+                peer: h.peer,
+                request_id: 1,
+                bin: bin(2),
+                topmost: 10,
+                chunks: vec![chunk],
+            },
+            // Caught up at the new resume point (request id 2).
+            PullsyncEvent::RangeDelivered {
+                peer: h.peer,
+                request_id: 2,
+                bin: bin(2),
+                topmost: 10,
+                chunks: vec![],
+            },
+        ],
+    )
+    .await;
+
+    // The stale page was discarded: the interval advanced only to the id-1
+    // delivery's topmost, and exactly its chunk was admitted.
+    assert_eq!(*h.admit.admitted.lock().unwrap(), vec![addr]);
+    assert_eq!(
+        h.intervals.interval(&h.overlay, bin(2)).unwrap(),
+        10,
+        "the interval advances by the new command's delivery, not the stale 500"
+    );
+    // Two range commands issued (the id-1 fetch from 0, the id-2 catch-up from
+    // 10); the stale reply triggered no extra command.
+    assert_eq!(
+        *h.control.ranges.lock().unwrap(),
+        vec![(h.peer, bin(2), 0), (h.peer, bin(2), 10)]
+    );
 }
 
 struct TwoTargets(Vec<SyncTarget>);
@@ -391,10 +469,13 @@ async fn silent_peer_is_abandoned_and_pass_proceeds() {
     // Let the silent peer's await park, then elapse its deadline.
     tokio::time::sleep(timeout + std::time::Duration::from_secs(1)).await;
 
-    // The pass is now awaiting the live peer; deliver its cursor and caught-up page.
+    // The pass is now awaiting the live peer; deliver its cursor and caught-up
+    // page. The silent peer consumed request id 0; the live peer's cursor takes
+    // id 1 and its range id 2.
     events_tx
         .send(PullsyncEvent::CursorsReceived {
             peer: live,
+            request_id: 1,
             cursors: vec![],
             epoch: 1,
         })
@@ -403,6 +484,7 @@ async fn silent_peer_is_abandoned_and_pass_proceeds() {
     events_tx
         .send(PullsyncEvent::RangeDelivered {
             peer: live,
+            request_id: 2,
             bin: bin(2),
             topmost: 0,
             chunks: vec![],

--- a/crates/swarm/storer-behaviour/src/behaviour.rs
+++ b/crates/swarm/storer-behaviour/src/behaviour.rs
@@ -33,7 +33,10 @@ const CHUNK_QUOTA: Quota = Quota::n_every(
     Duration::from_secs(1),
 );
 
-/// Events emitted by [`PullsyncBehaviour`].
+/// Events emitted by [`PullsyncBehaviour`]. `request_id` echoes the command
+/// that opened the exchange so the puller drops a stale buffered reply rather
+/// than matching it to a later command for the same peer and bin; it never
+/// crosses the wire.
 #[derive(Debug, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum PullsyncEvent {
@@ -41,6 +44,7 @@ pub enum PullsyncEvent {
     /// epoch.
     CursorsReceived {
         peer: PeerId,
+        request_id: u64,
         cursors: Vec<u64>,
         epoch: u64,
     },
@@ -48,6 +52,7 @@ pub enum PullsyncEvent {
     /// offer covered; the puller advances its cursor to it.
     RangeDelivered {
         peer: PeerId,
+        request_id: u64,
         bin: Bin,
         topmost: u64,
         chunks: Vec<StampedChunk>,
@@ -55,6 +60,7 @@ pub enum PullsyncEvent {
     /// An outbound command against `peer` failed.
     Failed {
         peer: PeerId,
+        request_id: u64,
         failure: PullsyncFailure,
     },
 }
@@ -80,22 +86,26 @@ impl PullsyncBehaviour {
     }
 
     /// Open the cursor handshake against `peer`. The peer's cursors arrive as a
-    /// [`PullsyncEvent::CursorsReceived`].
-    pub fn fetch_cursors(&mut self, peer: PeerId) {
+    /// [`PullsyncEvent::CursorsReceived`] carrying `request_id`.
+    pub fn fetch_cursors(&mut self, peer: PeerId, request_id: u64) {
         self.events.push_back(ToSwarm::NotifyHandler {
             peer_id: peer,
             handler: NotifyHandler::Any,
-            event: PullsyncCommand::FetchCursors,
+            event: PullsyncCommand::FetchCursors { request_id },
         });
     }
 
     /// Open a range exchange against `peer` for `bin` from `start`. The selected
-    /// chunks arrive as a [`PullsyncEvent::RangeDelivered`].
-    pub fn sync_range(&mut self, peer: PeerId, bin: Bin, start: u64) {
+    /// chunks arrive as a [`PullsyncEvent::RangeDelivered`] carrying `request_id`.
+    pub fn sync_range(&mut self, peer: PeerId, request_id: u64, bin: Bin, start: u64) {
         self.events.push_back(ToSwarm::NotifyHandler {
             peer_id: peer,
             handler: NotifyHandler::Any,
-            event: PullsyncCommand::SyncRange { bin, start },
+            event: PullsyncCommand::SyncRange {
+                request_id,
+                bin,
+                start,
+            },
         });
     }
 
@@ -151,25 +161,34 @@ impl NetworkBehaviour for PullsyncBehaviour {
         event: THandlerOutEvent<Self>,
     ) {
         let event = match event {
-            PullsyncHandlerEvent::CursorsReceived { cursors, epoch } => {
-                PullsyncEvent::CursorsReceived {
-                    peer: peer_id,
-                    cursors,
-                    epoch,
-                }
-            }
+            PullsyncHandlerEvent::CursorsReceived {
+                request_id,
+                cursors,
+                epoch,
+            } => PullsyncEvent::CursorsReceived {
+                peer: peer_id,
+                request_id,
+                cursors,
+                epoch,
+            },
             PullsyncHandlerEvent::RangeDelivered {
+                request_id,
                 bin,
                 topmost,
                 chunks,
             } => PullsyncEvent::RangeDelivered {
                 peer: peer_id,
+                request_id,
                 bin,
                 topmost,
                 chunks,
             },
-            PullsyncHandlerEvent::OutboundFailed { failure } => PullsyncEvent::Failed {
+            PullsyncHandlerEvent::OutboundFailed {
+                request_id,
+                failure,
+            } => PullsyncEvent::Failed {
                 peer: peer_id,
+                request_id,
                 failure,
             },
         };

--- a/crates/swarm/storer-behaviour/src/handler.rs
+++ b/crates/swarm/storer-behaviour/src/handler.rs
@@ -78,29 +78,43 @@ const fn nonzero(n: u32) -> NonZeroU32 {
     }
 }
 
-/// Commands from the behaviour to the handler.
+/// Commands from the behaviour to the handler. `request_id` correlates the
+/// reply event the puller awaits; it never crosses the wire.
 #[derive(Debug)]
 pub enum PullsyncCommand {
     /// Open the cursor handshake and report the peer's per-bin cursors.
-    FetchCursors,
+    FetchCursors { request_id: u64 },
     /// Open a range exchange for `bin` from `start` and collect the deliveries.
-    SyncRange { bin: Bin, start: u64 },
+    SyncRange {
+        request_id: u64,
+        bin: Bin,
+        start: u64,
+    },
 }
 
-/// Events from the handler to the behaviour.
+/// Events from the handler to the behaviour. `request_id` echoes the command
+/// that opened the exchange so the puller can drop a stale buffered reply.
 #[derive(Debug)]
 pub enum PullsyncHandlerEvent {
     /// Cursor handshake answered.
-    CursorsReceived { cursors: Vec<u64>, epoch: u64 },
+    CursorsReceived {
+        request_id: u64,
+        cursors: Vec<u64>,
+        epoch: u64,
+    },
     /// Range exchange delivered chunks for `bin`, with `topmost` the highest id
     /// the offer covered (the puller advances its cursor to it).
     RangeDelivered {
+        request_id: u64,
         bin: Bin,
         topmost: u64,
         chunks: Vec<StampedChunk>,
     },
     /// An outbound command failed.
-    OutboundFailed { failure: PullsyncFailure },
+    OutboundFailed {
+        request_id: u64,
+        failure: PullsyncFailure,
+    },
 }
 
 /// Outcome of one inbound serving future. The reply is already sent inside the
@@ -114,11 +128,15 @@ enum InboundOutcome {
 /// Outcome of one outbound range future.
 enum RangeOutcome {
     Delivered {
+        request_id: u64,
         bin: Bin,
         topmost: u64,
         chunks: Vec<StampedChunk>,
     },
-    Failed(PullsyncFailure),
+    Failed {
+        request_id: u64,
+        failure: PullsyncFailure,
+    },
 }
 
 /// Per-connection pullsync handler.
@@ -199,9 +217,10 @@ impl PullsyncHandler {
     }
 
     /// Drive a negotiated outbound range to completion.
-    fn drive_range(&mut self, bin: Bin, offer: Offer, requester: SyncRequester) {
-        self.outbound
-            .push(Box::pin(drive_range_inner(bin, offer, requester)));
+    fn drive_range(&mut self, request_id: u64, bin: Bin, offer: Offer, requester: SyncRequester) {
+        self.outbound.push(Box::pin(drive_range_inner(
+            request_id, bin, offer, requester,
+        )));
     }
 
     /// Index of the first queued command that may dispatch now. A `FetchCursors`
@@ -209,7 +228,7 @@ impl PullsyncHandler {
     fn next_dispatchable_command(&self) -> Option<usize> {
         let has_range_slot = self.outbound.len() < MAX_OUTBOUND_DRIVING;
         self.pending_commands.iter().position(|cmd| match cmd {
-            PullsyncCommand::FetchCursors => true,
+            PullsyncCommand::FetchCursors { .. } => true,
             PullsyncCommand::SyncRange { .. } => has_range_slot,
         })
     }
@@ -343,7 +362,12 @@ fn page_bin(
 /// Select every chunk in the offer, send the want, and collect the deliveries.
 /// Admission and verification belong to the puller service; the command surface
 /// wants all offered chunks so the round-trip is exercised end to end.
-async fn drive_range_inner(bin: Bin, offer: Offer, requester: SyncRequester) -> RangeOutcome {
+async fn drive_range_inner(
+    request_id: u64,
+    bin: Bin,
+    offer: Offer,
+    requester: SyncRequester,
+) -> RangeOutcome {
     let topmost = offer.topmost;
     let expected = offer.chunks.len();
 
@@ -352,11 +376,15 @@ async fn drive_range_inner(bin: Bin, offer: Offer, requester: SyncRequester) -> 
     if expected == 0 {
         return match requester.finish().await {
             Ok(()) => RangeOutcome::Delivered {
+                request_id,
                 bin,
                 topmost,
                 chunks: Vec::new(),
             },
-            Err(e) => RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
+            Err(e) => RangeOutcome::Failed {
+                request_id,
+                failure: PullsyncFailure::Stream(e.to_string()),
+            },
         };
     }
 
@@ -366,7 +394,12 @@ async fn drive_range_inner(bin: Bin, offer: Offer, requester: SyncRequester) -> 
     }
     let mut requester = match requester.send_want(Want::new(want)).await {
         Ok(r) => r,
-        Err(e) => return RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
+        Err(e) => {
+            return RangeOutcome::Failed {
+                request_id,
+                failure: PullsyncFailure::Stream(e.to_string()),
+            };
+        }
     };
 
     let mut chunks = Vec::with_capacity(expected);
@@ -376,11 +409,22 @@ async fn drive_range_inner(bin: Bin, offer: Offer, requester: SyncRequester) -> 
         match timeout(READ_TIMEOUT, requester.next_delivery()).await {
             Ok(Ok(Some(delivery))) => chunks.push(*delivery.chunk),
             Ok(Ok(None)) => break,
-            Ok(Err(e)) => return RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
-            Err(_) => return RangeOutcome::Failed(PullsyncFailure::TimedOut),
+            Ok(Err(e)) => {
+                return RangeOutcome::Failed {
+                    request_id,
+                    failure: PullsyncFailure::Stream(e.to_string()),
+                };
+            }
+            Err(_) => {
+                return RangeOutcome::Failed {
+                    request_id,
+                    failure: PullsyncFailure::TimedOut,
+                };
+            }
         }
     }
     RangeOutcome::Delivered {
+        request_id,
         bin,
         topmost,
         chunks,
@@ -426,20 +470,28 @@ impl ConnectionHandler for PullsyncHandler {
         if let Poll::Ready(Some(outcome)) = self.outbound.poll_next_unpin(cx) {
             let event = match outcome {
                 RangeOutcome::Delivered {
+                    request_id,
                     bin,
                     topmost,
                     chunks,
                 } => {
                     crate::metrics::outbound_range_delivered(chunks.len() as u64);
                     PullsyncHandlerEvent::RangeDelivered {
+                        request_id,
                         bin,
                         topmost,
                         chunks,
                     }
                 }
-                RangeOutcome::Failed(failure) => {
+                RangeOutcome::Failed {
+                    request_id,
+                    failure,
+                } => {
                     crate::metrics::outbound_failed();
-                    PullsyncHandlerEvent::OutboundFailed { failure }
+                    PullsyncHandlerEvent::OutboundFailed {
+                        request_id,
+                        failure,
+                    }
                 }
             };
             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
@@ -453,12 +505,17 @@ impl ConnectionHandler for PullsyncHandler {
             && let Some(cmd) = self.pending_commands.remove(idx)
         {
             let (protocol, info) = match cmd {
-                PullsyncCommand::FetchCursors => {
-                    (PullsyncOutboundUpgrade::Cursors, OutboundInfo::Cursors)
-                }
-                PullsyncCommand::SyncRange { bin, start } => (
+                PullsyncCommand::FetchCursors { request_id } => (
+                    PullsyncOutboundUpgrade::Cursors,
+                    OutboundInfo::Cursors { request_id },
+                ),
+                PullsyncCommand::SyncRange {
+                    request_id,
+                    bin,
+                    start,
+                } => (
                     PullsyncOutboundUpgrade::Sync(Get::new(bin, start)),
-                    OutboundInfo::Sync { bin },
+                    OutboundInfo::Sync { request_id, bin },
                 ),
             };
             return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
@@ -505,24 +562,31 @@ impl ConnectionHandler for PullsyncHandler {
                 protocol,
                 info,
             }) => match (protocol, info) {
-                (OutboundOutput::Cursors(ack), OutboundInfo::Cursors) => {
+                (OutboundOutput::Cursors(ack), OutboundInfo::Cursors { request_id }) => {
                     crate::metrics::outbound_cursors_received();
                     self.core.push_event(PullsyncHandlerEvent::CursorsReceived {
+                        request_id,
                         cursors: ack.cursors,
                         epoch: ack.epoch,
                     });
                 }
-                (OutboundOutput::Sync(offer, requester), OutboundInfo::Sync { bin }) => {
-                    self.drive_range(bin, offer, requester);
+                (
+                    OutboundOutput::Sync(offer, requester),
+                    OutboundInfo::Sync { request_id, bin },
+                ) => {
+                    self.drive_range(request_id, bin, offer, requester);
                 }
                 (_, info) => warn!(?info, "Mismatched pullsync outbound output"),
             },
 
             ConnectionEvent::DialUpgradeError(DialUpgradeError { error, info }) => {
+                let request_id = info.request_id();
                 let failure = classify(&error.to_string());
                 debug!(?info, %error, "Pullsync outbound error");
-                self.core
-                    .push_event(PullsyncHandlerEvent::OutboundFailed { failure });
+                self.core.push_event(PullsyncHandlerEvent::OutboundFailed {
+                    request_id,
+                    failure,
+                });
             }
 
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { error, .. }) => {
@@ -545,11 +609,22 @@ fn classify(error: &str) -> PullsyncFailure {
     }
 }
 
-/// Per-connection outbound open info carried alongside an outbound request.
+/// Per-connection outbound open info carried alongside an outbound request,
+/// echoing the command's `request_id` back to the puller via the reply event.
 #[derive(Debug)]
 pub enum OutboundInfo {
-    Cursors,
-    Sync { bin: Bin },
+    Cursors { request_id: u64 },
+    Sync { request_id: u64, bin: Bin },
+}
+
+impl OutboundInfo {
+    fn request_id(&self) -> u64 {
+        match self {
+            OutboundInfo::Cursors { request_id } | OutboundInfo::Sync { request_id, .. } => {
+                *request_id
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -566,16 +641,26 @@ mod tests {
         let stalled = pending::<Result<(), PullsyncFailure>>();
         let outcome = match timeout(READ_TIMEOUT, stalled).await {
             Ok(Ok(())) => RangeOutcome::Delivered {
+                request_id: 0,
                 bin: Bin::ZERO,
                 topmost: 0,
                 chunks: Vec::new(),
             },
-            Ok(Err(e)) => RangeOutcome::Failed(PullsyncFailure::Stream(e.to_string())),
-            Err(_) => RangeOutcome::Failed(PullsyncFailure::TimedOut),
+            Ok(Err(e)) => RangeOutcome::Failed {
+                request_id: 0,
+                failure: PullsyncFailure::Stream(e.to_string()),
+            },
+            Err(_) => RangeOutcome::Failed {
+                request_id: 0,
+                failure: PullsyncFailure::TimedOut,
+            },
         };
         assert!(matches!(
             outcome,
-            RangeOutcome::Failed(PullsyncFailure::TimedOut)
+            RangeOutcome::Failed {
+                failure: PullsyncFailure::TimedOut,
+                ..
+            }
         ));
     }
 }

--- a/crates/swarm/storer-behaviour/tests/composite.rs
+++ b/crates/swarm/storer-behaviour/tests/composite.rs
@@ -171,6 +171,7 @@ fn storer(storage: MockStorage) -> Swarm<StorerBehaviour> {
 fn event_routes_to_pullsync_arm() {
     let event = PullsyncEvent::CursorsReceived {
         peer: libp2p::PeerId::random(),
+        request_id: 1,
         cursors: vec![0, 1, 2],
         epoch: 7,
     };
@@ -197,7 +198,7 @@ async fn composite_routes_pullsync_range() {
     puller
         .behaviour_mut()
         .pullsync
-        .sync_range(server_peer, bin, 0);
+        .sync_range(server_peer, 1, bin, 0);
 
     let event = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
@@ -217,11 +218,13 @@ async fn composite_routes_pullsync_range() {
     match event {
         StorerBehaviourEvent::Pullsync(PullsyncEvent::RangeDelivered {
             peer,
+            request_id,
             bin: got_bin,
             topmost,
             chunks,
         }) => {
             assert_eq!(peer, server_peer);
+            assert_eq!(request_id, 1, "the reply echoes the command request id");
             assert_eq!(got_bin, bin);
             assert_eq!(topmost, 2);
             let delivered: Vec<ChunkAddress> = chunks.iter().map(|c| *c.address()).collect();

--- a/crates/swarm/storer-behaviour/tests/round_trip.rs
+++ b/crates/swarm/storer-behaviour/tests/round_trip.rs
@@ -166,7 +166,7 @@ async fn cursor_handshake_round_trips() {
     let server_peer = *server.local_peer_id();
 
     connect(&mut puller, &mut server).await;
-    puller.behaviour_mut().fetch_cursors(server_peer);
+    puller.behaviour_mut().fetch_cursors(server_peer, 1);
 
     let event = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
@@ -186,10 +186,12 @@ async fn cursor_handshake_round_trips() {
     match event {
         PullsyncEvent::CursorsReceived {
             peer,
+            request_id,
             cursors,
             epoch,
         } => {
             assert_eq!(peer, server_peer);
+            assert_eq!(request_id, 1, "the reply echoes the command request id");
             assert_eq!(epoch, 7);
             assert_eq!(cursors.len(), Bin::COUNT);
             assert_eq!(cursors.get(5), Some(&2), "bin 5 holds two entries");
@@ -209,7 +211,7 @@ async fn range_exchange_delivers_the_page() {
     let server_peer = *server.local_peer_id();
 
     connect(&mut puller, &mut server).await;
-    puller.behaviour_mut().sync_range(server_peer, bin, 0);
+    puller.behaviour_mut().sync_range(server_peer, 2, bin, 0);
 
     let event = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
@@ -229,11 +231,13 @@ async fn range_exchange_delivers_the_page() {
     match event {
         PullsyncEvent::RangeDelivered {
             peer,
+            request_id,
             bin: got_bin,
             topmost,
             chunks,
         } => {
             assert_eq!(peer, server_peer);
+            assert_eq!(request_id, 2, "the reply echoes the command request id");
             assert_eq!(got_bin, bin);
             assert_eq!(topmost, 2, "topmost covers both entries");
             assert_eq!(chunks.len(), 2, "the whole page is wanted and delivered");
@@ -256,7 +260,7 @@ async fn empty_range_completes_with_no_want() {
     let server_peer = *server.local_peer_id();
 
     connect(&mut puller, &mut server).await;
-    puller.behaviour_mut().sync_range(server_peer, bin, 0);
+    puller.behaviour_mut().sync_range(server_peer, 3, bin, 0);
 
     let event = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
@@ -276,11 +280,13 @@ async fn empty_range_completes_with_no_want() {
     match event {
         PullsyncEvent::RangeDelivered {
             peer,
+            request_id,
             bin: got_bin,
             topmost,
             chunks,
         } => {
             assert_eq!(peer, server_peer);
+            assert_eq!(request_id, 3, "the reply echoes the command request id");
             assert_eq!(got_bin, bin);
             assert_eq!(topmost, 0, "an empty range yields topmost 0, not start");
             assert!(chunks.is_empty(), "an empty range delivers no chunks");

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -299,6 +299,13 @@ impl<I: SwarmIdentity> TopologyHandle<I> {
         self.connection_registry.resolve_peer_id(overlay)
     }
 
+    /// The deepest bin the routing table tracks. The pullsync puller scopes its
+    /// neighbourhood bins to this so it never drives ranges for bins the table
+    /// cannot hold.
+    pub fn max_bin(&self) -> Bin {
+        self.routing.max_bin()
+    }
+
     /// Get agent version for a peer by PeerId.
     pub fn agent_version(&self, peer_id: &PeerId) -> Option<String> {
         self.agent_versions.read().peek(peer_id).cloned()


### PR DESCRIPTION
## What

Harden the puller bridge against three issues found in review of the storer-node integration:

- **Request-id event correlation:** a fresh monotonic `request_id` is threaded through the in-process behaviour-to-puller command/event API (NOT the on-wire protocol), and the puller matches each awaited reply on it. A late reply from a timed-out prior command is now discarded instead of being matched by the next command for the same `(peer, bin)` and advancing the interval past undelivered data.
- **Fail fast on an unconnected target:** `handle_pullsync_command` checks `is_connected` and synthesizes an immediate `Failed` event rather than dropping a `NotifyHandler` and stalling the puller for the full response timeout.
- **Bin scope:** the puller scopes its bins to the routing `max_bin()` (matching `neighbors(depth)`) instead of `Bin::MAX`, dropping wasted range round-trips for empty bins above the table max.

No on-wire bytes changed.

## Why

Follow-up hardening on the pullsync puller (#77). The request-id fix closes a silent-data-gap window; the other two trim a stall and wasted work.

## Testing

`cargo test -p vertex-swarm-puller -p vertex-swarm-storer-behaviour -p vertex-swarm-node -p vertex-swarm-builder` (adds `stale_range_reply_is_ignored`); clippy + `cargo fmt --check`; wasm `vertex-swarm-node` build.

## AI Assistance

Claude Code (Opus 4.8) used for the fixes and verification.