### PR TITLE
refactor(accounting-pricing): drop redundant Pricer trait

### DIFF
--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -41,4 +41,4 @@ pub use client_accounting::ClientAccounting;
 pub use config::{BandwidthConfig, BandwidthConfigError, DefaultBandwidthConfig};
 pub use noop::{NoAccounting, NoPeerBandwidth, NoProvideAction, NoReceiveAction};
 pub use settlement::NoSettlement;
-pub use vertex_swarm_accounting_pricing::{FixedPricer, FixedPricingConfig, NoPricer, Pricer};
+pub use vertex_swarm_accounting_pricing::{FixedPricer, FixedPricingConfig, NoPricer};

--- a/crates/swarm/accounting/pricing/src/fixed.rs
+++ b/crates/swarm/accounting/pricing/src/fixed.rs
@@ -3,11 +3,9 @@
 use std::sync::Arc;
 
 use nectar_primitives::{ChunkAddress, SwarmAddress};
-use vertex_swarm_api::Au;
+use vertex_swarm_api::{Au, SwarmPricing};
 use vertex_swarm_primitives::OverlayAddress;
 use vertex_swarm_spec::SwarmSpec;
-
-use crate::Pricer;
 
 /// Prices chunks based on Kademlia proximity to peer.
 #[derive(Debug)]
@@ -32,7 +30,7 @@ impl<S: SwarmSpec> FixedPricer<S> {
     }
 }
 
-impl<S: SwarmSpec> Pricer for FixedPricer<S> {
+impl<S: SwarmSpec + Send + Sync + 'static> SwarmPricing for FixedPricer<S> {
     fn price(&self, _chunk: &ChunkAddress) -> Au {
         Au::from_amount(self.base_price)
     }
@@ -50,16 +48,6 @@ impl<S: SwarmSpec> Pricer for FixedPricer<S> {
         Au::from_amount(self.base_price)
             .checked_scale(factor)
             .unwrap_or(Au::from_amount(u64::MAX))
-    }
-}
-
-impl<S: SwarmSpec + Send + Sync + 'static> vertex_swarm_api::SwarmPricing for FixedPricer<S> {
-    fn price(&self, chunk: &ChunkAddress) -> Au {
-        Pricer::price(self, chunk)
-    }
-
-    fn peer_price(&self, peer: &OverlayAddress, chunk: &ChunkAddress) -> Au {
-        Pricer::peer_price(self, peer, chunk)
     }
 }
 

--- a/crates/swarm/accounting/pricing/src/lib.rs
+++ b/crates/swarm/accounting/pricing/src/lib.rs
@@ -18,39 +18,19 @@ pub use config::FixedPricingConfig;
 pub use fixed::FixedPricer;
 
 use nectar_primitives::ChunkAddress;
-use vertex_swarm_api::Au;
+use vertex_swarm_api::{Au, SwarmPricing};
 use vertex_swarm_primitives::OverlayAddress;
-
-/// Trait for pricing chunks.
-#[auto_impl::auto_impl(&, Arc)]
-pub trait Pricer: Send + Sync {
-    /// Get the base price for a chunk in AU (not considering peer).
-    fn price(&self, chunk: &ChunkAddress) -> Au;
-
-    /// Get the price for a chunk in AU when served by a specific peer.
-    fn peer_price(&self, peer: &OverlayAddress, chunk: &ChunkAddress) -> Au;
-}
 
 /// No-op pricer for nodes that don't participate in pricing (e.g., bootnodes).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NoPricer;
 
-impl Pricer for NoPricer {
+impl SwarmPricing for NoPricer {
     fn price(&self, _chunk: &ChunkAddress) -> Au {
         Au::ZERO
     }
 
     fn peer_price(&self, _peer: &OverlayAddress, _chunk: &ChunkAddress) -> Au {
         Au::ZERO
-    }
-}
-
-impl vertex_swarm_api::SwarmPricing for NoPricer {
-    fn price(&self, chunk: &ChunkAddress) -> Au {
-        Pricer::price(self, chunk)
-    }
-
-    fn peer_price(&self, peer: &OverlayAddress, chunk: &ChunkAddress) -> Au {
-        Pricer::peer_price(self, peer, chunk)
     }
 }


### PR DESCRIPTION
## What

Delete the `Pricer` trait and implement `SwarmPricing` directly on `FixedPricer` and `NoPricer`, dropping the delegating impl bodies and the `Pricer` re-export.

## Why

`Pricer` and the api trait `SwarmPricing` had identical method signatures, and every consumer bounds on `SwarmPricing`; `Pricer` only added a second trait and hand-written delegation. Closes #482.

## Testing

`cargo clippy --all-targets --all-features` and `cargo test` on `vertex-swarm-accounting-pricing` and `vertex-swarm-accounting`. Workspace grep confirms no remaining consumer of the bare `Pricer` trait.

## AI Assistance

Claude Code used for the audit and the mechanical trait unification.
