### PR TITLE
fix(swarm-accounting): settle a client's own retrieval debt reliably through the provider fan-out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8698,6 +8698,7 @@ dependencies = [
  "serde",
  "strum 0.28.0",
  "thiserror 2.0.18",
+ "tokio",
  "vertex-metrics",
  "vertex-swarm-accounting-pricing",
  "vertex-swarm-api",

--- a/crates/swarm/accounting/core/Cargo.toml
+++ b/crates/swarm/accounting/core/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 vertex-swarm-test-utils = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 [features]
 default = ["std"]

--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -324,27 +324,43 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> PeerAffordability for Accountin
         let headroom = balance.saturating_add(threshold).saturating_sub(reserved);
         headroom.max(Au::ZERO)
     }
+
+    fn should_settle(&self, overlay: &OverlayAddress) -> bool {
+        // Settle once our projected debt (the negated balance plus the pending
+        // reservation) reaches the early-payment trigger, so the peer's view of
+        // our debt is reduced before it climbs to the disconnect threshold.
+        let (balance, reserved) = match self.peers.read().get(overlay) {
+            Some(state) => (state.balance(), state.reserved_balance()),
+            None => return false,
+        };
+
+        let debt = Au::ZERO
+            .saturating_sub(balance)
+            .saturating_add(reserved)
+            .max(Au::ZERO);
+        if debt <= Au::ZERO {
+            return false;
+        }
+
+        // Floored at one refresh-rate unit so a settle always offers at least the
+        // minimum the peer acts on.
+        let trigger = self
+            .config
+            .early_payment_trigger()
+            .max(self.config.refresh_rate());
+
+        debt >= trigger
+    }
 }
 
 /// Handle to a peer's accounting state. Cheap to clone.
+#[derive(Clone)]
 pub struct AccountingPeerHandle {
     peer: OverlayAddress,
     state: Arc<PeerState>,
     providers: Arc<[Box<dyn SwarmSettlementProvider>]>,
     disconnect_threshold: Au,
     payment_threshold: Au,
-}
-
-impl Clone for AccountingPeerHandle {
-    fn clone(&self) -> Self {
-        Self {
-            peer: self.peer,
-            state: Arc::clone(&self.state),
-            providers: Arc::clone(&self.providers),
-            disconnect_threshold: self.disconnect_threshold,
-            payment_threshold: self.payment_threshold,
-        }
-    }
 }
 
 impl AccountingPeerHandle {
@@ -835,5 +851,33 @@ mod tests {
         assert_eq!(handle.balance(), au(-400));
         assert_eq!(accounting.allowance_to_payment_threshold(&peer), au(600));
         assert_eq!(accounting.allowance_remaining(&peer), au(850));
+    }
+
+    #[test]
+    fn should_settle_fires_once_debt_reaches_the_early_trigger() {
+        // Default config: 13_500_000 payment threshold at 50% early percent gives
+        // a 6_750_000 trigger (above the 4_500_000 refresh-rate floor). An unknown
+        // peer never settles; a debt below the trigger does not; a debt at or past
+        // it does.
+        let accounting = test_accounting();
+        let peer = test_peer();
+        assert!(
+            !accounting.should_settle(&peer),
+            "unknown peer never settles"
+        );
+
+        let handle = accounting.for_peer(peer);
+        handle.record(au(1_000_000), Direction::Download);
+        assert!(
+            !accounting.should_settle(&peer),
+            "a debt below the trigger does not settle"
+        );
+
+        handle.record(au(6_000_000), Direction::Download);
+        assert_eq!(handle.balance(), au(-7_000_000));
+        assert!(
+            accounting.should_settle(&peer),
+            "a debt past the trigger settles"
+        );
     }
 }

