### PR TITLE
feat(swarm-demo): swap-capable browser client with IndexedDB cache

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -111,6 +111,9 @@ jobs:
         with:
           toolchain: nightly
           targets: wasm32-unknown-unknown
+          # rust-src is needed to rebuild std from source for the threaded-wasm
+          # demo (its `.cargo/config.toml` sets `build-std`).
+          components: rust-src
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           cache-on-failure: true
@@ -124,15 +127,16 @@ jobs:
       - name: Build client cone for wasm32
         run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node
       # The wasm-bindgen acceptance test for the converged client core: it
-      # composes the pseudosettle accounting and round-trips the in-memory
-      # cache, the first wasm test in the repo. Built here (not run, which needs
-      # a headless browser runner) as the wasm-reachability gate.
+      # composes the pseudosettle and SWAP accounting, round-trips the in-memory
+      # and IndexedDB-backed caches, and is the wasm-reachability gate. Built
+      # with the `swap-chequebook` and `indexeddb` features so the swap-provider
+      # and persisted-cache test bodies are compiled. Built here (not run, which
+      # needs a headless browser runner).
       - name: Build wasm client-core test for wasm32
-        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node --test wasm_client_core
+        run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node --features "swap-chequebook indexeddb" --test wasm_client_core
       # The chain-free SWAP path: cheque exchange (sign, send, validate, credit)
       # needs no chain, so the accounting stack and `vertex-swarm-node/swap`
-      # build for wasm with default features. The on-chain cashout path
-      # (`swap-chequebook`) is excluded; it lands in a later change.
+      # build for wasm with default features.
       - name: Build chain-free swap path for wasm32
         run: cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node --features swap -p vertex-swarm-accounting-swap -p vertex-swarm-accounting-chequebook -p vertex-swarm-accounting-pseudosettle -p vertex-swarm-accounting-pricing -p vertex-swarm-accounting
       # The on-chain cashout path: the chequebook client and the swap cashout
@@ -140,11 +144,14 @@ jobs:
       # browser fetch transport they build for wasm. `vertex-chain` is the shared
       # provider crate they sit on; its `provider` feature builds the
       # `build_chain_provider` construction seam over the browser fetch transport.
+      # `vertex-swarm-node/swap-chequebook` is the full launcher cone wiring that
+      # cashout into the embedded client.
       - name: Build cashout path for wasm32
         run: |
           cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-accounting-chequebook --features swap-chequebook
           cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-accounting-swap --features swap-chequebook
           cargo +nightly build --target wasm32-unknown-unknown -p vertex-chain --features provider
+          cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-node --features swap-chequebook
       # The wasm-bindgen reachability test for the construction seam: it asserts
       # `ProviderBuilder::new().connect_http(url)` links and constructs on wasm32
       # without a live RPC. Built here (not run, which needs a headless browser).
@@ -157,6 +164,14 @@ jobs:
         run: |
           cargo +nightly build --target wasm32-unknown-unknown -p vertex-storage-indexeddb
           cargo +nightly build --target wasm32-unknown-unknown -p vertex-swarm-localstore --features indexeddb
