### PR TITLE
feat(swarm-node): cap per-peer in-flight retrievals with a skip-busy scheduler

### DIFF
--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -25,14 +25,20 @@ const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
 /// Number of closest peers to try when pushing a chunk before giving up.
 const PUSH_CANDIDATE_COUNT: usize = 5;
 
-/// Closest connected peers considered for a retrieval before skip-busy
-/// filtering.
+/// Pool of closest connected peers scanned for a free retrieval slot before
+/// skip-busy filtering.
 ///
-/// Wider than the staggered race ever starts, so when address proximity clusters
-/// races onto a few close peers and one is at its in-flight cap it can be skipped
-/// in favour of the next-closest peer with a free slot, rather than overrunning
-/// the hot peer's per-connection substream budget.
+/// Intentionally wider than [`RETRIEVE_MAX_ATTEMPTS`] so that when address
+/// proximity clusters onto a few close peers and one is at its in-flight cap,
+/// skip-busy still has next-closest alternatives with a free slot rather than
+/// overrunning the hot peer's per-connection substream budget. This is only a
+/// selection pool: the race is bounded separately by [`RETRIEVE_MAX_ATTEMPTS`].
 const RETRIEVE_CANDIDATE_WIDTH: usize = 8;
+
+/// Maximum retrieval legs raced per chunk, so widening the skip-busy pool
+/// does not amplify paid bandwidth: the wider pool only supplies free-slot
+/// alternatives, the race still meters at most this many legs (the prior bound).
+const RETRIEVE_MAX_ATTEMPTS: usize = 3;
 
 /// Chunk provider using ClientHandle for network retrieval.
 #[derive(Clone)]
@@ -91,7 +97,13 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         // full list rather than failing the request: degraded service beats
         // failure. The cap is non-economic and composed after the economic
         // selector above; the throttle paces each chosen request below.
-        let candidates = skip_busy(closest_peers, self.inflight.as_deref());
+        let mut candidates = skip_busy(closest_peers, self.inflight.as_deref());
+        // Bound the raced legs so the wider skip-busy pool only supplies
+        // free-slot alternatives and never amplifies metered bandwidth: the
+        // survivor list is proximity-ordered and skip-busy preserves order, so
+        // this keeps the closest free-slot peers (or, in the all-busy
+        // fall-through, the closest few, the prior bound).
+        candidates.truncate(RETRIEVE_MAX_ATTEMPTS);
         let attempts = candidates.len();
 
         // Race the candidates with a staggered start, resolving on the first
@@ -638,7 +650,9 @@ mod tests {
             ChunkTransferError, ClientCommand, ClientHandle, PeerInflightLimiter, RetrievalResult,
         };
 
