### PR TITLE
refactor(accounting): preserve typed accounting error discriminants

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/error.rs
+++ b/crates/swarm/accounting/core/src/accounting/error.rs
@@ -1,41 +1,6 @@
 //! Accounting errors (threshold violations, settlement failures).
+//!
+//! The type lives in `vertex-swarm-api` so `SwarmError` can carry it typed; it
+//! is re-exported here for the original `crate::accounting::error` path.
 
-use vertex_swarm_api::Au;
-use vertex_swarm_primitives::OverlayAddress;
-
-/// Errors that can occur during accounting operations.
-#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
-#[strum(serialize_all = "snake_case")]
-pub enum AccountingError {
-    /// Peer has exceeded disconnect threshold.
-    #[error("peer {peer} balance {balance} exceeds disconnect threshold {threshold}")]
-    DisconnectThreshold {
-        peer: OverlayAddress,
-        balance: Au,
-        threshold: Au,
-    },
-
-    /// Operation would exceed payment threshold.
-    #[error("peer {peer} balance {balance} exceeds payment threshold {threshold}")]
-    PaymentThreshold {
-        peer: OverlayAddress,
-        balance: Au,
-        threshold: Au,
-    },
-
-    /// Peer not found.
-    #[error("peer {0} not found")]
-    PeerNotFound(OverlayAddress),
-
-    /// Settlement failed.
-    #[error("settlement failed: {0}")]
-    SettlementFailed(String),
-
-    /// Channel closed (service stopped).
-    #[error("channel closed")]
-    ChannelClosed,
-}
-
-impl AccountingError {
-    vertex_metrics::impl_record_error!("accounting_errors_total");
-}
+pub use vertex_swarm_api::AccountingError;

--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -259,13 +259,11 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> SwarmBandwidthAccounting for Ac
         price: Au,
         originated: bool,
     ) -> SwarmResult<ReceiveAction> {
-        Accounting::prepare_receive(self, peer, price, originated)
-            .map_err(vertex_swarm_api::SwarmError::accounting)
+        Ok(Accounting::prepare_receive(self, peer, price, originated)?)
     }
 
     fn prepare_provide(&self, peer: OverlayAddress, price: Au) -> SwarmResult<ProvideAction> {
-        Accounting::prepare_provide(self, peer, price)
-            .map_err(vertex_swarm_api::SwarmError::accounting)
+        Ok(Accounting::prepare_provide(self, peer, price)?)
     }
 }
 

--- a/crates/swarm/api/src/error.rs
+++ b/crates/swarm/api/src/error.rs
@@ -5,6 +5,51 @@ use nectar_primitives::ChunkAddress;
 use std::string::String;
 use vertex_swarm_primitives::OverlayAddress;
 
+use crate::Au;
+
+/// Errors raised while preparing a per-peer accounting decision.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum AccountingError {
+    /// Peer has exceeded disconnect threshold.
+    #[error("peer {peer} balance {balance} exceeds disconnect threshold {threshold}")]
+    DisconnectThreshold {
+        /// The peer whose balance breached the threshold.
+        peer: OverlayAddress,
+        /// The peer's current balance.
+        balance: Au,
+        /// The disconnect threshold that was exceeded.
+        threshold: Au,
+    },
+
+    /// Operation would exceed payment threshold.
+    #[error("peer {peer} balance {balance} exceeds payment threshold {threshold}")]
+    PaymentThreshold {
+        /// The peer whose balance breached the threshold.
+        peer: OverlayAddress,
+        /// The peer's current balance.
+        balance: Au,
+        /// The payment threshold that was exceeded.
+        threshold: Au,
+    },
+
+    /// Peer not found.
+    #[error("peer {0} not found")]
+    PeerNotFound(OverlayAddress),
+
+    /// Settlement failed.
+    #[error("settlement failed: {0}")]
+    SettlementFailed(String),
+
+    /// Channel closed (service stopped).
+    #[error("channel closed")]
+    ChannelClosed,
+}
+
+impl AccountingError {
+    vertex_metrics::impl_record_error!("accounting_errors_total");
+}
+
 /// Error type for Swarm API operations.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -129,6 +174,13 @@ pub enum SwarmError {
         source: Option<Box<dyn std::error::Error + Send + Sync>>,
     },
 
