### PR TITLE
fix(swarm): cover swap variants under feature unification (no-features workspace build)

### DIFF
--- a/crates/swarm/client-behaviour/src/behaviour.rs
+++ b/crates/swarm/client-behaviour/src/behaviour.rs
@@ -274,6 +274,15 @@ impl ClientBehaviour {
                     });
                 }
             }
+            // `ClientCommand` carries swap variants when `client-protocol/swap`
+            // is on, which Cargo feature unification can turn on (a workspace
+            // build also compiling `accounting-swap`) even when this crate's
+            // `swap` feature is off. The swap wire is then not linked here, so
+            // drop the command. The all-features build keeps full exhaustiveness.
+            // Unreachable when nothing in the build enables `client-protocol/swap`.
+            #[cfg(not(feature = "swap"))]
+            #[allow(unreachable_patterns)]
+            _ => {}
         }
     }
 

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -488,6 +488,15 @@ impl ClientService {
             } => {
                 debug!(%peer, %peer_id, %peer_rate, "Swap cheque sent");
             }
+            // `ClientEvent` carries swap variants when `client-protocol/swap`
+            // is on, which Cargo feature unification can turn on (a workspace
+            // build also compiling `accounting-swap`) even when this crate's
+            // `swap` feature is off. The swap wire is then not linked here, so
+            // ignore them. The all-features build keeps full exhaustiveness.
+            // Unreachable when nothing in the build enables `client-protocol/swap`.
+            #[cfg(not(feature = "swap"))]
+            #[allow(unreachable_patterns)]
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
## What

A default `cargo build --workspace` (no `--all-features`) fails with `error[E0004]: ClientCommand::SendCheque { .. } not covered` and the sibling `ClientEvent::SwapChequeReceived/Sent`.

The workspace build compiles `vertex-swarm-accounting-swap`, which depends on `vertex-swarm-client-protocol` with `features = ["swap"]`. Cargo resolver-v2 feature unification then enables `client-protocol/swap` for the whole graph, adding the `SendCheque`/`SwapCheque*` variants to the shared `ClientCommand`/`ClientEvent` enums. The consumers in `vertex-swarm-client-behaviour` (`on_command`) and `vertex-swarm-node` (`ClientService`) gate their swap match arms on their own `swap` feature, which stays off in a default build, so the matches become non-exhaustive.

This is not caught by CI because CI builds `--all-features`, where the swap arms are active and the match is exhaustive.

## Why

Closes #459. Accounting-swap genuinely uses `ClientCommand::SendCheque`, so it legitimately requires `client-protocol/swap`; the variants also carry `SignedCheque` from `net-swap`, so they cannot be ungated without leaking `net-swap` into the wasm/no-swap cone. The robust fix is consumer-side: handle the case where the variants exist via unification but this crates swap wire is not linked.

Each consumer gains a `#[cfg(not(feature = "swap"))]` fallback arm (with `#[allow(unreachable_patterns)]`, since the arm is unreachable when nothing in the build enables `client-protocol/swap`, e.g. a standalone crate build) that drops the swap command/event. The all-features build keeps no wildcard, so strict exhaustiveness checking is preserved there and CI still flags any genuinely unhandled variant.

## Testing

- `cargo build --workspace` (default features): now succeeds (previously E0004).
- `cargo check --workspace --all-features`: compiles, exhaustiveness intact.
- `cargo clippy -p vertex-swarm-client-behaviour -p vertex-swarm-node --all-targets -- -D warnings` in both no-features and all-features modes: clean.
- `cargo test -p vertex-swarm-client-behaviour -p vertex-swarm-node --all-features`: pass.

## AI Assistance

Claude Code (Claude Opus) used for the diagnosis, the fix, and this PR description, under human review.
