### PR TITLE
refactor(chain): use rustls for the native alloy transport, drop OpenSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1750,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cobs"
@@ -2922,21 +2953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +2960,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3587,6 +3609,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,22 +3633,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4880,23 +4901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5217,47 +5221,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6156,6 +6123,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6506,19 +6474,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -6703,12 +6673,25 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -6722,11 +6705,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7676,12 +7687,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
@@ -8228,12 +8239,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -9884,6 +9889,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -50,11 +50,12 @@ thiserror = { workspace = true }
 # `provider` feature: a single chain-connected log line in the construction seam.
 tracing = { workspace = true, optional = true }
 
-# Native uses the reqwest transport with native-tls (system OpenSSL). The rustls
-# path drags in a root-certs crate under a license outside the workspace
-# allow-list, so native TLS goes through system OpenSSL.
+# Native uses the reqwest transport with rustls (aws-lc-rs plus
+# rustls-platform-verifier). The bundled root certs are CDLA-Permissive-2.0,
+# which is allow-listed in the workspace deny.toml, so native TLS no longer
+# depends on the system OpenSSL.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-alloy-provider = { workspace = true, features = ["reqwest-native-tls"] }
+alloy-provider = { workspace = true, features = ["reqwest-rustls-tls"] }
 
 # alloy's signer stack pulls getrandom 0.2 transitively; on wasm32 its browser
 # backend needs the `js` feature. This direct dep only flips that feature on.

--- a/crates/swarm/accounting/chequebook/Cargo.toml
+++ b/crates/swarm/accounting/chequebook/Cargo.toml
@@ -17,9 +17,10 @@ workspace = true
 default = []
 # `swap-chequebook` adds the native on-chain chequebook client over a shared
 # alloy provider. It is off by default; a node role that settles over SWAP (the
-# storer) turns it on. It enables an HTTP transport with native-tls: the rustls
-# path drags in a platform root-certs crate under a license outside the
-# workspace allow-list, so the HTTP transport uses native-tls (system OpenSSL).
+# storer) turns it on. It enables an HTTP transport with rustls (aws-lc-rs plus
+# rustls-platform-verifier); the bundled root certs are CDLA-Permissive-2.0,
+# which is allow-listed in the workspace deny.toml, so the HTTP transport no
+# longer depends on the system OpenSSL.
 swap-chequebook = [
     "dep:vertex-chain",
     "dep:alloy-contract",
@@ -56,11 +57,14 @@ serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true, features = ["base64"] }
 serde_json = { workspace = true }
 
-# Native uses the reqwest transport with native-tls (system OpenSSL).
+# Native uses the reqwest transport with rustls (aws-lc-rs plus
+# rustls-platform-verifier); the bundled root certs are CDLA-Permissive-2.0,
+# which is allow-listed in the workspace deny.toml, so native TLS no longer
+# depends on the system OpenSSL.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 alloy-provider = { workspace = true, optional = true, features = [
     "reqwest",
-    "reqwest-native-tls",
+    "reqwest-rustls-tls",
 ] }
 
 # On wasm, the secp256k1 backend pulled in by `alloy-primitives/k256` reaches

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
     "MPL-2.0",
     "Unicode-3.0",
     "CDDL-1.0",    # inferno (pprof flamegraph generation)
+    "CDLA-Permissive-2.0", # webpki-root-certs (bundled CA root set for the rustls native transport)
 ]
 
 [bans]


### PR DESCRIPTION
## What

Switch the native alloy provider transport from native-tls (system OpenSSL) to rustls (aws-lc-rs plus rustls-platform-verifier) across the two consumers that drive an on-chain provider: `vertex-chain` and `vertex-swarm-accounting-chequebook`. The `cfg(not(target_arch = "wasm32"))` `alloy-provider` features move from `reqwest-native-tls` to `reqwest-rustls-tls`, and the stale comment blocks are rewritten to describe the rustls path. The wasm target is untouched: it keeps the browser fetch backend with no TLS feature selected.

To keep `cargo deny` green, `CDLA-Permissive-2.0` is added to the `[licenses].allow` list. That licence covers the bundled CA root-cert set in `webpki-root-certs`, which `rustls-platform-verifier` pulls in through reqwest's rustls feature.

## Why

Follow-up to the review on #502, where the maintainer approved standardizing on rustls throughout for the native transport rather than carrying a second TLS stack (system OpenSSL). This removes `openssl`, `openssl-sys`, `openssl-macros`, `native-tls`, `tokio-native-tls`, `hyper-tls`, and `foreign-types*` from the lockfile, dropping the system OpenSSL build dependency in favour of the in-tree aws-lc-rs stack already aligned with the rest of the workspace.

## Testing

`cargo deny check` passes for licenses, bans, and sources with `CDLA-Permissive-2.0` added (the pre-existing advisories backlog is unaffected by this change).
`cargo fmt --all`, and `cargo clippy -p vertex-chain -p vertex-swarm-accounting-chequebook -p vertex-swarm-builder -p vertex-swarm-node --all-targets --all-features -- -D warnings` are clean.
Native `cargo test -p vertex-chain -p vertex-swarm-accounting-chequebook -p vertex-swarm-builder --all-features` all pass.
Wasm is unaffected: `cargo build --target wasm32-unknown-unknown -p vertex-chain --features provider` and `-p vertex-swarm-node --features swap-chequebook` still build.
Confirmed `openssl`, `openssl-sys`, and `native-tls` are gone from `Cargo.lock`, while `rustls-platform-verifier`, `webpki-root-certs`, and `aws-lc-rs` are present.

AI Assistance: Claude Code (Opus 4.8) used for implementation.
