### PR TITLE
fix(swarm-accounting): stop scoring a peer for our own unpaid debt

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -31,8 +31,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use vertex_swarm_api::{
-    Au, Direction, PeerAffordability, PeerReporter, ReportSource, SwarmAccountingConfig,
-    SwarmBandwidthAccounting, SwarmIdentity, SwarmPeerBandwidth, SwarmResult, SwarmScoringEvent,
+    Au, Direction, PeerAffordability, SwarmAccountingConfig, SwarmBandwidthAccounting,
+    SwarmIdentity, SwarmPeerBandwidth, SwarmResult,
 };
 use vertex_swarm_primitives::OverlayAddress;
 
@@ -47,7 +47,6 @@ pub struct Accounting<C, I: SwarmIdentity> {
     identity: I,
     providers: Arc<[Box<dyn SwarmSettlementProvider>]>,
     peers: RwLock<HashMap<OverlayAddress, Arc<PeerState>>>,
-    reporter: Option<Arc<dyn PeerReporter>>,
 }
 
 impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
@@ -58,7 +57,6 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             identity,
             providers: Arc::from(Vec::new()),
             peers: RwLock::new(HashMap::new()),
-            reporter: None,
         }
     }
 
@@ -76,17 +74,7 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             identity,
             providers: Arc::from(providers),
             peers: RwLock::new(HashMap::new()),
-            reporter: None,
         }
-    }
-
-    /// Attach a peer reporter so accounting violations feed peer scoring.
-    ///
-    /// Reporting is best-effort and non-blocking. Without a reporter,
-    /// violations only surface as errors to the caller, exactly as before.
-    pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
-        self.reporter = Some(reporter);
-        self
     }
 
     /// Get a reference to the configuration.
@@ -122,28 +110,24 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
         let disconnect_threshold = self.config.disconnect_threshold();
         let threshold = -disconnect_threshold;
         if projected < threshold {
-            // Law broken: the peer stopped accepting settlement (refresh or
-            // payment), letting our debt reach the disconnect threshold.
+            // Refuse the receive: our debt to this peer would cross our own
+            // disconnect line, so the caller routes the chunk elsewhere while a
+            // background settle drains the debt below the line.
             //
-            // Reported once per breach episode: a successful grant ends the
-            // episode, so retries against an already-broken balance do not
-            // stack score penalties.
-            if state.mark_breach()
-                && let Some(reporter) = &self.reporter
-            {
-                reporter.report_peer(
-                    &peer,
-                    SwarmScoringEvent::AccountingViolation,
-                    ReportSource::Accounting,
-                );
-            }
+            // The breach is never scored against the peer. Our debt reaching our
+            // own disconnect line is a local pacing outcome, not peer
+            // misbehaviour: a debtor cannot blame its creditor for its own
+            // unpaid debt, and under a sustained download the closest serving
+            // peers reach this line purely because the download outruns the rate
+            // at which they forgive our pseudosettle debt. The remote enforces
+            // its own view by refusing or resetting us; we mirror that with the
+            // refusal alone.
             return Err(AccountingError::DisconnectThreshold {
                 peer,
                 balance: current_balance,
                 threshold: disconnect_threshold,
             });
         }
-        state.clear_breach();
 
         state.add_reserved(price);
         Ok(ReceiveAction::new(state, price))
@@ -637,22 +621,6 @@ mod tests {
         assert_eq!(handle.balance(), au(300));
     }
 
