### PR TITLE
feat(swarm-puller): verify on-chain batch funding before admitting pulled chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9407,6 +9407,8 @@ name = "vertex-swarm-puller"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
  "auto_impl",
  "libp2p",
  "nectar-postage",
@@ -9416,6 +9418,7 @@ dependencies = [
  "tokio",
  "tracing",
  "vertex-swarm-api",
+ "vertex-swarm-postage",
  "vertex-swarm-primitives",
  "vertex-swarm-storer-behaviour",
  "vertex-tasks",

--- a/crates/swarm/api/src/components/pullsync.rs
+++ b/crates/swarm/api/src/components/pullsync.rs
@@ -65,6 +65,19 @@ pub enum VerifyError {
     Malformed,
 }
 
+impl VerifyError {
+    /// Whether the serving peer is to blame for this rejection.
+    ///
+    /// Only [`UnknownBatch`](Self::UnknownBatch) is exempt: the chain indexer
+    /// lags pull-sync during catch-up, so a freshly pulled chunk's batch may not
+    /// be indexed locally yet. That is indexer lag, not malice, so the peer is
+    /// neither scored nor skipped and the page is retried once the batch lands.
+    /// Every other rejection is a genuinely bad stamp the peer served.
+    pub fn is_peer_blameworthy(&self) -> bool {
+        !matches!(self, Self::UnknownBatch)
+    }
+}
+
 /// Admission gate the puller runs before accepting a delivered chunk.
 ///
 /// A pluggable seam: the full check is stamp signature recovery plus on-chain

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -24,6 +24,7 @@ use vertex_swarm_node::{AccountingSettlement, BootNode, ClientNode, PeerSelector
 use vertex_swarm_peer_manager::{
     DEFAULT_TICK_INTERVAL, DbPeerSnapshotStore, PeerSnapshot, spawn_peer_manager_task,
 };
+use vertex_swarm_postage::DbBatchStore;
 use vertex_swarm_spec::{Loggable, Spec};
 use vertex_swarm_storer::DbReserve;
 use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
@@ -241,6 +242,11 @@ struct NodeStore {
     /// whose reserve is the default [`DbReserve`]. A reserve seam that is not a
     /// `DbReserve` leaves this `None`, so pullsync inbound serving is skipped.
     pullsync: Option<Arc<dyn vertex_swarm_api::PullStorage>>,
+    /// A second handle onto the reserve's batch set, carried only for the default
+    /// [`DbReserve`], so the puller's funding verifier reads the same batches the
+    /// reserve admits against. A reserve seam leaves this `None` and the puller
+    /// falls back to the signature-only verifier.
+    batches: Option<DbBatchStore<RedbDatabase>>,
 }
 
 /// A cache override supplied through the builder. With no seam the launch path
@@ -355,6 +361,7 @@ async fn build_client_backed_node(
         local: store,
         reserve,
         pullsync,
+        batches,
     } = (params.make_store)(db.clone())?;
     let node_store = Arc::clone(&store);
 
@@ -391,6 +398,7 @@ async fn build_client_backed_node(
             db.clone(),
             reserve.clone(),
             pullsync,
+            batches,
             #[cfg(feature = "swap")]
             swap_event_sender,
         )
@@ -579,6 +587,7 @@ async fn assemble_storer_node(
     db: Option<Arc<RedbDatabase>>,
     reserve: Option<Arc<dyn vertex_swarm_api::BinCursorStore>>,
     pullsync: Option<Arc<dyn vertex_swarm_api::PullStorage>>,
+    batches: Option<DbBatchStore<RedbDatabase>>,
     #[cfg(feature = "swap")] swap_event_sender: Option<
         tokio::sync::mpsc::UnboundedSender<vertex_swarm_node::SwapEvent>,
     >,
@@ -619,6 +628,7 @@ async fn assemble_storer_node(
         reserve.clone(),
         intervals,
         pullsync_control,
+        batches,
     );
     node.set_puller(puller_handle);
     let forward_topology = topology.clone();
@@ -676,8 +686,24 @@ fn spawn_storer_puller(
     reserve: Arc<dyn vertex_swarm_api::BinCursorStore>,
     intervals: Arc<vertex_swarm_storer::DbIntervalStore<RedbDatabase>>,
     control: vertex_swarm_node::StorerPullsyncControl,
+    batches: Option<DbBatchStore<RedbDatabase>>,
 ) -> vertex_swarm_puller::PullerHandle {
-    use vertex_swarm_puller::{PullerConfig, PullerSeams, SignatureVerifier, spawn_puller};
+    use vertex_swarm_api::PullChunkVerifier;
+    use vertex_swarm_postage::AdmissionValidator;
+    use vertex_swarm_puller::{
+        FundingVerifier, PullerConfig, PullerSeams, SignatureVerifier, spawn_puller,
+    };
+
+    // With the default reserve the puller verifies on-chain batch funding against
+    // the same batch set the reserve admits against; a reserve seam leaves no batch
+    // handle, so the puller falls back to the signature-only gate.
+    let verifier: Box<dyn PullChunkVerifier> = match batches {
+        Some(batches) => Box::new(FundingVerifier::new(
+            batches,
+            AdmissionValidator::new(RESERVE_CONFIRMATION_THRESHOLD),
+        )),
+        None => Box::new(SignatureVerifier),
+    };
 
     // The peer manager is the reporting authority: a neighbour that serves an
     // unverifiable chunk is scored down through it, the same path accounting and
@@ -687,7 +713,7 @@ fn spawn_storer_puller(
     let seams = PullerSeams {
         control,
         intervals,
-        verifier: SignatureVerifier,
+        verifier,
         // The reserve admits through its `SwarmLocalStore` put (the blanket
         // `ReserveAdmit` impl).
         admit: reserve as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
@@ -810,6 +836,7 @@ fn client_store_factory(
                 local: default_cache(cache_budget_bytes, soc_cache_ttl),
                 reserve: None,
                 pullsync: None,
+                batches: None,
             })
         }),
         Some(CacheSeam::Ready(local)) => Box::new(move |_db| {
@@ -817,6 +844,7 @@ fn client_store_factory(
                 local,
                 reserve: None,
                 pullsync: None,
+                batches: None,
             })
         }),
         Some(CacheSeam::Factory(factory)) => Box::new(move |db| {
@@ -824,6 +852,7 @@ fn client_store_factory(
                 local: factory(db)?,
                 reserve: None,
                 pullsync: None,
+                batches: None,
             })
         }),
     }
