### PR TITLE
feat(swarm-puller): report and skip neighbours that serve unverifiable chunks

### DIFF
--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -679,6 +679,11 @@ fn spawn_storer_puller(
 ) -> vertex_swarm_puller::PullerHandle {
     use vertex_swarm_puller::{PullerConfig, PullerSeams, SignatureVerifier, spawn_puller};
 
+    // The peer manager is the reporting authority: a neighbour that serves an
+    // unverifiable chunk is scored down through it, the same path accounting and
+    // the protocol handlers use.
+    let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
+
     let seams = PullerSeams {
         control,
         intervals,
@@ -688,6 +693,7 @@ fn spawn_storer_puller(
         admit: reserve as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
         readiness: crate::pullsync::TopologyReadiness::new(topology.clone()),
         neighbours: crate::pullsync::TopologyNeighbours::new(topology),
+        reporter,
     };
     spawn_puller(ctx.executor(), seams, PullerConfig::default())
 }

--- a/crates/swarm/puller/src/service.rs
+++ b/crates/swarm/puller/src/service.rs
@@ -7,18 +7,24 @@
 //! verifying and admitting each delivered chunk before advancing the interval.
 //! When caught up it backs off and re-passes (live tail).
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use libp2p::PeerId;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
-use vertex_swarm_api::{IntervalStore, PullChunkVerifier};
+use vertex_swarm_api::{
+    IntervalStore, PeerReporter, PullChunkVerifier, ReportSource, SwarmScoringEvent,
+};
 use vertex_swarm_primitives::{Bin, OverlayAddress};
 use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask, time};
 
 use crate::seams::{
     NeighbourSource, PullsyncControl, PullsyncEvent, ReadinessGate, ReserveAdmit, SyncTarget,
 };
+
+/// Reporting source stamped on puller-originated scoring events.
+const PULLSYNC_SOURCE: ReportSource = ReportSource::Protocol("pullsync");
 
 /// Backoff between sync passes once the neighbourhood is caught up.
 pub const DEFAULT_TAIL_BACKOFF: Duration = Duration::from_secs(5);
@@ -48,8 +54,8 @@ impl Default for PullerConfig {
 }
 
 /// The decoupling seams the [`Puller`] drives, bundled so the loop and its
