### PR TITLE
refactor(accounting): drop redundant domain AccountingAction trait

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/action.rs
+++ b/crates/swarm/accounting/core/src/accounting/action.rs
@@ -8,15 +8,6 @@ use vertex_swarm_api::Au;
 
 use super::PeerState;
 
-/// Trait for accounting actions.
-pub trait AccountingAction: Send {
-    /// Apply the action, committing the balance change.
-    fn apply(self);
-
-    /// Clean up without applying (releases reservations).
-    fn cleanup(&self);
-}
-
 /// Action for receiving service from a peer (balance decreases).
 ///
 /// Reserves balance on creation; commits on apply(), releases on drop.
@@ -50,14 +41,6 @@ impl Drop for ReceiveAction {
             self.state.sub_reserved(self.price);
         }
     }
-}
-
-impl AccountingAction for ReceiveAction {
-    fn apply(self) {
-        ReceiveAction::apply(self);
-    }
-
-    fn cleanup(&self) {}
 }
 
 impl vertex_swarm_api::AccountingAction for ReceiveAction {
@@ -103,14 +86,6 @@ impl Drop for ProvideAction {
             self.state.sub_shadow_reserved(self.price);
         }
     }
-}
-
-impl AccountingAction for ProvideAction {
-    fn apply(self) {
-        ProvideAction::apply(self);
-    }
-
-    fn cleanup(&self) {}
 }
 
 impl vertex_swarm_api::AccountingAction for ProvideAction {

--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -21,7 +21,7 @@ mod action;
 mod error;
 mod peer;
 
-pub use action::{AccountingAction, ProvideAction, ReceiveAction};
+pub use action::{ProvideAction, ReceiveAction};
 pub use error::AccountingError;
 pub use peer::{PeerState, PeerStateSnapshot};
 

--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -32,8 +32,8 @@ mod noop;
 mod settlement;
 
 pub use accounting::{
-    Accounting, AccountingAction, AccountingError, AccountingPeerHandle, PeerState,
-    PeerStateSnapshot, ProvideAction, ReceiveAction,
+    Accounting, AccountingError, AccountingPeerHandle, PeerState, PeerStateSnapshot, ProvideAction,
+    ReceiveAction,
 };
 pub use args::BandwidthArgs;
 pub use builder::{AccountingBuilder, NoAccountingBuilder};


### PR DESCRIPTION
## What

Delete the domain `AccountingAction` trait and its two impls, keeping the api `AccountingAction` impls on `ReceiveAction`/`ProvideAction`.

## Why

The domain trait duplicated the api trait; its only unique method (`cleanup`) had empty bodies and no caller (reservation release is handled by `Drop`), and the `SwarmBandwidthAccounting` bounds reference the api trait. Closes #483.

## Testing

`cargo clippy --all-targets --all-features` and `cargo test` on `vertex-swarm-accounting`. Workspace grep confirms no `.cleanup()` caller and no consumer importing the domain trait.

## AI Assistance

Claude Code used for the audit and the dead-trait removal.