@@ -922,6 +951,15 @@ pub(crate) async fn build_storer(
     Ok((parts.task, providers))
 }
 
+/// The storer reserve resolved from its seam: the reserve view, the optional
+/// pullsync server snapshot, and the optional second batch-store handle (both
+/// present only for the default [`DbReserve`]).
+type ResolvedReserve = (
+    Arc<dyn vertex_swarm_api::BinCursorStore>,
+    Option<Arc<dyn vertex_swarm_api::PullStorage>>,
+    Option<DbBatchStore<RedbDatabase>>,
+);
+
 /// Resolve a storer's cache and reserve seams into the internal store factory.
 ///
 /// The reserve (pushsync ingest) is carried separately while the retrieval-serve
@@ -940,10 +978,7 @@ fn storer_store_factory(
         // The pullsync server snapshot is only available for the default
         // `DbReserve`; a reserve seam erases to `BinCursorStore`, leaving pullsync
         // inbound serving unwired for that override.
-        let (reserve, pullsync): (
-            Arc<dyn vertex_swarm_api::BinCursorStore>,
-            Option<Arc<dyn vertex_swarm_api::PullStorage>>,
-        ) = match reserve {
+        let (reserve, pullsync, batches): ResolvedReserve = match reserve {
             None => {
                 let built = build_storer_reserve(db.clone(), &identity, capacity)?;
                 (
@@ -951,10 +986,11 @@ fn storer_store_factory(
                         .reserve
                         .ok_or_else(|| SwarmNodeError::Build(STORER_RESERVE_MISSING.into()))?,
                     built.pullsync,
+                    built.batches,
                 )
             }
-            Some(ReserveSeam::Ready(reserve)) => (reserve, None),
-            Some(ReserveSeam::Factory(factory)) => (factory(db.clone())?, None),
+            Some(ReserveSeam::Ready(reserve)) => (reserve, None, None),
+            Some(ReserveSeam::Factory(factory)) => (factory(db.clone())?, None, None),
         };
         let cache: Arc<dyn vertex_swarm_api::SwarmLocalStore> = match cache {
             None => default_cache(cache_budget_bytes, soc_cache_ttl),
@@ -971,6 +1007,7 @@ fn storer_store_factory(
             local,
             reserve: Some(reserve),
             pullsync,
+            batches,
         })
     })
 }