-        use super::super::{RETRIEVAL_STAGGER, RaceFailure, race_candidates, skip_busy};
+        use super::super::{
+            RETRIEVAL_STAGGER, RETRIEVE_MAX_ATTEMPTS, RaceFailure, race_candidates, skip_busy,
+        };
         use super::*;
 
         const CAP_ONE: NonZeroUsize = match NonZeroUsize::new(1) {
@@ -708,6 +722,26 @@ mod tests {
                 skip_busy(candidates.clone(), Some(&limiter)),
                 candidates,
                 "all-busy falls through to the full list rather than failing"
+            );
+        }
+
+        #[test]
+        fn skip_busy_pool_is_truncated_to_the_attempts_bound() {
+            // A wide pool of free-slot peers must not race every leg: the
+            // production path truncates the skip-busy survivors to the attempts
+            // bound, so the wider pool only supplies free-slot alternatives
+            // without amplifying metered bandwidth.
+            let limiter = PeerInflightLimiter::new(CAP_ONE);
+            let pool: Vec<SwarmAddress> = (1..=8).map(overlay).collect();
+
+            let mut candidates = skip_busy(pool, Some(&limiter));
+            candidates.truncate(RETRIEVE_MAX_ATTEMPTS);
+
+            assert_eq!(candidates.len(), RETRIEVE_MAX_ATTEMPTS);
+            assert_eq!(
+                candidates,
+                vec![overlay(1), overlay(2), overlay(3)],
+                "the closest attempts-bound free-slot peers are kept in order"
             );
         }
 

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -13,7 +13,10 @@ use vertex_swarm_api::{
 use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
 use vertex_swarm_topology::TopologyHandle;
 
-use crate::{ClientHandle, PeerSelector, RETRIEVAL_STAGGER, RaceFailure, race_candidates};
+use crate::{
+    ClientHandle, PeerInflightLimiter, PeerSelector, RETRIEVAL_STAGGER, RaceFailure,
+    race_candidates,
+};
 
 /// Report source for shallow/malformed receipts caught on the origin upload
 /// path.
@@ -22,8 +25,14 @@ const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
 /// Number of closest peers to try when pushing a chunk before giving up.
 const PUSH_CANDIDATE_COUNT: usize = 5;
 
-/// Number of closest peers to try when retrieving a chunk before giving up.
-const RETRIEVE_CANDIDATE_COUNT: usize = 3;
+/// Closest connected peers considered for a retrieval before skip-busy
+/// filtering.
+///
+/// Wider than the staggered race ever starts, so when address proximity clusters
+/// races onto a few close peers and one is at its in-flight cap it can be skipped
+/// in favour of the next-closest peer with a free slot, rather than overrunning
+/// the hot peer's per-connection substream budget.
+const RETRIEVE_CANDIDATE_WIDTH: usize = 8;
 
 /// Chunk provider using ClientHandle for network retrieval.
 #[derive(Clone)]
@@ -31,6 +40,7 @@ pub struct NetworkChunkProvider<I: SwarmIdentity> {
     client_handle: ClientHandle,
     topology: TopologyHandle<I>,
     selector: Option<Arc<PeerSelector>>,
+    inflight: Option<Arc<PeerInflightLimiter>>,
 }
 
 impl<I: SwarmIdentity> NetworkChunkProvider<I> {
@@ -39,6 +49,7 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
             client_handle,
             topology,
             selector: None,
+            inflight: None,
         }
     }
 
@@ -46,6 +57,13 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     /// affordability-aware) instead of plain proximity order.
     pub fn with_selector(mut self, selector: Arc<PeerSelector>) -> Self {
         self.selector = Some(selector);
+        self
+    }
+
+    /// Cap concurrent outbound retrieval substreams per peer, skipping a peer at
+    /// its cap in favour of the next-closest candidate with a free slot.
+    pub fn with_inflight_limiter(mut self, inflight: Arc<PeerInflightLimiter>) -> Self {
+        self.inflight = Some(inflight);
         self
     }
 
@@ -64,9 +82,17 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         let chunk_address = SwarmAddress::new(address.0.into());
         let closest_peers = self
             .topology
-            .closest_to(&chunk_address, RETRIEVE_CANDIDATE_COUNT);
+            .closest_to(&chunk_address, RETRIEVE_CANDIDATE_WIDTH);
         let closest_peers = self.select(closest_peers, &chunk_address);
-        let attempts = closest_peers.len();
+
+        // Skip-busy: prefer close peers with a free retrieval slot so a hot peer
+        // at its in-flight cap is skipped at selection time rather than
+        // overrun. When every close candidate is at its cap, fall through to the
+        // full list rather than failing the request: degraded service beats
+        // failure. The cap is non-economic and composed after the economic
+        // selector above; the throttle paces each chosen request below.
+        let candidates = skip_busy(closest_peers, self.inflight.as_deref());
+        let attempts = candidates.len();
 
         // Race the candidates with a staggered start, resolving on the first
         // success, so a withholding head candidate is overtaken by the next one
@@ -74,13 +100,24 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         // per-attempt deadline and blocking every later chunk behind it. Each
         // attempt carries its own pacing (the outbound self-throttle and
         // affordability check run inside `retrieve_chunk` before it dispatches),
