### PR TITLE
feat(swarm-node): account for own-request retrieval and pushsync (origin debit)

### DIFF
--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -193,6 +193,25 @@ pub trait SwarmBandwidthAccounting: Send + Sync {
     fn prepare_provide(&self, peer: OverlayAddress, price: Au) -> SwarmResult<Self::ProvideAction>;
 }
 
+/// Object-safe receive debit for callers that hold accounting behind a trait
+/// object (the client service, which cannot name the `ReceiveAction` type).
+///
+/// Commits in one step: the chunk is in hand when an origin request completes,
+/// so there is nothing to hold and release. An `Err` carries the
+/// disconnect-threshold breach the accounting already reported through its peer
+/// reporter.
+pub trait BandwidthDebit: Send + Sync {
+    /// Debit `peer` by `price` for a received chunk, committing immediately.
+    fn debit_received(&self, peer: OverlayAddress, price: Au, originated: bool) -> SwarmResult<()>;
+}
+
+impl<B: SwarmBandwidthAccounting> BandwidthDebit for B {
+    fn debit_received(&self, peer: OverlayAddress, price: Au, originated: bool) -> SwarmResult<()> {
+        self.prepare_receive(peer, price, originated)
+            .map(AccountingAction::apply)
+    }
+}
+
 /// Combined pricing and bandwidth accounting for client operations.
 ///
 /// Unifies chunk pricing and bandwidth accounting so callers don't need

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -9,7 +9,7 @@ mod reserve;
 mod topology;
 
 pub use self::bandwidth::{
-    AccountingAction, Direction, SwarmAccountingConfig, SwarmBandwidthAccounting,
+    AccountingAction, BandwidthDebit, Direction, SwarmAccountingConfig, SwarmBandwidthAccounting,
     SwarmClientAccounting, SwarmPeerBandwidth, SwarmPeerState, SwarmSettlementProvider,
 };
 pub use self::localstore::{SwarmLocalStore, SwarmLocalStoreConfig};

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -37,9 +37,9 @@ mod types;
 
 pub use self::accounting::{Au, AuConversionError};
 pub use self::components::{
-    AccountingAction, BinCursorStore, BinScanItem, BootnodeComponents, ClientComponents, Direction,
-    HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology, IntervalStore,
-    PullChunkVerifier, PullStorage, ReserveStore, SettableRadius, StorerComponents,
+    AccountingAction, BandwidthDebit, BinCursorStore, BinScanItem, BootnodeComponents,
+    ClientComponents, Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology,
+    IntervalStore, PullChunkVerifier, PullStorage, ReserveStore, SettableRadius, StorerComponents,
     SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore,
     SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing,
     SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -479,11 +479,17 @@ async fn build_client_backed_node(
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
     // The client service reports retrieval and pushsync outcomes through the same
-    // peer manager authority accounting uses, and shares the handle's throttle so
-    // a peer disconnect clears that peer's bucket.
+    // peer manager authority accounting uses, shares the handle's throttle so a
+    // peer disconnect clears that peer's bucket, and debits the serving peer for
+    // our own retrievals and pushes through the same shared accounting the
+    // selector, throttle, and forwarder use.
     let client_service = client_service
         .with_reporter(Arc::clone(&reporter))
-        .with_throttle(throttle);
+        .with_throttle(throttle)
+        .with_accounting(
+            Arc::new(accounting.pricing().clone()),
+            accounting.bandwidth().clone(),
+        );
     ctx.executor()
         .spawn_service("swarm.client_service", client_service);
 
@@ -1315,6 +1321,67 @@ mod tests {
             .get_peer_score(&overlay)
             .expect("peer still scored");
         assert!(after < baseline, "violation must lower the score");
+    }
+
+    /// The shared accounting wired into the client service via `with_accounting`
+    /// debits the serving peer for an own-request delivery. This proves the
+    /// builder's wiring expression activates the origin debit, not just that the
+    /// service supports it.
+    #[tokio::test]
+    async fn builder_wiring_debits_an_origin_delivery() {
+        use nectar_primitives::{AnyChunk, ChunkAddress, ContentChunk};
+        use vertex_swarm_api::{SwarmBandwidthAccounting, SwarmPeerBandwidth, SwarmPricing};
+        use vertex_swarm_node::{ClientEvent, ClientService};
+
+        let identity = test_identity_arc();
+        let config = DefaultBandwidthConfig::default();
+        let accounting = Arc::new(
+            AccountingBuilder::new(config)
+                .with_pricer_from_config(identity.spec().clone())
+                .build(&identity),
+        );
+
+        let chunk: AnyChunk = ContentChunk::new(b"origin debit through the builder".to_vec())
+            .expect("valid content chunk")
+            .into();
+        let address = *chunk.address();
+        let overlay = ChunkAddress::from([0x5cu8; 32]);
+        let price = accounting.pricing().peer_price(&overlay, &address);
+        assert!(price > Au::ZERO, "the per-chunk price is non-zero");
+
+        // The same wiring expression `build_client_backed_node` uses.
+        let (service, event_tx, _handle) = ClientService::new();
+        let service = service.with_accounting(
+            Arc::new(accounting.pricing().clone()),
+            accounting.bandwidth().clone(),
+        );
+
+        let manager = TaskManager::current();
+        let handle = manager
+            .executor()
+            .spawn_service("test.client_service", service);
+
+        event_tx
+            .send(ClientEvent::ChunkReceived {
+                peer: overlay,
+                address,
+                chunk,
+                stamp: None,
+                latency: std::time::Duration::from_millis(1),
+                originated: true,
+            })
+            .await
+            .expect("service is running");
+        // Dropping the sender closes the channel, so the run loop drains the one
+        // queued event and then exits.
+        drop(event_tx);
+        handle.await.expect("service task joins cleanly");
+
+        assert_eq!(
+            accounting.bandwidth().for_peer(overlay).balance(),
+            -price,
+            "an own-request delivery debits the serving peer by the per-chunk price"
+        );
     }
 
     /// The storer factory builds the admission-gated reserve, not the cache-only

--- a/crates/swarm/builder/src/providers.rs
+++ b/crates/swarm/builder/src/providers.rs
@@ -78,8 +78,10 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         // so the staggered starts preserve the per-peer pacing. Losing attempts
         // are dropped when the race resolves.
         match race_candidates(closest_peers, RETRIEVAL_STAGGER, |peer_overlay| {
+            // `originated = true`: our own retrieval, so the client service
+            // debits the serving peer on delivery.
             self.client_handle
-                .retrieve_chunk(peer_overlay, chunk_address)
+                .retrieve_chunk(peer_overlay, chunk_address, true)
         })
         .await
         {
@@ -147,7 +149,13 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
             chunk_address: address,
         });
         for peer in closest {
-            match self.client_handle.push_chunk(peer, chunk.clone()).await {
+            // `originated = true`: our own push, so the client service debits
+            // the storer on receipt.
+            match self
+                .client_handle
+                .push_chunk(peer, chunk.clone(), true)
+                .await
+            {
                 Ok(receipt) => {
                     match accept_origin_receipt(
                         &receipt,
@@ -463,7 +471,7 @@ mod tests {
         ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
             race_candidates(candidates, RETRIEVAL_STAGGER, move |peer| {
                 let handle = handle.clone();
-                async move { handle.retrieve_chunk(peer, address).await }
+                async move { handle.retrieve_chunk(peer, address, true).await }
             })
             .await
         }

--- a/crates/swarm/client-behaviour/src/behaviour.rs
+++ b/crates/swarm/client-behaviour/src/behaviour.rs
@@ -195,13 +195,18 @@ impl ClientBehaviour {
                 peer,
                 address,
                 response,
+                originated,
             } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %address, "Retrieving chunk");
                     self.push_event(ToSwarm::NotifyHandler {
                         peer_id,
                         handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::RetrieveChunk { address, response },
+                        event: HandlerCommand::RetrieveChunk {
+                            address,
+                            response,
+                            originated,
+                        },
                     });
                 } else {
                     debug!(%peer, "Unknown peer for retrieval");
@@ -213,13 +218,18 @@ impl ClientBehaviour {
                 address,
                 chunk,
                 response,
+                originated,
             } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %address, "Pushing chunk");
                     self.push_event(ToSwarm::NotifyHandler {
                         peer_id,
                         handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::PushChunk { chunk, response },
+                        event: HandlerCommand::PushChunk {
+                            chunk,
+                            response,
+                            originated,
+                        },
                     });
                 } else {
                     debug!(%peer, "Unknown peer for push");
@@ -352,6 +362,7 @@ impl ClientBehaviour {
                 chunk,
                 stamp,
                 latency,
+                originated,
             } => {
                 self.pending_events
                     .push_back(ToSwarm::GenerateEvent(ClientEvent::ChunkReceived {
@@ -360,17 +371,20 @@ impl ClientBehaviour {
                         chunk,
                         stamp,
                         latency,
+                        originated,
                     }));
             }
             HandlerEvent::ReceiptReceived {
                 overlay,
                 address,
                 latency,
+                originated,
             } => {
                 self.push_event(ToSwarm::GenerateEvent(ClientEvent::ReceiptReceived {
                     peer: overlay,
                     address,
                     latency,
+                    originated,
                 }));
             }
             HandlerEvent::RetrievalFailed {

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -153,11 +153,15 @@ pub enum HandlerCommand {
     RetrieveChunk {
         address: ChunkAddress,
         response: RetrievalResponseTx,
+        /// True for our own request, false for a forwarder relay leg.
+        originated: bool,
     },
     /// Push a chunk to the peer for storage.
     PushChunk {
         chunk: StampedChunk,
         response: PushResponseTx,
+        /// True for our own push, false for a forwarder relay leg.
+        originated: bool,
     },
     /// Send a pseudosettle payment to the peer.
     SendPseudosettle { amount: U256 },
@@ -207,12 +211,18 @@ pub enum HandlerEvent {
         chunk: AnyChunk,
         stamp: Option<Stamp>,
         latency: Duration,
+        /// Stamped from the per-substream request state: true for an origin
+        /// request, false for a forwarder relay leg.
+        originated: bool,
     },
     /// Received a receipt from peer. `latency` is request-to-receipt, for scoring.
     ReceiptReceived {
         overlay: OverlayAddress,
         address: ChunkAddress,
         latency: Duration,
+        /// Stamped from the per-substream request state: true for an origin
+        /// push, false for a forwarder relay leg.
+        originated: bool,
     },
     /// An outbound retrieval failed. The requester is already resolved through
     /// its response channel; this feeds scoring and metrics. `kind` distinguishes
@@ -657,6 +667,7 @@ impl ClientHandler {
         address: ChunkAddress,
         response: RetrievalResponseTx,
         latency: Duration,
+        originated: bool,
     ) {
         let overlay = self.overlay();
         match delivery {
@@ -690,6 +701,7 @@ impl ClientHandler {
                     chunk: chunk.clone(),
                     stamp: stamp.clone(),
                     latency,
+                    originated,
                 });
                 let _ = response.send(Ok(RetrievalResult {
                     chunk,
@@ -707,6 +719,7 @@ impl ClientHandler {
         address: ChunkAddress,
         response: PushResponseTx,
         latency: Duration,
+        originated: bool,
     ) {
         let overlay = self.overlay();
         match response_msg {
@@ -741,6 +754,7 @@ impl ClientHandler {
                             overlay,
                             address: receipt_address,
                             latency,
+                            originated,
                         });
                         let _ = response.send(Ok(receipt));
                     }
@@ -856,7 +870,11 @@ impl ConnectionHandler for ClientHandler {
                         });
                     }
                 }
-                HandlerCommand::RetrieveChunk { address, response } => {
+                HandlerCommand::RetrieveChunk {
+                    address,
+                    response,
+                    originated,
+                } => {
                     let upgrade = ClientOutboundUpgrade::retrieval(address);
                     return Poll::Ready(ConnectionHandlerEvent::OutboundSubstreamRequest {
                         protocol: SubstreamProtocol::new(
@@ -865,12 +883,17 @@ impl ConnectionHandler for ClientHandler {
                                 address,
                                 response,
                                 requested_at: Instant::now(),
+                                originated,
                             },
                         )
                         .with_timeout(self.config.retrieval_timeout),
                     });
                 }
-                HandlerCommand::PushChunk { chunk, response } => {
+                HandlerCommand::PushChunk {
+                    chunk,
+                    response,
+                    originated,
+                } => {
                     let address = *chunk.address();
                     let delivery = vertex_swarm_net_pushsync::Delivery::new(chunk);
                     let upgrade = ClientOutboundUpgrade::pushsync(delivery);
@@ -881,6 +904,7 @@ impl ConnectionHandler for ClientHandler {
                                 address,
                                 response,
                                 requested_at: Instant::now(),
+                                originated,
                             },
                         )
                         .with_timeout(self.config.pushsync_timeout),
@@ -993,6 +1017,7 @@ impl ConnectionHandler for ClientHandler {
                         address,
                         response,
                         requested_at,
+                        originated: _,
                     } => {
                         // A timeout is never a malformed chunk; an `Apply` error
                         // may be a malformed delivery.
@@ -1028,6 +1053,7 @@ impl ConnectionHandler for ClientHandler {
                         address,
                         response,
                         requested_at,
+                        originated: _,
                     } => {
                         let kind = apply_error
                             .map_or(FailureKind::Protocol, |e| e.pushsync_failure_kind());
@@ -1162,10 +1188,11 @@ impl ClientHandler {
                     address,
                     response,
                     requested_at,
+                    originated,
                 },
             ) => {
                 let latency = requested_at.elapsed();
-                self.on_retrieval_response(delivery, address, response, latency);
+                self.on_retrieval_response(delivery, address, response, latency, originated);
             }
             (
                 ClientOutboundOutput::Pushsync(receipt),
@@ -1173,11 +1200,12 @@ impl ClientHandler {
                     address,
                     response,
                     requested_at,
+                    originated,
                 },
             ) => {
                 let latency = requested_at.elapsed();
                 debug!(%address, "Received pushsync receipt");
-                self.on_pushsync_receipt(receipt, address, response, latency);
+                self.on_pushsync_receipt(receipt, address, response, latency, originated);
             }
             (
                 ClientOutboundOutput::Pseudosettle(ack),

--- a/crates/swarm/client-behaviour/src/upgrade.rs
+++ b/crates/swarm/client-behaviour/src/upgrade.rs
@@ -480,6 +480,9 @@ pub enum ClientOutboundInfo {
         response: super::events::RetrievalResponseTx,
         /// When the outbound substream was requested, for latency scoring.
         requested_at: vertex_util_runtime::time::Instant,
+        /// True for an origin request, false for a forwarder relay leg. Stamped
+        /// onto the completion event so only origin requests are debited.
+        originated: bool,
     },
     /// Pushsync request with chunk address and the caller's response channel.
     Pushsync {
@@ -487,6 +490,9 @@ pub enum ClientOutboundInfo {
         response: super::events::PushResponseTx,
         /// When the outbound substream was requested, for latency scoring.
         requested_at: vertex_util_runtime::time::Instant,
+        /// True for an origin push, false for a forwarder relay leg. Stamped
+        /// onto the completion event so only origin pushes are debited.
+        originated: bool,
     },
     /// Pseudosettle payment with amount.
     Pseudosettle { amount: U256 },

--- a/crates/swarm/client-protocol/src/lib.rs
+++ b/crates/swarm/client-protocol/src/lib.rs
@@ -195,6 +195,9 @@ pub enum ClientEvent {
         stamp: Option<Stamp>,
         /// Time from request to delivery, for latency scoring.
         latency: core::time::Duration,
+        /// True if this was our own request, false if a relay leg. Only an
+        /// origin delivery is debited; the forwarder debits its own legs.
+        originated: bool,
     },
 
     /// A chunk retrieval request failed.
@@ -217,6 +220,9 @@ pub enum ClientEvent {
         address: ChunkAddress,
         /// Time from push to receipt, for latency scoring.
         latency: core::time::Duration,
+        /// True if this was our own push, false if a relay leg. Only an origin
+        /// receipt is debited; the forwarder debits its own legs.
+        originated: bool,
     },
 
     /// A chunk push failed.
@@ -238,14 +244,6 @@ pub enum ClientEvent {
         peer: OverlayAddress,
         /// The protocol that rejected the data.
         protocol: &'static str,
-    },
-
-    /// The balance crossed the payment threshold; settle via swap or pseudosettle.
-    SettlementNeeded {
-        /// The peer to settle with.
-        peer: OverlayAddress,
-        /// Current balance (positive = they owe us).
-        balance: i64,
     },
 
     /// Received a pseudosettle payment from a peer.
@@ -357,6 +355,9 @@ pub enum ClientCommand {
         address: ChunkAddress,
         /// Resolves with the retrieved chunk or the failure.
         response: RetrievalResponseTx,
+        /// True for our own request, false for a forwarder relay leg. Echoed
+        /// back on the completion event so only origin requests are debited.
+        originated: bool,
     },
 
     /// Push a chunk to a peer.
@@ -369,6 +370,9 @@ pub enum ClientCommand {
         chunk: StampedChunk,
         /// Resolves with the storer's receipt or the failure.
         response: PushResponseTx,
+        /// True for our own push, false for a forwarder relay leg. Echoed back
+        /// on the completion event so only origin pushes are debited.
+        originated: bool,
     },
 
     /// Send a pseudosettle payment to a peer.

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -7,7 +7,10 @@ use std::sync::Arc;
 use nectar_primitives::ChunkAddress;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
-use vertex_swarm_api::{Au, PeerReporter, ReportSource, SwarmLocalStore, SwarmScoringEvent};
+use vertex_swarm_api::{
+    Au, BandwidthDebit, PeerReporter, ReportSource, SwarmLocalStore, SwarmPricing,
+    SwarmScoringEvent,
+};
 use vertex_swarm_client_protocol::PseudosettleAck;
 pub use vertex_swarm_client_protocol::{ChunkTransferError, RetrievalResult};
 use vertex_swarm_net_pushsync::Receipt;
@@ -72,11 +75,14 @@ impl ClientHandle {
     /// Retrieve a chunk from a specific peer.
     ///
     /// Any failure on the path resolves or drops the response channel, so this
-    /// future never hangs.
+    /// future never hangs. `originated` is `true` for our own request and
+    /// `false` for a forwarder relay leg; it travels to the completion event so
+    /// only origin requests are debited (the forwarder accounts its own legs).
     pub async fn retrieve_chunk(
         &self,
         peer: OverlayAddress,
         address: ChunkAddress,
+        originated: bool,
     ) -> Result<RetrievalResult, ChunkTransferError> {
         if let Some(throttle) = &self.throttle {
             throttle
@@ -90,6 +96,7 @@ impl ClientHandle {
             peer,
             address,
             response: tx,
+            originated,
         })?;
 
         rx.await.map_err(|_| ChunkTransferError::Cancelled)?
@@ -99,11 +106,13 @@ impl ClientHandle {
     ///
     /// Same failure semantics as [`Self::retrieve_chunk`]. The returned
     /// [`Receipt`] is storer-verified at the decode boundary, so an `Ok` here
-    /// always carries a recovered storer.
+    /// always carries a recovered storer. `originated` distinguishes our own
+    /// push from a forwarder relay leg.
     pub async fn push_chunk(
         &self,
         peer: OverlayAddress,
         chunk: StampedChunk,
+        originated: bool,
     ) -> Result<Receipt, ChunkTransferError> {
         let address = *chunk.address();
 
@@ -120,6 +129,7 @@ impl ClientHandle {
             address,
             chunk,
             response: tx,
+            originated,
         })?;
 
         rx.await.map_err(|_| ChunkTransferError::Cancelled)?
@@ -139,6 +149,17 @@ pub struct ClientService {
     /// Outbound self-throttle shared with the handle; cleared per peer on
     /// disconnect so memory does not grow with distinct peers seen.
     throttle: Option<Arc<SelfThrottle>>,
+    /// Per-peer chunk pricer and the receive-debit half of the shared
+    /// accounting. Present only on the full builder; absent on the lightweight
+    /// launcher, where the origin debit is a no-op.
+    accounting: Option<OriginAccounting>,
+}
+
+/// The pricing and debit handles the service needs to debit own-request
+/// deliveries. Both halves come from the one shared accounting instance.
+struct OriginAccounting {
+    pricing: Arc<dyn SwarmPricing>,
+    bandwidth: Arc<dyn BandwidthDebit>,
 }
 
 impl ClientService {
@@ -156,6 +177,7 @@ impl ClientService {
             reporter: None,
             store: None,
             throttle: None,
+            accounting: None,
         };
 
         (service, event_tx, handle)
@@ -175,6 +197,7 @@ impl ClientService {
             reporter: None,
             store: None,
             throttle: None,
+            accounting: None,
         };
 
         (service, handle)
@@ -210,9 +233,42 @@ impl ClientService {
         self
     }
 
+    /// Attach the shared accounting so own-request deliveries debit the serving
+    /// peer by the per-chunk price.
+    ///
+    /// `pricing` and `bandwidth` are the two halves of the one accounting
+    /// instance the selector, throttle, and forwarder also share. Only origin
+    /// (own-request) completions are debited here; relay legs are accounted by
+    /// the forwarder, so debiting them here would double-charge.
+    #[must_use]
+    pub fn with_accounting(
+        mut self,
+        pricing: Arc<dyn SwarmPricing>,
+        bandwidth: Arc<dyn BandwidthDebit>,
+    ) -> Self {
+        self.accounting = Some(OriginAccounting { pricing, bandwidth });
+        self
+    }
+
     /// Get a handle for sending commands.
     pub fn handle(&self) -> ClientHandle {
         self.handle.clone()
+    }
+
+    /// Debit the serving peer by the per-chunk price for a completed
+    /// own-request delivery. A no-op when no accounting handle is attached.
+    ///
+    /// The chunk is already in hand, so the debit commits immediately. A
+    /// disconnect-threshold breach is already reported to peer scoring inside
+    /// accounting; this only logs it.
+    fn debit_origin(&self, peer: &OverlayAddress, address: &ChunkAddress) {
+        let Some(accounting) = &self.accounting else {
+            return;
+        };
+        let price = accounting.pricing.peer_price(peer, address);
+        if let Err(error) = accounting.bandwidth.debit_received(*peer, price, true) {
+            debug!(%peer, %address, %error, "origin debit refused at disconnect threshold");
+        }
     }
 
     fn report(&self, peer: &OverlayAddress, event: SwarmScoringEvent, source: ReportSource) {
@@ -274,11 +330,17 @@ impl ClientService {
                 chunk,
                 stamp,
                 latency,
+                originated,
             } => {
                 // The requester is resolved by the handler; this event exists for
                 // accounting, scoring, and caching. Content chunks are cached by
-                // address (immutable); SOCs are not (no version signal).
+                // address (immutable); SOCs are not (no version signal). The
+                // debit is origin-gated (a relay leg is debited by the
+                // forwarder); cache and scoring apply to every delivery.
                 debug!(%peer, %address, ?latency, "Chunk received");
+                if originated {
+                    self.debit_origin(&peer, &address);
+                }
                 if let Some(store) = &self.store
                     && chunk.is_content()
                 {
@@ -325,10 +387,15 @@ impl ClientService {
                 peer,
                 address,
                 latency,
+                originated,
             } => {
                 // The pusher is resolved by the handler; this event exists for
-                // accounting and scoring.
+                // accounting and scoring. The debit is origin-gated; a relay leg
+                // is debited by the forwarder.
                 debug!(%peer, %address, ?latency, "Receipt received");
+                if originated {
+                    self.debit_origin(&peer, &address);
+                }
                 self.report(
                     &peer,
                     SwarmScoringEvent::PushSuccess { latency },
@@ -434,11 +501,6 @@ impl ClientService {
                     SwarmScoringEvent::InvalidData,
                     ReportSource::Protocol(protocol),
                 );
-            }
-
-            ClientEvent::SettlementNeeded { peer, balance } => {
-                debug!(%peer, %balance, "Settlement needed");
-                // TODO: Initiate settlement (swap or pseudosettle)
             }
 
             ClientEvent::PseudosettleReceived {
@@ -642,6 +704,7 @@ mod tests {
             peer: peer(6),
             address: ChunkAddress::zero(),
             latency: Duration::from_millis(42),
+            originated: false,
         });
         let (_, event, source) = reporter.single();
         assert_eq!(
@@ -651,6 +714,140 @@ mod tests {
             }
         );
         assert_eq!(source, ReportSource::Protocol("pushsync"));
+    }
+
+    /// A fixed per-chunk price for the origin-debit tests.
+    const ORIGIN_PRICE: u64 = 7;
+
+    /// Records every receive debit so a test can assert exactly which peer was
+    /// charged, how much, and that the `originated` flag carried through.
+    #[derive(Default)]
+    struct RecordingDebit {
+        debits: Mutex<Vec<(OverlayAddress, Au, bool)>>,
+    }
+
+    impl vertex_swarm_api::BandwidthDebit for RecordingDebit {
+        fn debit_received(
+            &self,
+            peer: OverlayAddress,
+            price: Au,
+            originated: bool,
+        ) -> vertex_swarm_api::SwarmResult<()> {
+            self.debits.lock().unwrap().push((peer, price, originated));
+            Ok(())
+        }
+    }
+
+    /// A pricer charging `ORIGIN_PRICE` for every peer and chunk.
+    struct FixedPricer;
+    impl vertex_swarm_api::SwarmPricing for FixedPricer {
+        fn price(&self, _chunk: &ChunkAddress) -> Au {
+            Au::from_amount(ORIGIN_PRICE)
+        }
+        fn peer_price(&self, _peer: &OverlayAddress, _chunk: &ChunkAddress) -> Au {
+            Au::from_amount(ORIGIN_PRICE)
+        }
+    }
+
+    fn service_with_accounting() -> (ClientService, Arc<RecordingDebit>) {
+        let debit = Arc::new(RecordingDebit::default());
+        let (service, _event_tx, _handle) = ClientService::new();
+        let service = service.with_accounting(
+            Arc::new(FixedPricer) as Arc<dyn SwarmPricing>,
+            Arc::clone(&debit) as Arc<dyn BandwidthDebit>,
+        );
+        (service, debit)
+    }
+
+    fn content_chunk() -> nectar_primitives::AnyChunk {
+        nectar_primitives::ContentChunk::new(&b"origin-debit-test"[..])
+            .expect("valid content chunk")
+            .into()
+    }
+
+    #[test]
+    fn origin_retrieval_debits_serving_peer_exactly_once() {
+        let (service, debit) = service_with_accounting();
+        service.process_event(ClientEvent::ChunkReceived {
+            peer: peer(1),
+            address: ChunkAddress::zero(),
+            chunk: content_chunk(),
+            stamp: None,
+            latency: Duration::from_millis(1),
+            originated: true,
+        });
+        let debits = debit.debits.lock().unwrap();
+        assert_eq!(
+            *debits,
+            vec![(peer(1), Au::from_amount(ORIGIN_PRICE), true)],
+            "an origin retrieval debits the serving peer once by the per-chunk price"
+        );
+    }
+
+    #[test]
+    fn relay_retrieval_is_not_debited_by_the_service() {
+        // The forwarder accounts a relay leg itself; the service must not also
+        // debit it, or the transfer is charged twice.
+        let (service, debit) = service_with_accounting();
+        service.process_event(ClientEvent::ChunkReceived {
+            peer: peer(2),
+            address: ChunkAddress::zero(),
+            chunk: content_chunk(),
+            stamp: None,
+            latency: Duration::from_millis(1),
+            originated: false,
+        });
+        assert!(
+            debit.debits.lock().unwrap().is_empty(),
+            "a relay retrieval is debited by the forwarder, never by the service"
+        );
+    }
+
+    #[test]
+    fn origin_push_debits_serving_peer_exactly_once() {
+        let (service, debit) = service_with_accounting();
+        service.process_event(ClientEvent::ReceiptReceived {
+            peer: peer(3),
+            address: ChunkAddress::zero(),
+            latency: Duration::from_millis(1),
+            originated: true,
+        });
+        let debits = debit.debits.lock().unwrap();
+        assert_eq!(
+            *debits,
+            vec![(peer(3), Au::from_amount(ORIGIN_PRICE), true)],
+            "an origin push debits the storer once by the per-chunk price"
+        );
+    }
+
+    #[test]
+    fn relay_push_is_not_debited_by_the_service() {
+        let (service, debit) = service_with_accounting();
+        service.process_event(ClientEvent::ReceiptReceived {
+            peer: peer(4),
+            address: ChunkAddress::zero(),
+            latency: Duration::from_millis(1),
+            originated: false,
+        });
+        assert!(
+            debit.debits.lock().unwrap().is_empty(),
+            "a relay push is debited by the forwarder, never by the service"
+        );
+    }
+
+    #[test]
+    fn origin_delivery_without_accounting_is_a_noop() {
+        // The lightweight launcher attaches no accounting; an origin delivery
+        // must not panic and simply skips the debit.
+        let (service, _event_tx, _handle) = ClientService::new();
+        service.process_event(ClientEvent::ChunkReceived {
+            peer: peer(5),
+            address: ChunkAddress::zero(),
+            chunk: content_chunk(),
+            stamp: None,
+            latency: Duration::from_millis(1),
+            originated: true,
+        });
     }
 
     // Throttle wiring at the outbound API boundary.
@@ -763,7 +960,7 @@ mod tests {
         let (handle, mut rx) = throttled_handle(100);
         let peer = peer(1);
         let stamped = test_stamped_chunk();
-        let push = tokio::spawn(async move { handle.push_chunk(peer, stamped).await });
+        let push = tokio::spawn(async move { handle.push_chunk(peer, stamped, true).await });
 
         let cmd = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await
@@ -803,7 +1000,7 @@ mod tests {
                         .ok();
                 }
             };
-            let (_outcome, ()) = tokio::join!(handle.retrieve_chunk(peer(1), address), serve);
+            let (_outcome, ()) = tokio::join!(handle.retrieve_chunk(peer(1), address, true), serve);
             start.elapsed()
         }
 
@@ -831,7 +1028,7 @@ mod tests {
         let address = test_address();
         let task = tokio::spawn({
             let handle = handle.clone();
-            async move { handle.retrieve_chunk(peer(1), address).await }
+            async move { handle.retrieve_chunk(peer(1), address, true).await }
         });
         let cmd = rx.recv().await.expect("command emitted");
         assert!(matches!(cmd, ClientCommand::RetrieveChunk { .. }));

--- a/crates/swarm/node/src/protocol/behaviour_tests.rs
+++ b/crates/swarm/node/src/protocol/behaviour_tests.rs
@@ -140,6 +140,7 @@ async fn serves_a_content_chunk_from_the_cache() {
             peer: server_overlay,
             address,
             response: tx,
+            originated: true,
         });
 
     let result = drive_until_retrieved(&mut client, &mut server, rx).await;
@@ -174,6 +175,7 @@ async fn serves_a_fresh_soc_from_the_cache() {
             peer: server_overlay,
             address,
             response: tx,
+            originated: true,
         });
 
     let delivered = drive_until_retrieved(&mut client, &mut server, rx)
@@ -210,6 +212,7 @@ async fn expired_soc_is_not_served_and_resets() {
             peer: server_overlay,
             address,
             response: tx,
+            originated: true,
         });
 
     let result = drive_until_retrieved(&mut client, &mut server, rx).await;
@@ -238,6 +241,7 @@ async fn cache_miss_resets_with_stub_forwarder() {
             peer: server_overlay,
             address,
             response: tx,
+            originated: true,
         });
 
     let result = drive_until_retrieved(&mut client, &mut server, rx).await;
@@ -265,6 +269,7 @@ async fn inbound_pushsync_resets_with_stub_forwarder() {
         address: *chunk.address(),
         chunk,
         response: tx,
+        originated: true,
     });
 
     let drive = async {
@@ -455,6 +460,7 @@ async fn responsible_storer_stores_and_signs_a_receipt() {
         address,
         chunk,
         response: tx,
+        originated: true,
     });
 
     let drive = async {
@@ -510,6 +516,7 @@ async fn non_responsible_storer_forwards_instead_of_storing() {
         address,
         chunk,
         response: tx,
+        originated: true,
     });
 
     let drive = async {
@@ -670,6 +677,7 @@ async fn three_node_retrieval_relays_verifies_and_accounts() {
         peer: b_overlay,
         address,
         response: tx,
+        originated: true,
     });
 
     // B's forwarder commands are pumped back into B.
@@ -762,6 +770,7 @@ async fn relay_does_not_cache_a_forwarded_soc() {
         peer: b_overlay,
         address,
         response: tx,
+        originated: true,
     });
 
     let result = {
@@ -825,6 +834,7 @@ async fn relay_without_strictly_closer_peer_resets_rather_than_looping() {
         peer: b_overlay,
         address,
         response: tx,
+        originated: true,
     });
 
     let result = {
@@ -932,6 +942,7 @@ async fn three_node_pushsync_relays_receipt_verbatim_and_accounts() {
         address,
         chunk,
         response: tx,
+        originated: true,
     });
 
     let result = {

--- a/crates/swarm/node/src/protocol/forward.rs
+++ b/crates/swarm/node/src/protocol/forward.rs
@@ -152,7 +152,10 @@ where
                     }
                 };
 
-                match handle.retrieve_chunk(closer, address).await {
+                // `originated = false`: this is a relay leg, so the service must
+                // not debit the completion event. The forwarder debits this leg
+                // itself via `prepare_receive_chunk` above.
+                match handle.retrieve_chunk(closer, address, false).await {
                     Ok(result) => {
                         // Edge verification: the relayed chunk must answer the
                         // requested address before we account, cache, or relay
@@ -236,7 +239,9 @@ where
                     }
                 };
 
-                match handle.push_chunk(closer, chunk.clone()).await {
+                // `originated = false`: a relay leg, debited by the forwarder
+                // above, so the service must not debit the completion event.
+                match handle.push_chunk(closer, chunk.clone(), false).await {
                     Ok(receipt) => {
                         // The receipt's storer was recovered and verified at the
                         // decode boundary, so a malformed receipt never reaches
@@ -507,7 +512,9 @@ mod tests {
                     peer,
                     address: requested,
                     response,
+                    originated,
                 } => {
+                    assert!(!originated, "a relay leg is never an origin request");
                     assert_eq!(peer, closer, "the upstream leg targets the closer peer");
                     assert_eq!(requested, address);
                     response
@@ -666,7 +673,9 @@ mod tests {
                     address: requested,
                     chunk: pushed,
                     response,
+                    originated,
                 } => {
+                    assert!(!originated, "a relay leg is never an origin push");
                     assert_eq!(peer, closer);
                     assert_eq!(requested, address);
                     assert_eq!(*pushed.address(), address);

--- a/crates/swarm/node/src/protocol/timeout_repro.rs
+++ b/crates/swarm/node/src/protocol/timeout_repro.rs
@@ -189,6 +189,7 @@ async fn withholding_peer_resolves_as_timed_out_within_the_deadline() {
             peer: server_overlay,
             address,
             response: tx,
+            originated: true,
         });
 
     let start = Instant::now();


### PR DESCRIPTION
## What

The origin (own-request) retrieval and pushsync paths previously debited nothing: only the relay `NetworkForwarder` legs called into accounting, and the `originated` flag on `prepare_receive` was only ever passed `false`. This threads an `originated` discriminator through the client command and event contract (`ClientHandle::retrieve_chunk`/`push_chunk`, `ClientCommand`, `HandlerCommand`, `HandlerEvent`, and `ClientEvent::ChunkReceived`/`ReceiptReceived`) and debits the serving peer on the node's own completed deliveries.

Application and provider call sites pass `true`; the forwarder relay legs pass `false`. On an origin delivery the client service debits the serving peer by the per-chunk price (`SwarmPricing::peer_price`), the same figure the self-throttle charges and the forwarder debits. The debit is gated on an attached accounting handle: the full builder wires the shared accounting through a new `with_accounting`, while the lightweight launcher stays a no-op (its sharing is deferred to #496). Caching and scoring continue to run on every delivery; only the debit is origin-gated.

A new object-safe `BandwidthDebit` trait gives the service a one-step receive debit it can hold behind a trait object, since the chunk is already in hand when an origin request completes. The dead `ClientEvent::SettlementNeeded` variant is removed.

## Why

Swarm bandwidth accounting is bilateral: the requester of a chunk owes the serving peer and is responsible for settling. Without an origin debit the requester's balance never moves, the self-throttle's affordability signal stays static, and settlement never triggers for the node's own traffic. Against reference peers the un-tracked debt accrues on the creditor's side until the disconnect threshold trips.

The double-debit invariant is the load-bearing concern: the forwarder already relays via `ClientHandle::retrieve_chunk`/`push` and debits the downstream leg itself with `prepare_receive_chunk(closer, &addr, false)`. Those relay retrievals also emit `ChunkReceived`/`ReceiptReceived`, so the service must debit only the originated requests, never the relay legs, or a relayed transfer is charged twice.

## Testing

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` on `vertex-swarm-client-behaviour`, `vertex-swarm-node`, `vertex-swarm-builder`, and a `wasm32-unknown-unknown` build of `vertex-swarm-client-behaviour` and `vertex-swarm-node`, all green.

New tests prove the invariant directly: `origin_retrieval_debits_serving_peer_exactly_once` and `origin_push_debits_serving_peer_exactly_once` (an origin transfer is debited once by the per-chunk price), `relay_retrieval_is_not_debited_by_the_service` and `relay_push_is_not_debited_by_the_service` (a relay leg is never debited by the service), `origin_delivery_without_accounting_is_a_noop`, and a `forward.rs` assertion that a relay leg always carries `originated = false`. `builder_wiring_debits_an_origin_delivery` proves the full builder's wiring expression activates the origin debit end to end against real accounting.

Closes #495

AI Assistance: Claude Code (Opus 4.8) used for implementation.