### PR TITLE
feat(swarm-node): converge the client assembly onto one wasm-clean core

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -123,6 +123,12 @@ jobs:
       # browser client node.
       - name: Build client cone for wasm32
         run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node
+      # The wasm-bindgen acceptance test for the converged client core: it
+      # composes the pseudosettle accounting and round-trips the in-memory
+      # cache, the first wasm test in the repo. Built here (not run, which needs
+      # a headless browser runner) as the wasm-reachability gate.
+      - name: Build wasm client-core test for wasm32
+        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node --test wasm_client_core
       # The chain-free SWAP path: cheque exchange (sign, send, validate, credit)
       # needs no chain, so the accounting stack and `vertex-swarm-node/swap`
       # build for wasm with default features. The on-chain cashout path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9276,6 +9276,7 @@ dependencies = [
  "vertex-node-api",
  "vertex-swarm-accounting",
  "vertex-swarm-accounting-pricing",
+ "vertex-swarm-accounting-pseudosettle",
  "vertex-swarm-api",
  "vertex-swarm-client-behaviour",
  "vertex-swarm-client-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9299,6 +9299,7 @@ dependencies = [
  "vertex-swarm-topology",
  "vertex-tasks",
  "vertex-util-runtime",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/bin/swarm-demo/src/lib.rs
+++ b/bin/swarm-demo/src/lib.rs
@@ -21,6 +21,7 @@
 mod ui;
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use tracing::info;
 use vertex_net_dnsaddr_doh::{DohClient, resolve_mainnet_wss_bootnodes};
