### PR TITLE
fix(swarm-accounting): run a client node on the storer-enforced client thresholds

### DIFF
--- a/crates/swarm/accounting/core/src/config.rs
+++ b/crates/swarm/accounting/core/src/config.rs
@@ -66,6 +66,19 @@ impl<P> BandwidthConfig<P> {
     pub fn throttle_allowance_percent(&self) -> u8 {
         self.throttle_allowance_percent
     }
+
+    /// This config scaled to the line a storer enforces on a client:
+    /// `payment_threshold` and `refresh_rate` divided by `client_only_factor`,
+    /// floored at one. Pacing against the unscaled storer figures would let a
+    /// burst cross the storer's disconnect line before our settle engages.
+    pub fn for_client(self) -> Self {
+        let factor = self.client_only_factor.max(1);
+        Self {
+            payment_threshold: (self.payment_threshold / factor).max(1),
+            refresh_rate: (self.refresh_rate / factor).max(1),
+            ..self
+        }
+    }
 }
 
 impl TryFrom<&BandwidthArgs> for BandwidthConfig<FixedPricingConfig> {
@@ -175,5 +188,41 @@ mod tests {
                 Err(BandwidthConfigError::ThrottleAllowancePercentOutOfRange)
             ));
         }
+    }
+
+    #[test]
+    fn for_client_scales_threshold_and_refresh_by_the_factor() {
+        let storer = DefaultBandwidthConfig::default();
+        let factor = storer.client_only_factor();
+        let storer_threshold = storer.payment_threshold().as_amount();
+        let storer_refresh = storer.refresh_rate().as_amount();
+        let storer_disconnect = storer.disconnect_threshold();
+        let storer_tolerance = storer.payment_tolerance_percent();
+
+        let client = storer.for_client();
+        assert_eq!(
+            client.payment_threshold().as_amount(),
+            storer_threshold / factor
+        );
+        assert_eq!(client.refresh_rate().as_amount(), storer_refresh / factor);
+        // The disconnect threshold derives from the now-scaled payment threshold,
+        // so it scales down with it: we pace against the same client ceiling the
+        // serving storer enforces on us.
+        assert!(client.disconnect_threshold() < storer_disconnect);
+        assert_eq!(client.payment_tolerance_percent(), storer_tolerance);
+        assert_eq!(client.client_only_factor(), factor);
+    }
+
+    #[test]
+    fn for_client_floors_at_one() {
+        let cfg = BandwidthConfig {
+            payment_threshold: 5,
+            refresh_rate: 5,
+            client_only_factor: 1000,
+            ..DefaultBandwidthConfig::default()
+        }
+        .for_client();
+        assert_eq!(cfg.payment_threshold().as_amount(), 1);
+        assert_eq!(cfg.refresh_rate().as_amount(), 1);
     }
 }

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -308,6 +308,16 @@ pub(crate) async fn build_client_backed_node<F: NodeAssembly>(
     let node_type = F::NODE_TYPE;
     log_build_start(node_type, params.spec);
 
+    // A client paces against the scaled line a storer enforces on it; a storer
+    // keeps the unscaled figures.
+    let scaled_bandwidth;
+    let bandwidth = if node_type.requires_storage() {
+        params.bandwidth
+    } else {
+        scaled_bandwidth = params.bandwidth.clone().for_client();
+        &scaled_bandwidth
+    };
+
     // SWAP defaults on for storers (maximum support) and off for clients; an
     // explicit --swap overrides. The tail derives the same value for its swap
     // wiring; here it gates the chain precondition.
@@ -343,7 +353,7 @@ pub(crate) async fn build_client_backed_node<F: NodeAssembly>(
         node_type,
         spec: params.spec,
         identity: params.identity,
-        bandwidth: params.bandwidth,
+        bandwidth,
         verify: params.verify,
         #[cfg(feature = "swap")]
         swap: ClientSwapParams {

--- a/crates/swarm/builder/src/lib.rs
+++ b/crates/swarm/builder/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The crate has two build modes, selected by the `chain` cargo feature:
 //!
-//! - Default (`chain` off): the light, chain-free build. No Ethereum RPC stack
+//! - Default (`chain` off): the lean, chain-free build. No Ethereum RPC stack
 //!   is compiled in; only chain-free node types (a bootnode, a client without
 //!   SWAP) launch, and a chain-needing node type hard-fails the build with
 //!   `SwarmNodeError::ChainRequired`. This is what the default `vertex` binary

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -367,11 +367,14 @@ impl ClientLauncher {
             .map_err(|e| eyre::eyre!("{e}"))?
         };
 
+        // The launcher always builds a client, which paces against the scaled line.
+        let bandwidth = self.bandwidth.for_client();
+
         let tail_params = ClientTailParams {
             node_type: SwarmNodeType::Client,
             spec: &spec,
             identity: &self.identity,
-            bandwidth: &self.bandwidth,
+            bandwidth: &bandwidth,
             verify: self.verify,
             #[cfg(feature = "swap")]
             swap: ClientSwapParams {


### PR DESCRIPTION
## What

A client node now scales its own bandwidth accounting and self-throttle to the thresholds a storer enforces on it: `payment_threshold` and `refresh_rate` are divided by `client_only_factor` (default 10) at launch, and the disconnect line derives from the scaled payment threshold. A storer keeps the unscaled figures.

Adds `BandwidthConfig::for_client()` and wires it at both client launch paths (`build_client_backed_node`, gated on `requires_storage()`, and `ClientLauncher`, which always builds a client). Also rewords one builder module-doc line ("light" to "lean", describing the chain-free build) so the codebase carries no node-type "light" vocab.

## Why

Closes #547.

A storer meters a client's debt against a reduced disconnect line: the storer line divided by the client factor (16,875,000 / 10 = 1,687,500 AU). On `main` a client builds the unscaled storer thresholds, so it self-paces against a line ten times higher than the one the storer actually enforces, and a sustained download crosses the storer's client disconnect limit before our own accounting engages. This is the calibration the rest of the client retrieval hardening spine (the receive refusal and the admission gate) depends on, so it lands first.

## Testing

`cargo test` across `vertex-swarm-accounting`, `vertex-swarm-builder`, `vertex-swarm-node` (default and `--all-features`), including the new `for_client_*` unit tests and the existing `default_client_accounting_wires_pseudosettle` / `client_accounting_wires_pseudosettle_and_swap` wiring tests. `cargo clippy --all-targets --all-features -- -D warnings` clean on the three crates, plus a default (swap-off) clippy pass.

## AI Assistance

Claude Code used for the analysis, implementation, and verification of this change.