-    #[derive(Default)]
-    struct RecordingReporter {
-        reports: parking_lot::Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
-    }
-
-    impl PeerReporter for RecordingReporter {
-        fn report_peer(
-            &self,
-            overlay: &OverlayAddress,
-            event: SwarmScoringEvent,
-            source: ReportSource,
-        ) {
-            self.reports.lock().push((*overlay, event, source));
-        }
-    }
-
     /// Config with payment threshold 1000 and 25% tolerance, so the
     /// disconnect threshold is 1250.
     fn small_config() -> BandwidthConfig {
@@ -670,38 +638,31 @@ mod tests {
     const SMALL_DISCONNECT_THRESHOLD: Au = Au::new(1250);
 
     #[test]
-    fn test_violation_reported_once_per_breach_episode() {
-        let reporter = Arc::new(RecordingReporter::default());
-        let accounting = Accounting::new(small_config(), test_identity())
-            .with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
+    fn test_receive_breach_refuses_without_scoring_the_peer() {
+        // A debtor breaching its own disconnect line refuses the receive so the
+        // caller routes elsewhere, but never scores the creditor: the debt
+        // reaching our own line is a local pacing outcome, not peer
+        // misbehaviour. Accounting holds no reporter, so a breach can never feed
+        // peer scoring.
+        let accounting = Accounting::new(small_config(), test_identity());
         let peer = test_peer();
 
-        // First breach reports exactly once.
         assert!(matches!(
             accounting.prepare_receive(peer, au(2000), true),
             Err(AccountingError::DisconnectThreshold { .. })
         ));
-        assert_eq!(reporter.reports.lock().len(), 1);
-        let (reported_peer, event, source) = reporter.reports.lock()[0];
-        assert_eq!(reported_peer, peer);
-        assert_eq!(event, SwarmScoringEvent::AccountingViolation);
-        assert_eq!(source, ReportSource::Accounting);
 
-        // Retrying against the same broken state does not stack reports.
+        // Retrying against the broken state keeps refusing.
         assert!(accounting.prepare_receive(peer, au(2000), true).is_err());
         assert!(accounting.prepare_receive(peer, au(3000), true).is_err());
-        assert_eq!(reporter.reports.lock().len(), 1);
 
-        // A successful grant ends the episode...
+        // A receive within the line is granted again, then a fresh breach
+        // refuses once more.
         let action = accounting
             .prepare_receive(peer, au(100), true)
             .expect("within threshold");
         drop(action);
-        assert_eq!(reporter.reports.lock().len(), 1);
-
-        // ...so the next breach is a new episode and reports again.
         assert!(accounting.prepare_receive(peer, au(2000), true).is_err());
-        assert_eq!(reporter.reports.lock().len(), 2);
     }
 
     #[test]

--- a/crates/swarm/accounting/core/src/accounting/peer.rs
+++ b/crates/swarm/accounting/core/src/accounting/peer.rs
@@ -1,6 +1,6 @@
 //! Atomic per-peer balance tracking for lock-free bandwidth recording.
 
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use vertex_swarm_api::{Au, SwarmPeerState};
@@ -51,9 +51,6 @@ pub struct PeerState {
     payment_threshold: Au,
     disconnect_threshold: Au,
     last_refresh: AtomicU64,
-    /// True while a disconnect-threshold breach episode is in progress and
-    /// has already been reported.
-    breach_reported: AtomicBool,
 }
 
 impl PeerState {
@@ -67,7 +64,6 @@ impl PeerState {
             payment_threshold,
             disconnect_threshold,
             last_refresh: AtomicU64::new(0),
-            breach_reported: AtomicBool::new(false),
         }
     }
 
@@ -157,19 +153,6 @@ impl PeerState {
     pub fn set_last_refresh(&self, timestamp: u64) {
         self.last_refresh.store(timestamp, Ordering::Relaxed);
     }
-
-    /// Mark the start of a disconnect-threshold breach episode.
-    ///
-    /// Returns true only on the first call of an episode, so a breach is
-    /// reported once until `clear_breach` starts a new episode.
-    pub(crate) fn mark_breach(&self) -> bool {
-        !self.breach_reported.swap(true, Ordering::Relaxed)
-    }
-
-    /// End the current breach episode (the peer was granted service again).
-    pub(crate) fn clear_breach(&self) {
-        self.breach_reported.store(false, Ordering::Relaxed);
-    }
 }
 
 impl SwarmPeerState for PeerState {
@@ -233,7 +216,6 @@ impl PeerState {
             payment_threshold: Au::from_amount(snapshot.payment_threshold),
             disconnect_threshold: Au::from_amount(snapshot.disconnect_threshold),
             last_refresh: AtomicU64::new(snapshot.last_refresh),
-            breach_reported: AtomicBool::new(false),
         }
     }
 }

--- a/crates/swarm/accounting/core/src/builder.rs
+++ b/crates/swarm/accounting/core/src/builder.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use vertex_swarm_accounting_pricing::NoPricer;
 use vertex_swarm_api::{
-    PeerReporter, SwarmAccountingConfig, SwarmIdentity, SwarmPricing, SwarmPricingBuilder,
-    SwarmPricingConfig, SwarmSettlementProvider, SwarmSpec,
+    SwarmAccountingConfig, SwarmIdentity, SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig,
+    SwarmSettlementProvider, SwarmSpec,
 };
 
 use crate::{Accounting, ClientAccounting};
@@ -27,7 +27,6 @@ pub struct AccountingBuilder<C, P = NoPricer> {
     config: C,
     pricing: P,
     providers: Vec<Box<dyn SwarmSettlementProvider>>,
-    reporter: Option<Arc<dyn PeerReporter>>,
 }
 
 impl<C: SwarmAccountingConfig> AccountingBuilder<C, NoPricer> {
@@ -37,7 +36,6 @@ impl<C: SwarmAccountingConfig> AccountingBuilder<C, NoPricer> {
             config,
             pricing: NoPricer,
             providers: Vec::new(),
-            reporter: None,
         }
     }
 }
@@ -52,14 +50,7 @@ impl<C, P> AccountingBuilder<C, P> {
             config: self.config,
             pricing,
             providers: self.providers,
-            reporter: self.reporter,
         }
-    }
-
-    /// Attach a peer reporter so accounting violations feed peer scoring.
-    pub fn with_reporter(mut self, reporter: Arc<dyn PeerReporter>) -> Self {
-        self.reporter = Some(reporter);
-        self
     }
 
     /// Add a settlement provider.