-        // so the staggered starts preserve the per-peer pacing. Losing attempts
-        // are dropped when the race resolves.
-        match race_candidates(closest_peers, RETRIEVAL_STAGGER, |peer_overlay| {
+        // so the staggered starts preserve the per-peer pacing. The per-peer
+        // in-flight permit is reserved lazily as each leg starts and rides its
+        // request future, releasing the slot on drop including a cancelled
+        // losing leg.
+        match race_candidates(candidates, RETRIEVAL_STAGGER, |peer_overlay| {
+            let permit = self
+                .inflight
+                .as_ref()
+                .and_then(|limiter| limiter.try_acquire(&peer_overlay));
             // `originated = true`: our own retrieval, so the client service
             // debits the serving peer on delivery.
-            self.client_handle
-                .retrieve_chunk(peer_overlay, chunk_address, true)
+            let request = self
+                .client_handle
+                .retrieve_chunk(peer_overlay, chunk_address, true);
+            async move {
+                let _permit = permit;
+                request.await
+            }
         })
         .await
         {
@@ -204,6 +241,31 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         }
 
         outcome
+    }
+}
+
+/// Filter proximity-ordered `candidates` to those with a free retrieval slot.
+///
+/// With no limiter the list is unchanged. When every close candidate is at its
+/// in-flight cap the full list is returned (fall through, since degraded service
+/// beats failing the request). Skip-busy happens here, at selection time, so a
+/// busy head peer is never raced and the next-closest free peer leads instead.
+fn skip_busy(
+    candidates: Vec<SwarmAddress>,
+    inflight: Option<&PeerInflightLimiter>,
+) -> Vec<SwarmAddress> {
+    let Some(limiter) = inflight else {
+        return candidates;
+    };
+    let survivors: Vec<SwarmAddress> = candidates
+        .iter()
+        .copied()
+        .filter(|peer| limiter.has_free_slot(peer))
+        .collect();
+    if survivors.is_empty() {
+        candidates
+    } else {
+        survivors
     }
 }
 