@@ -996,7 +1033,7 @@ fn build_storer_reserve(
     capacity: u64,
 ) -> Result<NodeStore, SwarmNodeError> {
     use vertex_swarm_api::StorageRadius;
-    use vertex_swarm_postage::{AdmissionValidator, DbBatchStore};
+    use vertex_swarm_postage::AdmissionValidator;
     use vertex_swarm_storer::EvictionStrategy;
 
     let db = match db {
@@ -1009,7 +1046,8 @@ fn build_storer_reserve(
         }
     };
     // Batch store and reserve share one handle so the postage ingest seam and the
-    // reserve see a single consistent view.
+    // reserve see a single consistent view. The clone is a second handle onto the
+    // same tables, carried out for the puller's funding verifier.
     let batches =
         DbBatchStore::new(Arc::clone(&db)).map_err(|e| SwarmNodeError::Build(e.into()))?;
     let admission = AdmissionValidator::new(RESERVE_CONFIRMATION_THRESHOLD);
@@ -1017,7 +1055,7 @@ fn build_storer_reserve(
         DbReserve::new(
             db,
             identity.as_ref(),
-            batches,
+            batches.clone(),
             admission,
             capacity,
             EvictionStrategy::EvictFurthest,
@@ -1032,6 +1070,7 @@ fn build_storer_reserve(
         local: Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::SwarmLocalStore>,
         pullsync: Some(Arc::clone(&reserve) as Arc<dyn vertex_swarm_api::PullStorage>),
         reserve: Some(reserve as Arc<dyn vertex_swarm_api::BinCursorStore>),
+        batches: Some(batches),
     })
 }
 

--- a/crates/swarm/postage/src/store.rs
+++ b/crates/swarm/postage/src/store.rs
@@ -79,9 +79,21 @@ pub enum DbBatchStoreError {
 /// Batch store backed by the `vertex-storage` `Database` trait.
 ///
 /// Implements both [`BatchStore`] (persistence) and [`BatchEventHandler`]
-/// (on-chain ingest). Cheap to clone by `Arc` and thread-safe.
+/// (on-chain ingest). Cloning shares the one `Arc<DB>`, so every clone reads and
+/// writes the same tables (the reserve and the puller's funding verifier hold
+/// independent handles onto the same batch set).
 pub struct DbBatchStore<DB: Database> {
     db: Arc<DB>,
+}
+
+// Hand-written so the clone bounds only the `Arc`, not `DB` (the backend is never
+// `Clone`); a clone shares the one handle onto the same tables.
+impl<DB: Database> Clone for DbBatchStore<DB> {
+    fn clone(&self) -> Self {
+        Self {
+            db: Arc::clone(&self.db),
+        }
+    }
 }
 
 impl<DB: Database> DbBatchStore<DB> {

--- a/crates/swarm/puller/Cargo.toml
+++ b/crates/swarm/puller/Cargo.toml
@@ -14,9 +14,13 @@ workspace = true
 [dependencies]
 ## vertex
 vertex-swarm-api.workspace = true
+vertex-swarm-postage.workspace = true
 vertex-swarm-primitives.workspace = true
 vertex-swarm-storer-behaviour.workspace = true
 vertex-tasks.workspace = true
+
+## nectar (the `BatchStore` trait and postage models)
+nectar-postage.workspace = true
 
 ## p2p (PeerId only; no NetworkBehaviour or Swarm)
 libp2p.workspace = true
@@ -36,6 +40,8 @@ strum.workspace = true
 
 [dev-dependencies]
 alloy-primitives.workspace = true
+alloy-signer.workspace = true
+alloy-signer-local.workspace = true
 nectar-postage.workspace = true
 nectar-primitives.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "test-util"] }

--- a/crates/swarm/puller/src/lib.rs
+++ b/crates/swarm/puller/src/lib.rs
@@ -21,4 +21,4 @@ pub use service::{
     BuiltPuller, DEFAULT_EVENT_CAPACITY, DEFAULT_PEER_RESPONSE_TIMEOUT, DEFAULT_TAIL_BACKOFF,
     Puller, PullerConfig, PullerHandle, PullerSeams, build_puller, spawn_puller,
 };
-pub use verifier::SignatureVerifier;
+pub use verifier::{FundingVerifier, SignatureVerifier};

--- a/crates/swarm/puller/src/service.rs
+++ b/crates/swarm/puller/src/service.rs
@@ -279,8 +279,11 @@ where
 
     /// Drive one bin from its persisted interval upward until caught up.
     ///
-    /// Returns `true` if a delivered chunk failed verification: the peer is
-    /// reported for invalid data and skipped for the rest of the pass.
+    /// Returns `true` only on a peer-blameworthy rejection: that peer is reported
+    /// for invalid data and skipped for the rest of the pass. A transient
+    /// rejection (an unknown batch during catch-up) also leaves the interval
+    /// unadvanced so the page is retried on a later pass, but neither reports nor
+    /// skips the peer.
     async fn sync_bin(&mut self, target: &SyncTarget, bin: Bin) -> bool {
         loop {
             let start = match self.intervals.interval(&target.overlay, bin) {
@@ -300,6 +303,7 @@ where
             };
 
             let mut rejected = false;
+            let mut blameworthy = false;
             for chunk in chunks {
                 match self.verifier.verify(&chunk) {
                     Ok(()) => {
@@ -308,24 +312,28 @@ where
                         }
                     }
                     Err(e) => {
-                        // A rejected chunk taints the whole offer: do not advance
+                        // Any rejection taints the whole offer: do not advance
                         // past it, or the unverified span is skipped forever.
                         rejected = true;
+                        blameworthy |= e.is_peer_blameworthy();
                         debug!(overlay = %target.overlay, reason = <&'static str>::from(&e), "puller rejected chunk");
                     }
                 }
             }
 
-            // A tainted page does not advance the interval; report the source for
-            // invalid data and stop, so the same poison peer is skipped for the
-            // rest of the pass rather than re-requested.
+            // A tainted page never advances the interval. A blameworthy rejection
+            // also reports the source for invalid data and skips it for the rest
+            // of the pass; a transient one (an unknown batch the indexer has not
+            // caught up to) only stops this bin so the page is retried later.
             if rejected {
-                self.reporter.report_peer(
-                    &target.overlay,
-                    SwarmScoringEvent::InvalidData,
-                    PULLSYNC_SOURCE,
-                );
-                return true;
+                if blameworthy {
+                    self.reporter.report_peer(
+                        &target.overlay,
+                        SwarmScoringEvent::InvalidData,
+                        PULLSYNC_SOURCE,
+                    );
+                }
+                return blameworthy;
             }
 
             // Caught up: the offer covered nothing past the resume point.

--- a/crates/swarm/puller/src/verifier.rs
+++ b/crates/swarm/puller/src/verifier.rs
@@ -1,11 +1,16 @@
-//! Interim signature-only [`PullChunkVerifier`].
+//! [`PullChunkVerifier`] implementations.
 //!
-//! Recovers the stamp signer over the chunk address, proving the stamp signature
-//! is well-formed and bound to the chunk. The full check also resolves the batch
-//! and confirms on-chain funding; that plugs in once the batch-store verifier
-//! lands. Until then this admits any structurally-sound, correctly-signed chunk.
+//! [`SignatureVerifier`] is the interim signature-only gate: it proves the stamp
+//! signature is well-formed and bound to the chunk address but does not consult
+//! the batch set. [`FundingVerifier`] is the full check: it loads the stamp's
+//! batch from a [`BatchStore`] and runs the same usability, expiry, capacity and
+//! owner checks the reserve enforces on admission, so an underfunded or expired
+//! batch taints the syncing page rather than being silently dropped at the
+//! reserve put.
 
+use nectar_postage::{BatchStore, StampError};
 use vertex_swarm_api::{PullChunkVerifier, VerifyError};
+use vertex_swarm_postage::{AdmissionError, AdmissionValidator};
 use vertex_swarm_primitives::StampedChunk;
 
 /// Signature-only verifier: recovers the stamp signer over the chunk address.
@@ -22,17 +27,87 @@ impl PullChunkVerifier for SignatureVerifier {
     }
 }
 
+/// Full admission verifier: signature recovery plus on-chain batch funding.
+///
+/// Resolves the stamp's batch from `batches` (the chain-indexed postage set) and
+/// runs [`AdmissionValidator`], so a chunk stamped under an unknown, unconfirmed,
+/// expired or over-capacity batch, or signed by a non-owner, is rejected before
+/// it reaches the reserve. An unknown batch is the common case during catch-up,
+/// not an error.
+#[derive(Debug)]
+pub struct FundingVerifier<BS> {
+    batches: BS,
+    admission: AdmissionValidator,
+}
+
+impl<BS> FundingVerifier<BS> {
+    pub const fn new(batches: BS, admission: AdmissionValidator) -> Self {
+        Self { batches, admission }
+    }
+}
+
+impl<BS> PullChunkVerifier for FundingVerifier<BS>
+where
+    BS: BatchStore + Send + Sync,
+    BS::Error: Send + Sync,
+{
+    fn verify(&self, chunk: &StampedChunk) -> Result<(), VerifyError> {
+        let stamp = chunk.stamp();
+        let address = chunk.address();
+
+        let batch = self
+            .batches
+            .get(&stamp.batch())
+            .map_err(|_| VerifyError::Malformed)?
+            .ok_or(VerifyError::UnknownBatch)?;
+        let context = self.batches.context().map_err(|_| VerifyError::Malformed)?;
+
+        self.admission
+            .validate(stamp, address, &batch, &context)
+            .map_err(map_admission_error)
+    }
+}
+
+/// Map the reserve's admission taxonomy onto the puller's verify taxonomy.
+///
+/// Unusable and expired batches collapse onto `UnknownBatch` (the verifier's
+/// "not currently a fundable batch" outcome); an index or bucket overflow is the
+/// batch lacking capacity at the stamp's slot; a foreign signer is an invalid
+/// signature; everything else is structural.
+fn map_admission_error(err: AdmissionError) -> VerifyError {
+    match err {
+        AdmissionError::UnknownBatch(_)
+        | AdmissionError::BatchNotUsable
+        | AdmissionError::BatchExpired => VerifyError::UnknownBatch,
+        AdmissionError::OwnerMismatch => VerifyError::InvalidSignature,
+        AdmissionError::Stamp(StampError::InvalidIndex | StampError::BucketFull { .. }) => {
+            VerifyError::InsufficientFunding
+        }
+        AdmissionError::Stamp(StampError::InvalidSignature) => VerifyError::InvalidSignature,
+        AdmissionError::Stamp(_) => VerifyError::Malformed,
+    }
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
+    clippy::expect_used,
     reason = "test assertions over known-bounds fixtures"
 )]
 mod tests {
     use super::*;
-    use alloy_primitives::B256;
-    use nectar_postage::Stamp;
-    use nectar_primitives::ContentChunk;
+    use alloy_primitives::{Address, B256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use nectar_postage::{
+        Batch, BatchId, PostageContext, Stamp, StampDigest, StampIndex, current_timestamp,
+    };
+    use nectar_primitives::{Chunk, ContentChunk};
+    use std::collections::HashMap;
+    use std::convert::Infallible;
     use vertex_swarm_primitives::StampedChunk;
+
+    const THRESHOLD: u64 = 8;
 
     /// A stamp whose signature does not recover to a valid signer (zeroed sig).
     fn unsigned_chunk() -> StampedChunk {
@@ -48,6 +123,196 @@ mod tests {
     fn malformed_signature_is_rejected() {
         // A zero signature recovers no signer; the verifier rejects it.
         let err = SignatureVerifier.verify(&unsigned_chunk()).unwrap_err();
+        assert!(matches!(err, VerifyError::InvalidSignature));
+    }
+
+    /// In-memory `BatchStore` exposing only the two methods the funding verifier
+    /// reads; the rest are unreachable in these tests.
+    #[derive(Default)]
+    struct MockBatchStore {
+        batches: HashMap<BatchId, Batch>,
+        context: PostageContext,
+    }
+
+    impl MockBatchStore {
+        fn with_batch(mut self, batch: Batch) -> Self {
+            self.batches.insert(batch.id(), batch);
+            self
+        }
+
+        fn with_context(mut self, context: PostageContext) -> Self {
+            self.context = context;
+            self
+        }
+    }
+
+    impl BatchStore for MockBatchStore {
+        type Error = Infallible;
+
+        fn get(&self, id: &BatchId) -> Result<Option<Batch>, Self::Error> {
+            Ok(self.batches.get(id).cloned())
+        }
+
+        fn put(&self, _batch: Batch) -> Result<(), Self::Error> {
+            unreachable!("verifier never writes")
+        }
+
+        fn remove(&self, _id: &BatchId) -> Result<bool, Self::Error> {
+            unreachable!("verifier never removes")
+        }
+
+        fn contains(&self, _id: &BatchId) -> Result<bool, Self::Error> {
+            unreachable!("verifier never probes presence")
+        }
+
+        fn context(&self) -> Result<PostageContext, Self::Error> {
+            Ok(self.context)
+        }
+
+        fn set_context(&self, _state: PostageContext) -> Result<(), Self::Error> {
+            unreachable!("verifier never writes the context")
+        }
+
+        fn batch_ids(&self) -> Result<Vec<BatchId>, Self::Error> {
+            unreachable!("verifier never enumerates")
+        }
+
+        fn count(&self) -> Result<usize, Self::Error> {
+            unreachable!("verifier never counts")
+        }
+    }
+
+    fn signer() -> PrivateKeySigner {
+        PrivateKeySigner::from_bytes(&B256::repeat_byte(0x42)).expect("valid signer")
+    }
+
+    fn content_chunk() -> ContentChunk {
+        ContentChunk::new(b"funding verifier payload".to_vec()).expect("valid content chunk")
+    }
+
+    /// Batch owned by `owner`, depth 18 / bucket depth 16, with `value` funding.
+    fn batch_for(owner: Address, value: u128) -> Batch {
+        Batch::new(B256::repeat_byte(0x11), value, 0, owner, 18, 16, false)
+    }
+
+    /// Build a stamped chunk whose stamp is signed for `chunk` under `batch`,
+    /// using `index` so capacity behaviour can be exercised.
+    fn signed_chunk(
+        s: &PrivateKeySigner,
+        batch: &Batch,
+        chunk: &ContentChunk,
+        index: u32,
+    ) -> StampedChunk {
+        let address = chunk.address();
+        let bucket = batch.bucket_for_address(address);
+        let stamp_index = StampIndex::new(bucket, index);
+        let timestamp = current_timestamp();
+        let digest = StampDigest::new(*address, batch.id(), stamp_index, timestamp);
+        let sig = s
+            .sign_hash_sync(&alloy_primitives::eip191_hash_message(
+                digest.to_prehash().as_slice(),
+            ))
+            .expect("sign");
+        let stamp = Stamp::with_index(batch.id(), stamp_index, timestamp, sig);
+        StampedChunk::new(chunk.clone().into(), stamp)
+    }
+
+    fn verifier(store: MockBatchStore) -> FundingVerifier<MockBatchStore> {
+        FundingVerifier::new(store, AdmissionValidator::new(THRESHOLD))
+    }
+
+    /// A context with enough confirmations and no consumed payout.
+    fn usable_context() -> PostageContext {
+        PostageContext::new(THRESHOLD + 1, 0)
+    }
+
+    #[test]
+    fn funded_batch_admits() {
+        let s = signer();
+        let batch = batch_for(s.address(), 1_000_000);
+        let chunk = content_chunk();
+        let stamped = signed_chunk(&s, &batch, &chunk, 0);
+
+        let store = MockBatchStore::default()
+            .with_batch(batch)
+            .with_context(usable_context());
+        verifier(store)
+            .verify(&stamped)
+            .expect("funded chunk admits");
+    }
+
+    #[test]
+    fn unknown_batch_is_rejected() {
+        let s = signer();
+        // The batch is never inserted into the store.
+        let batch = batch_for(s.address(), 1_000_000);
+        let chunk = content_chunk();
+        let stamped = signed_chunk(&s, &batch, &chunk, 0);
+
+        let store = MockBatchStore::default().with_context(usable_context());
+        let err = verifier(store).verify(&stamped).unwrap_err();
+        assert!(matches!(err, VerifyError::UnknownBatch));
+    }
+
+    #[test]
+    fn expired_batch_is_rejected() {
+        let s = signer();
+        let batch = batch_for(s.address(), 1_000);
+        let chunk = content_chunk();
+        let stamped = signed_chunk(&s, &batch, &chunk, 0);
+
+        // Consumed payout exceeds the batch value: expired.
+        let store = MockBatchStore::default()
+            .with_batch(batch)
+            .with_context(PostageContext::new(THRESHOLD + 1, u128::MAX));
+        let err = verifier(store).verify(&stamped).unwrap_err();
+        assert!(matches!(err, VerifyError::UnknownBatch));
+    }
+
+    #[test]
+    fn unconfirmed_batch_is_rejected() {
+        let s = signer();
+        let batch = batch_for(s.address(), 1_000_000);
+        let chunk = content_chunk();
+        let stamped = signed_chunk(&s, &batch, &chunk, 0);
+
+        // Block below the confirmation threshold: not yet usable.
+        let store = MockBatchStore::default()
+            .with_batch(batch)
+            .with_context(PostageContext::new(1, 0));
+        let err = verifier(store).verify(&stamped).unwrap_err();
+        assert!(matches!(err, VerifyError::UnknownBatch));
+    }
+
+    #[test]
+    fn over_capacity_index_is_insufficient_funding() {
+        let s = signer();
+        let batch = batch_for(s.address(), 1_000_000);
+        let chunk = content_chunk();
+        // depth 18, bucket depth 16: per-bucket capacity is 2^(18-16) = 4, so
+        // index 4 exceeds the batch's capacity at this slot.
+        let stamped = signed_chunk(&s, &batch, &chunk, 4);
+
+        let store = MockBatchStore::default()
+            .with_batch(batch)
+            .with_context(usable_context());
+        let err = verifier(store).verify(&stamped).unwrap_err();
+        assert!(matches!(err, VerifyError::InsufficientFunding));
+    }
+
+    #[test]
+    fn foreign_signer_is_invalid_signature() {
+        let s = signer();
+        let owner = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x99)).unwrap();
+        // Batch owned by `owner`, but the stamp is signed by `s`.
+        let batch = batch_for(owner.address(), 1_000_000);
+        let chunk = content_chunk();
+        let stamped = signed_chunk(&s, &batch, &chunk, 0);
+
+        let store = MockBatchStore::default()
+            .with_batch(batch)
+            .with_context(usable_context());
+        let err = verifier(store).verify(&stamped).unwrap_err();
         assert!(matches!(err, VerifyError::InvalidSignature));
     }
 }

--- a/crates/swarm/puller/tests/loop.rs
+++ b/crates/swarm/puller/tests/loop.rs
@@ -570,6 +570,84 @@ impl PullChunkVerifier for AddressRejectVerifier {
     }
 }
 
+// Rejects every chunk as an unknown batch, the transient catch-up verdict.
+#[derive(Clone, Copy)]
+struct UnknownBatchVerifier;
+
+impl PullChunkVerifier for UnknownBatchVerifier {
+    fn verify(&self, _chunk: &StampedChunk) -> Result<(), VerifyError> {
+        Err(VerifyError::UnknownBatch)
+    }
+}
+
+// An unknown batch is the common transient case during catch-up (the chain
+// indexer lags pull-sync), not peer misbehaviour. The peer is neither reported
+// nor skipped, and the interval is not advanced so the page is retried once the
+// batch is indexed.
+#[tokio::test]
+async fn unknown_batch_does_not_report_or_skip_peer() {
+    let control = MockControl::default();
+    let intervals = MockIntervals::default();
+    let admit = MockAdmit::default();
+    let reporter = MockReporter::default();
+
+    let peer = PeerId::random();
+    let peer_ov = overlay(1);
+    let target = SyncTarget {
+        peer,
+        overlay: peer_ov,
+        bins: vec![bin(2)],
+    };
+
+    let (events_tx, events_rx) = mpsc::channel(32);
+    let mut puller = Puller::new(
+        PullerSeams {
+            control: control.clone(),
+            intervals: intervals.clone(),
+            verifier: UnknownBatchVerifier,
+            admit: admit.clone(),
+            readiness: NoGate,
+            neighbours: OneTarget(target),
+            reporter: reporter.clone(),
+        },
+        events_rx,
+        PullerConfig::default(),
+    );
+
+    events_tx
+        .send(PullsyncEvent::CursorsReceived {
+            peer,
+            request_id: 0,
+            cursors: vec![],
+            epoch: 1,
+        })
+        .await
+        .unwrap();
+    events_tx
+        .send(PullsyncEvent::RangeDelivered {
+            peer,
+            request_id: 1,
+            bin: bin(2),
+            topmost: 10,
+            chunks: vec![stamped(0xbb)],
+        })
+        .await
+        .unwrap();
+
+    puller.sync_pass().await;
+
+    // Transient rejection: nothing admitted, the peer is not reported, and the
+    // interval is not advanced so the page is retried on a later pass.
+    assert!(admit.admitted.lock().unwrap().is_empty());
+    assert!(
+        reporter.reports.lock().unwrap().is_empty(),
+        "an unknown batch must not report the peer"
+    );
+    assert_eq!(intervals.interval(&peer_ov, bin(2)).unwrap(), 0);
+    // The bin stopped on the unverified page: exactly one range, from 0.
+    assert_eq!(*control.ranges.lock().unwrap(), vec![(peer, bin(2), 0)]);
+}
+
 // A neighbour that serves an unverifiable chunk is reported for invalid data and
 // skipped for the rest of the pass; a different neighbour in the same pass still
 // syncs through to its caught-up page.


### PR DESCRIPTION
## What

Add `FundingVerifier`, the full `PullChunkVerifier` for the storer puller: it resolves the stamp's batch from the chain-indexed `BatchStore` and runs the same `AdmissionValidator` checks the reserve enforces (usability/confirmations, expiry, index and bucket capacity, owner-match against the recovered signer), mapping `AdmissionError` onto the puller's `VerifyError`. The default `DbReserve` storer path now uses it (threading a second `DbBatchStore` handle); a custom reserve seam falls back to the interim `SignatureVerifier`. Moving funding to the verify seam means an underfunded or invalid stamp taints the syncing page rather than being silently dropped at the reserve put.

The puller's rejection handling is refined to avoid false-positive peer bans: `VerifyError::is_peer_blameworthy()` exempts `UnknownBatch` (the common, transient case during catch-up, when the chain indexer lags pull-sync), so an unknown batch neither reports nor skips the neighbour and is simply retried once indexed; only `InvalidSignature`/`InsufficientFunding`/`Malformed` (genuinely bad stamps) report to scoring and skip the peer.

## Why

Closes #464. The interim verifier was signature-only; this adds the on-chain funding check the persistent reserve should require, without penalising honest neighbours during normal catch-up.

## Testing

`cargo test -p vertex-swarm-puller -p vertex-swarm-api -p vertex-swarm-storer -p vertex-swarm-builder -p vertex-swarm-postage`: funding-verifier cases (funded/unknown/expired/unconfirmed/over-capacity/foreign-signer/malformed via a mock batch store), plus `unknown_batch_does_not_report_or_skip_peer` and the retained poison-peer report/skip test. clippy + `cargo fmt --check`.

## AI Assistance

Claude Code (Opus 4.8) used for the implementation, the cross-PR interaction fix, and verification.