@@ -112,12 +103,7 @@ impl<C: SwarmAccountingConfig + Clone + 'static, P: SwarmPricing + Clone + Send 
         self,
         identity: &I,
     ) -> ClientAccounting<Arc<Accounting<C, I>>, P> {
-        let mut accounting =
-            Accounting::with_providers(self.config, identity.clone(), self.providers);
-        if let Some(reporter) = self.reporter {
-            accounting = accounting.with_reporter(reporter);
-        }
-
+        let accounting = Accounting::with_providers(self.config, identity.clone(), self.providers);
         ClientAccounting::new(Arc::new(accounting), self.pricing)
     }
 }

--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -13,10 +13,9 @@
 //!
 //! Settlement providers (`PseudosettleProvider`, `SwapProvider`) are in sibling crates.
 //!
-//! [`Accounting`] also implements the `PeerAffordability` query surface and
-//! can report accounting violations through an optional `PeerReporter`
-//! (both from `vertex-swarm-api`), so peer selection and peer scoring can
-//! consume accounting state without depending on this crate's internals.
+//! [`Accounting`] also implements the `PeerAffordability` query surface (from
+//! `vertex-swarm-api`), so peer selection can consume accounting state without
+//! depending on this crate's internals.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -556,9 +556,7 @@ mod tests {
 
     use nectar_primitives::Nonce;
     use vertex_swarm_accounting::AccountingBuilder;
-    use vertex_swarm_api::{
-        Au, PeerReporter, SwarmAccountingConfig, SwarmClientAccounting, SwarmIdentity,
-    };
+    use vertex_swarm_api::{Au, SwarmAccountingConfig, SwarmClientAccounting, SwarmIdentity};
     use vertex_swarm_node::args::NetworkArgs;
     use vertex_swarm_peer_manager::{PeerManager, PeerManagerConfig};
     use vertex_swarm_spec::init_dev;