+    /// A typed accounting decision failed.
+    ///
+    /// Carries the [`AccountingError`] so its discriminant survives the boundary
+    /// rather than collapsing into a single `accounting` label.
+    #[error(transparent)]
+    AccountingDecision(#[from] AccountingError),
+
     /// Internal error.
     #[error("internal error: {message}")]
     Internal {
@@ -187,6 +239,7 @@ impl SwarmError {
             Self::Network { .. }
                 | Self::PeerUnavailable { .. }
                 | Self::Accounting { .. }
+                | Self::AccountingDecision { .. }
                 | Self::NoStorer { .. }
                 | Self::AllPeersFailed { .. }
                 | Self::UnconfirmedCustody { .. }

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -55,7 +55,8 @@ pub use self::config::{
     SwarmStorerLaunchConfig, estimate_chunks_for_bytes, estimate_storage_bytes,
 };
 pub use self::error::{
-    ConfigAddressKind, ConfigError, ConfigResult, IdentityError, SwarmError, SwarmResult,
+    AccountingError, ConfigAddressKind, ConfigError, ConfigResult, IdentityError, SwarmError,
+    SwarmResult,
 };
 pub use self::identity::SwarmIdentity;
 pub use self::protocol::SwarmProtocol;

--- a/crates/swarm/net/pseudosettle/src/error.rs
+++ b/crates/swarm/net/pseudosettle/src/error.rs
@@ -2,9 +2,5 @@
 
 vertex_net_codec::protocol_error! {
     /// Pseudosettle protocol errors.
-    pub enum PseudosettleError {
-        /// Invalid timestamp in acknowledgment.
-        #[error("invalid timestamp: {0}")]
-        InvalidTimestamp(String),
-    }
+    pub enum PseudosettleError {}
 }

--- a/crates/swarm/net/pseudosettle/src/protocol.rs
+++ b/crates/swarm/net/pseudosettle/src/protocol.rs
@@ -171,42 +171,6 @@ mod tests {
     use super::*;
     use alloy_primitives::U256;
 
-    /// Validate that a timestamp is within acceptable bounds of the current time.
-    fn validate_timestamp(timestamp: i64, tolerance_secs: u64) -> Result<(), PseudosettleError> {
-        let now = vertex_util_runtime::time::now_unix_nanos();
-
-        let tolerance_nanos = (tolerance_secs as i64) * 1_000_000_000;
-        let diff = (now - timestamp).abs();
-
-        if diff > tolerance_nanos {
-            return Err(PseudosettleError::InvalidTimestamp(format!(
-                "timestamp {} is {}s away from current time (tolerance: {}s)",
-                timestamp,
-                diff / 1_000_000_000,
-                tolerance_secs
-            )));
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_validate_timestamp_valid() {
-        let now = vertex_util_runtime::time::now_unix_nanos();
-
-        assert!(validate_timestamp(now, 3).is_ok());
-        assert!(validate_timestamp(now - 1_000_000_000, 3).is_ok());
-        assert!(validate_timestamp(now + 2_000_000_000, 3).is_ok());
-    }
-
-    #[test]
-    fn test_validate_timestamp_invalid() {
-        let now = vertex_util_runtime::time::now_unix_nanos();
-
-        assert!(validate_timestamp(now - 5_000_000_000, 3).is_err());
-        assert!(validate_timestamp(now + 10_000_000_000, 3).is_err());
-    }
-
     #[test]
     fn test_payment_creation() {
         let payment = Payment::from_u64(1_000_000);
@@ -218,6 +182,9 @@ mod tests {
         let amount = U256::from(500_000u64);
         let ack = PaymentAck::now(amount);
         assert_eq!(ack.amount, amount);
-        assert!(validate_timestamp(ack.timestamp, 1).is_ok());
+
+        // `now` stamps the current wall clock; allow a one-second window.
+        let now = vertex_util_runtime::time::now_unix_nanos();
+        assert!((now - ack.timestamp).abs() < 1_000_000_000);
     }
 }


### PR DESCRIPTION
## What

Preserve typed accounting error discriminants and remove a dead wire-timestamp validator.

Move `AccountingError` into `vertex-swarm-api` (re-exported from `vertex-swarm-accounting` for the original path) and add an additive `SwarmError::AccountingDecision(#[from] AccountingError)` variant, so `prepare_receive`/`prepare_provide` propagate the typed error with `?` and the discriminant survives the boundary instead of collapsing to a single `accounting` metric label. Remove the dead `validate_timestamp` helper and the unused `PseudosettleError::InvalidTimestamp` variant from net/pseudosettle (the production read path never validated ack timestamps).

The remaining `(String)` settlement-error variants were left opaque: each wraps a non-`Clone` source (`mpsc::SendError`, `alloy_signer::Error`, `ChequeError`) while the enums derive `Clone`, so `#[source]` is not possible without breaking the derive; each already carries a clean snake_case strum label.

## Why

Metric labels should distinguish `DisconnectThreshold`, `PaymentThreshold`, and the rest rather than collapsing to one label, and dead validation code should not ship. Closes #486. Also closes the dead `validate_timestamp` item (L12) tracked in #439.

## Testing

`cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean across the workspace including `vertex`, `vertex-swarm-node`, `vertex-swarm-ffi`); `cargo test` on `vertex-swarm-api`, the five accounting crates, and `vertex-swarm-net-pseudosettle`.

## AI Assistance

Claude Code used for the audit, the per-variant error analysis, and the implementation.