@@ -561,6 +623,200 @@ mod tests {
 
             let outcome = race_over_handle(handle, Vec::new(), address(0xcc)).await;
             assert!(matches!(outcome, Err(RaceFailure::NoCandidates)));
+        }
+    }
+
+    mod skip_busy_scheduler {
+        use std::num::NonZeroUsize;
+        use std::sync::Arc;
+        use std::time::{Duration, Instant};
+
+        use nectar_primitives::ContentChunk;
+        use tokio::sync::mpsc;
+
+        use crate::{
+            ChunkTransferError, ClientCommand, ClientHandle, PeerInflightLimiter, RetrievalResult,
+        };
+
+        use super::super::{RETRIEVAL_STAGGER, RaceFailure, race_candidates, skip_busy};
+        use super::*;
+
+        const CAP_ONE: NonZeroUsize = match NonZeroUsize::new(1) {
+            Some(cap) => cap,
+            None => unreachable!(),
+        };
+
+        fn overlay(n: u8) -> SwarmAddress {
+            SwarmAddress::from([n; 32])
+        }
+
+        fn test_chunk() -> nectar_primitives::AnyChunk {
+            ContentChunk::new(&b"skip-busy-chunk"[..])
+                .expect("valid content chunk")
+                .into()
+        }
+
+        /// Drive the exact composition the provider builds: skip-busy filtering
+        /// at selection time, then the staggered race whose legs reserve an
+        /// in-flight permit that rides the request future and releases on drop.
+        async fn race_with_limiter(
+            handle: ClientHandle,
+            limiter: Arc<PeerInflightLimiter>,
+            candidates: Vec<SwarmAddress>,
+            address: ChunkAddress,
+        ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
+            let candidates = skip_busy(candidates, Some(&limiter));
+            race_candidates(candidates, RETRIEVAL_STAGGER, move |peer| {
+                let permit = limiter.try_acquire(&peer);
+                let handle = handle.clone();
+                async move {
+                    let _permit = permit;
+                    handle.retrieve_chunk(peer, address, true).await
+                }
+            })
+            .await
+        }
+
+        #[test]
+        fn skip_busy_without_a_limiter_keeps_every_candidate() {
+            let candidates = vec![overlay(1), overlay(2), overlay(3)];
+            assert_eq!(skip_busy(candidates.clone(), None), candidates);
+        }
+
+        #[test]
+        fn skip_busy_drops_a_capped_head() {
+            let limiter = PeerInflightLimiter::new(CAP_ONE);
+            let busy = overlay(1);
+            let _held = limiter.try_acquire(&busy).expect("first slot");
+
+            let survivors = skip_busy(vec![busy, overlay(2), overlay(3)], Some(&limiter));
+            assert_eq!(
+                survivors,
+                vec![overlay(2), overlay(3)],
+                "the capped head is skipped, the next-closest free peers remain"
+            );
+        }
+
+        #[test]
+        fn skip_busy_falls_through_when_every_candidate_is_capped() {
+            let limiter = PeerInflightLimiter::new(CAP_ONE);
+            let candidates = vec![overlay(1), overlay(2)];
+            let _h1 = limiter.try_acquire(&overlay(1)).expect("slot a");
+            let _h2 = limiter.try_acquire(&overlay(2)).expect("slot b");
+
+            assert_eq!(
+                skip_busy(candidates.clone(), Some(&limiter)),
+                candidates,
+                "all-busy falls through to the full list rather than failing"
+            );
+        }
+
+        #[tokio::test]
+        async fn capped_head_is_skipped_for_the_next_free_peer() {
+            // The closest peer is at its cap; the race must dispatch to the
+            // next-closest peer with a free slot, never blocking on or contacting
+            // the capped head.
+            let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+            let handle = ClientHandle::new(tx);
+            let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
+
+            let head = overlay(1);
+            let next = overlay(2);
+            // Saturate the head so it has no free slot at selection time.
+            let _held = limiter.try_acquire(&head).expect("saturate the head");
+
+            let address = address(0xab);
+            let race = tokio::spawn(race_with_limiter(
+                handle,
+                Arc::clone(&limiter),
+                vec![head, next],
+                address,
+            ));
+
+            // The only command dispatched is to the next-closest peer: the capped
+            // head was skipped at selection time, not contacted.
+            match rx.recv().await.expect("a command for the free peer") {
+                ClientCommand::RetrieveChunk { peer, response, .. } => {
+                    assert_eq!(peer, next, "the skipped head is not contacted");
+                    response
+                        .send(Ok(RetrievalResult {
+                            chunk: test_chunk(),
+                            stamp: None,
+                            peer: next,
+                        }))
+                        .expect("receiver alive");
+                }
+                other => panic!("unexpected command: {other:?}"),
+            }
+
+            let result = race.await.unwrap().expect("race resolves");
+            assert_eq!(result.peer, next, "the free next-closest peer serves");
+        }
+
+        #[tokio::test]
+        async fn losing_leg_releases_its_permit_on_drop() {
+            // The head leg reserves a permit and then withholds; the staggered
+            // second wins and the head leg is dropped. Dropping it must release
+            // the head's in-flight slot, so the head is reservable again.
+            let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+            let handle = ClientHandle::new(tx);
+            let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
+
+            let head = overlay(1);
+            let second = overlay(2);
+            let address = address(0xcd);
+
+            let start = Instant::now();
+            let race = tokio::spawn(race_with_limiter(
+                handle,
+                Arc::clone(&limiter),
+                vec![head, second],
+                address,
+            ));
+
+            // The head leg dispatches first and reserves the head's only slot.
+            let _head_response = match rx.recv().await.expect("head command") {
+                ClientCommand::RetrieveChunk { peer, response, .. } => {
+                    assert_eq!(peer, head);
+                    assert!(
+                        !limiter.has_free_slot(&head),
+                        "the in-flight head leg holds the head's slot"
+                    );
+                    response
+                }
+                other => panic!("unexpected command: {other:?}"),
+            };
+            // After the stagger the second candidate joins and resolves the race.
+            match rx.recv().await.expect("second command after stagger") {
+                ClientCommand::RetrieveChunk { peer, response, .. } => {
+                    assert_eq!(peer, second);
+                    response
+                        .send(Ok(RetrievalResult {
+                            chunk: test_chunk(),
+                            stamp: None,
+                            peer: second,
+                        }))
+                        .expect("receiver alive");
+                }
+                other => panic!("unexpected command: {other:?}"),
+            }
+
+            let result = race.await.unwrap().expect("race resolves");
+            assert_eq!(result.peer, second, "the staggered second wins");
+            assert!(
+                start.elapsed() < Duration::from_secs(5),
+                "resolved within the stagger, not a per-attempt deadline"
+            );
+            // The losing head leg was dropped when the race resolved, releasing
+            // its permit: the head's slot is free again.
+            assert!(
+                limiter.has_free_slot(&head),
+                "the cancelled head leg released its in-flight slot on drop"
+            );
+            assert!(
+                limiter.try_acquire(&head).is_some(),
+                "the freed head slot is reservable again"
+            );
         }
     }
 }

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -17,6 +17,7 @@ use vertex_swarm_net_pushsync::Receipt;
 use vertex_swarm_primitives::{CachedChunk, OverlayAddress, StampedChunk};
 use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask};
 
+use crate::inflight::PeerInflightLimiter;
 use crate::protocol::{ClientCommand, ClientEvent, FailureKind};
 use crate::throttle::{ProtocolKind, SelfThrottle};
 