@@ -46,7 +47,7 @@ const EVENT_BUFFER_CAP: usize = 256;
 /// handle is the read surface the UI polls.
 #[wasm_bindgen]
 pub struct SwarmDemo {
-    topology: TopologyHandle<Identity>,
+    topology: TopologyHandle<Arc<Identity>>,
     events: std::rc::Rc<std::cell::RefCell<VecDeque<TopologyEvent>>>,
     overlay: String,
     // The task manager owns the global executor the node tasks were spawned
@@ -222,7 +223,7 @@ pub async fn start() -> Result<SwarmDemo, JsValue> {
 /// receiver skips ahead and keeps going rather than stalling, since the live
 /// counters come from `readiness`, not this stream.
 fn spawn_event_pump(
-    topology: TopologyHandle<Identity>,
+    topology: TopologyHandle<Arc<Identity>>,
     events: std::rc::Rc<std::cell::RefCell<VecDeque<TopologyEvent>>>,
 ) {
     use tokio::sync::broadcast::error::RecvError;
@@ -253,7 +254,7 @@ fn spawn_event_pump(
 /// Each tick snapshots readiness into the stats grid and per-bin table. The
 /// scrolling event log is updated by the event pump as events arrive, not here.
 /// Runs on the browser event loop for the session.
-fn spawn_render_loop(topology: TopologyHandle<Identity>) {
+fn spawn_render_loop(topology: TopologyHandle<Arc<Identity>>) {
     use gloo_timers::future::TimeoutFuture;
 
     wasm_bindgen_futures::spawn_local(async move {
@@ -265,7 +266,7 @@ fn spawn_render_loop(topology: TopologyHandle<Identity>) {
 }
 
 /// Render a single frame: the status line, stats grid, and per-bin table.
-fn render_once(topology: &TopologyHandle<Identity>) {
+fn render_once(topology: &TopologyHandle<Arc<Identity>>) {
     let snap = topology.readiness();
 
     if snap.connected_peers == 0 {

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -9,9 +9,7 @@ use tracing::{info, warn};
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_node_api::InfrastructureContext;
 use vertex_storage_redb::RedbDatabase;
-use vertex_swarm_accounting::{
-    Accounting, AccountingBuilder, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
-};
+use vertex_swarm_accounting::{Accounting, ClientAccounting, DefaultBandwidthConfig, FixedPricer};
 #[cfg(feature = "chain")]
 use vertex_swarm_api::SwarmSpec;
 use vertex_swarm_api::{
@@ -21,8 +19,7 @@ use vertex_swarm_api::{
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::args::NetworkConfig;
 use vertex_swarm_node::{
-    AccountingSettlement, BootNode, ClientNode, PeerSelector, PseudosettleWiring, SelfThrottle,
-    SharedAccounting,
+    BootNode, ClientCoreCtx, ClientNode, PseudosettleWiring, SharedAccounting, assemble_client_core,
 };
 use vertex_swarm_peer_manager::{
     DEFAULT_TICK_INTERVAL, DbPeerSnapshotStore, PeerSnapshot, spawn_peer_manager_task,
@@ -437,70 +434,57 @@ async fn build_client_backed_node(
     // services report violations through it so misbehaving peers are scored down.
     let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
 
-    // Pseudosettle is registered first so soft accounting forgives total debt
-    // before SWAP settles originated debt; the order matches `settle_all`.
-    let accounting_builder = AccountingBuilder::new(params.bandwidth.clone())
-        .with_pricer_from_config(Arc::clone(params.spec))
-        .with_reporter(Arc::clone(&reporter))
-        .with_settlement(pseudosettle_provider);
-    #[cfg(feature = "swap")]
-    let accounting = match swap_provider {
-        Some(provider) => accounting_builder
-            .with_settlement(provider)
-            .build(params.identity),
-        None => accounting_builder.build(params.identity),
+    // SWAP is the only native-only provider; pseudosettle is registered first
+    // inside the core so soft accounting forgives total debt before SWAP settles.
+    let extra_settlement: Vec<Box<dyn vertex_swarm_api::SwarmSettlementProvider>> = {
+        #[cfg(feature = "swap")]
+        {
+            swap_provider
+                .map(|provider| {
+                    Box::new(provider) as Box<dyn vertex_swarm_api::SwarmSettlementProvider>
+                })
+                .into_iter()
+                .collect()
+        }
+        #[cfg(not(feature = "swap"))]
+        Vec::new()
     };
-    #[cfg(not(feature = "swap"))]
-    let accounting = accounting_builder.build(params.identity);
-    // One accounting instance is shared by the selector, the two-leg forwarder,
-    // and the node task that keeps it alive.
-    let accounting = Arc::new(accounting);
+
+    // Assemble the shared client middle (accounting, selector, throttle, service)
+    // once; both client entry points wire the same instances through this.
+    let core = assemble_client_core(ClientCoreCtx {
+        spec: Arc::clone(params.spec),
+        identity: params.identity.clone(),
+        bandwidth: params.bandwidth.clone(),
+        topology: topology.clone(),
+        client_service,
+        client_handle: client_handle.clone(),
+        pseudosettle_provider,
+        extra_settlement,
+        reporter: Arc::clone(&reporter),
+    });
 
     // Multi-hop forwarding plus storer ingest must precede the event loop. The
-    // run closure applies both to its concrete node, then returns the run task.
+    // run closure applies both to its concrete node over the shared accounting
+    // and throttled handle, then returns the run task.
     let task = (run)(
-        Arc::clone(&accounting),
+        Arc::clone(&core.accounting),
         reporter.clone(),
-        client_handle.clone(),
+        core.throttled_handle.clone(),
     );
 
-    let selector = Arc::new(PeerSelector::new(
-        Arc::new(topology.clone()),
-        accounting.bandwidth().clone(),
-        Arc::new(accounting.pricing().clone()),
-        Arc::new(AccountingSettlement::new(accounting.bandwidth().clone())),
-    ));
-
-    // Outbound self-throttle: pace our retrieval and pushsync requests under each
-    // peer's pseudosettle allowance so a burst never crosses the settlement
-    // trigger. See `SelfThrottle` for the token/price/sizing model.
-    let throttle = Arc::new(SelfThrottle::new(&accounting, params.bandwidth));
-    let throttled_handle = client_handle.clone().with_throttle(Arc::clone(&throttle));
-
-    let chunk_provider =
-        NetworkChunkProvider::new(throttled_handle, topology.clone()).with_selector(selector);
+    let chunk_provider = NetworkChunkProvider::new(core.throttled_handle.clone(), topology.clone())
+        .with_selector(Arc::clone(&core.selector));
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
-    // The client service reports retrieval and pushsync outcomes through the same
-    // peer manager authority accounting uses, shares the handle's throttle so a
-    // peer disconnect clears that peer's bucket, and debits the serving peer for
-    // our own retrievals and pushes through the same shared accounting the
-    // selector, throttle, and forwarder use.
-    let client_service = client_service
-        .with_reporter(Arc::clone(&reporter))
-        .with_throttle(throttle)
-        .with_accounting(
-            Arc::new(accounting.pricing().clone()),
-            accounting.bandwidth().clone(),
-        );
     ctx.executor()
-        .spawn_service("swarm.client_service", client_service);
+        .spawn_service("swarm.client_service", core.client_service);
 
     // Pseudosettle settlement service over the shared accounting: applies
     // time-based refresh and forwards our outbound settlement to the node.
     pseudosettle_wiring.spawn(
         ctx.executor(),
-        accounting.bandwidth().clone(),
+        core.accounting.bandwidth().clone(),
         client_handle.clone(),
         Arc::clone(&reporter),
     );
@@ -512,7 +496,7 @@ async fn build_client_backed_node(
     if let Some(wiring) = swap_wiring {
         wiring.spawn(
             ctx.executor(),
-            accounting.bandwidth().clone(),
+            core.accounting.bandwidth().clone(),
             client_handle,
             Arc::clone(&reporter),
             #[cfg(feature = "chain")]
@@ -1112,6 +1096,7 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use nectar_primitives::Nonce;
+    use vertex_swarm_accounting::AccountingBuilder;
     use vertex_swarm_api::{Au, SwarmAccountingConfig, SwarmIdentity};
     use vertex_swarm_node::args::NetworkArgs;
     use vertex_swarm_peer_manager::{PeerManager, PeerManagerConfig};

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -465,12 +465,14 @@ async fn build_client_backed_node(
     });
 
     // Multi-hop forwarding plus storer ingest must precede the event loop. The
-    // run closure applies both to its concrete node over the shared accounting
-    // and throttled handle, then returns the run task.
+    // run closure applies both to its concrete node over the shared accounting,
+    // then returns the run task. The forwarder relay legs run over the
+    // unthrottled handle: the self-throttle paces only our own origin retrieval
+    // and pushsync, never chunks we relay on another peer's behalf.
     let task = (run)(
         Arc::clone(&core.accounting),
         reporter.clone(),
-        core.throttled_handle.clone(),
+        core.client_handle.clone(),
     );
 
     let chunk_provider = NetworkChunkProvider::new(core.throttled_handle.clone(), topology.clone())

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -20,7 +20,10 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::args::NetworkConfig;
-use vertex_swarm_node::{AccountingSettlement, BootNode, ClientNode, PeerSelector, SelfThrottle};
+use vertex_swarm_node::{
+    AccountingSettlement, BootNode, ClientNode, PeerSelector, PseudosettleWiring, SelfThrottle,
+    SharedAccounting,
+};
 use vertex_swarm_peer_manager::{
     DEFAULT_TICK_INTERVAL, DbPeerSnapshotStore, PeerSnapshot, spawn_peer_manager_task,
 };
@@ -369,7 +372,7 @@ async fn build_client_backed_node(
     // prepare the provider so it embeds in the accounting, and the event sink so
     // pseudosettle wire events route at node build time.
     let (pseudosettle_provider, pseudosettle_wiring) =
-        crate::pseudosettle::PseudosettleWiring::prepare(params.bandwidth);
+        PseudosettleWiring::prepare(params.bandwidth);
     let pseudosettle_event_sender = pseudosettle_wiring.event_sender();
 
     // SWAP settlement is prepared next: the provider embeds in the accounting
@@ -496,7 +499,7 @@ async fn build_client_backed_node(
     // Pseudosettle settlement service over the shared accounting: applies
     // time-based refresh and forwards our outbound settlement to the node.
     pseudosettle_wiring.spawn(
-        ctx,
+        ctx.executor(),
         accounting.bandwidth().clone(),
         client_handle.clone(),
         Arc::clone(&reporter),
@@ -508,7 +511,7 @@ async fn build_client_backed_node(
     #[cfg(feature = "swap")]
     if let Some(wiring) = swap_wiring {
         wiring.spawn(
-            ctx,
+            ctx.executor(),
             accounting.bandwidth().clone(),
             client_handle,
             Arc::clone(&reporter),
@@ -530,44 +533,6 @@ async fn build_client_backed_node(
         reserve,
     })
 }
-
-/// Forward a settlement service's `ClientCommand`s to the node command channel.
-///
-/// A settlement service (pseudosettle or swap) emits commands on an unbounded
-/// channel; this task drains it and hands each command to the node through the
-/// non-blocking [`ClientHandle::send_command`], so the service never blocks on a
-/// full queue. The task ends when the service drops its sender or on shutdown.
-pub(crate) fn spawn_client_command_bridge(
-    ctx: &dyn InfrastructureContext,
-    task_name: &'static str,
-    mut command_rx: tokio::sync::mpsc::UnboundedReceiver<vertex_swarm_node::ClientCommand>,
-    client_handle: vertex_swarm_node::ClientHandle,
-) {
-    ctx.executor()
-        .spawn_with_graceful_shutdown_signal(task_name, move |shutdown| async move {
-            let mut shutdown = std::pin::pin!(shutdown);
-            loop {
-                tokio::select! {
-                    guard = &mut shutdown => {
-                        drop(guard);
-                        break;
-                    }
-                    command = command_rx.recv() => {
-                        let Some(command) = command else { break };
-                        if let Err(e) = client_handle.send_command(command) {
-                            warn!(error = %e, "Failed to forward settlement command to node");
-                        }
-                    }
-                }
-            }
-        });
-}
-
-/// The shared accounting type both client-backed node types build: the default
-/// bandwidth accounting wrapped with the config pricer.
-type SharedAccounting = Arc<
-    ClientAccounting<Arc<Accounting<DefaultBandwidthConfig, Arc<Identity>>>, FixedPricer<Spec>>,
->;
 
 /// A run-task factory: applies multi-hop forwarding (and storer ingest) over the
 /// shared accounting, then returns the node's event-loop task. The factory keeps

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -43,7 +43,6 @@ mod handle;
 mod launch;
 mod node;
 mod providers;
-mod pseudosettle;
 mod pullsync;
 #[cfg(feature = "swap")]
 mod swap;

--- a/crates/swarm/builder/src/swap.rs
+++ b/crates/swarm/builder/src/swap.rs
@@ -25,16 +25,16 @@ use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
-use vertex_node_api::InfrastructureContext;
 use vertex_swarm_accounting_swap::service::SwapCommand;
 use vertex_swarm_accounting_swap::{SwapEvent, SwapHandle, SwapProvider, SwapService};
 use vertex_swarm_api::{
     PeerReporter, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmIdentity, SwarmSpec,
 };
 use vertex_swarm_identity::Identity;
-use vertex_swarm_node::ClientHandle;
 use vertex_swarm_node::args::SwapConfig;
+use vertex_swarm_node::{ClientHandle, spawn_client_command_bridge};
 use vertex_swarm_spec::Spec;
+use vertex_tasks::TaskExecutor;
 
 #[cfg(feature = "chain")]
 use crate::chain::SharedChainProvider;
@@ -140,7 +140,7 @@ impl SwapWiring {
     /// also cashed on chain, paying out to our beneficiary.
     pub(crate) fn spawn<A>(
         self,
-        ctx: &dyn InfrastructureContext,
+        executor: &TaskExecutor,
         accounting: Arc<A>,
         client_handle: ClientHandle,
         reporter: Arc<dyn PeerReporter>,
@@ -152,8 +152,8 @@ impl SwapWiring {
         // is bounded and reached through `ClientHandle::send_command`. Bridge the
         // two with a forwarding task so the service never blocks on a full queue.
         let (client_command_tx, client_command_rx) = mpsc::unbounded_channel();
-        crate::launch::spawn_client_command_bridge(
-            ctx,
+        spawn_client_command_bridge(
+            executor,
             "swarm.swap_command_bridge",
             client_command_rx,
             client_handle,
@@ -175,7 +175,7 @@ impl SwapWiring {
         #[cfg(feature = "chain")]
         let service = attach_cashout(service, chain_provider, self.beneficiary);
 
-        ctx.executor().spawn_service("swarm.swap_service", service);
+        executor.spawn_service("swarm.swap_service", service);
     }
 }
 

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -49,6 +49,7 @@ vertex-swarm-spec.workspace = true
 
 ## vertex - infrastructure
 vertex-swarm-accounting.workspace = true
+vertex-swarm-accounting-pseudosettle.workspace = true
 vertex-tasks.workspace = true
 vertex-util-runtime.workspace = true
 

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -113,6 +113,14 @@ libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91f
 libp2p-websocket-websys.workspace = true
 
 [dev-dependencies]
+nectar-postage.workspace = true
+alloy-signer-local.workspace = true
+
+# Native test harness: the multi-thread runtime, the cluster rig (which spawns
+# `!Send` node futures), the behaviour test rig, and the tracing subscriber are
+# native-only and would drag native-only transitive crates (mio, errno) into the
+# wasm test build, so they stay off wasm32.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 vertex-swarm-test-utils = { workspace = true, features = ["cluster"] }
 vertex-swarm-topology.workspace = true
@@ -120,8 +128,11 @@ eyre.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 libp2p-swarm-test.workspace = true
 rand_08.workspace = true
-nectar-postage.workspace = true
-alloy-signer-local.workspace = true
+
+# Wasm test harness: the network-free identity fixtures plus the bindgen runner.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+vertex-swarm-test-utils.workspace = true
+wasm-bindgen-test.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -22,8 +22,9 @@ mod staggered_race;
 mod throttle;
 
 pub use node::{
-    BaseNode, BuiltInfrastructure, ClientLauncher, ClientNode, ClientNodeBuilder, LaunchedClient,
-    NodeBuildError, PseudosettleWiring, SharedAccounting, spawn_client_command_bridge,
+    BaseNode, BuiltInfrastructure, ClientCore, ClientCoreCtx, ClientLauncher, ClientNode,
+    ClientNodeBuilder, LaunchedClient, NodeBuildError, PseudosettleWiring, SharedAccounting,
+    assemble_client_core, spawn_client_command_bridge,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder, StorerNode, StorerNodeBuilder, StorerPullsyncControl};

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -23,7 +23,7 @@ mod throttle;
 
 pub use node::{
     BaseNode, BuiltInfrastructure, ClientLauncher, ClientNode, ClientNodeBuilder, LaunchedClient,
-    NodeBuildError,
+    NodeBuildError, PseudosettleWiring, SharedAccounting, spawn_client_command_bridge,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder, StorerNode, StorerNodeBuilder, StorerPullsyncControl};

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -12,17 +12,25 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 use tracing::warn;
-use vertex_swarm_accounting::{Accounting, ClientAccounting, DefaultBandwidthConfig, FixedPricer};
+use vertex_swarm_accounting::{
+    Accounting, AccountingBuilder, ClientAccounting, DefaultBandwidthConfig, FixedPricer,
+};
 use vertex_swarm_accounting_pseudosettle::{
     PseudosettleCommand, PseudosettleEvent, PseudosettleHandle, PseudosettleProvider,
     PseudosettleService,
 };
-use vertex_swarm_api::{Au, PeerReporter, SwarmAccountingConfig, SwarmBandwidthAccounting};
+use vertex_swarm_api::{
+    Au, PeerReporter, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting,
+    SwarmSettlementProvider,
+};
 use vertex_swarm_identity::Identity;
 use vertex_swarm_spec::Spec;
+use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::TaskExecutor;
 
-use crate::{ClientCommand, ClientHandle};
+use crate::{
+    AccountingSettlement, ClientCommand, ClientHandle, ClientService, PeerSelector, SelfThrottle,
+};
 
 /// The concrete shared accounting both client-backed node types build: the
 /// default bandwidth accounting wrapped with the config pricer, pinned to the
@@ -31,6 +39,129 @@ use crate::{ClientCommand, ClientHandle};
 pub type SharedAccounting = Arc<
     ClientAccounting<Arc<Accounting<DefaultBandwidthConfig, Arc<Identity>>>, FixedPricer<Spec>>,
 >;
+
+/// The shared client middle both client-backed entry points assemble: the
+/// accounting, the candidate selector, the outbound self-throttle, the throttled
+/// client handle, and the accounting-attached client service.
+///
+/// Provider-free by design: the chunk provider lives in the native builder
+/// (which depends up on this crate) and is also the RPC providers payload, so
+/// each entry point builds its own from `throttled_handle` and `selector` after
+/// calling [`assemble_client_core`]. `enable_forwarding` is likewise the entry
+/// point's call: it borrows the node mutably before the node moves into the run
+/// loop, so the borrow and the move stay in one scope.
+pub struct ClientCore {
+    /// The one accounting instance shared across selector, throttle, forwarder,
+    /// service, and settlement.
+    pub accounting: SharedAccounting,
+    /// Retrieval and pushsync candidate selection over the shared accounting.
+    pub selector: Arc<PeerSelector>,
+    /// Outbound self-throttle shared by both protocols and the service.
+    pub throttle: Arc<SelfThrottle>,
+    /// The client handle paced by `throttle`; the provider dispatches through it.
+    pub throttled_handle: ClientHandle,
+    /// The node's topology handle, threaded through unchanged.
+    pub topology: TopologyHandle<Arc<Identity>>,
+    /// The client service with accounting, throttle, and reporter attached.
+    pub client_service: ClientService,
+    /// The unthrottled client handle settlement services forward commands to.
+    pub client_handle: ClientHandle,
+}
+
+/// Inputs to [`assemble_client_core`].
+///
+/// Carries the prepared pseudosettle provider plus any native-only providers
+/// (swap) in `extra_settlement`; pseudosettle is registered first so soft
+/// accounting forgives total debt before swap settles originated debt.
+pub struct ClientCoreCtx {
+    /// Network spec for the config pricer.
+    pub spec: Arc<Spec>,
+    /// Node identity the accounting and overlay are pinned to.
+    pub identity: Arc<Identity>,
+    /// Bandwidth config; the accounting builder consumes a clone and the
+    /// throttle derives its sizing from a borrow.
+    pub bandwidth: DefaultBandwidthConfig,
+    /// The node's topology handle.
+    pub topology: TopologyHandle<Arc<Identity>>,
+    /// The client service to attach accounting, throttle, and reporter to.
+    pub client_service: ClientService,
+    /// The unthrottled client handle.
+    pub client_handle: ClientHandle,
+    /// Soft-accounting settlement, registered first.
+    pub pseudosettle_provider: PseudosettleProvider<DefaultBandwidthConfig>,
+    /// Native-only settlement providers (swap) registered after pseudosettle.
+    pub extra_settlement: Vec<Box<dyn SwarmSettlementProvider>>,
+    /// The peer-scoring authority accounting and the service report through.
+    pub reporter: Arc<dyn PeerReporter>,
+}
+
+/// Assemble the shared client middle: build the accounting with its settlement
+/// providers, the selector and throttle over it, the throttled handle, and the
+/// accounting-attached service.
+///
+/// Does not build a chunk provider and does not call `enable_forwarding`; both
+/// stay with the caller. Returns the shared accounting `Arc` so the caller can
+/// thread it into `enable_forwarding` and keep it alive for the run loop.
+pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
+    let ClientCoreCtx {
+        spec,
+        identity,
+        bandwidth,
+        topology,
+        client_service,
+        client_handle,
+        pseudosettle_provider,
+        extra_settlement,
+        reporter,
+    } = ctx;
+
+    // Pseudosettle is registered first so soft accounting forgives total debt
+    // before swap settles originated debt; the order matches `settle_all`.
+    let accounting = AccountingBuilder::new(bandwidth.clone())
+        .with_pricer_from_config(spec)
+        .with_reporter(Arc::clone(&reporter))
+        .with_settlement(pseudosettle_provider)
+        .with_settlements(extra_settlement)
+        .build(&identity);
+    // One accounting instance is shared by the selector, throttle, forwarder,
+    // service, and settlement services.
+    let accounting: SharedAccounting = Arc::new(accounting);
+
+    let selector = Arc::new(PeerSelector::new(
+        Arc::new(topology.clone()),
+        accounting.bandwidth().clone(),
+        Arc::new(accounting.pricing().clone()),
+        Arc::new(AccountingSettlement::new(accounting.bandwidth().clone())),
+    ));
+
+    // Outbound self-throttle: pace our retrieval and pushsync requests under each
+    // peer's pseudosettle allowance so a burst never crosses the settlement
+    // trigger.
+    let throttle = Arc::new(SelfThrottle::new(&accounting, &bandwidth));
+    let throttled_handle = client_handle.clone().with_throttle(Arc::clone(&throttle));
+
+    // The service reports through the same peer-manager authority accounting
+    // uses, shares the handle's throttle so a disconnect clears that peer's
+    // bucket, and debits the serving peer for our own-request deliveries through
+    // the same shared accounting the selector, throttle, and forwarder use.
+    let client_service = client_service
+        .with_reporter(reporter)
+        .with_throttle(Arc::clone(&throttle))
+        .with_accounting(
+            Arc::new(accounting.pricing().clone()),
+            accounting.bandwidth().clone(),
+        );
+
+    ClientCore {
+        accounting,
+        selector,
+        throttle,
+        throttled_handle,
+        topology,
+        client_service,
+        client_handle,
+    }
+}
 
 /// Channels connecting the pseudosettle provider, service, and node.
 ///

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -1,33 +1,43 @@
-//! Pseudosettle (soft accounting) settlement wiring for the client launch path.
+//! Shared client-core assembly surface for the native builder and the embedded
+//! launcher.
 //!
-//! Pseudosettle is always on for client and storer nodes. It ties together a
-//! [`PseudosettleProvider`] registered with the accounting builder, the
-//! [`PseudosettleService`] actor that runs the time-based-refresh settlement,
-//! and the wire plumbing that routes pseudosettle events from the node into the
-//! service and the service's outbound `SendPseudosettle` commands back to the
-//! node. Because the provider must be embedded in the accounting before it is
-//! built, the wiring is split: [`PseudosettleWiring::prepare`] builds the handle
-//! and provider up front, then [`PseudosettleWiring::spawn`] constructs and
-//! spawns the service once the accounting instance and the node command channel
-//! exist. Mirrors the SWAP wiring, minus the chain, signer, and chequebook.
+//! Both client entry points wire the same accounting/selector/throttle middle.
+//! This module owns the pieces that middle needs to be reachable from the wasm
+//! launcher: the concrete shared accounting alias, the pseudosettle service
+//! wiring, and the command bridge that drains a settlement service onto the node
+//! command channel. Spawning takes a bare [`TaskExecutor`] so both the native
+//! context and the browser launcher drive it.
 
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use vertex_node_api::InfrastructureContext;
+use tracing::warn;
+use vertex_swarm_accounting::{Accounting, ClientAccounting, DefaultBandwidthConfig, FixedPricer};
 use vertex_swarm_accounting_pseudosettle::{
     PseudosettleCommand, PseudosettleEvent, PseudosettleHandle, PseudosettleProvider,
     PseudosettleService,
 };
 use vertex_swarm_api::{Au, PeerReporter, SwarmAccountingConfig, SwarmBandwidthAccounting};
-use vertex_swarm_node::ClientHandle;
+use vertex_swarm_identity::Identity;
+use vertex_swarm_spec::Spec;
+use vertex_tasks::TaskExecutor;
+
+use crate::{ClientCommand, ClientHandle};
+
+/// The concrete shared accounting both client-backed node types build: the
+/// default bandwidth accounting wrapped with the config pricer, pinned to the
+/// node identity. One instance is shared across the selector, throttle,
+/// forwarder, client service, and settlement services.
+pub type SharedAccounting = Arc<
+    ClientAccounting<Arc<Accounting<DefaultBandwidthConfig, Arc<Identity>>>, FixedPricer<Spec>>,
+>;
 
 /// Channels connecting the pseudosettle provider, service, and node.
 ///
 /// Produced by [`PseudosettleWiring::prepare`] before the accounting is built;
 /// consumed by [`PseudosettleWiring::spawn`] after the node command channel
-/// exists.
-pub(crate) struct PseudosettleWiring {
+/// exists. Wasm-clean: tokio sync channels and an `Au` refresh rate only.
+pub struct PseudosettleWiring {
     command_rx: mpsc::UnboundedReceiver<PseudosettleCommand>,
     event_tx: mpsc::UnboundedSender<PseudosettleEvent>,
     event_rx: mpsc::UnboundedReceiver<PseudosettleEvent>,
@@ -40,7 +50,7 @@ impl PseudosettleWiring {
     /// The handle is created here so the provider can be embedded in the
     /// accounting before the accounting is built; its command channel is drained
     /// by the service spawned in [`Self::spawn`].
-    pub(crate) fn prepare<C>(config: &C) -> (PseudosettleProvider<C>, Self)
+    pub fn prepare<C>(config: &C) -> (PseudosettleProvider<C>, Self)
     where
         C: SwarmAccountingConfig + Clone + 'static,
     {
@@ -61,7 +71,7 @@ impl PseudosettleWiring {
     }
 
     /// The sender the node behaviour routes pseudosettle wire events into.
-    pub(crate) fn event_sender(&self) -> mpsc::UnboundedSender<PseudosettleEvent> {
+    pub fn event_sender(&self) -> mpsc::UnboundedSender<PseudosettleEvent> {
         self.event_tx.clone()
     }
 
@@ -72,9 +82,9 @@ impl PseudosettleWiring {
     /// channel, and consumes routed pseudosettle wire events. Settlement
     /// violations are reported through `reporter`. Its outbound `SendPseudosettle`
     /// commands are forwarded to the node through `client_handle`.
-    pub(crate) fn spawn<A>(
+    pub fn spawn<A>(
         self,
-        ctx: &dyn InfrastructureContext,
+        executor: &TaskExecutor,
         accounting: Arc<A>,
         client_handle: ClientHandle,
         reporter: Arc<dyn PeerReporter>,
@@ -84,8 +94,8 @@ impl PseudosettleWiring {
         // The service speaks unbounded `ClientCommand`; bridge it to the bounded
         // node command channel so the service never blocks on a full queue.
         let (client_command_tx, client_command_rx) = mpsc::unbounded_channel();
-        crate::launch::spawn_client_command_bridge(
-            ctx,
+        spawn_client_command_bridge(
+            executor,
             "swarm.pseudosettle_command_bridge",
             client_command_rx,
             client_handle,
@@ -100,16 +110,46 @@ impl PseudosettleWiring {
         )
         .with_reporter(reporter);
 
-        ctx.executor()
-            .spawn_service("swarm.pseudosettle_service", service);
+        executor.spawn_service("swarm.pseudosettle_service", service);
     }
+}
+
+/// Forward a settlement service's `ClientCommand`s to the node command channel.
+///
+/// A settlement service (pseudosettle or swap) emits commands on an unbounded
+/// channel; this task drains it and hands each command to the node through the
+/// non-blocking [`ClientHandle::send_command`], so the service never blocks on a
+/// full queue. The task ends when the service drops its sender or on shutdown.
+pub fn spawn_client_command_bridge(
+    executor: &TaskExecutor,
+    task_name: &'static str,
+    mut command_rx: mpsc::UnboundedReceiver<ClientCommand>,
+    client_handle: ClientHandle,
+) {
+    executor.spawn_with_graceful_shutdown_signal(task_name, move |shutdown| async move {
+        let mut shutdown = std::pin::pin!(shutdown);
+        loop {
+            tokio::select! {
+                guard = &mut shutdown => {
+                    drop(guard);
+                    break;
+                }
+                command = command_rx.recv() => {
+                    let Some(command) = command else { break };
+                    if let Err(e) = client_handle.send_command(command) {
+                        warn!(error = %e, "Failed to forward settlement command to node");
+                    }
+                }
+            }
+        }
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use vertex_swarm_accounting::{AccountingBuilder, DefaultBandwidthConfig};
+    use vertex_swarm_accounting::AccountingBuilder;
     use vertex_swarm_api::{SwarmClientAccounting, SwarmIdentity};
     use vertex_swarm_test_utils::test_identity_arc;
 

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -3,19 +3,29 @@
 //! [`ClientLauncher`] is the lightweight entry point shared by native
 //! embedders and the browser client: no database, no chain provider, no RPC
 //! server. It composes a [`ClientNode`] from an identity and a handful of
-//! network knobs, spawns the node run loop, the client service, and the
+//! network knobs, wires the shared client core (pseudosettle accounting,
+//! candidate selector, outbound throttle, relay forwarder), spawns the node
+//! run loop, the client service, the pseudosettle settlement service, and the
 //! peer-manager tick on the current [`TaskExecutor`], and hands back a
 //! [`LaunchedClient`] with the handles a caller needs to observe the topology
-//! and issue chunk reads and writes. The full native stack (storage, chain,
-//! settlement, RPC) goes through `vertex-swarm-builder` instead.
+//! and issue chunk reads and writes. Settlement here is pseudosettle only; the
+//! full native stack (storage, chain, swap, RPC) goes through
+//! `vertex-swarm-builder` instead.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::{Result, WrapErr};
 use libp2p::{Multiaddr, PeerId};
 use nectar_primitives::SwarmAddress;
+use vertex_swarm_accounting::DefaultBandwidthConfig;
 use vertex_swarm_api::{
-    DefaultPeerConfig, SwarmIdentity, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
+    DefaultPeerConfig, PeerReporter, SwarmClientAccounting, SwarmLocalStore, SwarmNetworkConfig,
+    SwarmPeerConfig, SwarmRoutingConfig,
+};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_localstore::{
+    ChunkStore, DEFAULT_CACHE_BUDGET_BYTES, DEFAULT_SOC_CACHE_TTL_NS, SystemClock,
 };
 use vertex_swarm_peer_manager::{DEFAULT_TICK_INTERVAL, spawn_peer_manager_task};
 use vertex_swarm_spec::HasSpec;
@@ -23,6 +33,7 @@ use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
 use vertex_tasks::TaskExecutor;
 
 use super::client::ClientNode;
+use super::core::{ClientCoreCtx, PseudosettleWiring, SharedAccounting, assemble_client_core};
 use crate::ClientHandle;
 
 /// Default connection idle timeout for a launched client.
@@ -122,22 +133,24 @@ impl SwarmRoutingConfig for LaunchNetworkConfig {
 ///     .await?;
 /// let topology = launched.topology().clone();
 /// ```
-pub struct ClientLauncher<I: SwarmIdentity + Clone> {
-    identity: I,
+pub struct ClientLauncher {
+    identity: Arc<Identity>,
     bootnodes: Vec<Multiaddr>,
     kademlia: KademliaConfig,
+    bandwidth: DefaultBandwidthConfig,
     max_peers: usize,
     idle_timeout: Duration,
 }
 
-impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
+impl ClientLauncher {
     /// Create a launcher for the given identity with default settings.
     #[must_use]
-    pub fn new(identity: I) -> Self {
+    pub fn new(identity: impl Into<Arc<Identity>>) -> Self {
         Self {
-            identity,
+            identity: identity.into(),
             bootnodes: Vec::new(),
             kademlia: KademliaConfig::default(),
+            bandwidth: DefaultBandwidthConfig::default(),
             max_peers: DEFAULT_MAX_PEERS,
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
         }
@@ -161,6 +174,16 @@ impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
         self
     }
 
+    /// Set the bandwidth accounting configuration.
+    ///
+    /// Drives the pseudosettle allowance, the per-chunk price, and the outbound
+    /// self-throttle sizing. Defaults to [`DefaultBandwidthConfig::default`].
+    #[must_use]
+    pub fn with_bandwidth(mut self, bandwidth: DefaultBandwidthConfig) -> Self {
+        self.bandwidth = bandwidth;
+        self
+    }
+
     /// Set the transport-layer cap on established connections.
     #[must_use]
     pub fn with_max_peers(mut self, max: usize) -> Self {
@@ -178,11 +201,15 @@ impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
     /// Build and start the client node, returning its handles.
     ///
     /// Assembles a [`ClientNode`] over the platform transport (TCP with DNS
-    /// natively, secure websockets in the browser), spawns the node run loop,
-    /// the client service, and the peer-manager tick on the current
-    /// [`TaskExecutor`], and returns a [`LaunchedClient`]. The node dials its
-    /// bootnodes as part of startup; from there the Kademlia routing table
-    /// fills on its own.
+    /// natively, secure websockets in the browser), wires the shared client
+    /// core (pseudosettle accounting, candidate selector, outbound throttle,
+    /// and the relay forwarder), spawns the node run loop, the client service,
+    /// the pseudosettle settlement service, and the peer-manager tick on the
+    /// current [`TaskExecutor`], and returns a [`LaunchedClient`]. The node
+    /// dials its bootnodes as part of startup; from there the Kademlia routing
+    /// table fills on its own.
+    ///
+    /// Settlement is pseudosettle only; swap stays a native-builder concern.
     ///
     /// The returned handles own nothing the spawned tasks need, so the client
     /// keeps running after they are dropped. Shutdown goes through the task
@@ -193,10 +220,7 @@ impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
     /// Returns an error if the swarm fails to assemble (transport or behaviour
     /// construction). Failures after spawn, including the run loop exiting
     /// with an error, are logged by the spawned task.
-    pub async fn launch(self) -> Result<LaunchedClient<I>>
-    where
-        I: HasSpec,
-    {
+    pub async fn launch(self) -> Result<LaunchedClient> {
         let config = LaunchNetworkConfig {
             bootnodes: self.bootnodes,
             peer: DefaultPeerConfig::default(),
@@ -205,15 +229,64 @@ impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
             idle_timeout: self.idle_timeout,
         };
 
-        let (node, client_service, client_handle) = ClientNode::builder(self.identity)
-            .with_kademlia_config(self.kademlia)
-            .build(&config, None)
-            .await
-            .wrap_err("failed to build client node")?;
+        let spec = Arc::clone(HasSpec::spec(&self.identity));
+
+        // The launcher owns the in-memory client cache so callers can read it
+        // back; the node serves inbound retrievals and the client's own
+        // deliveries from the same store.
+        let store = Arc::new(ChunkStore::with_budget(
+            DEFAULT_CACHE_BUDGET_BYTES as usize,
+            DEFAULT_SOC_CACHE_TTL_NS,
+        ));
+
+        // Pseudosettle wiring is prepared before the node so the event sink
+        // routes wire events at build time and the provider embeds in the
+        // accounting the core assembles.
+        let (pseudosettle_provider, pseudosettle_wiring) =
+            PseudosettleWiring::prepare(&self.bandwidth);
+
+        let store_dyn: Arc<dyn SwarmLocalStore> = store.clone();
+        let (mut node, client_service, client_handle) =
+            ClientNode::builder(Arc::clone(&self.identity))
+                .with_kademlia_config(self.kademlia)
+                .with_store(store_dyn)
+                .with_pseudosettle_events(pseudosettle_wiring.event_sender())
+                .build(&config, None)
+                .await
+                .wrap_err("failed to build client node")?;
 
         let topology = node.topology_handle().clone();
         let overlay = node.overlay_address();
         let peer_id = *node.local_peer_id();
+
+        // The peer manager is the reporting authority: accounting and the
+        // pseudosettle service report violations through it.
+        let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
+
+        // Assemble the shared client middle (accounting, selector, throttle,
+        // service) the native builder also goes through; the embedded client
+        // carries no native-only settlement, so the swap providers are absent.
+        let core = assemble_client_core(ClientCoreCtx {
+            spec,
+            identity: Arc::clone(&self.identity),
+            bandwidth: self.bandwidth,
+            topology: topology.clone(),
+            client_service,
+            client_handle: client_handle.clone(),
+            pseudosettle_provider,
+            extra_settlement: Vec::new(),
+            reporter: Arc::clone(&reporter),
+        });
+
+        // Multi-hop forwarding must precede the event loop: a handler created
+        // earlier captures the stub forwarder. The node is borrowed mutably
+        // here and then moved into the run loop below, so the borrow and the
+        // move stay in this scope.
+        node.enable_forwarding(
+            Arc::new(topology.clone()),
+            Arc::clone(&core.accounting),
+            core.throttled_handle.clone(),
+        );
 
         let executor = TaskExecutor::current();
 
@@ -229,7 +302,17 @@ impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
         // It must run even for callers that never issue downloads, so the node
         // can answer the protocols its peers speak during topology building.
         // Its task is `Send`, so it goes through the ordinary service spawner.
-        executor.spawn_service("swarm.client_service", client_service);
+        executor.spawn_service("swarm.client_service", core.client_service);
+
+        // The pseudosettle settlement service applies time-based refresh over
+        // the same shared accounting and forwards our outbound settlement to
+        // the node through the unthrottled handle.
+        pseudosettle_wiring.spawn(
+            &executor,
+            core.accounting.bandwidth().clone(),
+            core.client_handle.clone(),
+            reporter,
+        );
 
         // The node run loop owns the libp2p swarm. It starts listening (a
         // no-op for a dial-only client) and then dials bootnodes and services
@@ -238,7 +321,9 @@ impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
 
         Ok(LaunchedClient {
             topology,
-            client: client_handle,
+            client: core.throttled_handle,
+            accounting: core.accounting,
+            store,
             overlay,
             peer_id,
         })
@@ -250,7 +335,7 @@ impl<I: SwarmIdentity + Clone> ClientLauncher<I> {
 /// The native swarm and its futures are `Send`, so the run loop spawns as a
 /// critical task on the tokio runtime and participates in graceful shutdown.
 #[cfg(not(target_arch = "wasm32"))]
-fn spawn_node_run_loop<I: SwarmIdentity + Clone>(executor: &TaskExecutor, node: ClientNode<I>) {
+fn spawn_node_run_loop(executor: &TaskExecutor, node: ClientNode<Arc<Identity>>) {
     executor.spawn_critical_with_graceful_shutdown_signal(
         "swarm.client_node",
         move |shutdown| async move {
@@ -267,7 +352,7 @@ fn spawn_node_run_loop<I: SwarmIdentity + Clone>(executor: &TaskExecutor, node: 
 /// loop goes through the executor's local spawner instead of the Send-bounded
 /// critical one.
 #[cfg(target_arch = "wasm32")]
-fn spawn_node_run_loop<I: SwarmIdentity + Clone>(executor: &TaskExecutor, node: ClientNode<I>) {
+fn spawn_node_run_loop(executor: &TaskExecutor, node: ClientNode<Arc<Identity>>) {
     executor.spawn_local_with_graceful_shutdown_signal(
         "swarm.client_node",
         move |shutdown| async move {
@@ -283,23 +368,36 @@ fn spawn_node_run_loop<I: SwarmIdentity + Clone>(executor: &TaskExecutor, node: 
 /// Returned by [`ClientLauncher::launch`]. The spawned tasks do not depend on
 /// this value staying alive; dropping it leaves the node running until the
 /// executor shuts down.
-pub struct LaunchedClient<I: SwarmIdentity> {
-    topology: TopologyHandle<I>,
+pub struct LaunchedClient {
+    topology: TopologyHandle<Arc<Identity>>,
     client: ClientHandle,
+    accounting: SharedAccounting,
+    store: Arc<ChunkStore<SystemClock>>,
     overlay: SwarmAddress,
     peer_id: PeerId,
 }
 
-impl<I: SwarmIdentity> LaunchedClient<I> {
+impl LaunchedClient {
     /// Topology handle for readiness polling and
     /// [`TopologyEvent`](vertex_swarm_topology::TopologyEvent) subscription.
-    pub fn topology(&self) -> &TopologyHandle<I> {
+    pub fn topology(&self) -> &TopologyHandle<Arc<Identity>> {
         &self.topology
     }
 
-    /// Client handle for chunk retrieval and upload.
+    /// Throttled client handle for chunk retrieval and upload.
     pub fn client(&self) -> &ClientHandle {
         &self.client
+    }
+
+    /// The shared client accounting (selector, throttle, forwarder, service,
+    /// and settlement all read this instance).
+    pub fn accounting(&self) -> &SharedAccounting {
+        &self.accounting
+    }
+
+    /// The in-memory client chunk cache.
+    pub fn store(&self) -> &Arc<ChunkStore<SystemClock>> {
+        &self.store
     }
 
     /// The node's overlay address.

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -285,7 +285,7 @@ impl ClientLauncher {
         node.enable_forwarding(
             Arc::new(topology.clone()),
             Arc::clone(&core.accounting),
-            core.throttled_handle.clone(),
+            core.client_handle.clone(),
         );
 
         let executor = TaskExecutor::current();

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -35,7 +35,10 @@ pub use base::BaseNode;
 pub use bootnode::{BootNode, BootNodeBuilder};
 pub use builder::BuiltInfrastructure;
 pub use client::{ClientNode, ClientNodeBuilder};
-pub use core::{PseudosettleWiring, SharedAccounting, spawn_client_command_bridge};
+pub use core::{
+    ClientCore, ClientCoreCtx, PseudosettleWiring, SharedAccounting, assemble_client_core,
+    spawn_client_command_bridge,
+};
 pub use error::NodeBuildError;
 pub use launch::{ClientLauncher, LaunchedClient};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -16,6 +16,7 @@ mod bootnode;
 mod builder;
 #[allow(unreachable_pub)]
 mod client;
+mod core;
 mod error;
 mod launch;
 // NAT traversal and LAN discovery only exist natively. The browser client
@@ -34,6 +35,7 @@ pub use base::BaseNode;
 pub use bootnode::{BootNode, BootNodeBuilder};
 pub use builder::BuiltInfrastructure;
 pub use client::{ClientNode, ClientNodeBuilder};
+pub use core::{PseudosettleWiring, SharedAccounting, spawn_client_command_bridge};
 pub use error::NodeBuildError;
 pub use launch::{ClientLauncher, LaunchedClient};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/swarm/node/tests/autonat_dialback.rs
+++ b/crates/swarm/node/tests/autonat_dialback.rs
@@ -8,6 +8,7 @@
 //! event loop. It guards against an upstream libp2p change altering the autonat
 //! event shapes our handlers destructure.
 
+#![cfg(not(target_arch = "wasm32"))]
 #![allow(clippy::expect_used)]
 
 use std::time::Duration;

--- a/crates/swarm/node/tests/bootnode_cluster.rs
+++ b/crates/swarm/node/tests/bootnode_cluster.rs
@@ -14,6 +14,8 @@
 //! transport is real TCP (`tokio::time::pause()` would freeze timers without
 //! freezing the OS network stack).
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use std::collections::HashSet;
 use std::time::Duration;
 

--- a/crates/swarm/node/tests/client_launcher.rs
+++ b/crates/swarm/node/tests/client_launcher.rs
@@ -7,12 +7,19 @@
 //! task spawning, handle plumbing), not connectivity; the cluster tests cover
 //! the connected paths.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use std::sync::Arc;
 
 use eyre::Result;
-use vertex_swarm_api::{SwarmIdentity as _, SwarmNodeType, SwarmTopologyStats as _};
+use nectar_primitives::{AnyChunk, ContentChunk};
+use vertex_swarm_api::{
+    SwarmClientAccounting as _, SwarmIdentity as _, SwarmLocalStore as _, SwarmNodeType,
+    SwarmTopologyStats as _,
+};
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::ClientLauncher;
+use vertex_swarm_primitives::CachedChunk;
 use vertex_swarm_spec::SpecBuilder;
 use vertex_swarm_test_utils::TEST_NETWORK_ID;
 use vertex_tasks::{TaskExecutor, TaskManager};
@@ -47,6 +54,23 @@ async fn launcher_brings_up_client_node() -> Result<()> {
     // client handle is clonable for embedding.
     let _peer_id = launched.local_peer_id();
     let _client = launched.client().clone();
+
+    // The launcher now wires the shared client core: the accounting carries the
+    // pseudosettle settlement mechanism instead of an empty provider list.
+    let providers = launched.accounting().bandwidth().provider_names();
+    assert!(
+        providers.contains(&"pseudosettle"),
+        "expected pseudosettle in the launched provider list, got {providers:?}"
+    );
+
+    // The in-memory client cache round-trips a content chunk.
+    let chunk: AnyChunk = ContentChunk::new(&b"launcher core round trip"[..])
+        .expect("valid content chunk")
+        .into();
+    let cached = CachedChunk::new(chunk, None);
+    let address = *cached.address();
+    launched.store().put(cached).expect("put");
+    assert!(launched.store().contains(&address));
 
     Ok(())
 }

--- a/crates/swarm/node/tests/wasm_client_core.rs
+++ b/crates/swarm/node/tests/wasm_client_core.rs
@@ -1,0 +1,62 @@
+//! Acceptance test for the wasm-clean client core.
+//!
+//! Runs on `wasm32-unknown-unknown` under `wasm-bindgen-test`: it composes the
+//! accounting half of the shared client core (the pseudosettle provider embedded
+//! through [`PseudosettleWiring::prepare`]) and round-trips a chunk through the
+//! in-memory client cache, proving the settlement wiring and cache the launcher
+//! assembles are reachable in the browser cone. The full [`assemble_client_core`]
+//! also needs a `TopologyHandle`, which only a built node produces, so this
+//! exercises the network-free half; the native launcher smoke test covers the
+//! assembled whole.
+
+#![cfg(target_arch = "wasm32")]
+#![allow(clippy::expect_used)]
+
+use nectar_primitives::{AnyChunk, ContentChunk};
+use vertex_swarm_accounting::{AccountingBuilder, DefaultBandwidthConfig};
+use vertex_swarm_api::{SwarmClientAccounting, SwarmIdentity, SwarmLocalStore};
+use vertex_swarm_localstore::{ChunkStore, DEFAULT_CACHE_BUDGET_BYTES, DEFAULT_SOC_CACHE_TTL_NS};
+use vertex_swarm_node::PseudosettleWiring;
+use vertex_swarm_primitives::CachedChunk;
+use vertex_swarm_test_utils::test_identity_arc;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[wasm_bindgen_test]
+fn client_core_accounting_wires_pseudosettle_on_wasm() {
+    let identity = test_identity_arc();
+    let bandwidth = DefaultBandwidthConfig::default();
+
+    // The launcher prepares the pseudosettle provider before the accounting is
+    // built; the core then embeds it through the same builder tail.
+    let (provider, _wiring) = PseudosettleWiring::prepare(&bandwidth);
+    let accounting = AccountingBuilder::new(bandwidth)
+        .with_pricer_from_config(identity.spec().clone())
+        .with_settlement(provider)
+        .build(&identity);
+
+    let names = accounting.bandwidth().provider_names();
+    assert!(
+        names.contains(&"pseudosettle"),
+        "expected pseudosettle in the provider list, got {names:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn client_cache_round_trips_on_wasm() {
+    let store = ChunkStore::with_budget(
+        DEFAULT_CACHE_BUDGET_BYTES as usize,
+        DEFAULT_SOC_CACHE_TTL_NS,
+    );
+
+    // A content chunk is immutable and stampless on the retrieval path, so the
+    // cache serves it by address with no freshness signal.
+    let chunk: AnyChunk = ContentChunk::new(&b"wasm client core round trip"[..])
+        .expect("valid content chunk")
+        .into();
+    let cached = CachedChunk::new(chunk, None);
+    let address = *cached.address();
+
+    store.put(cached.clone()).expect("put");
+    assert!(store.contains(&address), "cache must contain the chunk");
+    assert_eq!(store.get(&address).expect("get"), Some(cached));
+}


### PR DESCRIPTION
## What

Introduce one shared `assemble_client_core` helper in `vertex-swarm-node`, consumed by both client entry points: the native `build_client_backed_node` and the embedded/browser `ClientLauncher`. The core is provider-free and identity-concrete; it builds the accounting (with its settlement providers), the candidate selector, the outbound self-throttle, the throttled handle, and the accounting-attached client service, returning the shared accounting `Arc` so each entry point enables forwarding and builds its own chunk provider itself.

This stage wires `ClientLauncher` through that core, so the embedded and browser client now gains accounting, the selector, the self-throttle, the relay forwarder, and the pseudosettle settlement service instead of a bare `ClientNode` with none of them. The launcher prepares the pseudosettle wiring, threads its event sink into the node builder, owns the in-memory client cache, calls the core, enables forwarding on the live node before the run loop is spawned, and spawns the pseudosettle service over the same shared accounting on the current `TaskExecutor`. The launcher is now identity-concrete on `Arc<Identity>` (the core pins the concrete identity), and `LaunchedClient` exposes the shared accounting and the cache.

Adds the first `wasm-bindgen-test` in the repo: a `wasm32-unknown-unknown` acceptance test that composes the client-core accounting and round-trips the in-memory cache, asserting the pseudosettle provider is present. Native-only dev-dependencies and the behaviour and cluster integration tests are gated off wasm32 so the wasm test cone stays clean, and the wasm CI job builds the new test target.

Settlement here is pseudosettle only: swap stays a native-builder provider for this change. Making `SwapWiring::spawn` plus its chain provider wasm-reachable (full wasm SWAP) is tracked separately in #487.

## Why

The wasm client path built a bare `ClientNode` with no accounting, cache, or forwarding, so the new accounting and settlement seams were unreachable from the only path wasm uses. Converging both entry points onto one shared middle preserves the single shared `Arc<accounting>` across the selector, throttle, forwarder, service, and settlement on both paths, keeps `enable_forwarding` before the run loop, and keeps the no-double-debit invariant (origin completions debit once via the merged `with_accounting` seam; relay legs stay accounted by the forwarder).

Closes #424

## Testing

- `cargo fmt --all`
- `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean)
- `cargo test -p vertex-swarm-node` (native, all pass; the launcher smoke test now asserts the pseudosettle provider list and a cache round-trip)
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (default and `--features swap`)
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node --test wasm_client_core` (default and `--features swap`)
- `cargo clippy --target wasm32-unknown-unknown -p vertex-swarm-node --test wasm_client_core -- -D warnings` (clean)
- `cargo check --target wasm32-unknown-unknown` for the `swarm-demo` browser app (the launcher API change is source-compatible)

The wasm test is built in CI, not run: running needs a headless-browser wasm-bindgen test runner that is not part of the wasm job.

The forwarder relay legs run over the unthrottled handle exactly as on main: only the origin retrieval and pushsync path is self-throttled, so the convergence is behaviour-preserving. Throttling relay legs would be a separate deliberate change, not part of this refactor. Verified by the existing `origin_*_debits_serving_peer_exactly_once` and `relay_*_is_not_debited_by_the_service` tests.

AI Assistance: Claude Code (Opus 4.8) used for implementation.
