### PR TITLE
feat(swarm-builder): wire pseudosettle settlement by default

### DIFF
--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -365,7 +365,14 @@ async fn build_client_backed_node(
     } = (params.make_store)(db.clone())?;
     let node_store = Arc::clone(&store);
 
-    // SWAP settlement is prepared first: the provider embeds in the accounting
+    // Pseudosettle (soft accounting) is always on for client and storer nodes:
+    // prepare the provider so it embeds in the accounting, and the event sink so
+    // pseudosettle wire events route at node build time.
+    let (pseudosettle_provider, pseudosettle_wiring) =
+        crate::pseudosettle::PseudosettleWiring::prepare(params.bandwidth);
+    let pseudosettle_event_sender = pseudosettle_wiring.event_sender();
+
+    // SWAP settlement is prepared next: the provider embeds in the accounting
     // and the swap event sink routes at node build time.
     #[cfg(feature = "swap")]
     let (swap_provider, swap_wiring) = crate::swap::SwapWiring::prepare(
@@ -399,6 +406,7 @@ async fn build_client_backed_node(
             reserve.clone(),
             pullsync,
             batches,
+            pseudosettle_event_sender,
             #[cfg(feature = "swap")]
             swap_event_sender,
         )
@@ -409,6 +417,7 @@ async fn build_client_backed_node(
             params.network,
             node_store,
             peer_store,
+            pseudosettle_event_sender,
             #[cfg(feature = "swap")]
             swap_event_sender,
         )
@@ -425,9 +434,12 @@ async fn build_client_backed_node(
     // services report violations through it so misbehaving peers are scored down.
     let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
 
+    // Pseudosettle is registered first so soft accounting forgives total debt
+    // before SWAP settles originated debt; the order matches `settle_all`.
     let accounting_builder = AccountingBuilder::new(params.bandwidth.clone())
         .with_pricer_from_config(Arc::clone(params.spec))
-        .with_reporter(Arc::clone(&reporter));
+        .with_reporter(Arc::clone(&reporter))
+        .with_settlement(pseudosettle_provider);
     #[cfg(feature = "swap")]
     let accounting = match swap_provider {
         Some(provider) => accounting_builder
@@ -475,6 +487,15 @@ async fn build_client_backed_node(
     ctx.executor()
         .spawn_service("swarm.client_service", client_service);
 
+    // Pseudosettle settlement service over the shared accounting: applies
+    // time-based refresh and forwards our outbound settlement to the node.
+    pseudosettle_wiring.spawn(
+        ctx,
+        accounting.bandwidth().clone(),
+        client_handle.clone(),
+        Arc::clone(&reporter),
+    );
+
     // SWAP settlement service over the shared accounting: forwards cheque
     // commands to the node and cashes received cheques on chain when a provider
     // is present.
@@ -502,6 +523,38 @@ async fn build_client_backed_node(
         store,
         reserve,
     })
+}
+
+/// Forward a settlement service's `ClientCommand`s to the node command channel.
+///
+/// A settlement service (pseudosettle or swap) emits commands on an unbounded
+/// channel; this task drains it and hands each command to the node through the
+/// non-blocking [`ClientHandle::send_command`], so the service never blocks on a
+/// full queue. The task ends when the service drops its sender or on shutdown.
+pub(crate) fn spawn_client_command_bridge(
+    ctx: &dyn InfrastructureContext,
+    task_name: &'static str,
+    mut command_rx: tokio::sync::mpsc::UnboundedReceiver<vertex_swarm_node::ClientCommand>,
+    client_handle: vertex_swarm_node::ClientHandle,
+) {
+    ctx.executor()
+        .spawn_with_graceful_shutdown_signal(task_name, move |shutdown| async move {
+            let mut shutdown = std::pin::pin!(shutdown);
+            loop {
+                tokio::select! {
+                    guard = &mut shutdown => {
+                        drop(guard);
+                        break;
+                    }
+                    command = command_rx.recv() => {
+                        let Some(command) = command else { break };
+                        if let Err(e) = client_handle.send_command(command) {
+                            warn!(error = %e, "Failed to forward settlement command to node");
+                        }
+                    }
+                }
+            }
+        });
 }
 
 /// The shared accounting type both client-backed node types build: the default
@@ -536,11 +589,16 @@ async fn assemble_client_node(
     network: &NetworkConfig<KademliaConfig>,
     node_store: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
     peer_store: Option<PeerStore>,
+    pseudosettle_event_sender: tokio::sync::mpsc::UnboundedSender<
+        vertex_swarm_node::PseudosettleEvent,
+    >,
     #[cfg(feature = "swap")] swap_event_sender: Option<
         tokio::sync::mpsc::UnboundedSender<vertex_swarm_node::SwapEvent>,
     >,
 ) -> Result<StorerCapable, SwarmNodeError> {
-    let node_builder = ClientNode::builder(identity.clone()).with_store(node_store);
+    let node_builder = ClientNode::builder(identity.clone())
+        .with_store(node_store)
+        .with_pseudosettle_events(pseudosettle_event_sender);
     #[cfg(feature = "swap")]
     let node_builder = match swap_event_sender {
         Some(tx) => node_builder.with_swap_events(tx),
@@ -588,6 +646,9 @@ async fn assemble_storer_node(
     reserve: Option<Arc<dyn vertex_swarm_api::BinCursorStore>>,
     pullsync: Option<Arc<dyn vertex_swarm_api::PullStorage>>,
     batches: Option<DbBatchStore<RedbDatabase>>,
+    pseudosettle_event_sender: tokio::sync::mpsc::UnboundedSender<
+        vertex_swarm_node::PseudosettleEvent,
+    >,
     #[cfg(feature = "swap")] swap_event_sender: Option<
         tokio::sync::mpsc::UnboundedSender<vertex_swarm_node::SwapEvent>,
     >,
@@ -599,16 +660,15 @@ async fn assemble_storer_node(
     let pullsync_storage =
         pullsync.ok_or_else(|| SwarmNodeError::Build(STORER_PULLSYNC_MISSING.into()))?;
 
-    let mut node_builder = StorerNode::builder(identity.clone())
+    let node_builder = StorerNode::builder(identity.clone())
         .with_store(node_store)
-        .with_pullsync_storage(pullsync_storage);
+        .with_pullsync_storage(pullsync_storage)
+        .with_pseudosettle_events(pseudosettle_event_sender);
     #[cfg(feature = "swap")]
-    {
-        node_builder = match swap_event_sender {
-            Some(tx) => node_builder.with_swap_events(tx),
-            None => node_builder,
-        };
-    }
+    let node_builder = match swap_event_sender {
+        Some(tx) => node_builder.with_swap_events(tx),
+        None => node_builder,
+    };
     let (mut node, client_service, client_handle, pullsync_control) = node_builder
         .build(network, peer_store)
         .await

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -43,6 +43,7 @@ mod handle;
 mod launch;
 mod node;
 mod providers;
+mod pseudosettle;
 mod pullsync;
 #[cfg(feature = "swap")]
 mod swap;

--- a/crates/swarm/builder/src/pseudosettle.rs
+++ b/crates/swarm/builder/src/pseudosettle.rs
@@ -1,0 +1,137 @@
+//! Pseudosettle (soft accounting) settlement wiring for the client launch path.
+//!
+//! Pseudosettle is always on for client and storer nodes. It ties together a
+//! [`PseudosettleProvider`] registered with the accounting builder, the
+//! [`PseudosettleService`] actor that runs the time-based-refresh settlement,
+//! and the wire plumbing that routes pseudosettle events from the node into the
+//! service and the service's outbound `SendPseudosettle` commands back to the
+//! node. Because the provider must be embedded in the accounting before it is
+//! built, the wiring is split: [`PseudosettleWiring::prepare`] builds the handle
+//! and provider up front, then [`PseudosettleWiring::spawn`] constructs and
+//! spawns the service once the accounting instance and the node command channel
+//! exist. Mirrors the SWAP wiring, minus the chain, signer, and chequebook.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use vertex_node_api::InfrastructureContext;
+use vertex_swarm_accounting_pseudosettle::{
+    PseudosettleCommand, PseudosettleEvent, PseudosettleHandle, PseudosettleProvider,
+    PseudosettleService,
+};
+use vertex_swarm_api::{Au, PeerReporter, SwarmAccountingConfig, SwarmBandwidthAccounting};
+use vertex_swarm_node::ClientHandle;
+
+/// Channels connecting the pseudosettle provider, service, and node.
+///
+/// Produced by [`PseudosettleWiring::prepare`] before the accounting is built;
+/// consumed by [`PseudosettleWiring::spawn`] after the node command channel
+/// exists.
+pub(crate) struct PseudosettleWiring {
+    command_rx: mpsc::UnboundedReceiver<PseudosettleCommand>,
+    event_tx: mpsc::UnboundedSender<PseudosettleEvent>,
+    event_rx: mpsc::UnboundedReceiver<PseudosettleEvent>,
+    refresh_rate: Au,
+}
+
+impl PseudosettleWiring {
+    /// Build the handle-backed provider and the wiring up front.
+    ///
+    /// The handle is created here so the provider can be embedded in the
+    /// accounting before the accounting is built; its command channel is drained
+    /// by the service spawned in [`Self::spawn`].
+    pub(crate) fn prepare<C>(config: &C) -> (PseudosettleProvider<C>, Self)
+    where
+        C: SwarmAccountingConfig + Clone + 'static,
+    {
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let handle = PseudosettleHandle::new(command_tx);
+        let provider = PseudosettleProvider::with_handle(config.clone(), handle);
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+
+        (
+            provider,
+            Self {
+                command_rx,
+                event_tx,
+                event_rx,
+                refresh_rate: config.refresh_rate(),
+            },
+        )
+    }
+
+    /// The sender the node behaviour routes pseudosettle wire events into.
+    pub(crate) fn event_sender(&self) -> mpsc::UnboundedSender<PseudosettleEvent> {
+        self.event_tx.clone()
+    }
+
+    /// Construct, spawn, and wire the pseudosettle service.
+    ///
+    /// The service applies time-based refresh against `accounting` (the same
+    /// instance the provider settles through), drains the provider's command
+    /// channel, and consumes routed pseudosettle wire events. Settlement
+    /// violations are reported through `reporter`. Its outbound `SendPseudosettle`
+    /// commands are forwarded to the node through `client_handle`.
+    pub(crate) fn spawn<A>(
+        self,
+        ctx: &dyn InfrastructureContext,
+        accounting: Arc<A>,
+        client_handle: ClientHandle,
+        reporter: Arc<dyn PeerReporter>,
+    ) where
+        A: SwarmBandwidthAccounting + 'static,
+    {
+        // The service speaks unbounded `ClientCommand`; bridge it to the bounded
+        // node command channel so the service never blocks on a full queue.
+        let (client_command_tx, client_command_rx) = mpsc::unbounded_channel();
+        crate::launch::spawn_client_command_bridge(
+            ctx,
+            "swarm.pseudosettle_command_bridge",
+            client_command_rx,
+            client_handle,
+        );
+
+        let service = PseudosettleService::new(
+            self.command_rx,
+            self.event_rx,
+            client_command_tx,
+            accounting,
+            self.refresh_rate,
+        )
+        .with_reporter(reporter);
+
+        ctx.executor()
+            .spawn_service("swarm.pseudosettle_service", service);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use vertex_swarm_accounting::{AccountingBuilder, DefaultBandwidthConfig};
+    use vertex_swarm_api::{SwarmClientAccounting, SwarmIdentity};
+    use vertex_swarm_test_utils::test_identity_arc;
+
+    #[test]
+    fn default_client_accounting_wires_pseudosettle() {
+        let identity = test_identity_arc();
+        let config = DefaultBandwidthConfig::default();
+
+        let (provider, wiring) = PseudosettleWiring::prepare(&config);
+        assert_eq!(wiring.refresh_rate, config.refresh_rate());
+
+        // Compose the accounting exactly as the launch tail does for a default
+        // client: the pseudosettle provider is registered, so outbound settlement
+        // has a mechanism instead of an empty provider list.
+        let accounting = AccountingBuilder::new(config)
+            .with_pricer_from_config(identity.spec().clone())
+            .with_settlement(provider)
+            .build(&identity);
+
+        assert_eq!(
+            accounting.bandwidth().provider_names(),
+            vec!["pseudosettle"]
+        );
+    }
+}

--- a/crates/swarm/builder/src/swap.rs
+++ b/crates/swarm/builder/src/swap.rs
@@ -32,8 +32,8 @@ use vertex_swarm_api::{
     PeerReporter, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmIdentity, SwarmSpec,
 };
 use vertex_swarm_identity::Identity;
+use vertex_swarm_node::ClientHandle;
 use vertex_swarm_node::args::SwapConfig;
-use vertex_swarm_node::{ClientCommand, ClientHandle};
 use vertex_swarm_spec::Spec;
 
 #[cfg(feature = "chain")]
@@ -152,7 +152,12 @@ impl SwapWiring {
         // is bounded and reached through `ClientHandle::send_command`. Bridge the
         // two with a forwarding task so the service never blocks on a full queue.
         let (client_command_tx, client_command_rx) = mpsc::unbounded_channel();
-        spawn_command_bridge(ctx, client_command_rx, client_handle);
+        crate::launch::spawn_client_command_bridge(
+            ctx,
+            "swarm.swap_command_bridge",
+            client_command_rx,
+            client_handle,
+        );
 
         let service = SwapService::new(
             self.command_rx,
@@ -172,38 +177,6 @@ impl SwapWiring {
 
         ctx.executor().spawn_service("swarm.swap_service", service);
     }
-}
-
-/// Forward the swap service's `ClientCommand`s to the node command channel.
-///
-/// The service emits commands on an unbounded channel; this task drains it and
-/// hands each command to the node through `ClientHandle::send_command`, which is
-/// non-blocking. The task ends when the service drops its sender or on shutdown.
-fn spawn_command_bridge(
-    ctx: &dyn InfrastructureContext,
-    mut client_command_rx: mpsc::UnboundedReceiver<ClientCommand>,
-    client_handle: ClientHandle,
-) {
-    ctx.executor().spawn_with_graceful_shutdown_signal(
-        "swarm.swap_command_bridge",
-        move |shutdown| async move {
-            let mut shutdown = std::pin::pin!(shutdown);
-            loop {
-                tokio::select! {
-                    guard = &mut shutdown => {
-                        drop(guard);
-                        break;
-                    }
-                    command = client_command_rx.recv() => {
-                        let Some(command) = command else { break };
-                        if let Err(e) = client_handle.send_command(command) {
-                            warn!(error = %e, "Failed to forward swap command to node");
-                        }
-                    }
-                }
-            }
-        },
-    );
 }
 
 /// Attach an on-chain cashout client to the swap service when a chain provider is


### PR DESCRIPTION
## What

A default client backed its accounting with an empty settlement provider list. `build_client_backed_node` registered the SWAP provider conditionally but never a `PseudosettleProvider`, and the `PseudosettleService` was never instantiated anywhere in the launch path. So a default client (and storer) had no time-based debt forgiveness, and outbound settlement silently no-oped when our debt to a peer crossed the payment threshold: the settlement trigger fired (`PeerSelector` -> `AccountingSettlement::trigger_settlement` -> `settle_all`) but iterated an empty provider list. This is despite pseudosettle being the documented default for client and storer nodes.

This change wires pseudosettle end to end:

- New `PseudosettleWiring`, mirroring the existing `SwapWiring` but unconditional (pseudosettle is always on for client and storer, not feature-gated) and without the chain, signer, and chequebook. `prepare` builds the handle-backed `PseudosettleProvider` up front so it embeds in the accounting before the accounting is built; `spawn` constructs and spawns the `PseudosettleService` once the shared accounting instance and the node command channel exist.
- The provider is registered before SWAP, so soft accounting forgives total debt before SWAP settles originated debt, matching the in-order semantics of `settle_all`.
- The pseudosettle wire event sink is routed into both the client and storer node builders via the existing-but-unused `with_pseudosettle_events`.
- The service-to-node `ClientCommand` bridge that swap used is extracted into a shared `spawn_client_command_bridge` so both settlement services reuse one implementation.
- The storer assembly switches to the same shadowing style the client assembly already uses, which also drops a latent unused-mut warning in no-feature builds.

## Why

Closes #416 (RFC step 2 from the node-type API design). This restores the intended soft-accounting behaviour: a default client now has a populated provider list and a live pseudosettle service, so the self-throttle allowance accrues and outbound settlement actually issues a pseudosettle payment. This is a live-path behavioural change, not a wire change.

## Testing

- New unit test `default_client_accounting_wires_pseudosettle` asserts the default client accounting provider list is `["pseudosettle"]` (previously empty), composing the accounting exactly as the launch tail does.
- `cargo test -p vertex-swarm-builder --all-features`: 32 pass (the launch-path node-build tests exercise the new service spawn).
- `cargo clippy -p vertex-swarm-builder --all-targets -- -D warnings` in both no-features and all-features modes: clean.
- `cargo check -p vertex-swarm-builder` for the swap, chain, and swap+chain feature combinations: all compile.

## AI Assistance

Claude Code (Claude Opus) used for the diagnosis (including an adversarial check that the settlement trigger and outbound path were genuinely unwired), the implementation, and this PR description, under human review.