-/// constructors take one value rather than six.
-pub struct PullerSeams<C, S, V, A, G, N> {
+/// constructors take one value rather than seven.
+pub struct PullerSeams<C, S, V, A, G, N, R> {
     /// Outbound command surface, bridged to `PullsyncBehaviour`.
     pub control: C,
     /// Per-peer interval and epoch persistence.
@@ -62,6 +68,8 @@ pub struct PullerSeams<C, S, V, A, G, N> {
     pub readiness: G,
     /// Source of neighbours and in-scope bins.
     pub neighbours: N,
+    /// Scoring sink for peers that serve unverifiable chunks.
+    pub reporter: R,
 }
 
 /// Neighbourhood pull-sync service.
@@ -70,7 +78,7 @@ pub struct PullerSeams<C, S, V, A, G, N> {
 /// mocks unchanged. The reserve epoch is read from each peer's cursor handshake;
 /// a change resets that peer's persisted intervals so a wiped or recreated source
 /// reserve is re-synced from zero.
-pub struct Puller<C, E, S, V, A, G, N> {
+pub struct Puller<C, E, S, V, A, G, N, R> {
     control: C,
     events: mpsc::Receiver<E>,
     intervals: S,
@@ -78,6 +86,7 @@ pub struct Puller<C, E, S, V, A, G, N> {
     admit: A,
     readiness: G,
     neighbours: N,
+    reporter: R,
     config: PullerConfig,
     /// Monotonic id stamped on each outbound command so a late reply from a
     /// timed-out command cannot be matched to the next command for the same
@@ -85,7 +94,7 @@ pub struct Puller<C, E, S, V, A, G, N> {
     next_request_id: u64,
 }
 
-impl<C, S, V, A, G, N> Puller<C, PullsyncEvent, S, V, A, G, N>
+impl<C, S, V, A, G, N, R> Puller<C, PullsyncEvent, S, V, A, G, N, R>
 where
     C: PullsyncControl,
     S: IntervalStore,
@@ -93,10 +102,11 @@ where
     A: ReserveAdmit,
     G: ReadinessGate,
     N: NeighbourSource,
+    R: PeerReporter,
 {
     /// Construct a puller over the decoupling seams and its event receiver.
     pub fn new(
-        seams: PullerSeams<C, S, V, A, G, N>,
+        seams: PullerSeams<C, S, V, A, G, N, R>,
         events: mpsc::Receiver<PullsyncEvent>,
         config: PullerConfig,
     ) -> Self {
@@ -107,6 +117,7 @@ where
             admit,
             readiness,
             neighbours,
+            reporter,
         } = seams;
         Self {
             control,
@@ -116,6 +127,7 @@ where
             admit,
             readiness,
             neighbours,
+            reporter,
             config,
             next_request_id: 0,
         }
@@ -164,32 +176,49 @@ where
 
     /// One sync pass: fetch and sync every current neighbour target once.
     ///
+    /// A peer that serves an unverifiable chunk is reported and added to a
+    /// per-pass skip set, so the same poison source is not re-requested for the
+    /// remainder of this pass; the next pass re-evaluates targets afresh (by
+    /// then scoring may have dropped it).
+    ///
     /// Public for deterministic testing; the live driver wraps it with the
     /// readiness gate and tail backoff in [`run`](Self::run).
     pub async fn sync_pass(&mut self) {
+        let mut rejected = HashSet::new();
         for target in self.neighbours.targets() {
-            self.sync_peer(&target).await;
+            if rejected.contains(&target.peer) {
+                continue;
+            }
+            if self.sync_peer(&target).await {
+                rejected.insert(target.peer);
+            }
         }
     }
 
     /// Fetch a peer's cursors, reconcile its epoch, then sync each in-scope bin.
-    async fn sync_peer(&mut self, target: &SyncTarget) {
+    ///
+    /// Returns `true` if a delivered chunk failed verification, so the caller
+    /// skips this peer for the rest of the pass.
+    async fn sync_peer(&mut self, target: &SyncTarget) -> bool {
         let request_id = self.next_request_id();
         self.control.fetch_cursors(target.peer, request_id);
 
         let epoch = match self.await_cursors(target.peer, request_id).await {
             Some(epoch) => epoch,
-            None => return,
+            None => return false,
         };
 
         if let Err(e) = self.reconcile_epoch(&target.overlay, epoch) {
             warn!(overlay = %target.overlay, error = %e, "puller epoch reconcile failed");
-            return;
+            return false;
         }
 
         for bin in &target.bins {
-            self.sync_bin(target, *bin).await;
+            if self.sync_bin(target, *bin).await {
+                return true;
+            }
         }
+        false
     }
 
     /// Drain the event stream until this command's cursor handshake answers,
@@ -249,13 +278,16 @@ where
     }
 
     /// Drive one bin from its persisted interval upward until caught up.
-    async fn sync_bin(&mut self, target: &SyncTarget, bin: Bin) {
+    ///
+    /// Returns `true` if a delivered chunk failed verification: the peer is
+    /// reported for invalid data and skipped for the rest of the pass.
+    async fn sync_bin(&mut self, target: &SyncTarget, bin: Bin) -> bool {
         loop {
             let start = match self.intervals.interval(&target.overlay, bin) {
                 Ok(start) => start,
                 Err(e) => {
                     warn!(overlay = %target.overlay, error = %e, "puller interval read failed");
-                    return;
+                    return false;
                 }
             };
 
@@ -264,7 +296,7 @@ where
 
             let (topmost, chunks) = match self.await_range(target.peer, request_id, bin).await {
                 Some(page) => page,
-                None => return,
+                None => return false,
             };
 
             let mut rejected = false;
@@ -284,20 +316,26 @@ where
                 }
             }
 
-            // A tainted page does not advance the interval; stop tailing this bin
-            // so the same start is retried on a later pass rather than spun on now.
+            // A tainted page does not advance the interval; report the source for
+            // invalid data and stop, so the same poison peer is skipped for the
+            // rest of the pass rather than re-requested.
             if rejected {
-                return;
+                self.reporter.report_peer(
+                    &target.overlay,
+                    SwarmScoringEvent::InvalidData,
+                    PULLSYNC_SOURCE,
+                );
+                return true;
             }
 
             // Caught up: the offer covered nothing past the resume point.
             if topmost <= start {
-                return;
+                return false;
             }
 
             if let Err(e) = self.intervals.set_interval(&target.overlay, bin, topmost) {
                 warn!(overlay = %target.overlay, error = %e, "puller interval write failed");
-                return;
+                return false;
             }
         }
     }
@@ -370,7 +408,7 @@ impl PullerHandle {
 /// Default event-channel capacity.
 pub const DEFAULT_EVENT_CAPACITY: usize = 256;
 
-impl<C, S, V, A, G, N> SpawnableTask for Puller<C, PullsyncEvent, S, V, A, G, N>
+impl<C, S, V, A, G, N, R> SpawnableTask for Puller<C, PullsyncEvent, S, V, A, G, N, R>
 where
     C: PullsyncControl + 'static,
     S: IntervalStore + 'static,
@@ -378,6 +416,7 @@ where
     A: ReserveAdmit + 'static,
     G: ReadinessGate + Send + 'static,
     N: NeighbourSource + 'static,
+    R: PeerReporter + 'static,
 {
     fn into_task(
         self,
@@ -389,15 +428,16 @@ where
 
 /// A constructed [`Puller`] paired with the handle the node bridge feeds events
 /// through.
-pub type BuiltPuller<C, S, V, A, G, N> = (Puller<C, PullsyncEvent, S, V, A, G, N>, PullerHandle);
+pub type BuiltPuller<C, S, V, A, G, N, R> =
+    (Puller<C, PullsyncEvent, S, V, A, G, N, R>, PullerHandle);
 
 /// Build a puller plus its event handle, wiring an mpsc channel of the given
 /// capacity between the node bridge and the loop.
-pub fn build_puller<C, S, V, A, G, N>(
-    seams: PullerSeams<C, S, V, A, G, N>,
+pub fn build_puller<C, S, V, A, G, N, R>(
+    seams: PullerSeams<C, S, V, A, G, N, R>,
     config: PullerConfig,
     event_capacity: usize,
-) -> BuiltPuller<C, S, V, A, G, N>
+) -> BuiltPuller<C, S, V, A, G, N, R>
 where
     C: PullsyncControl,
     S: IntervalStore,
@@ -405,6 +445,7 @@ where
     A: ReserveAdmit,
     G: ReadinessGate,
     N: NeighbourSource,
+    R: PeerReporter,
 {
     let (events_tx, events_rx) = mpsc::channel(event_capacity);
     let puller = Puller::new(seams, events_rx, config);
@@ -412,9 +453,9 @@ where
 }
 
 /// Spawn the puller as a graceful-shutdown service, returning its event handle.
-pub fn spawn_puller<C, S, V, A, G, N>(
+pub fn spawn_puller<C, S, V, A, G, N, R>(
     executor: &vertex_tasks::TaskExecutor,
-    seams: PullerSeams<C, S, V, A, G, N>,
+    seams: PullerSeams<C, S, V, A, G, N, R>,
     config: PullerConfig,
 ) -> PullerHandle
 where
@@ -424,6 +465,7 @@ where
     A: ReserveAdmit + 'static,
     G: ReadinessGate + Send + 'static,
     N: NeighbourSource + 'static,
+    R: PeerReporter + 'static,
 {
     let (puller, handle) = build_puller(seams, config, DEFAULT_EVENT_CAPACITY);
     executor.spawn_service("swarm.puller", puller);

--- a/crates/swarm/puller/tests/loop.rs
+++ b/crates/swarm/puller/tests/loop.rs
@@ -13,7 +13,10 @@ use libp2p::PeerId;
 use nectar_postage::Stamp;
 use nectar_primitives::ContentChunk;
 use tokio::sync::mpsc;
-use vertex_swarm_api::{IntervalStore, PullChunkVerifier, SwarmResult, VerifyError};
+use vertex_swarm_api::{
+    IntervalStore, PeerReporter, PullChunkVerifier, ReportSource, SwarmResult, SwarmScoringEvent,
+    VerifyError,
+};
 use vertex_swarm_primitives::{Bin, OverlayAddress, StampedChunk};
 use vertex_swarm_puller::{
     NeighbourSource, Puller, PullerConfig, PullerSeams, PullsyncControl, PullsyncEvent,
@@ -109,6 +112,23 @@ impl ReserveAdmit for MockAdmit {
     }
 }
 
+/// Records every reported scoring event by reported overlay.
+#[derive(Clone, Default)]
+struct MockReporter {
+    reports: Arc<Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>>,
+}
+
+impl PeerReporter for MockReporter {
+    fn report_peer(
+        &self,
+        overlay: &OverlayAddress,
+        event: SwarmScoringEvent,
+        source: ReportSource,
+    ) {
+        self.reports.lock().unwrap().push((*overlay, event, source));
+    }
+}
+
 /// Verifier with a fixed verdict for all chunks.
 #[derive(Clone, Copy)]
 struct FixedVerifier {
@@ -157,6 +177,7 @@ struct Harness {
     control: MockControl,
     intervals: MockIntervals,
     admit: MockAdmit,
+    reporter: MockReporter,
     events_tx: mpsc::Sender<PullsyncEvent>,
     peer: PeerId,
     overlay: OverlayAddress,
@@ -164,13 +185,22 @@ struct Harness {
 
 /// Build a puller over the mocks and the scripted target, returning the puller
 /// (caller spawns it) and the harness handles to assert against.
-type TestPuller =
-    Puller<MockControl, PullsyncEvent, MockIntervals, FixedVerifier, MockAdmit, NoGate, OneTarget>;
+type TestPuller = Puller<
+    MockControl,
+    PullsyncEvent,
+    MockIntervals,
+    FixedVerifier,
+    MockAdmit,
+    NoGate,
+    OneTarget,
+    MockReporter,
+>;
 
 fn harness(accept: bool) -> (TestPuller, Harness) {
     let control = MockControl::default();
     let intervals = MockIntervals::default();
     let admit = MockAdmit::default();
+    let reporter = MockReporter::default();
     let peer = PeerId::random();
     let ov = overlay(1);
     let target = SyncTarget {
@@ -188,6 +218,7 @@ fn harness(accept: bool) -> (TestPuller, Harness) {
             admit: admit.clone(),
             readiness: NoGate,
             neighbours: OneTarget(target),
+            reporter: reporter.clone(),
         },
         events_rx,
         PullerConfig::default(),
@@ -199,6 +230,7 @@ fn harness(accept: bool) -> (TestPuller, Harness) {
             control,
             intervals,
             admit,
+            reporter,
             events_tx,
             peer,
             overlay: ov,
@@ -334,6 +366,15 @@ async fn rejected_chunk_is_not_admitted_and_interval_not_advanced() {
     assert_eq!(h.intervals.interval(&h.overlay, bin(2)).unwrap(), 0);
     // Exactly one sync_range was issued (from 0); the tainted page stops the bin.
     assert_eq!(*h.control.ranges.lock().unwrap(), vec![(h.peer, bin(2), 0)]);
+    // The serving peer's overlay was reported for invalid data through pullsync.
+    assert_eq!(
+        *h.reporter.reports.lock().unwrap(),
+        vec![(
+            h.overlay,
+            SwarmScoringEvent::InvalidData,
+            ReportSource::Protocol("pullsync")
+        )]
+    );
 }
 
 // A late reply from a prior timed-out command stays buffered in the channel. It
@@ -448,6 +489,7 @@ async fn silent_peer_is_abandoned_and_pass_proceeds() {
             admit: admit.clone(),
             readiness: NoGate,
             neighbours: TwoTargets(targets),
+            reporter: MockReporter::default(),
         },
         events_rx,
         PullerConfig {
@@ -508,5 +550,147 @@ async fn silent_peer_is_abandoned_and_pass_proceeds() {
         *control.ranges.lock().unwrap(),
         vec![(live, bin(2), 0)],
         "only the live peer drove a range exchange"
+    );
+}
+
+// Rejects only the one chunk at the poison address, so one peer's page fails
+// verification while another's passes in the same pass.
+#[derive(Clone, Copy)]
+struct AddressRejectVerifier {
+    poison: nectar_primitives::ChunkAddress,
+}
+
+impl PullChunkVerifier for AddressRejectVerifier {
+    fn verify(&self, chunk: &StampedChunk) -> Result<(), VerifyError> {
+        if *chunk.address() == self.poison {
+            Err(VerifyError::InvalidSignature)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// A neighbour that serves an unverifiable chunk is reported for invalid data and
+// skipped for the rest of the pass; a different neighbour in the same pass still
+// syncs through to its caught-up page.
+#[tokio::test]
+async fn poison_peer_is_reported_and_skipped_other_peer_syncs() {
+    let control = MockControl::default();
+    let intervals = MockIntervals::default();
+    let admit = MockAdmit::default();
+    let reporter = MockReporter::default();
+
+    let poison = PeerId::random();
+    let poison_ov = overlay(1);
+    let good = PeerId::random();
+    let good_ov = overlay(2);
+
+    let targets = vec![
+        SyncTarget {
+            peer: poison,
+            overlay: poison_ov,
+            bins: vec![bin(2)],
+        },
+        SyncTarget {
+            peer: good,
+            overlay: good_ov,
+            bins: vec![bin(2)],
+        },
+    ];
+
+    let bad_chunk = stamped(0xbb);
+    let bad_addr = *bad_chunk.address();
+    let good_chunk = stamped(0xaa);
+    let good_addr = *good_chunk.address();
+
+    let (events_tx, events_rx) = mpsc::channel(32);
+    let mut puller = Puller::new(
+        PullerSeams {
+            control: control.clone(),
+            intervals: intervals.clone(),
+            verifier: AddressRejectVerifier { poison: bad_addr },
+            admit: admit.clone(),
+            readiness: NoGate,
+            neighbours: TwoTargets(targets),
+            reporter: reporter.clone(),
+        },
+        events_rx,
+        PullerConfig::default(),
+    );
+
+    // Poison peer: cursor id 0, then a page (id 1) whose chunk fails verification.
+    // The page taints the bin, so no id-2 catch-up is issued for this peer.
+    events_tx
+        .send(PullsyncEvent::CursorsReceived {
+            peer: poison,
+            request_id: 0,
+            cursors: vec![],
+            epoch: 1,
+        })
+        .await
+        .unwrap();
+    events_tx
+        .send(PullsyncEvent::RangeDelivered {
+            peer: poison,
+            request_id: 1,
+            bin: bin(2),
+            topmost: 10,
+            chunks: vec![bad_chunk],
+        })
+        .await
+        .unwrap();
+    // Good peer: cursor id 2, a verifiable page (id 3), then a caught-up page
+    // (id 4) at the advanced resume point.
+    events_tx
+        .send(PullsyncEvent::CursorsReceived {
+            peer: good,
+            request_id: 2,
+            cursors: vec![],
+            epoch: 1,
+        })
+        .await
+        .unwrap();
+    events_tx
+        .send(PullsyncEvent::RangeDelivered {
+            peer: good,
+            request_id: 3,
+            bin: bin(2),
+            topmost: 10,
+            chunks: vec![good_chunk],
+        })
+        .await
+        .unwrap();
+    events_tx
+        .send(PullsyncEvent::RangeDelivered {
+            peer: good,
+            request_id: 4,
+            bin: bin(2),
+            topmost: 10,
+            chunks: vec![],
+        })
+        .await
+        .unwrap();
+
+    puller.sync_pass().await;
+
+    // The poison peer was reported once for invalid data through pullsync.
+    assert_eq!(
+        *reporter.reports.lock().unwrap(),
+        vec![(
+            poison_ov,
+            SwarmScoringEvent::InvalidData,
+            ReportSource::Protocol("pullsync")
+        )]
+    );
+    // It was skipped: no admit, no interval advance, exactly one range (from 0).
+    assert_eq!(intervals.interval(&poison_ov, bin(2)).unwrap(), 0);
+    // The good peer synced: its chunk admitted and its interval advanced to 10.
+    assert_eq!(*admit.admitted.lock().unwrap(), vec![good_addr]);
+    assert_eq!(intervals.interval(&good_ov, bin(2)).unwrap(), 10);
+    // The poison peer drove one range (the tainted page); the good peer drove the
+    // fetch from 0 and the catch-up from 10.
+    assert_eq!(
+        *control.ranges.lock().unwrap(),
+        vec![(poison, bin(2), 0), (good, bin(2), 0), (good, bin(2), 10)]
     );
 }


### PR DESCRIPTION
## What

When a delivered chunk fails verification, the puller now reports the serving neighbour through the existing `PeerReporter` path (`SwarmScoringEvent::InvalidData`, source `Protocol("pullsync")`, the same severe event retrieval and pushsync use for an invalid chunk) and skips that peer for the rest of the current sync pass. The next pass re-evaluates targets, by which point scoring may have dropped the peer.

The correctness invariants are unchanged: a tainted page never admits a chunk and never advances the interval; nothing unverified is trusted.

## Why

Closes #463. Without this, a single neighbour that serves one unverifiable chunk could hold a bin's cursor fixed indefinitely; now it is scored down (and eventually dropped) and skipped.

## Testing

`cargo test -p vertex-swarm-puller -p vertex-swarm-node -p vertex-swarm-builder`: a verification rejection reports the peer exactly once with the right event/source, and a poison peer is skipped while a second peer in the same pass still syncs. clippy + `cargo fmt --check`.

## AI Assistance

Claude Code (Opus 4.8) used for the implementation and verification.