@@ -702,10 +700,13 @@ mod tests {
         );
     }
 
-    /// An accounting violation must reach the peer manager wired as reporter and
-    /// lower the peer's score.
+    /// A debtor breaching its own disconnect line refuses the receive but never
+    /// scores the creditor: downloading past our own debt line is a local pacing
+    /// outcome, not peer misbehaviour, so a peer wired as reporter keeps its
+    /// score. Scoring it evicted and banned the healthy storers a download
+    /// depends on.
     #[test]
-    fn accounting_violation_reaches_peer_manager() {
+    fn receive_breach_does_not_lower_peer_score() {
         let identity = test_identity_arc();
         let peer_manager = PeerManager::new(&identity, PeerManagerConfig::default());
         let overlay = peer_manager.store_discovered_peer(test_swarm_peer(0xab));
@@ -713,25 +714,23 @@ mod tests {
             .get_peer_score(&overlay)
             .expect("stored peer has a score");
 
-        let reporter: Arc<dyn PeerReporter> = peer_manager.clone();
         let config = DefaultBandwidthConfig::default();
         let over_limit = config.disconnect_threshold() + Au::new(1);
         let accounting = AccountingBuilder::new(config)
             .with_pricer_from_config(identity.spec().clone())
-            .with_reporter(reporter)
             .build(&identity);
 
-        // A debit projected past the disconnect threshold is the violation the
-        // accounting reports.
+        // A debit projected past the disconnect threshold is refused.
         let result = accounting
             .bandwidth()
             .prepare_receive(overlay, over_limit, true);
         assert!(result.is_err());
 
+        // The peer's score is unchanged: the breach is never scored.
         let after = peer_manager
             .get_peer_score(&overlay)
             .expect("peer still scored");
-        assert!(after < baseline, "violation must lower the score");
+        assert_eq!(after, baseline, "a receive breach must not score the peer");
     }
 
     /// The shared accounting wired into the client service via `with_accounting`

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -143,7 +143,6 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     // before swap settles originated debt; the order matches `settle_all`.
     let accounting = AccountingBuilder::new(bandwidth.clone())
         .with_pricer_from_config(spec)
-        .with_reporter(Arc::clone(&reporter))
         .with_settlement(pseudosettle_provider)
         .with_settlements(extra_settlement)
         .build(&identity);


### PR DESCRIPTION
## What

A client no longer scores a serving storer for our own unpaid debt. When our debt to a peer crosses our disconnect threshold the receive path still refuses (returns the disconnect-threshold error so the caller routes the chunk elsewhere while a background settle drains the debt), but it no longer reports an accounting violation against the peer. Since the accounting-core reporter was used only by that own-debt path, the now-unused reporter plumbing (`Accounting`/`AccountingBuilder` reporter field and `with_reporter`, and `PeerState`'s breach bookkeeping) is removed.

The over-acceptance scoring on the settlement wire (pseudosettle and swap services) and the malformed-chunk scoring (the client service `InvalidData` path) are unchanged; their reporter wiring stays.

## Why

Closes #515.

Under a sustained download the closest storers cross our disconnect line purely because the download outruns the rate they forgive our debt, not because they misbehave. Scoring them for that bans the very storers the client depends on, shrinking its own neighbourhood and amplifying churn. A debtor cannot blame its creditor for its own unpaid debt.

## Testing

`cargo nextest run -p vertex-swarm-accounting -p vertex-swarm-builder -p vertex-swarm-node --all-features`: 188 pass. New/updated tests assert the receive still refuses at the line without scoring the peer (`test_receive_breach_refuses_without_scoring_the_peer`, `receive_breach_does_not_lower_peer_score`); the over-acceptance and malformed-chunk scoring tests still pass. `cargo clippy --all-targets --all-features -- -D warnings` clean on the touched crates plus a swap-off pass.

## AI Assistance

Claude Code used for the analysis, implementation, and verification.
