### PR TITLE
refactor(accounting): remove unused builder apply combinators

### DIFF
--- a/crates/swarm/accounting/core/src/builder.rs
+++ b/crates/swarm/accounting/core/src/builder.rs
@@ -80,22 +80,6 @@ impl<C, P> AccountingBuilder<C, P> {
         self
     }
 
-    /// Apply a transformation function.
-    pub fn apply<F>(self, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        f(self)
-    }
-
-    /// Apply a transformation function if condition is true.
-    pub fn apply_if<F>(self, cond: bool, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        if cond { f(self) } else { self }
-    }
-
     /// Get a reference to the config.
     pub fn config(&self) -> &C {
         &self.config
@@ -177,17 +161,6 @@ mod tests {
 
         let _accounting = AccountingBuilder::new(config)
             .with_pricing(pricer)
-            .build(&identity);
-    }
-
-    #[test]
-    fn test_builder_apply() {
-        let identity = test_identity();
-        let config = DefaultBandwidthConfig::default();
-
-        let _accounting = AccountingBuilder::new(config)
-            .with_pricer_from_config(identity.spec().clone())
-            .apply_if(true, |b| b)
             .build(&identity);
     }
 }

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -49,9 +49,6 @@ mod pullsync;
 mod swap;
 pub mod verify;
 
-// Traits
-pub use node::BuilderExt;
-
 // Builders
 pub use node::{
     ClientNodeBuilder, DefaultClientBuilder, DefaultNodeBuilder, DefaultStorerBuilder, NodeBuilder,

--- a/crates/swarm/builder/src/node.rs
+++ b/crates/swarm/builder/src/node.rs
@@ -26,23 +26,6 @@ use crate::handle::{BuiltBootnode, BuiltClient, BuiltNode, BuiltStorer};
 use crate::launch::{CacheSeam, ReserveSeam};
 use crate::verify::ChunkVerifyConfig;
 
-/// Fluent transformation API for builders.
-pub trait BuilderExt: Sized {
-    fn apply<F>(self, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        f(self)
-    }
-
-    fn apply_if<F>(self, cond: bool, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        if cond { f(self) } else { self }
-    }
-}
-
 /// Builder for bootnodes.
 pub struct NodeBuilder<I, N>
 where
@@ -52,13 +35,6 @@ where
     spec: Arc<Spec>,
     identity: I,
     network: N,
-}
-
-impl<I, N> BuilderExt for NodeBuilder<I, N>
-where
-    I: SwarmIdentity,
-    N: SwarmNetworkConfig + SwarmPeerConfig + SwarmRoutingConfig,
-{
 }
 
 impl<I, N> NodeBuilder<I, N>
@@ -122,14 +98,6 @@ where
     /// Carried here so a wrapping storer builder keeps it across the storage
     /// transition; consumed only by the storer build path.
     reserve: Option<ReserveSeam>,
-}
-
-impl<I, N, A> BuilderExt for ClientNodeBuilder<I, N, A>
-where
-    I: SwarmIdentity,
-    N: SwarmNetworkConfig + SwarmPeerConfig + SwarmRoutingConfig,
-    A: SwarmAccountingConfig + SwarmPricingConfig,
-{
 }
 
 impl<I, N, A> ClientNodeBuilder<I, N, A>
@@ -253,16 +221,6 @@ where
     client: ClientNodeBuilder<I, N, A>,
     local_store: S,
     storage: St,
-}
-
-impl<I, N, A, S, St> BuilderExt for StorerNodeBuilder<I, N, A, S, St>
-where
-    I: SwarmIdentity,
-    N: SwarmNetworkConfig + SwarmPeerConfig + SwarmRoutingConfig,
-    A: SwarmAccountingConfig + SwarmPricingConfig,
-    S: SwarmLocalStoreConfig,
-    St: SwarmStorageConfig,
-{
 }
 
 impl<I, N, A, S, St> StorerNodeBuilder<I, N, A, S, St>


### PR DESCRIPTION
## What

Remove the `apply`/`apply_if` builder combinators entirely (from both `AccountingBuilder` and the swarm builder), rather than relocating them.

## Why

Reviewing the call sites, these combinators have no production callers; the only use anywhere was a single self-referential test (`apply_if(true, |b| b)`). Rather than move a generic, unused utility into (or out of) the swarm-domain crate path, both copies are deleted. If a generic builder combinator is wanted later it belongs in a generic node or util crate, not a `vertex-swarm-*` crate. Closes #484.

## Testing

`cargo clippy --all-targets --all-features` and `cargo test` on `vertex-swarm-accounting` and `vertex-swarm-builder`; workspace grep confirms no remaining `BuilderExt` reference.

## AI Assistance

Claude Code used for the audit, the call-site analysis, and the removal.