@@ -149,6 +150,9 @@ pub struct ClientService {
     /// Outbound self-throttle shared with the handle; cleared per peer on
     /// disconnect so memory does not grow with distinct peers seen.
     throttle: Option<Arc<SelfThrottle>>,
+    /// Per-peer retrieval in-flight limiter shared with the chunk provider;
+    /// the peer entry is forgotten on disconnect.
+    inflight: Option<Arc<PeerInflightLimiter>>,
     /// Per-peer chunk pricer and the receive-debit half of the shared
     /// accounting. Present only on the full builder; absent on the lightweight
     /// launcher, where the origin debit is a no-op.
@@ -177,6 +181,7 @@ impl ClientService {
             reporter: None,
             store: None,
             throttle: None,
+            inflight: None,
             accounting: None,
         };
 
@@ -197,6 +202,7 @@ impl ClientService {
             reporter: None,
             store: None,
             throttle: None,
+            inflight: None,
             accounting: None,
         };
 
@@ -230,6 +236,19 @@ impl ClientService {
     #[must_use]
     pub fn with_throttle(mut self, throttle: Arc<SelfThrottle>) -> Self {
         self.throttle = Some(throttle);
+        self
+    }
+
+    /// Attach the per-peer retrieval in-flight limiter so the service forgets a
+    /// peer's slot accounting on disconnect.
+    ///
+    /// Must be the same [`PeerInflightLimiter`] the chunk provider reserves
+    /// against via [`NetworkChunkProvider::with_inflight_limiter`].
+    ///
+    /// [`NetworkChunkProvider::with_inflight_limiter`]: crate::NetworkChunkProvider::with_inflight_limiter
+    #[must_use]
+    pub fn with_inflight_limiter(mut self, inflight: Arc<PeerInflightLimiter>) -> Self {
+        self.inflight = Some(inflight);
         self
     }
 
@@ -407,6 +426,9 @@ impl ClientService {
                 debug!(%peer_id, %overlay, "Peer disconnected");
                 if let Some(throttle) = &self.throttle {
                     throttle.clear(&overlay);
+                }
+                if let Some(inflight) = &self.inflight {
+                    inflight.forget(&overlay);
                 }
             }
 

--- a/crates/swarm/node/src/inflight.rs
+++ b/crates/swarm/node/src/inflight.rs
@@ -1,0 +1,195 @@
+//! Non-blocking per-peer cap on concurrent outbound retrieval substreams.
+//!
+//! Retrieval fan-out clusters races onto a few close peers, so one hot peer can
+//! accumulate more simultaneous outbound substreams than the remote's
+//! per-connection multiplexer budget allows, and the remote resets them. This is
+//! the non-economic overrun guard: it bounds concurrent retrieval substreams per
+//! peer and is composed AFTER economic selection (selector, then skip-busy, then
+//! throttle). It must never be merged with the affordability or debt signals.
+//!
+//! Skip-busy is non-blocking by construction: a peer at its cap is skipped at
+//! selection time so the next-closest peer with a free slot serves the chunk,
+//! never blocking on the head peer (which would reintroduce head-of-line
+//! blocking). The permit rides the chosen request future and releases the slot on
+//! drop, including a cancelled race leg.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use vertex_swarm_primitives::OverlayAddress;
+
+/// Default per-peer cap on concurrent outbound retrieval substreams.
+///
+/// One conservative cap for every peer, sized to stay under the remote's
+/// per-connection multiplexer budget (around 32 streams shared across retrieval,
+/// pushsync, pricing, pseudosettle, swap, and identity). It is not keyed on peer
+/// type: the multiplexer limit is type-independent and the type signals are
+/// spoofable. A later handshake-negotiated higher vertex-to-vertex cap can
+/// replace this constant.
+pub const DEFAULT_PEER_INFLIGHT_CAP: NonZeroUsize = match NonZeroUsize::new(4) {
+    Some(cap) => cap,
+    None => unreachable!(),
+};
+
+/// Bounds concurrent outbound retrieval substreams per peer with non-blocking,
+/// permit-on-drop reservations.
+///
+/// Cheap to clone-by-`Arc`; one instance is shared by the retrieval candidate
+/// race (which reserves slots) and the client service (which forgets a peer on
+/// disconnect).
+pub struct PeerInflightLimiter {
+    /// Uniform per-peer slot count.
+    cap: NonZeroUsize,
+    /// Per-peer semaphores keyed by overlay. A missing entry means the peer has
+    /// its full cap free; the entry is created on first reservation and dropped
+    /// on disconnect.
+    peers: Mutex<HashMap<OverlayAddress, Arc<Semaphore>>>,
+}
+
+impl PeerInflightLimiter {
+    /// Build a limiter capping every peer at `cap` concurrent outbound retrieval
+    /// substreams.
+    pub fn new(cap: NonZeroUsize) -> Self {
+        Self {
+            cap,
+            peers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Whether `peer` currently has a free retrieval slot.
+    ///
+    /// A peek used to skip busy peers at selection time. An unknown peer has its
+    /// full cap free. The result can race a concurrent reservation, so the
+    /// dispatching leg still reserves through [`Self::try_acquire`].
+    pub fn has_free_slot(&self, peer: &OverlayAddress) -> bool {
+        self.peers
+            .lock()
+            .get(peer)
+            .is_none_or(|semaphore| semaphore.available_permits() > 0)
+    }
+
+    /// Reserve an outbound retrieval slot for `peer`, or `None` when it is at its
+    /// cap.
+    ///
+    /// Non-blocking. The returned permit releases the slot on drop, including a
+    /// cancelled race leg, so a slot is held only for the lifetime of the request
+    /// future it rides.
+    pub fn try_acquire(&self, peer: &OverlayAddress) -> Option<OwnedSemaphorePermit> {
+        let semaphore = {
+            let mut peers = self.peers.lock();
+            Arc::clone(
+                peers
+                    .entry(*peer)
+                    .or_insert_with(|| Arc::new(Semaphore::new(self.cap.get()))),
+            )
+        };
+        semaphore.try_acquire_owned().ok()
+    }
+
+    /// Forget `peer`'s slot accounting on disconnect so memory does not grow with
+    /// the count of distinct peers seen.
+    ///
+    /// Permits already handed out keep their own reference to the old semaphore
+    /// and release harmlessly on drop; a later reconnect starts from a fresh cap.
+    pub fn forget(&self, peer: &OverlayAddress) {
+        self.peers.lock().remove(peer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CAP: NonZeroUsize = match NonZeroUsize::new(2) {
+        Some(cap) => cap,
+        None => unreachable!(),
+    };
+
+    fn peer(n: u8) -> OverlayAddress {
+        OverlayAddress::from([n; 32])
+    }
+
+    #[test]
+    fn acquires_up_to_the_cap_then_skips() {
+        let limiter = PeerInflightLimiter::new(CAP);
+        let p = peer(1);
+
+        let first = limiter.try_acquire(&p).expect("first slot free");
+        let second = limiter.try_acquire(&p).expect("second slot free");
+        assert!(!limiter.has_free_slot(&p), "at the cap, no free slot");
+        assert!(
+            limiter.try_acquire(&p).is_none(),
+            "a peer at its cap is skipped, not blocked"
+        );
+
+        drop(first);
+        drop(second);
+    }
+
+    #[test]
+    fn dropping_a_permit_releases_the_slot() {
+        let limiter = PeerInflightLimiter::new(CAP);
+        let p = peer(2);
+
+        let first = limiter.try_acquire(&p).expect("first slot");
+        let second = limiter.try_acquire(&p).expect("second slot");
+        assert!(limiter.try_acquire(&p).is_none(), "at the cap");
+
+        // Releasing one permit frees exactly one slot, modelling a cancelled or
+        // completed race leg returning a slot for the next request.
+        drop(first);
+        assert!(limiter.has_free_slot(&p), "a released slot is free again");
+        let third = limiter.try_acquire(&p).expect("slot freed by the drop");
+
+        drop(second);
+        drop(third);
+    }
+
+    #[test]
+    fn per_peer_slots_are_independent() {
+        let limiter = PeerInflightLimiter::new(CAP);
+        let a = peer(1);
+        let b = peer(2);
+
+        let _a1 = limiter.try_acquire(&a).expect("a slot");
+        let _a2 = limiter.try_acquire(&a).expect("a slot");
+        assert!(limiter.try_acquire(&a).is_none(), "a is at its cap");
+
+        // b has its own untouched cap.
+        assert!(limiter.has_free_slot(&b));
+        let _b1 = limiter.try_acquire(&b).expect("b slot independent of a");
+    }
+
+    #[test]
+    fn forget_resets_a_peer_to_a_fresh_cap() {
+        let limiter = PeerInflightLimiter::new(CAP);
+        let p = peer(3);
+
+        let held = limiter.try_acquire(&p).expect("first slot");
+        let _held2 = limiter.try_acquire(&p).expect("second slot");
+        assert!(
+            limiter.try_acquire(&p).is_none(),
+            "at the cap before forget"
+        );
+
+        // A disconnect forgets the entry; a reconnect starts from a fresh cap even
+        // while an old permit is still alive (it releases against the old
+        // semaphore harmlessly).
+        limiter.forget(&p);
+        assert!(limiter.has_free_slot(&p), "forgotten peer has a fresh cap");
+        let _fresh = limiter.try_acquire(&p).expect("fresh cap after forget");
+        drop(held);
+    }
+
+    #[test]
+    fn unknown_peer_has_a_free_slot() {
+        let limiter = PeerInflightLimiter::new(DEFAULT_PEER_INFLIGHT_CAP);
+        assert!(
+            limiter.has_free_slot(&peer(9)),
+            "an unseen peer is not busy"
+        );
+    }
+}

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -16,6 +16,7 @@ pub use config::ProtocolConfig;
 mod bootnodes;
 mod chunks;
 mod client_service;
+mod inflight;
 mod node;
 mod protocol;
 mod selection;
@@ -52,6 +53,7 @@ pub use protocol::{
     ClientCommand, ClientEvent, FailureKind, PseudosettleEvent, PushResponseTx, RetrievalResponseTx,
 };
 
+pub use inflight::{DEFAULT_PEER_INFLIGHT_CAP, PeerInflightLimiter};
 pub use selection::{AccountingSettlement, PeerScores, PeerSelector, SettlementTrigger};
 pub use staggered_race::{RETRIEVAL_STAGGER, RaceFailure, race_candidates};
 pub use throttle::SelfThrottle;

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -49,7 +49,8 @@ use vertex_swarm_accounting_swap::{SwapEvent, SwapHandle, SwapProvider, SwapServ
 use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 
 use crate::{
-    AccountingSettlement, ClientCommand, ClientHandle, ClientService, PeerSelector, SelfThrottle,
+    AccountingSettlement, ClientCommand, ClientHandle, ClientService, DEFAULT_PEER_INFLIGHT_CAP,
+    PeerInflightLimiter, PeerSelector, SelfThrottle,
 };
 
 /// The concrete shared accounting both client-backed node types build: the
@@ -78,6 +79,9 @@ pub struct ClientCore {
     pub selector: Arc<PeerSelector>,
     /// Outbound self-throttle shared by both protocols and the service.
     pub throttle: Arc<SelfThrottle>,
+    /// Per-peer retrieval in-flight cap shared by the chunk provider (reserves
+    /// slots) and the service (forgets a peer on disconnect).
+    pub inflight: Arc<PeerInflightLimiter>,
     /// The client handle paced by `throttle`; the provider dispatches through it.
     pub throttled_handle: ClientHandle,
     /// The node's topology handle, threaded through unchanged.
@@ -160,13 +164,20 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     let throttle = Arc::new(SelfThrottle::new(&accounting, &bandwidth));
     let throttled_handle = client_handle.clone().with_throttle(Arc::clone(&throttle));
 
+    // Per-peer retrieval substream cap: the non-economic overrun guard the chunk
+    // provider consults at selection time. One shared instance so a disconnect on
+    // the service path forgets the same peer the provider reserves against.
+    let inflight = Arc::new(PeerInflightLimiter::new(DEFAULT_PEER_INFLIGHT_CAP));
+
     // The service reports through the same peer-manager authority accounting
     // uses, shares the handle's throttle so a disconnect clears that peer's
-    // bucket, and debits the serving peer for our own-request deliveries through
-    // the same shared accounting the selector, throttle, and forwarder use.
+    // bucket, forgets that peer's in-flight slots on disconnect, and debits the
+    // serving peer for our own-request deliveries through the same shared
+    // accounting the selector, throttle, and forwarder use.
     let client_service = client_service
         .with_reporter(reporter)
         .with_throttle(Arc::clone(&throttle))
+        .with_inflight_limiter(Arc::clone(&inflight))
         .with_accounting(
             Arc::new(accounting.pricing().clone()),
             accounting.bandwidth().clone(),
@@ -176,6 +187,7 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
         accounting,
         selector,
         throttle,
+        inflight,
         throttled_handle,
         topology,
         client_service,
@@ -715,7 +727,8 @@ where
     );
 
     let chunk_provider = NetworkChunkProvider::new(core.throttled_handle.clone(), topology.clone())
-        .with_selector(Arc::clone(&core.selector));
+        .with_selector(Arc::clone(&core.selector))
+        .with_inflight_limiter(Arc::clone(&core.inflight));
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
     executor.spawn_service("swarm.client_service", core.client_service);


### PR DESCRIPTION
## What

Cap concurrent outbound retrieval substreams per peer with a skip-busy scheduler, so a wide download cannot pile many simultaneous substreams onto the same close peer and trip its per-connection multiplexer budget.

A new `PeerInflightLimiter` (`crates/swarm/node/src/inflight.rs`) holds a lazily created per-peer semaphore. Retrieval selection now draws a wider pool of the closest connected peers (`RETRIEVE_CANDIDATE_WIDTH = 8`), runs the existing economic `PeerSelector`, then filters to peers with a free slot (`skip_busy`); a peer at its cap is skipped at selection time in favour of the next-closest peer with a free slot, never blocked on. The raced legs are then bounded to `RETRIEVE_MAX_ATTEMPTS = 3` (the prior attempt count), so the wider pool only supplies free-slot alternatives and does not amplify metered bandwidth. The per-peer permit is reserved lazily as each race leg starts and rides its request future, releasing the slot on drop including a cancelled losing leg. On `PeerDisconnected` the peer's limiter entry is forgotten beside the existing throttle clear, bounding per-peer map growth.

The cap is one uniform `DEFAULT_PEER_INFLIGHT_CAP: NonZeroUsize = 4` plus a `new(cap)` seam. It is not keyed on peer type: the binding per-connection multiplexer limit is type-independent, and the node-type and agent-version signals are unauthenticated and spoofable (spoofing only ever induces overrun, never underrun). A future handshake-negotiated higher vertex-to-vertex cap can replace the constant.

## Why

Closes #520. This is the non-economic half of the neighbourhood-collapse symptom in #519: with no per-peer cap, a wide retrieval fan-out overran one close peer's substream budget, the reference peer reset the streams, the close bins drained below saturation and routing depth collapsed mid-download. The economic half (per-peer debt crossing the remote disconnect line) is tracked separately by #516/#513/#514 and stays orthogonal: the substream cap is composed AFTER economic selection (selector then skip-busy then throttle) and never merged with the affordability or debt signals.

The placement (a dedicated limiter, not folded into `SelfThrottle`) makes that orthogonality structural rather than a comment. Design note: `docs/design/retrieval-per-peer-substream-cap.md` (landed in #543, which also documents the unordered-delivery invariant this scheduler relies on). Part of the light-client retrieval hardening epic #526.

## Accepted limits

The cap is best-effort under cross-request contention: `skip_busy` filters by a free-slot peek, and each race leg then reserves lazily, so a leg that loses the peek-to-acquire window to a concurrent chunk request dispatches without a permit rather than re-skipping. Bounded to at most `RETRIEVE_MAX_ATTEMPTS` legs per chunk, this is a conscious accepted limit (the filter is the dominant guard; degraded service beats failure) and is documented in the rustdoc.

## Testing

Scoped to the touched crates (CI runs the full matrix):

- `cargo fmt --all`: clean.
- `cargo clippy -p vertex-swarm-node -p vertex-swarm-builder --all-targets --all-features -- -D warnings`: pass.
- swap cone: `cargo clippy -p vertex-swarm-node --features swap -- -D warnings` (lib) and `--features swap,cli --all-targets -- -D warnings`: pass. (`--features swap` with `--all-targets` but without `cli` fails on a pre-existing issue on main, where a builder test references `crate::args` gated behind `cli`; it reproduces on the parent commit and is unrelated to this change.)
- `cargo test -p vertex-swarm-node -p vertex-swarm-builder --all-features`: pass, including the new `PeerInflightLimiter` unit tests and the `skip_busy_scheduler` tests (capped-head skip, permit-released-on-drop for a losing leg, pool truncated to the attempts bound).
- wasm cone: `nix develop --command cargo build --target wasm32-unknown-unknown -p vertex-swarm-node --features swap`: pass.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the multi-agent design and implementation (implement plus QA, red-team and rust-idiomacy gates) and the bandwidth-bound refinement.
