### PR TITLE
fix(swarm-node): treat the topology broadcast Closed as shutdown in the node run loops

### DIFF
--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -15,7 +15,7 @@ use futures::StreamExt;
 use libp2p::connection_limits;
 use libp2p::{PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
 use nectar_primitives::SwarmAddress;
-use tracing::info;
+use tracing::{info, warn};
 use vertex_swarm_api::{
     SwarmIdentity, SwarmIdentityConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
 };
@@ -202,8 +202,15 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
                     }
                 }
                 result = topo_events.recv() => {
-                    if let Ok(event) = result {
-                        self.handle_topology_event(event);
+                    match result {
+                        Ok(event) => self.handle_topology_event(event),
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            warn!(skipped, "Bootnode lagged behind topology events");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            info!("Topology event channel closed, shutting down bootnode");
+                            break;
+                        }
                     }
                 }
             }

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -289,8 +289,15 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
                 }
 
                 result = topo_events.recv() => {
-                    if let Ok(event) = result {
-                        self.handle_topology_service_event(event);
+                    match result {
+                        Ok(event) => self.handle_topology_service_event(event),
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            warn!(skipped, "Client node lagged behind topology events");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            info!("Topology event channel closed, shutting down client node");
+                            break;
+                        }
                     }
                 }
             }

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -367,8 +367,15 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
                 }
 
                 result = topo_events.recv() => {
-                    if let Ok(event) = result {
-                        self.handle_topology_service_event(event);
+                    match result {
+                        Ok(event) => self.handle_topology_service_event(event),
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            warn!(skipped, "Storer node lagged behind topology events");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            info!("Topology event channel closed, shutting down storer node");
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What

The node run-loop `select!` arm reading the topology `broadcast::Receiver` matched only `Ok(event)` and dropped every `Err`, so once the channel returned `Err(Closed)` the arm was permanently ready and busy-spun the loop. Replace it with a full match: `Ok` handles the event, `Err(Lagged)` warns and continues (lag is recoverable), `Err(Closed)` breaks (the topology sender lives for the node's lifetime, so Closed means teardown). Applied identically in the client, storer, and bootnode loops.

## Why

Closes #467. Pre-existing busy-loop surfaced during the pullsync storer-node review.

## Testing

`cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings`; `cargo test -p vertex-swarm-node` (69 + integration suites); `cargo fmt --check`.

## AI Assistance

Claude Code (Opus 4.8) used for the fix and verification.