--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -394,9 +394,11 @@ impl AccountingPeerHandle {
         for provider in self.providers.iter() {
             total = total.saturating_add(provider.settle(self.peer, self.state.as_ref()).await?);
 
-            // Check if still over threshold
+            // Stop once the remaining debt is below the payment threshold. Balance is
+            // negative while we owe, so compare against the negated threshold; the next
+            // provider only needs to run while debt still exceeds it.
             let balance = self.state.balance();
-            if balance <= self.payment_threshold {
+            if balance >= Au::ZERO.saturating_sub(self.payment_threshold) {
                 break;
             }
         }
@@ -851,6 +853,90 @@ mod tests {
         assert_eq!(handle.balance(), au(-400));
         assert_eq!(accounting.allowance_to_payment_threshold(&peer), au(600));
         assert_eq!(accounting.allowance_remaining(&peer), au(850));
+    }
+
+    /// Credits a fixed amount, modelling a provider that pays only part of a
+    /// large debt.
+    struct PartialSettleProvider(Au);
+
+    #[async_trait::async_trait]
+    impl SwarmSettlementProvider for PartialSettleProvider {
+        fn pre_allow(
+            &self,
+            _peer: OverlayAddress,
+            _state: &dyn vertex_swarm_api::SwarmPeerState,
+        ) -> Au {
+            Au::ZERO
+        }
+
+        async fn settle(
+            &self,
+            _peer: OverlayAddress,
+            state: &dyn vertex_swarm_api::SwarmPeerState,
+        ) -> SwarmResult<Au> {
+            state.add_balance(self.0);
+            Ok(self.0)
+        }
+
+        fn name(&self) -> &'static str {
+            "partial-settle"
+        }
+    }
+
+    /// Records whether its `settle` ran.
+    struct RecordingProvider(Arc<std::sync::atomic::AtomicBool>);
+
+    #[async_trait::async_trait]
+    impl SwarmSettlementProvider for RecordingProvider {
+        fn pre_allow(
+            &self,
+            _peer: OverlayAddress,
+            _state: &dyn vertex_swarm_api::SwarmPeerState,
+        ) -> Au {
+            Au::ZERO
+        }
+
+        async fn settle(
+            &self,
+            _peer: OverlayAddress,
+            _state: &dyn vertex_swarm_api::SwarmPeerState,
+        ) -> SwarmResult<Au> {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(Au::ZERO)
+        }
+
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+    }
+
+    #[tokio::test]
+    async fn settle_all_reaches_every_provider_while_debt_remains() {
+        // Payment threshold 1000. A 5000 debt, of which the first provider settles
+        // only 1000 (leaving -4000, still past the threshold), so the fan-out must
+        // run the second provider.
+        let ran_second = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let accounting = Accounting::with_providers(
+            small_config(),
+            test_identity(),
+            vec![
+                Box::new(PartialSettleProvider(au(1000))),
+                Box::new(RecordingProvider(Arc::clone(&ran_second))),
+            ],
+        );
+
+        let handle = accounting.for_peer(test_peer());
+        handle.record(au(5000), Direction::Download);
+        assert_eq!(handle.balance(), au(-5000));
+
+        handle.settle().await.expect("settle succeeds");
+
+        assert!(
+            ran_second.load(std::sync::atomic::Ordering::SeqCst),
+            "the second provider must run while debt remains past the threshold"
+        );
+        // The first provider credited 1000, leaving -4000.
+        assert_eq!(handle.balance(), au(-4000));
     }
 
     #[test]

--- a/crates/swarm/accounting/pseudosettle/src/lib.rs
+++ b/crates/swarm/accounting/pseudosettle/src/lib.rs
@@ -1,7 +1,9 @@
 //! Time-based settlement provider for bandwidth accounting.
 //!
-//! Peers accumulate a time-based allowance (refresh rate × elapsed seconds)
-//! that forgives debt periodically, enabling bandwidth usage without payments.
+//! Peers forgive a time-based allowance (refresh rate times elapsed seconds)
+//! when they receive a settle from us. A debtor never forgives its own debt
+//! locally: our balance drops only when the peer acks a settle we sent, so the
+//! debt we track matches the debt the peer records.
 //!
 //! # Usage
 //!
@@ -35,13 +37,13 @@ pub use handle::PseudosettleHandle;
 pub use service::{PseudosettleCommand, PseudosettleService};
 pub use vertex_swarm_client_protocol::PseudosettleEvent;
 
-/// Time-based debt forgiveness provider.
+/// Debtor-initiated time-based settlement provider.
 ///
-/// On `pre_allow()`, credits the peer based on elapsed time:
-/// `credit = min(elapsed_seconds × refresh_rate, abs(debt))`
-///
-/// With a handle, `settle()` delegates to the network service.
-/// Without a handle, only local refresh via `pre_allow()` is performed.
+/// `settle()` sends a pseudosettle to the peer offering our debt; the peer
+/// forgives up to its time-based allowance and acks the accepted amount, which
+/// the service credits back. `pre_allow()` is a no-op: a debtor must not forgive
+/// its own debt on elapsed time, or our balance would understate the debt the
+/// peer records and we would under-settle.
 pub struct PseudosettleProvider<C> {
     config: C,
     /// Optional handle for delegating to the service.
@@ -81,8 +83,13 @@ impl<C: SwarmAccountingConfig> PseudosettleProvider<C> {
 
 #[async_trait::async_trait]
 impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for PseudosettleProvider<C> {
-    fn pre_allow(&self, _peer: OverlayAddress, state: &dyn SwarmPeerState) -> Au {
-        refresh_allowance(state, self.config.refresh_rate())
+    fn pre_allow(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> Au {
+        // A debtor never forgives its own debt locally. The peer reduces its view
+        // of our debt only when it acks a settle we sent; crediting our balance
+        // on elapsed time here would mask a debt that has actually climbed at the
+        // peer, suppressing the settle that recovers it and letting the peer drop
+        // us. Debt recovers only through the network ack credited in the service.
+        Au::ZERO
     }
 
     async fn settle(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> SwarmResult<Au> {
@@ -101,7 +108,7 @@ impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for Pseudosettl
 
             Ok(accepted)
         } else {
-            // No handle - refresh happens automatically in pre_allow()
+            // No handle: nothing to send over the wire, so nothing settles.
             Ok(Au::ZERO)
         }
     }
@@ -134,48 +141,6 @@ pub fn create_pseudosettle_actor<A: SwarmBandwidthAccounting + 'static>(
     let handle = PseudosettleHandle::new(command_tx);
 
     (service, handle)
-}
-
-/// Apply time-based credit to peer's negative balance. Returns credit applied.
-fn refresh_allowance(state: &dyn SwarmPeerState, refresh_rate: Au) -> Au {
-    let now = current_timestamp();
-    let last = state.last_refresh();
-
-    if last == 0 {
-        state.set_last_refresh(now);
-        return Au::ZERO;
-    }
-
-    let elapsed = now.saturating_sub(last);
-    if elapsed == 0 {
-        return Au::ZERO;
-    }
-
-    // Allowance is refresh_rate AU per elapsed second. The scaling is checked
-    // so a large rate times a long gap cannot wrap into a tiny allowance; on
-    // overflow the allowance saturates at the maximum, which is then capped by
-    // the actual debt below.
-    let allowance = refresh_rate
-        .checked_scale(elapsed)
-        .unwrap_or(Au::from_amount(u64::MAX));
-
-    // Only add credit if balance is negative (we owe them)
-    let balance = state.balance();
-    let credit = if balance.is_negative() {
-        let credit = allowance.min(-balance);
-        state.add_balance(credit);
-        credit
-    } else {
-        Au::ZERO
-    };
-
-    state.set_last_refresh(now);
-    credit
-}
-
-/// Get current timestamp in seconds.
-fn current_timestamp() -> u64 {
-    vertex_util_runtime::time::now_unix_secs()
 }
 
 /// Create a new pseudosettle-only accounting instance.
@@ -228,154 +193,48 @@ mod tests {
     }
 
     #[test]
-    fn test_refresh_allowance_positive_balance() {
+    fn pre_allow_never_forgives_debt_locally() {
+        // A debtor's balance must track the debt the peer records; only a network
+        // ack reduces it. `pre_allow` leaves the balance untouched however much
+        // time has elapsed, so the debt cannot look settled locally while the peer
+        // still counts it.
+        let provider = PseudosettleProvider::new(BandwidthConfig::default());
         let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        state.add_balance(Au::new(1000));
-
-        let credit = refresh_allowance(&state, Au::from_amount(4_500_000));
-
-        assert_eq!(credit, Au::new(0));
-        assert_eq!(state.balance(), Au::new(1000));
-    }
-
-    #[test]
-    fn test_refresh_allowance_negative_balance() {
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        state.add_balance(Au::new(-1000));
-        state.set_last_refresh(current_timestamp() - 1);
-
-        let credit = refresh_allowance(&state, Au::from_amount(100));
-
-        assert_eq!(credit, Au::new(100));
-        assert_eq!(state.balance(), Au::new(-900));
-    }
-
-    #[test]
-    fn test_refresh_allowance_caps_at_zero() {
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        state.add_balance(Au::new(-100));
-        state.set_last_refresh(current_timestamp() - 10);
-
-        let credit = refresh_allowance(&state, Au::from_amount(1000));
-
-        assert_eq!(credit, Au::new(100));
-        assert_eq!(state.balance(), Au::new(0));
-    }
-
-    #[test]
-    fn test_settlement_too_soon_same_second() {
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        let now = current_timestamp();
-
-        state.set_last_refresh(now);
         state.add_balance(Au::new(-10_000));
+        state.set_last_refresh(vertex_util_runtime::time::now_unix_secs() - 10);
 
-        let credit = refresh_allowance(&state, Au::from_amount(4_500_000));
+        let credit = provider.pre_allow(test_peer(), &state);
 
-        assert_eq!(credit, Au::new(0));
+        assert_eq!(credit, Au::ZERO);
         assert_eq!(state.balance(), Au::new(-10_000));
     }
 
-    #[test]
-    fn test_time_limited_partial_acceptance() {
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        state.add_balance(Au::new(-50_000));
-        state.set_last_refresh(current_timestamp() - 3);
-
-        let credit = refresh_allowance(&state, Au::from_amount(10_000));
-
-        assert_eq!(credit, Au::new(30_000));
-        assert_eq!(state.balance(), Au::new(-20_000));
-    }
-
-    #[test]
-    fn test_full_debt_acceptance() {
+    #[tokio::test]
+    async fn settle_without_handle_is_a_noop() {
+        // A handle-less provider has no wire to send a pseudosettle on, so settle
+        // is a no-op even with an outstanding debt.
+        let provider = PseudosettleProvider::new(BandwidthConfig::default());
         let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
         state.add_balance(Au::new(-10_000));
-        state.set_last_refresh(current_timestamp() - 10);
 
-        let credit = refresh_allowance(&state, Au::from_amount(10_000));
-
-        assert_eq!(credit, Au::new(10_000));
-        assert_eq!(state.balance(), Au::new(0));
+        let settled = provider
+            .settle(test_peer(), &state)
+            .await
+            .expect("handle-less settle is a no-op");
+        assert_eq!(settled, Au::ZERO);
     }
 
-    #[test]
-    fn test_sequential_refreshes() {
+    #[tokio::test]
+    async fn settle_is_a_noop_when_not_in_debt() {
+        // A positive balance means the peer owes us; there is nothing to settle.
+        let provider = PseudosettleProvider::new(BandwidthConfig::default());
         let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        let base_time = current_timestamp();
+        state.add_balance(Au::new(1_000_000));
 
-        state.add_balance(Au::new(-100_000));
-        state.set_last_refresh(base_time - 5);
-
-        let credit1 = refresh_allowance(&state, Au::from_amount(10_000));
-        assert_eq!(credit1, Au::new(50_000));
-        assert_eq!(state.balance(), Au::new(-50_000));
-
-        let credit2 = refresh_allowance(&state, Au::from_amount(10_000));
-        assert_eq!(credit2, Au::new(0));
-        assert_eq!(state.balance(), Au::new(-50_000));
-
-        state.set_last_refresh(current_timestamp() - 3);
-
-        let credit3 = refresh_allowance(&state, Au::from_amount(10_000));
-        assert_eq!(credit3, Au::new(30_000));
-        assert_eq!(state.balance(), Au::new(-20_000));
-    }
-
-    #[test]
-    fn test_refresh_allowance_does_not_overflow_into_a_tiny_allowance() {
-        // A very large refresh rate over a long gap previously multiplied with a
-        // raw saturating multiply: the checked scaling now bounds it instead of
-        // wrapping into a small allowance. The credit is still capped at the
-        // actual debt, so a large debt is fully forgiven and never under-credited
-        // by a wrapped allowance.
-        let state = PeerState::new(Au::from_amount(u64::MAX), Au::from_amount(u64::MAX));
-        let debt = i64::MAX / 2;
-        state.add_balance(Au::new(-debt));
-        state.set_last_refresh(current_timestamp() - 1_000_000);
-
-        let credit = refresh_allowance(&state, Au::from_amount(u64::MAX));
-
-        // The whole debt is forgiven; the allowance never wrapped below it.
-        assert_eq!(credit, Au::new(debt));
-        assert_eq!(state.balance(), Au::ZERO);
-    }
-
-    #[test]
-    fn test_first_refresh_initialization() {
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-
-        assert_eq!(state.last_refresh(), 0);
-        state.add_balance(Au::new(-10_000));
-
-        let credit = refresh_allowance(&state, Au::from_amount(10_000));
-
-        assert_eq!(credit, Au::new(0));
-        assert_eq!(state.balance(), Au::new(-10_000));
-        assert!(state.last_refresh() > 0);
-    }
-
-    #[test]
-    fn test_client_vs_storer_refresh_rate() {
-        let storer_state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        let client_state = PeerState::new_client_only(
-            Au::from_amount(13_500_000),
-            Au::from_amount(16_875_000),
-            10,
-        );
-
-        storer_state.add_balance(Au::new(-50_000));
-        client_state.add_balance(Au::new(-50_000));
-        storer_state.set_last_refresh(current_timestamp() - 10);
-        client_state.set_last_refresh(current_timestamp() - 10);
-
-        let storer_credit = refresh_allowance(&storer_state, Au::from_amount(10_000));
-        assert_eq!(storer_credit, Au::new(50_000));
-        assert_eq!(storer_state.balance(), Au::new(0));
-
-        let client_credit = refresh_allowance(&client_state, Au::from_amount(1_000));
-        assert_eq!(client_credit, Au::new(10_000));
-        assert_eq!(client_state.balance(), Au::new(-40_000));
+        let settled = provider
+            .settle(test_peer(), &state)
+            .await
+            .expect("settle with a creditor balance is a no-op");
+        assert_eq!(settled, Au::ZERO);
     }
 }

--- a/crates/swarm/accounting/swap/src/lib.rs
+++ b/crates/swarm/accounting/swap/src/lib.rs
@@ -87,8 +87,7 @@ impl<C: SwarmAccountingConfig> SwapProvider<C> {
     /// The early-payment trigger: pay once debt reaches this fraction of the
     /// payment threshold, mirroring pseudosettle's early-payment behaviour.
     fn early_payment_trigger(&self) -> Au {
-        let early = self.config.early_payment_percent().min(100);
-        self.config.payment_threshold().scale_percent(100 - early)
+        self.config.early_payment_trigger()
     }
 }
 

--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -97,6 +97,17 @@ pub trait SwarmAccountingConfig: Send + Sync {
         let percent = 100u64.saturating_add(self.payment_tolerance_percent());
         self.payment_threshold().scale_percent(percent)
     }
+
+    /// The debt at which a debtor should settle early: the payment threshold less
+    /// the early-payment headroom. The refresh-rate floor is applied by callers
+    /// that need a minimum the peer will act on.
+    fn early_payment_trigger(&self) -> Au {
+        let early = self.early_payment_percent().min(100);
+        self.payment_threshold()
+            .checked_scale(100 - early)
+            .map(|scaled| Au::from_amount(scaled.as_amount() / 100))
+            .unwrap_or(Au::from_amount(u64::MAX))
+    }
 }
 
 /// A reserved accounting action awaiting commit or release.

--- a/crates/swarm/api/src/reporting.rs
+++ b/crates/swarm/api/src/reporting.rs
@@ -214,6 +214,17 @@ pub trait PeerAffordability: Send + Sync {
     fn allowance_to_payment_threshold(&self, overlay: &OverlayAddress) -> Au {
         self.allowance_remaining(overlay)
     }
+
+    /// True when our debt to the peer has reached the early-payment trigger, so a
+    /// debtor-initiated settlement should be sent before the debt reaches the
+    /// peer's threshold and it refuses or drops us.
+    ///
+    /// The default is `false`; accounting overrides it with the real per-peer
+    /// debt measured against the configured trigger.
+    fn should_settle(&self, overlay: &OverlayAddress) -> bool {
+        let _ = overlay;
+        false
+    }
 }
 
 /// Why a connection to a peer closed.

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -8,8 +8,8 @@ use nectar_primitives::ChunkAddress;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use vertex_swarm_api::{
-    Au, BandwidthDebit, PeerReporter, ReportSource, SwarmLocalStore, SwarmPricing,
-    SwarmScoringEvent,
+    Au, BandwidthDebit, PeerAffordability, PeerReporter, ReportSource, SwarmLocalStore,
+    SwarmPricing, SwarmScoringEvent,
 };
 use vertex_swarm_client_protocol::PseudosettleAck;
 pub use vertex_swarm_client_protocol::{ChunkTransferError, RetrievalResult};
@@ -19,6 +19,7 @@ use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask};
 
 use crate::inflight::PeerInflightLimiter;
 use crate::protocol::{ClientCommand, ClientEvent, FailureKind};
+use crate::selection::SettlementTrigger;
 use crate::throttle::{ProtocolKind, SelfThrottle};
 
 const RETRIEVAL_SOURCE: ReportSource = ReportSource::Protocol("retrieval");
@@ -157,6 +158,11 @@ pub struct ClientService {
     /// accounting. Present only on the full builder; absent on the lightweight
     /// launcher, where the origin debit is a no-op.
     accounting: Option<OriginAccounting>,
+    /// Debtor-initiated settlement over the shared accounting. Present whenever
+    /// accounting is. The selector drives settlement on the candidate-selection
+    /// path, which the shared retrieval path the client drives never runs, so the
+    /// service settles after an own delivery instead.
+    settlement: Option<ClientSettlement>,
 }
 
 /// The pricing and debit handles the service needs to debit own-request
@@ -164,6 +170,15 @@ pub struct ClientService {
 struct OriginAccounting {
     pricing: Arc<dyn SwarmPricing>,
     bandwidth: Arc<dyn BandwidthDebit>,
+}
+
+/// The affordability query and settlement trigger the service needs to settle
+/// after an own-request delivery. Both read the same shared accounting the origin
+/// debit, the selector, and the throttle use, and the trigger shares its
+/// in-flight set with the selector so overlapping settles are deduped.
+struct ClientSettlement {
+    affordability: Arc<dyn PeerAffordability>,
+    trigger: Arc<dyn SettlementTrigger>,
 }
 
 impl ClientService {
@@ -183,6 +198,7 @@ impl ClientService {
             throttle: None,
             inflight: None,
             accounting: None,
+            settlement: None,
         };
 
         (service, event_tx, handle)
@@ -204,6 +220,7 @@ impl ClientService {
             throttle: None,
             inflight: None,
             accounting: None,
+            settlement: None,
         };
 
         (service, handle)
@@ -269,6 +286,27 @@ impl ClientService {
         self
     }
 
+    /// Attach debtor-initiated settlement so each own-request delivery that
+    /// leaves us past the early-payment trigger settles the serving peer.
+    ///
+    /// `affordability` and `trigger` must read the same shared accounting the
+    /// origin debit uses, and `trigger` must be the selector's so the in-flight
+    /// dedup is shared. The selector drives settlement on the candidate-selection
+    /// path; the shared retrieval path never runs the selector, so without this a
+    /// client's debt only ever climbs until peers drop it.
+    #[must_use]
+    pub fn with_settlement(
+        mut self,
+        affordability: Arc<dyn PeerAffordability>,
+        trigger: Arc<dyn SettlementTrigger>,
+    ) -> Self {
+        self.settlement = Some(ClientSettlement {
+            affordability,
+            trigger,
+        });
+        self
+    }
+
     /// Get a handle for sending commands.
     pub fn handle(&self) -> ClientHandle {
         self.handle.clone()
@@ -287,6 +325,22 @@ impl ClientService {
         let price = accounting.pricing.peer_price(peer, address);
         if let Err(error) = accounting.bandwidth.debit_received(*peer, price, true) {
             debug!(%peer, %address, %error, "origin debit refused at disconnect threshold");
+        }
+    }
+
+    /// Settle the serving peer when the own-request debit just committed has
+    /// pushed our debt to the early-payment trigger. A no-op without settlement.
+    ///
+    /// The trigger self-gates (a settle already in flight to this peer is skipped)
+    /// and `should_settle` gates on the debt, so polling every in-debt delivery is
+    /// cheap. The accepted amount is credited back by the pseudosettle service on
+    /// the ack.
+    fn settle_origin(&self, peer: &OverlayAddress) {
+        let Some(settlement) = &self.settlement else {
+            return;
+        };
+        if settlement.affordability.should_settle(peer) {
+            settlement.trigger.trigger_settlement(*peer);
         }
     }
 
@@ -359,6 +413,7 @@ impl ClientService {
                 debug!(%peer, %address, ?latency, "Chunk received");
                 if originated {
                     self.debit_origin(&peer, &address);
+                    self.settle_origin(&peer);
                 }
                 if let Some(store) = &self.store
                     && chunk.is_content()
@@ -414,6 +469,7 @@ impl ClientService {
                 debug!(%peer, %address, ?latency, "Receipt received");
                 if originated {
                     self.debit_origin(&peer, &address);
+                    self.settle_origin(&peer);
                 }
                 self.report(
                     &peer,

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -151,11 +151,18 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     // service, and settlement services.
     let accounting: SharedAccounting = Arc::new(accounting);
 
+    // One affordability query and settlement trigger shared by the selector and
+    // the client service, so the service settles after an own delivery even though
+    // it never runs the selector, and both paths share the trigger's in-flight
+    // dedup set.
+    let affordability = accounting.bandwidth().clone();
+    let settlement_trigger = Arc::new(AccountingSettlement::new(accounting.bandwidth().clone()));
+
     let selector = Arc::new(PeerSelector::new(
         Arc::new(topology.clone()),
-        accounting.bandwidth().clone(),
+        affordability.clone(),
         Arc::new(accounting.pricing().clone()),
-        Arc::new(AccountingSettlement::new(accounting.bandwidth().clone())),
+        settlement_trigger.clone(),
     ));
 
     // Outbound self-throttle: pace our retrieval and pushsync requests under each
@@ -181,7 +188,8 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
         .with_accounting(
             Arc::new(accounting.pricing().clone()),
             accounting.bandwidth().clone(),
-        );
+        )
+        .with_settlement(affordability, settlement_trigger);
 
     ClientCore {
         accounting,

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -651,90 +651,23 @@ mod tests {
         });
     }
 
-    struct PanicPeerBandwidth {
-        peer: OverlayAddress,
-    }
-
-    impl SwarmPeerBandwidth for PanicPeerBandwidth {
-        fn record(&self, _amount: Au, _direction: Direction) {}
-        fn allow(&self, _amount: Au) -> bool {
-            true
-        }
-        fn balance(&self) -> Au {
-            Au::ZERO
-        }
-        async fn settle(&self) -> SwarmResult<()> {
-            panic!("settle panics mid-flight");
-        }
-        fn peer(&self) -> OverlayAddress {
-            self.peer
-        }
-    }
-
-    struct PanicBandwidth {
-        for_peer_calls: Arc<AtomicUsize>,
-    }
-
-    impl SwarmBandwidthAccounting for PanicBandwidth {
-        type Identity = MockIdentity;
-        type Peer = PanicPeerBandwidth;
-        type ReceiveAction = NoReceiveAction;
-        type ProvideAction = NoProvideAction;
-
-        fn identity(&self) -> &Self::Identity {
-            unreachable!("settlement never reads the identity")
-        }
-        fn for_peer(&self, peer: OverlayAddress) -> Self::Peer {
-            self.for_peer_calls.fetch_add(1, Ordering::SeqCst);
-            PanicPeerBandwidth { peer }
-        }
-        fn peers(&self) -> Vec<OverlayAddress> {
-            Vec::new()
-        }
-        fn remove_peer(&self, _peer: &OverlayAddress) {}
-        fn prepare_receive(
-            &self,
-            _peer: OverlayAddress,
-            _price: Au,
-            _originated: bool,
-        ) -> SwarmResult<Self::ReceiveAction> {
-            Ok(NoReceiveAction)
-        }
-        fn prepare_provide(
-            &self,
-            _peer: OverlayAddress,
-            _price: Au,
-        ) -> SwarmResult<Self::ProvideAction> {
-            Ok(NoProvideAction)
-        }
-    }
-
     #[test]
-    fn panicking_settle_still_clears_the_peer() {
-        // A settle that panics must drop the in-flight guard while unwinding, so
-        // the peer leaves the set and a later trigger starts a fresh settle. The
-        // panic is caught at the tokio task boundary.
-        settlement_runtime().block_on(async {
-            let for_peer_calls = Arc::new(AtomicUsize::new(0));
-            let bandwidth = Arc::new(PanicBandwidth {
-                for_peer_calls: Arc::clone(&for_peer_calls),
-            });
-            let trigger = AccountingSettlement::new(bandwidth);
-
-            // First trigger spawns a settle that panics; its guard clears the peer
-            // on unwind. Retry until a second settle is created, proving the set
-            // cleared.
-            trigger.trigger_settlement(peer(1));
-            let mut tries = 0;
-            while for_peer_calls.load(Ordering::SeqCst) < 2 {
-                trigger.trigger_settlement(peer(1));
-                tries += 1;
-                assert!(
-                    tries < 10_000,
-                    "in-flight set never cleared after the settle panicked"
-                );
-                tokio::task::yield_now().await;
-            }
-        });
+    fn in_flight_guard_clears_the_peer_on_drop() {
+        // The guard removes the peer in Drop, which runs on normal completion,
+        // unwind (a panicking settle), and cancellation alike, so a settle that
+        // never completes cleanly cannot pin the peer and starve its settlement.
+        let in_flight = Arc::new(parking_lot::Mutex::new(HashSet::new()));
+        in_flight.lock().insert(peer(1));
+        {
+            let _guard = InFlightGuard {
+                in_flight: Arc::clone(&in_flight),
+                peer: peer(1),
+            };
+            assert!(in_flight.lock().contains(&peer(1)));
+        }
+        assert!(
+            !in_flight.lock().contains(&peer(1)),
+            "the guard must clear the peer when dropped"
+        );
     }
 }

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -20,9 +20,11 @@
 //! per-peer chunk price the accounting layer debits when the request is
 //! served.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use nectar_primitives::ChunkAddress;
+use parking_lot::Mutex;
 use tracing::debug;
 use vertex_swarm_api::{
     DEFAULT_PEER_WARN_THRESHOLD, PeerAffordability, SwarmBandwidthAccounting, SwarmIdentity,
@@ -63,14 +65,36 @@ pub trait SettlementTrigger: Send + Sync {
 /// Settlement runs as a spawned task on the current task executor so
 /// selection never blocks on settlement I/O. Failures are logged at debug
 /// level; the next request retries naturally.
+///
+/// A shared in-flight set keeps at most one settle per peer running at a time:
+/// the second trigger for a peer with a settle still outstanding is dropped, so
+/// the set is both the dedup and the per-peer rate limit (the next settle cannot
+/// start until the prior one is acked).
 pub struct AccountingSettlement<B> {
     bandwidth: B,
+    in_flight: Arc<Mutex<HashSet<OverlayAddress>>>,
 }
 
 impl<B> AccountingSettlement<B> {
     /// Trigger settlement through `bandwidth`.
     pub fn new(bandwidth: B) -> Self {
-        Self { bandwidth }
+        Self {
+            bandwidth,
+            in_flight: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+/// Removes a peer from the in-flight set on drop, so a panic or cancellation of
+/// the settle future cannot pin the peer and starve its settlement.
+struct InFlightGuard {
+    in_flight: Arc<Mutex<HashSet<OverlayAddress>>>,
+    peer: OverlayAddress,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.in_flight.lock().remove(&self.peer);
     }
 }
 
@@ -84,8 +108,19 @@ where
             debug!(%peer, "no task executor; settlement not triggered");
             return;
         };
+        // Skip if a settle to this peer is already running; the entry is cleared
+        // when the spawned settle completes, so the next trigger can start a fresh
+        // one.
+        if !self.in_flight.lock().insert(peer) {
+            return;
+        }
         let handle = self.bandwidth.for_peer(peer);
+        let guard = InFlightGuard {
+            in_flight: Arc::clone(&self.in_flight),
+            peer,
+        };
         executor.spawn(async move {
+            let _guard = guard;
             if let Err(error) = handle.settle().await {
                 debug!(%peer, %error, "best-effort settlement failed");
             }
@@ -123,10 +158,14 @@ impl PeerSelector {
 
     /// Order `candidates` (in proximity order) for a request on `chunk`.
     ///
-    /// Applies the ranking described at the module level. When the request is
-    /// blocked on balance (candidates exist but none is affordable), triggers
-    /// best-effort settlement for the unaffordable candidates before
-    /// returning them in proximity order.
+    /// Applies the ranking described at the module level. Triggers best-effort
+    /// settlement for any candidate whose debt has reached the early-payment
+    /// trigger, so the peer's view of our debt drops before it reaches the
+    /// disconnect threshold. When the request is blocked on balance (candidates
+    /// exist but none is affordable), the unaffordable candidates are settled too,
+    /// so a debt that built without crossing the early trigger is still settled
+    /// before the request gives up on the peer. A single pass triggers each peer
+    /// at most once; the in-flight set dedups across repeated calls.
     pub fn order(
         &self,
         candidates: Vec<OverlayAddress>,
@@ -141,8 +180,11 @@ impl PeerSelector {
             },
         );
 
-        if ranked.blocked_on_balance() {
-            for peer in &ranked.unaffordable {
+        let blocked = ranked.blocked_on_balance();
+        for peer in &candidates {
+            if self.affordability.should_settle(peer)
+                || (blocked && ranked.unaffordable.contains(peer))
+            {
                 self.settlement.trigger_settlement(*peer);
             }
         }
@@ -235,6 +277,17 @@ mod tests {
 
     struct FixedAffordability {
         unaffordable: Vec<OverlayAddress>,
+        /// Peers whose debt has reached the early-payment trigger.
+        settle_due: Vec<OverlayAddress>,
+    }
+
+    impl FixedAffordability {
+        fn new(unaffordable: Vec<OverlayAddress>) -> Self {
+            Self {
+                unaffordable,
+                settle_due: Vec::new(),
+            }
+        }
     }
 
     impl PeerAffordability for FixedAffordability {
@@ -244,6 +297,10 @@ mod tests {
 
         fn allowance_remaining(&self, _overlay: &OverlayAddress) -> Au {
             Au::ZERO
+        }
+
+        fn should_settle(&self, overlay: &OverlayAddress) -> bool {
+            self.settle_due.contains(overlay)
         }
     }
 
@@ -351,7 +408,23 @@ mod tests {
     ) -> PeerSelector {
         PeerSelector::new(
             Arc::new(FixedScores(scores)),
-            Arc::new(FixedAffordability { unaffordable }),
+            Arc::new(FixedAffordability::new(unaffordable)),
+            Arc::new(UnitPricer),
+            settlement,
+        )
+    }
+
+    fn selector_with_settle_due(
+        unaffordable: Vec<OverlayAddress>,
+        settle_due: Vec<OverlayAddress>,
+        settlement: Arc<RecordingSettlement>,
+    ) -> PeerSelector {
+        PeerSelector::new(
+            Arc::new(FixedScores(HashMap::new())),
+            Arc::new(FixedAffordability {
+                unaffordable,
+                settle_due,
+            }),
             Arc::new(UnitPricer),
             settlement,
         )
@@ -385,6 +458,30 @@ mod tests {
     }
 
     #[test]
+    fn selector_settles_proactively_when_debt_reaches_early_trigger() {
+        // A still-affordable peer whose debt has reached the early-payment trigger
+        // is settled before it becomes unaffordable, so its view of our debt drops
+        // before it would refuse or drop us.
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel = selector_with_settle_due(Vec::new(), vec![peer(1)], Arc::clone(&settlement));
+
+        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
+        assert_eq!(ordered, vec![peer(1), peer(2)]);
+        assert_eq!(*settlement.triggered.lock().unwrap(), vec![peer(1)]);
+    }
+
+    #[test]
+    fn selector_does_not_settle_below_the_early_trigger() {
+        // No candidate is over the trigger and all are affordable: no settle.
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel = selector_with_settle_due(Vec::new(), Vec::new(), Arc::clone(&settlement));
+
+        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
+        assert_eq!(ordered, vec![peer(1), peer(2)]);
+        assert!(settlement.triggered.lock().unwrap().is_empty());
+    }
+
+    #[test]
     fn selector_excludes_warned_peers() {
         let settlement = Arc::new(RecordingSettlement::default());
         let mut scores = HashMap::new();
@@ -393,5 +490,251 @@ mod tests {
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
         assert_eq!(ordered, vec![peer(2)]);
+    }
+
+    // Dedup of `AccountingSettlement` over a mock bandwidth accounting whose
+    // settle parks until released, so two triggers for one peer can overlap.
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::sync::Notify;
+    use vertex_swarm_accounting::{NoProvideAction, NoReceiveAction};
+    use vertex_swarm_api::{Direction, SwarmBandwidthAccounting, SwarmPeerBandwidth, SwarmResult};
+    use vertex_swarm_test_utils::MockIdentity;
+    use vertex_tasks::TaskManager;
+
+    /// One process-wide multi-thread runtime for the settlement tests.
+    ///
+    /// `AccountingSettlement` spawns onto the global `TaskExecutor`, a process-wide
+    /// `OnceLock` bound to the first `TaskManager::current()`. Binding it once to a
+    /// long-lived runtime keeps every spawned settle on a live runtime regardless of
+    /// test order; a per-test `#[tokio::test]` runtime would be torn down under the
+    /// still-pointing global and starve the next test's settles.
+    fn settlement_runtime() -> &'static tokio::runtime::Runtime {
+        use std::sync::OnceLock;
+        static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+        RUNTIME.get_or_init(|| {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .expect("build settlement runtime");
+            rt.block_on(async {
+                // Bind the global executor to this runtime for the whole binary.
+                std::mem::forget(TaskManager::current());
+            });
+            rt
+        })
+    }
+
+    struct MockPeerBandwidth {
+        peer: OverlayAddress,
+        started: Arc<AtomicUsize>,
+        finished: Arc<AtomicUsize>,
+        gate: Arc<Notify>,
+    }
+
+    impl SwarmPeerBandwidth for MockPeerBandwidth {
+        fn record(&self, _amount: Au, _direction: Direction) {}
+        fn allow(&self, _amount: Au) -> bool {
+            true
+        }
+        fn balance(&self) -> Au {
+            Au::ZERO
+        }
+        async fn settle(&self) -> SwarmResult<()> {
+            self.started.fetch_add(1, Ordering::SeqCst);
+            self.gate.notified().await;
+            self.finished.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn peer(&self) -> OverlayAddress {
+            self.peer
+        }
+    }
+
+    struct MockBandwidth {
+        for_peer_calls: Arc<AtomicUsize>,
+        started: Arc<AtomicUsize>,
+        finished: Arc<AtomicUsize>,
+        gate: Arc<Notify>,
+    }
+
+    impl SwarmBandwidthAccounting for MockBandwidth {
+        type Identity = MockIdentity;
+        type Peer = MockPeerBandwidth;
+        type ReceiveAction = NoReceiveAction;
+        type ProvideAction = NoProvideAction;
+
+        fn identity(&self) -> &Self::Identity {
+            unreachable!("settlement never reads the identity")
+        }
+        fn for_peer(&self, peer: OverlayAddress) -> Self::Peer {
+            self.for_peer_calls.fetch_add(1, Ordering::SeqCst);
+            MockPeerBandwidth {
+                peer,
+                started: Arc::clone(&self.started),
+                finished: Arc::clone(&self.finished),
+                gate: Arc::clone(&self.gate),
+            }
+        }
+        fn peers(&self) -> Vec<OverlayAddress> {
+            Vec::new()
+        }
+        fn remove_peer(&self, _peer: &OverlayAddress) {}
+        fn prepare_receive(
+            &self,
+            _peer: OverlayAddress,
+            _price: Au,
+            _originated: bool,
+        ) -> SwarmResult<Self::ReceiveAction> {
+            Ok(NoReceiveAction)
+        }
+        fn prepare_provide(
+            &self,
+            _peer: OverlayAddress,
+            _price: Au,
+        ) -> SwarmResult<Self::ProvideAction> {
+            Ok(NoProvideAction)
+        }
+    }
+
+    #[test]
+    fn trigger_settlement_runs_one_settle_per_peer_in_flight() {
+        // The trigger spawns its settle on the shared global task executor.
+        settlement_runtime().block_on(async {
+            let for_peer_calls = Arc::new(AtomicUsize::new(0));
+            let started = Arc::new(AtomicUsize::new(0));
+            let finished = Arc::new(AtomicUsize::new(0));
+            let gate = Arc::new(Notify::new());
+            let bandwidth = Arc::new(MockBandwidth {
+                for_peer_calls: Arc::clone(&for_peer_calls),
+                started: Arc::clone(&started),
+                finished: Arc::clone(&finished),
+                gate: Arc::clone(&gate),
+            });
+            let trigger = AccountingSettlement::new(bandwidth);
+
+            // Two synchronous triggers for one peer. The first reserves the peer and
+            // spawns a settle that parks on the gate; the second finds the peer
+            // already in flight and is dropped before it reaches the accounting, so
+            // only one settle is ever created.
+            trigger.trigger_settlement(peer(1));
+            trigger.trigger_settlement(peer(1));
+            assert_eq!(
+                for_peer_calls.load(Ordering::SeqCst),
+                1,
+                "the second trigger is deduped while the first settle is in flight"
+            );
+
+            // Release the parked settle and wait for it to finish; the peer then
+            // leaves the in-flight set. `notify_one` stores a permit if the settle has
+            // not parked yet, so the wakeup is never lost.
+            gate.notify_one();
+            while finished.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+
+            // Once the prior settle has cleared the set, a fresh trigger starts a new
+            // settle. Retry across the brief window in which the spawned wrapper has
+            // not yet removed the peer.
+            let mut tries = 0;
+            while for_peer_calls.load(Ordering::SeqCst) < 2 {
+                trigger.trigger_settlement(peer(1));
+                tries += 1;
+                assert!(
+                    tries < 10_000,
+                    "in-flight set never cleared after completion"
+                );
+                tokio::task::yield_now().await;
+            }
+            gate.notify_one();
+        });
+    }
+
+    struct PanicPeerBandwidth {
+        peer: OverlayAddress,
+    }
+
+    impl SwarmPeerBandwidth for PanicPeerBandwidth {
+        fn record(&self, _amount: Au, _direction: Direction) {}
+        fn allow(&self, _amount: Au) -> bool {
+            true
+        }
+        fn balance(&self) -> Au {
+            Au::ZERO
+        }
+        async fn settle(&self) -> SwarmResult<()> {
+            panic!("settle panics mid-flight");
+        }
+        fn peer(&self) -> OverlayAddress {
+            self.peer
+        }
+    }
+
+    struct PanicBandwidth {
+        for_peer_calls: Arc<AtomicUsize>,
+    }
+
+    impl SwarmBandwidthAccounting for PanicBandwidth {
+        type Identity = MockIdentity;
+        type Peer = PanicPeerBandwidth;
+        type ReceiveAction = NoReceiveAction;
+        type ProvideAction = NoProvideAction;
+
+        fn identity(&self) -> &Self::Identity {
+            unreachable!("settlement never reads the identity")
+        }
+        fn for_peer(&self, peer: OverlayAddress) -> Self::Peer {
+            self.for_peer_calls.fetch_add(1, Ordering::SeqCst);
+            PanicPeerBandwidth { peer }
+        }
+        fn peers(&self) -> Vec<OverlayAddress> {
+            Vec::new()
+        }
+        fn remove_peer(&self, _peer: &OverlayAddress) {}
+        fn prepare_receive(
+            &self,
+            _peer: OverlayAddress,
+            _price: Au,
+            _originated: bool,
+        ) -> SwarmResult<Self::ReceiveAction> {
+            Ok(NoReceiveAction)
+        }
+        fn prepare_provide(
+            &self,
+            _peer: OverlayAddress,
+            _price: Au,
+        ) -> SwarmResult<Self::ProvideAction> {
+            Ok(NoProvideAction)
+        }
+    }
+
+    #[test]
+    fn panicking_settle_still_clears_the_peer() {
+        // A settle that panics must drop the in-flight guard while unwinding, so
+        // the peer leaves the set and a later trigger starts a fresh settle. The
+        // panic is caught at the tokio task boundary.
+        settlement_runtime().block_on(async {
+            let for_peer_calls = Arc::new(AtomicUsize::new(0));
+            let bandwidth = Arc::new(PanicBandwidth {
+                for_peer_calls: Arc::clone(&for_peer_calls),
+            });
+            let trigger = AccountingSettlement::new(bandwidth);
+
+            // First trigger spawns a settle that panics; its guard clears the peer
+            // on unwind. Retry until a second settle is created, proving the set
+            // cleared.
+            trigger.trigger_settlement(peer(1));
+            let mut tries = 0;
+            while for_peer_calls.load(Ordering::SeqCst) < 2 {
+                trigger.trigger_settlement(peer(1));
+                tries += 1;
+                assert!(
+                    tries < 10_000,
+                    "in-flight set never cleared after the settle panicked"
+                );
+                tokio::task::yield_now().await;
+            }
+        });
     }
 }

--- a/docs/design/client-credit-admission.md
+++ b/docs/design/client-credit-admission.md
@@ -1,0 +1,59 @@
+# Client credit admission and settlement
+
+## Scope
+
+How a client bounds and settles its per-peer debt during retrieval and pushsync so a storer never disconnects it for unpaid debt. This layers on the mechanism-agnostic accounting and settlement substrate (see `accounting-settlement.md`); the concern here is the client-side coordination: reservation, settle triggering, and candidate filtering.
+
+A client meters its debt against the line a storer enforces on it: the storer line divided by the client factor (see `BandwidthConfig::for_client`). The only per-peer brake a storer applies is accounting debt; cross its disconnect line and it resets the connection and blocklists us. So a client must hold per-peer unsettled debt under that line at all times, including across separate requests, not just within one.
+
+## One surface, shared by retrieval and pushsync
+
+Candidate selection for both retrieval and pushsync already runs through `PeerSelector`, which ranks proximity-ordered peers by score and affordability. The credit-admission surface extends what is already there rather than adding a parallel mechanism:
+
+- `PeerAffordability` answers "can this peer take another request now" from committed balance plus in-flight reservation, measured against the client threshold.
+- `PeerSelector` hard-skips a peer that cannot, so the request routes to the next-closest peer while a background settle drains the skipped one.
+- A peer with a settle already in flight is in a settle-pending state and is skipped on the same path.
+
+Because both protocols consume `PeerSelector`, the filter, the reservation accounting, and the settle-pending state are defined once and apply to both.
+
+## The reserve, settle, skip chain
+
+A request is admitted by reserving its price against two thresholds a tolerance band apart: the payment threshold (the point at which we should settle) and the disconnect line (the point at which a storer drops us). The gap between them is the storer's own tolerance, and it is the margin that lets us settle and request back to back without waiting.
+
+1. Reserve at dispatch. Reserve the chunk price for the in-flight leg, with the same reserve then apply-on-delivery then drop-on-failure shape the forwarder uses for its two legs, so committed-plus-reserved debt reflects outstanding requests the way a storer's shadow reserve does.
+2. Below the payment threshold. Admit; no settle is needed.
+3. In the tolerance band (payment threshold up to the disconnect line). Trigger a single-in-flight settle and admit the request immediately rather than waiting for the settle to complete. This is safe whatever order the storer processes them in: the settle and the request travel on separate substreams with no cross-stream ordering guarantee, but the debt is still under the disconnect line even if the request is metered before the settle is applied. The settle, often applied first, hands back allowance; the band is the margin that covers us when it is not. Correctness comes from the margin, not from the processing order.
+4. At the disconnect line. The reserve fails. The peer is hard-skipped so the chunk routes to another peer while a background settle drains it, because here admitting could cross the line before the settle lands. While its settle is in flight the peer is settle-pending and selection skips it; once the settle is acked and the debt drops back into the band, it is admissible again.
+
+So the settle-and-request-immediately path runs through the whole tolerance band, keeping the closest peers in play at no added latency, and a peer is shed only when its debt is genuinely at the line.
+
+## Single in-flight settle: dedup, rate-limit, and pending-state in one
+
+At most one settlement is in flight to any one peer. This single rule provides three properties that would otherwise need three mechanisms:
+
+- Dedup. Hundreds of admission failures per second against the same peer collapse to one settle, so the single-thread executor is never flooded with redundant settle futures.
+- Rate-limit bound to acceptance. The next settle to a peer cannot start until the previous one is acked, so the client physically cannot send settlements faster than the storer refreshes its allowance.
+- Settle-pending state. "A settle is in flight" is exactly the predicate selection uses to skip the peer.
+
+A settle offers the whole outstanding debt over the wire; once acked, the debt drops below the early-payment trigger and the peer is admissible again.
+
+## Mechanism-agnostic settlement
+
+Settlement always goes through the accounting settle entry point, which fans out to every registered provider in registration order: pseudosettle forgives the time-based allowance first, then swap (when compiled and enabled) settles the originated remainder, with an early break once the balance clears the payment threshold. The client-credit surface never calls a settlement provider directly, so a swap-enabled build settles through swap with no change to this layer, and a swap-off client speaks only pseudosettle and is a normal peer.
+
+## A debtor does not blame its creditor
+
+Crossing our own debt line is our own failure to settle in time, not peer misbehaviour. The receive path refuses at the line so the request routes elsewhere, but it does not score the peer down. Scoring stays for genuine misbehaviour on other paths: over-acceptance on the settlement wire and malformed chunks.
+
+## Delivery order
+
+The surface lands in layers, each independently useful and shippable:
+
+1. Reliable settlement. A deduped single-in-flight settle trigger that fires on a debt-threshold approach, not only when every candidate is already unaffordable, routed through the provider fan-out. Local time-refresh of our own debt is removed, so our debt view matches the storer's rather than masking it.
+2. No self-scoring. The receive path refuses at the line without scoring the peer.
+3. Reserve as gate. Reservation at dispatch for retrieval and origin pushsync; reservation failure drives settle-and-skip on the shared selector.
+4. Pre-pay and pacing. Settle a peer past the trigger before admitting the next request, and pace the full threshold headroom once the gate guarantees the margin.
+
+## Terminology and non-goals
+
+Node types are client and storer; the client factor scales a client's thresholds below a storer's. This is client-side debt management only: it does not change wire bytes, and it does not alter how the node behaves as a creditor serving others.


### PR DESCRIPTION
## What

Makes a client settle its own retrieval debt reliably, the first layer of the client credit admission surface (design note added in this PR at `docs/design/client-credit-admission.md`).

- A debtor-initiated settle fires on a debt-threshold approach, on both the shared candidate-selection path (`PeerSelector`) and after an own-request delivery in the client service. The client drives retrieval through the shared path, which never runs the selector, so without the delivery-path settle a client's debt only climbs until peers drop it.
- `AccountingSettlement` keeps at most one settle per peer in flight via a shared in-flight set. This is the dedup and the per-peer rate limit at once: the next settle to a peer cannot start until the prior one is acked, so deliveries cannot flood the executor with redundant settle futures. The selector and the client service share the one trigger instance, so the dedup spans both paths.
- `pre_allow` no longer locally refreshes our own debt. A debtor must not forgive its own debt on elapsed time, or our balance understates the debt the peer records and we under-settle. Our balance now drops only when the peer acks a settle we sent.
- Settlement routes through the accounting settle entry point, which fans out to every registered provider (pseudosettle now, swap when enabled), so a swap build settles through swap with no change here.

Adds `PeerAffordability::should_settle` (default false, implemented on accounting against the early-payment trigger). Scope is held to reliable settlement: reservation, the admission gate, the selector skip-filter, and pre-pay are later layers.

## Why

Closes #512.

Pseudosettle is the only thing that lowers a client's debt to a serving storer, and a storer never forgives spontaneously. The settle was reachable only on the gRPC/FFI origin path and only when every candidate was already unaffordable, so under sustained retrieval it never fired on a debt-threshold approach and debt grew until the storer hit its disconnect line and blocklisted us. A client that does not settle in time cannot acquire users on the live network.

## Also in this PR (from a red-team review of the seam)

- Fixes a pre-existing sign-inverted break in `settle_all` that compared a negative balance against a positive threshold and so always stopped after the first provider, meaning swap never settled on a swap-enabled node. The break now compares against the negated threshold so each provider runs while debt remains. Dormant for the bare client (one provider) but load-bearing for swap.
- Hardens the new single-in-flight dedup: the in-flight entry now clears from an RAII `Drop` guard, so a panic or cancellation of the settle future cannot pin a peer and starve its settlement.
- Centralises the early-payment-trigger formula onto `SwarmAccountingConfig` (it was duplicated in the swap provider), corrects a stale pseudosettle comment, derives `Clone` on `AccountingPeerHandle`, and folds the selector's two settle passes into one.

A first-principles redesign of the accounting trait surface (removing the now-dead `pre_allow` seam and other dead code surfaced by the review) follows as a separate stacked PR.

## Testing

`cargo test` on `vertex-swarm-accounting`, `vertex-swarm-accounting-pseudosettle`, `vertex-swarm-api`, and `vertex-swarm-node` (the node crate under `--all-features`). New tests cover `should_settle` firing at the trigger, `pre_allow` never forgiving locally, settle being a no-op without a handle or in credit, the selector settling proactively at the trigger, and the single-in-flight dedup of the trigger under overlapping calls. Existing wiring tests `default_client_accounting_wires_pseudosettle` and `client_accounting_wires_pseudosettle_and_swap` still pass. `cargo clippy --all-targets --all-features -- -D warnings` clean on the touched crates, plus a default (swap-off) clippy pass on the node crate.

## AI Assistance

Claude Code used for the analysis, design note, implementation, and verification of this change.
