### PR TITLE
docs(accounting): drop stale tracker refs and reference-impl mentions

### DIFF
--- a/crates/swarm/accounting/chequebook/src/cheque.rs
+++ b/crates/swarm/accounting/chequebook/src/cheque.rs
@@ -26,8 +26,7 @@
 //! JSON bytes. Verification rebuilds the EIP-712 hash and recovers against it
 //! (see [`SignedCheque::recover_signer`]), so the JSON only needs to be
 //! cross-implementation parseable and to round-trip the field values; it does not
-//! need to be byte-identical. The whole JSON path is slated for protobuf
-//! replacement, tracked in issue #183.
+//! need to be byte-identical.
 //!
 //! For parseability the encoding follows the field-value conventions other
 //! Swarm nodes emit: PascalCase keys, lowercase `0x`-hex addresses,
@@ -241,9 +240,9 @@ struct WireCheque {
     beneficiary: Address,
     // Bare decimal JSON number across the full 256-bit range. A helper is needed
     // on both sides: `serde_json` is built here without `arbitrary_precision`, so
-    // its native number path tops out at `u64`/`i64` and a bee-sized payout would
-    // either fail to encode or decode lossily through `f64`. The helper carries
-    // the decimal token verbatim through a `RawValue`.
+    // its native number path tops out at `u64`/`i64` and a full 256-bit payout
+    // would either fail to encode or decode lossily through `f64`. The helper
+    // carries the decimal token verbatim through a `RawValue`.
     #[serde(with = "payout_number")]
     cumulative_payout: U256,
     // Standard base64 (padded, standard alphabet) over the fixed 65-byte
@@ -258,11 +257,10 @@ struct WireCheque {
 /// `arbitrary_precision`: its native number path tops out at `u64`/`i64`, so
 /// `U256`'s own serde cannot emit or accept a 256-bit value as a bare JSON
 /// number (encode would fall back to a `0x`-hex string, decode would coerce a
-/// bee-sized payout through a lossy `f64`). A [`RawValue`] carries the decimal
+/// full 256-bit payout through a lossy `f64`). A [`RawValue`] carries the decimal
 /// token verbatim in both directions. The decoder rejects anything that is not a
 /// bare decimal number (quoted strings, signs, decimal points, exponents),
-/// keeping the payout shape strict. The whole helper disappears with the
-/// protobuf migration tracked in issue #183.
+/// keeping the payout shape strict.
 mod payout_number {
     use alloy_primitives::U256;
     use serde::{Deserialize, Deserializer, Serialize, Serializer, de};

--- a/crates/swarm/accounting/chequebook/src/lib.rs
+++ b/crates/swarm/accounting/chequebook/src/lib.rs
@@ -47,8 +47,7 @@
 //! directly. The shape follows the field-value conventions other Swarm nodes
 //! emit: PascalCase keys, lowercase `0x`-hex addresses, `CumulativePayout` as a
 //! bare decimal JSON number spanning the full 256-bit range, and `Signature` as
-//! standard base64. This whole JSON path is slated for protobuf replacement,
-//! tracked in issue #183.
+//! standard base64.
 
 #[cfg(feature = "swap-chequebook")]
 pub mod chain;

--- a/crates/swarm/net/pricing/src/codec.rs
+++ b/crates/swarm/net/pricing/src/codec.rs
@@ -2,8 +2,8 @@
 //!
 //! # Wire Format
 //!
-//! The payment threshold is encoded as big-endian bytes with leading zeros trimmed,
-//! matching Go's `big.Int.Bytes()` serialization used by Bee.
+//! The payment threshold is encoded as trimmed big-endian bytes (leading zero
+//! bytes removed).
 
 use alloy_primitives::U256;
 use vertex_net_codec::{Codec, ProtoMessage, decode_u256_be, encode_u256_be};

--- a/crates/swarm/net/pseudosettle/src/codec.rs
+++ b/crates/swarm/net/pseudosettle/src/codec.rs
@@ -4,8 +4,8 @@
 //! - `PaymentCodec` - Encodes/decodes `Payment` messages only
 //! - `PaymentAckCodec` - Encodes/decodes `PaymentAck` messages only
 //!
-//! Amounts are encoded as big-endian bytes with leading zeros trimmed,
-//! matching Go's `big.Int.Bytes()` serialization used by Bee.
+//! Amounts are encoded as trimmed big-endian bytes (leading zero bytes
+//! removed).
 
 use alloy_primitives::U256;
 use vertex_net_codec::{

--- a/crates/swarm/net/swap/src/codec.rs
+++ b/crates/swarm/net/swap/src/codec.rs
@@ -7,7 +7,7 @@
 //! The cheque rides as a JSON object in a protobuf `bytes` field. It is encoded
 //! and decoded with `serde_json` directly over [`SignedCheque`]; the JSON is
 //! transport-only (the signature is EIP-712 over the cheque fields, not the JSON
-//! bytes) and is slated for protobuf replacement, tracked in issue #183.
+//! bytes).
 
 use alloy_primitives::Address;
 use vertex_net_codec::{Codec, ProtoMessage};

--- a/crates/swarm/net/swap/src/lib.rs
+++ b/crates/swarm/net/swap/src/lib.rs
@@ -3,9 +3,8 @@
 //! The signed cheque travels as a JSON object embedded in a protobuf `bytes`
 //! field, encoded and decoded with `serde_json` over
 //! [`vertex_swarm_accounting_chequebook::SignedCheque`]. The JSON is
-//! transport-only (the cheque signature is EIP-712 over the cheque fields, not
-//! over the JSON bytes) and is slated for protobuf replacement, tracked in issue
-//! #183.
+//! transport-only: the cheque signature is EIP-712 over the cheque fields, not
+//! over the JSON bytes.
 
 mod codec;
 mod error;


### PR DESCRIPTION
## What

Remove stale issue-tracker references and reference-implementation mentions from the accounting and swap rustdoc, rewording each to state the byte or format convention directly.

## Why

Shipped code and rustdoc must not carry issue numbers or name another implementation; the convention should stand on its own. Closes #481.

## Testing

`cargo clippy --all-targets --all-features` on the four touched crates (net/pricing, net/pseudosettle, net/swap, accounting/chequebook) and the chequebook doctests. Comment-only change, so no test suite per the scope-verification rule.

## AI Assistance

Claude Code used for the audit that surfaced these sites and for the rustdoc rewording.