+      # The browser demo is the integration target: a swap-capable client node
+      # with the IndexedDB cache. It is its own workspace root (own
+      # `.cargo/config.toml` with the threaded-wasm `build-std` config), so it is
+      # built from inside its directory. Its `vertex-swarm-node` dep carries the
+      # `swap`/`swap-chequebook` and `indexeddb` features.
+      - name: Build browser demo for wasm32
+        working-directory: bin/swarm-demo
+        run: cargo +nightly build --target wasm32-unknown-unknown
 
   ci-success:
     name: ci success

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9314,6 +9314,7 @@ dependencies = [
  "vertex-net-peer-store",
  "vertex-net-ratelimiter",
  "vertex-node-api",
+ "vertex-storage-indexeddb",
  "vertex-swarm-accounting",
  "vertex-swarm-accounting-pricing",
  "vertex-swarm-accounting-pseudosettle",

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -27,14 +27,24 @@ crate-type = ["cdylib"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_arch, values("wasm32"))'] }
 
 [dependencies]
-# The wasm client launch path and topology monitoring surface.
-vertex-swarm-node = { path = "../../crates/swarm/node" }
+# The wasm client launch path and topology monitoring surface. The `swap`
+# features wire SWAP cheque settlement into the launched client: cheque exchange
+# is chain-free, and `swap-chequebook` adds on-chain cashout when an RPC URL is
+# supplied.
+vertex-swarm-node = { path = "../../crates/swarm/node", features = ["swap", "swap-chequebook"] }
 vertex-swarm-api = { path = "../../crates/swarm/api" }
 vertex-swarm-identity = { path = "../../crates/swarm/identity" }
 vertex-swarm-spec = { path = "../../crates/swarm/spec" }
 vertex-swarm-topology = { path = "../../crates/swarm/topology" }
 vertex-swarm-primitives = { path = "../../crates/swarm/primitives" }
+# The client cache: the IndexedDB-backed `ChunkStore` survives a page reload.
+vertex-swarm-localstore = { path = "../../crates/swarm/localstore", features = ["indexeddb"] }
+vertex-storage-indexeddb = { path = "../../crates/storage/indexeddb" }
 vertex-net-dnsaddr-doh = { path = "../../crates/net/dnsaddr-doh" }
+
+# Chequebook address parsing for the optional SWAP config input. Pinned to the
+# workspace version so the `Address` type unifies with the node crate's.
+alloy-primitives = { version = "1.6", default-features = false }
 # The task manager establishes the global executor that the node spawn paths
 # (topology tasks, peer-manager tick, client service) resolve through
 # `TaskExecutor::current`. The demo owns it for the page session.
@@ -52,8 +62,10 @@ web-sys = { version = "0.3", features = [
     "Window",
     "Element",
     "HtmlElement",
+    "Location",
     "Node",
     "Text",
+    "UrlSearchParams",
 ] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 console_error_panic_hook = "0.1"

--- a/bin/swarm-demo/README.md
+++ b/bin/swarm-demo/README.md
@@ -8,10 +8,14 @@ This crate is wasm-only (`crate-type = ["cdylib"]`) and is intentionally **not**
 
 ## How it is wired
 
-The native node builder (`vertex-swarm-builder`) pulls the redb database, the chain provider, the SWAP settlement service, and the gRPC server, none of which build for `wasm32`. So the demo does not use it. Instead it goes through the fluent launcher in `vertex-swarm-node`, shared by native embedders and the browser:
+The native node builder (`vertex-swarm-builder`) pulls the redb database and the gRPC server, neither of which builds for `wasm32`. So the demo does not use it. Instead it goes through the fluent launcher in `vertex-swarm-node`, shared by native embedders and the browser:
 
 - `vertex_swarm_node::ClientLauncher::new(identity).with_bootnodes(bootnodes).launch()` composes a `ClientNode` (connection-limits + identify + topology + client protocols) over the browser WebSocket transport, spawns the node run loop and the peer-manager tick on the wasm executor, and returns a `LaunchedClient` whose `topology()` accessor hands the demo its `TopologyHandle`.
 - The node run loop owns a `!Send` libp2p swarm (the websocket transport futures are `!Send`), so it is spawned through `TaskExecutor::spawn_local_with_graceful_shutdown_signal`, a wasm-only sibling of the Send-bounded spawner that routes through `wasm_bindgen_futures::spawn_local`.
+- The client cache is the IndexedDB-backed `ChunkStore` (`vertex-storage-indexeddb` mirrored through `vertex-swarm-localstore`'s `indexeddb` feature), supplied through `with_store`, so cached chunks survive a page reload. A failed open falls back to the in-memory default.
+- SWAP cheque settlement (`vertex-swarm-node`'s `swap`/`swap-chequebook` features) is wired through `with_swap` when a chequebook address is supplied in the page URL query string. Cheque exchange is chain-free; an RPC URL turns on on-chain cashout.
+
+Settlement and the cache read their optional config from the page URL: `?chequebook=0x...` enables SWAP, and an additional `&rpc=https://...` turns on cashout. Without a chequebook the client settles by pseudosettle alone.
 
 The wasm-bindgen surface in `src/lib.rs` is small: a `#[wasm_bindgen(start)]` `main` that calls the exported async `start`, plus a `SwarmDemo` handle exposing `readiness()` (a JS snapshot object) and `drainEvents()` (the buffered topology events). The UI in `src/ui.rs` renders into the document via `web-sys`, updated on a one-second poll loop.
 

--- a/bin/swarm-demo/src/lib.rs
+++ b/bin/swarm-demo/src/lib.rs
@@ -23,15 +23,23 @@ mod ui;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-use tracing::info;
+use alloy_primitives::Address;
+use tracing::{info, warn};
 use vertex_net_dnsaddr_doh::{DohClient, resolve_mainnet_wss_bootnodes};
-use vertex_swarm_api::SwarmIdentity;
+use vertex_swarm_api::{SwarmIdentity, SwarmLocalStore};
 use vertex_swarm_identity::Identity;
-use vertex_swarm_node::{ClientLauncher, SwarmNodeType};
+use vertex_swarm_localstore::{
+    ChunkStore, DEFAULT_CACHE_BUDGET_BYTES, DEFAULT_SOC_CACHE_TTL_NS, IndexedDbBackend, SystemClock,
+};
+use vertex_swarm_node::{ClientLauncher, LauncherSwapConfig, SwarmNodeType};
 use vertex_swarm_spec::{init_mainnet, mainnet_wss_bootnodes};
 use vertex_swarm_topology::{TopologyEvent, TopologyHandle};
+use vertex_storage_indexeddb::IndexedDbDatabase;
 use vertex_tasks::TaskManager;
 use wasm_bindgen::prelude::*;
+
+/// IndexedDB database name for the browser client cache.
+const CACHE_DB_NAME: &str = "vertex-swarm-cache";
 
 /// Maximum topology events buffered between UI drains.
 ///
@@ -190,8 +198,26 @@ pub async fn start() -> Result<SwarmDemo, JsValue> {
         bootnodes.len()
     ));
 
-    let client = ClientLauncher::new(identity)
-        .with_bootnodes(bootnodes)
+    // The IndexedDB-backed cache survives a page reload; a failed open falls
+    // back to the launcher's in-memory default so the demo still runs.
+    let mut launcher = ClientLauncher::new(identity).with_bootnodes(bootnodes);
+    match open_indexeddb_store().await {
+        Ok(store) => {
+            info!("using IndexedDB-backed client cache");
+            launcher = launcher.with_store(store);
+        }
+        Err(e) => warn!(?e, "IndexedDB cache unavailable, using the in-memory cache"),
+    }
+
+    // SWAP cheque settlement is enabled when a chequebook address is supplied
+    // through the page config; without one the client settles by pseudosettle
+    // alone. Cheque exchange is chain-free unless an RPC URL is also supplied.
+    if let Some(swap) = swap_config_from_page() {
+        info!(chequebook = %swap.chequebook, "SWAP settlement enabled");
+        launcher = launcher.with_swap(swap);
+    }
+
+    let client = launcher
         .launch()
         .await
         .map_err(|e| JsValue::from_str(&format!("failed to launch client: {e}")))?;
@@ -212,6 +238,44 @@ pub async fn start() -> Result<SwarmDemo, JsValue> {
         _task_manager: task_manager,
     };
     Ok(demo)
+}
+
+/// Open the IndexedDB-backed client cache.
+///
+/// Hydrates the resident LRU from any chunks persisted in a prior session and
+/// mirrors future writes back to IndexedDB. Returned erased as the
+/// [`SwarmLocalStore`] the launcher takes.
+async fn open_indexeddb_store() -> Result<Arc<dyn SwarmLocalStore>, JsValue> {
+    let db = IndexedDbDatabase::open(CACHE_DB_NAME, &[IndexedDbBackend::store_name()])
+        .await
+        .map_err(|e| JsValue::from_str(&format!("failed to open IndexedDB cache: {e}")))?;
+    let backend = IndexedDbBackend::new(db.into_arc(), DEFAULT_CACHE_BUDGET_BYTES as usize);
+    let store = ChunkStore::with_backend(backend, DEFAULT_SOC_CACHE_TTL_NS, SystemClock);
+    Ok(Arc::new(store))
+}
+
+/// Read the optional SWAP config from the page URL query string.
+///
+/// `?chequebook=0x...` enables SWAP cheque settlement; an additional `&rpc=...`
+/// turns on on-chain cashout of received cheques. Returns `None` when no
+/// chequebook is supplied or the address does not parse, leaving the client on
+/// pseudosettle-only settlement.
+fn swap_config_from_page() -> Option<LauncherSwapConfig> {
+    let search = web_sys::window()?.location().search().ok()?;
+    let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
+
+    let chequebook_raw = params.get("chequebook")?;
+    let chequebook = match chequebook_raw.parse::<Address>() {
+        Ok(address) => address,
+        Err(e) => {
+            warn!(?e, "ignoring unparsable chequebook address");
+            return None;
+        }
+    };
+
+    let mut config = LauncherSwapConfig::new(chequebook);
+    config.rpc_url = params.get("rpc").filter(|url| !url.is_empty());
+    Some(config)
 }
 
 /// Forward topology events from the broadcast subscription to both consumers.

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -142,8 +142,11 @@ libp2p-swarm-test.workspace = true
 rand_08.workspace = true
 
 # Wasm test harness: the network-free identity fixtures plus the bindgen runner.
+# `vertex-storage-indexeddb` opens the database the IndexedDB cache test mirrors
+# through; it builds empty off wasm32, so it is wasm-only here.
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 vertex-swarm-test-utils.workspace = true
+vertex-storage-indexeddb.workspace = true
 wasm-bindgen-test.workspace = true
 
 [features]
@@ -179,3 +182,9 @@ cli = [
     "vertex-swarm-primitives/serde",
     "alloy-primitives/serde",
 ]
+# Browser-only IndexedDB cache backend for the embedded client. Test-facing on
+# the node crate: it enables the localstore backend so the wasm acceptance test
+# can round-trip a chunk through the persisted store. The launcher itself takes
+# any `SwarmLocalStore` through `with_store`, so the node crate needs no backend
+# code of its own.
+indexeddb = ["vertex-swarm-localstore/indexeddb"]

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -21,8 +21,6 @@ mod selection;
 mod staggered_race;
 mod throttle;
 
-#[cfg(feature = "swap")]
-pub use node::SwapWiring;
 pub use node::{
     BaseNode, BuiltInfrastructure, ClientCore, ClientCoreCtx, ClientLauncher, ClientNode,
     ClientNodeBuilder, LaunchedClient, NodeBuildError, PseudosettleWiring, SharedAccounting,
@@ -30,6 +28,8 @@ pub use node::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder, StorerNode, StorerNodeBuilder, StorerPullsyncControl};
+#[cfg(feature = "swap")]
+pub use node::{LauncherSwapConfig, SwapWiring};
 
 pub use vertex_swarm_api::SwarmNodeType;
 

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -42,6 +42,8 @@ pub use core::{
     spawn_client_command_bridge,
 };
 pub use error::NodeBuildError;
+#[cfg(feature = "swap")]
+pub use launch::LauncherSwapConfig;
 pub use launch::{ClientLauncher, LaunchedClient};
 #[cfg(not(target_arch = "wasm32"))]
 pub use storer::{StorerNode, StorerNodeBuilder, StorerPullsyncControl};

--- a/crates/swarm/node/tests/wasm_client_core.rs
+++ b/crates/swarm/node/tests/wasm_client_core.rs
@@ -2,12 +2,13 @@
 //!
 //! Runs on `wasm32-unknown-unknown` under `wasm-bindgen-test`: it composes the
 //! accounting half of the shared client core (the pseudosettle provider embedded
-//! through [`PseudosettleWiring::prepare`]) and round-trips a chunk through the
-//! in-memory client cache, proving the settlement wiring and cache the launcher
-//! assembles are reachable in the browser cone. The full [`assemble_client_core`]
-//! also needs a `TopologyHandle`, which only a built node produces, so this
-//! exercises the network-free half; the native launcher smoke test covers the
-//! assembled whole.
+//! through [`PseudosettleWiring::prepare`], plus SWAP under the `swap` feature)
+//! and round-trips a chunk through the client cache, proving the settlement
+//! wiring and cache the launcher assembles are reachable in the browser cone.
+//! Under the `indexeddb` feature it also round-trips a chunk through the
+//! IndexedDB-backed cache. The full [`assemble_client_core`] also needs a
+//! `TopologyHandle`, which only a built node produces, so this exercises the
+//! network-free half; the native launcher smoke test covers the assembled whole.
 
 #![cfg(target_arch = "wasm32")]
 #![allow(clippy::expect_used)]
@@ -51,6 +52,76 @@ fn client_cache_round_trips_on_wasm() {
     // A content chunk is immutable and stampless on the retrieval path, so the
     // cache serves it by address with no freshness signal.
     let chunk: AnyChunk = ContentChunk::new(&b"wasm client core round trip"[..])
+        .expect("valid content chunk")
+        .into();
+    let cached = CachedChunk::new(chunk, None);
+    let address = *cached.address();
+
+    store.put(cached.clone()).expect("put");
+    assert!(store.contains(&address), "cache must contain the chunk");
+    assert_eq!(store.get(&address).expect("get"), Some(cached));
+}
+
+/// A swap-enabled client registers both settlement providers, pseudosettle first
+/// (soft accounting) and swap second (originated-debt settlement), composed
+/// exactly as the launcher's swap tail does. A chain-free config is enough: the
+/// provider list does not depend on cashout.
+#[cfg(feature = "swap")]
+#[wasm_bindgen_test]
+fn client_core_accounting_wires_pseudosettle_and_swap_on_wasm() {
+    use alloy_primitives::Address;
+    use vertex_swarm_api::SwarmSettlementProvider;
+    use vertex_swarm_node::SwapWiring;
+
+    let identity = test_identity_arc();
+    let bandwidth = DefaultBandwidthConfig::default();
+    let spec = identity.spec().clone();
+
+    let (pseudosettle_provider, _) = PseudosettleWiring::prepare(&bandwidth);
+    let (swap_provider, _) = SwapWiring::prepare(
+        &spec,
+        &identity,
+        &bandwidth,
+        Some(Address::repeat_byte(0xab)),
+        None,
+        false,
+        0,
+        true,
+    )
+    .expect("swap wiring is prepared for a chequebook on a named chain");
+
+    let accounting = AccountingBuilder::new(bandwidth)
+        .with_pricer_from_config(spec)
+        .with_settlement(pseudosettle_provider)
+        .with_settlements(vec![
+            Box::new(swap_provider) as Box<dyn SwarmSettlementProvider>
+        ])
+        .build(&identity);
+
+    assert_eq!(
+        accounting.bandwidth().provider_names(),
+        vec!["pseudosettle", "swap"],
+        "a swap-enabled client reports pseudosettle then swap"
+    );
+}
+
+/// The IndexedDB-backed cache round-trips a chunk, mirroring the in-memory case
+/// over the persisted backend the browser client supplies through `with_store`.
+/// Built (not run) in CI as the wasm-reachability gate; the round-trip executes
+/// only under a headless browser runner.
+#[cfg(feature = "indexeddb")]
+#[wasm_bindgen_test]
+async fn indexeddb_cache_round_trips_on_wasm() {
+    use vertex_storage_indexeddb::IndexedDbDatabase;
+    use vertex_swarm_localstore::{IndexedDbBackend, SystemClock};
+
+    let db = IndexedDbDatabase::open("vertex-swarm-cache-test", &[IndexedDbBackend::store_name()])
+        .await
+        .expect("open IndexedDB");
+    let backend = IndexedDbBackend::new(db.into_arc(), DEFAULT_CACHE_BUDGET_BYTES as usize);
+    let store = ChunkStore::with_backend(backend, DEFAULT_SOC_CACHE_TTL_NS, SystemClock);
+
+    let chunk: AnyChunk = ContentChunk::new(&b"wasm indexeddb round trip"[..])
         .expect("valid content chunk")
         .into();
     let cached = CachedChunk::new(chunk, None);


### PR DESCRIPTION
## What

Make the browser demo a swap-capable client backed by the IndexedDB cache, and flip the wasm CI job to build that full cone. This is the final unit of the embedded-client SWAP and IndexedDB epic.

- The demo enables the `swap` and `swap-chequebook` features on its `vertex-swarm-node` dependency and adds the `indexeddb` localstore backend (`vertex-swarm-localstore`'s `indexeddb` feature plus `vertex-storage-indexeddb`).
- In the launch path it builds an IndexedDB-backed `ChunkStore` and passes it through `with_store`, falling back to the in-memory default if the database fails to open, and wires SWAP through `with_swap(LauncherSwapConfig::new(chequebook))` when a chequebook address is supplied. The chequebook address (and an optional RPC URL for on-chain cashout) come from the page URL query string (`?chequebook=0x...&rpc=https://...`); without a chequebook the client settles by pseudosettle alone.
- `LauncherSwapConfig` is now re-exported from `vertex-swarm-node` (behind the `swap` feature) so embedders can construct the launcher swap config.
- The wasm acceptance test (`crates/swarm/node/tests/wasm_client_core.rs`) gains two cases: one composes the launcher accounting with a chain-free swap config and asserts the provider list is `["pseudosettle", "swap"]` (under `swap`), and one round-trips a chunk through the IndexedDB-backed `ChunkStore` (under `indexeddb`), mirroring the existing in-memory cache test. Both are build-checked in CI, matching the compile-only wasm-test convention.
- The wasm CI job now builds `vertex-swarm-node` with `swap-chequebook`, builds the wasm test target with the `swap-chequebook` and `indexeddb` features, and builds the browser demo from its own workspace root (adding the `rust-src` component the threaded-wasm `build-std` config needs).

## Why

Closes #487. The launcher already supports `with_swap` and `with_store`, the IndexedDB backend exists, and CI already builds the swap and chequebook crates for wasm. This unit consumes those: it wires the demo, adds the acceptance tests, and extends CI to build the integrated demo cone, so the browser client ships swap-capable with a persisted cache.

## Testing

- `cargo fmt --all`
- `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean)
- `cargo test -p vertex-swarm-node --all-features` (98 unit plus the launcher, bootnode-cluster, and autonat integration tests pass)
- wasm cone with the pinned stable toolchain in `nix develop`: `cargo build --target wasm32-unknown-unknown` for `vertex-swarm-node --features swap`, `--features swap-chequebook`, `vertex-swarm-localstore --features indexeddb`, `vertex-storage-indexeddb`, and the `wasm_client_core` test target with `swap-chequebook indexeddb` all build green.
- The demo (`bin/swarm-demo`) type-checks for `wasm32-unknown-unknown` with its swap and indexeddb features; the full threaded link (`build-std` plus `+atomics`) is a nightly-only step CI runs.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for implementation.