### PR TITLE
refactor(swarm-accounting): remove the dead pre_allow chain and unused accounting surface

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -23,7 +23,7 @@ mod peer;
 
 pub use action::{ProvideAction, ReceiveAction};
 pub use error::AccountingError;
-pub use peer::{PeerState, PeerStateSnapshot};
+pub use peer::PeerState;
 
 use alloc::vec::Vec;
 use parking_lot::RwLock;
@@ -75,16 +75,6 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             providers: Arc::from(providers),
             peers: RwLock::new(HashMap::new()),
         }
-    }
-
-    /// Get a reference to the configuration.
-    pub fn config(&self) -> &C {
-        &self.config
-    }
-
-    /// Get a reference to the settlement providers.
-    pub fn providers(&self) -> &[Box<dyn SwarmSettlementProvider>] {
-        &self.providers
     }
 
     /// Returns the names of the active settlement providers.
@@ -182,26 +172,6 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
                 Arc::new(PeerState::new(
                     self.config.payment_threshold(),
                     self.config.disconnect_threshold(),
-                ))
-            })
-            .clone()
-    }
-
-    /// Get or create peer state for a Client peer, with thresholds scaled
-    /// by the client-only factor.
-    pub fn get_or_create_client_peer(&self, peer: OverlayAddress) -> Arc<PeerState> {
-        if let Some(state) = self.peers.read().get(&peer) {
-            return Arc::clone(state);
-        }
-
-        self.peers
-            .write()
-            .entry(peer)
-            .or_insert_with(|| {
-                Arc::new(PeerState::new_client_only(
-                    self.config.payment_threshold(),
-                    self.config.disconnect_threshold(),
-                    self.config.client_only_factor(),
                 ))
             })
             .clone()
@@ -363,14 +333,6 @@ impl AccountingPeerHandle {
         self.disconnect_threshold
     }
 
-    /// Call `pre_allow()` on all providers, returning total adjustment.
-    fn pre_allow_all(&self) -> Au {
-        self.providers
-            .iter()
-            .map(|p| p.pre_allow(self.peer, self.state.as_ref()))
-            .sum()
-    }
-
     /// Call `settle()` on providers in order until debt is below threshold.
     async fn settle_all(&self) -> SwarmResult<Au> {
         let mut total = Au::ZERO;
@@ -397,18 +359,6 @@ impl SwarmPeerBandwidth for AccountingPeerHandle {
             Direction::Upload => self.state.add_balance(amount),
             Direction::Download => self.state.add_balance(-amount),
         }
-    }
-
-    fn allow(&self, amount: Au) -> bool {
-        // Let providers adjust balance first (e.g., pseudosettle refresh)
-        self.pre_allow_all();
-
-        // Check threshold
-        let balance = self.state.balance();
-        let reserved = self.state.reserved_balance();
-        let projected = balance.saturating_sub(amount).saturating_sub(reserved);
-
-        projected >= -self.disconnect_threshold
     }
 
     fn balance(&self) -> Au {
@@ -515,23 +465,6 @@ mod tests {
     }
 
     #[test]
-    fn test_allow_under_threshold() {
-        let accounting = test_accounting();
-
-        let handle = accounting.for_peer(test_peer());
-
-        // Should allow small transfers
-        assert!(handle.allow(au(1000)));
-
-        // Record some debt
-        handle.record(au(1000), Direction::Download);
-        assert_eq!(handle.balance(), au(-1000));
-
-        // Should still allow more (under disconnect threshold)
-        assert!(handle.allow(au(1000)));
-    }
-
-    #[test]
     fn test_peers_list() {
         let accounting = test_accounting();
 
@@ -573,52 +506,6 @@ mod tests {
         // Both handles should see the same balance (shared state)
         assert_eq!(handle1.balance(), au(1000));
         assert_eq!(handle2.balance(), au(1000));
-    }
-
-    struct FixedAdjustProvider(Au);
-
-    #[async_trait::async_trait]
-    impl SwarmSettlementProvider for FixedAdjustProvider {
-        fn pre_allow(
-            &self,
-            _peer: OverlayAddress,
-            state: &dyn vertex_swarm_api::SwarmPeerState,
-        ) -> Au {
-            state.add_balance(self.0);
-            self.0
-        }
-
-        async fn settle(
-            &self,
-            _peer: OverlayAddress,
-            _state: &dyn vertex_swarm_api::SwarmPeerState,
-        ) -> SwarmResult<Au> {
-            Ok(Au::ZERO)
-        }
-
-        fn name(&self) -> &'static str {
-            "fixed-adjust"
-        }
-    }
-
-    #[test]
-    fn test_provider_composition_pre_allow() {
-        let accounting = Accounting::with_providers(
-            BandwidthConfig::default(),
-            test_identity(),
-            vec![
-                Box::new(FixedAdjustProvider(au(100))),
-                Box::new(FixedAdjustProvider(au(200))),
-            ],
-        );
-
-        let handle = accounting.for_peer(test_peer());
-
-        // Trigger pre_allow via allow()
-        handle.allow(au(0));
-
-        // Both providers should have adjusted the balance
-        assert_eq!(handle.balance(), au(300));
     }
 
     /// Config with payment threshold 1000 and 25% tolerance, so the
@@ -816,26 +703,19 @@ mod tests {
         assert_eq!(accounting.allowance_remaining(&peer), au(850));
     }
 
-    /// Credits a fixed amount, modelling a provider that pays only part of a
-    /// large debt.
+    /// Reports settling a fixed amount, modelling a provider that pays only part
+    /// of a large debt. In production the tracked balance is reduced by the
+    /// async service ack, not by the provider, so the mock leaves the state arg
+    /// untouched.
     struct PartialSettleProvider(Au);
 
     #[async_trait::async_trait]
     impl SwarmSettlementProvider for PartialSettleProvider {
-        fn pre_allow(
-            &self,
-            _peer: OverlayAddress,
-            _state: &dyn vertex_swarm_api::SwarmPeerState,
-        ) -> Au {
-            Au::ZERO
-        }
-
         async fn settle(
             &self,
             _peer: OverlayAddress,
-            state: &dyn vertex_swarm_api::SwarmPeerState,
+            _state: &dyn vertex_swarm_api::SwarmPeerState,
         ) -> SwarmResult<Au> {
-            state.add_balance(self.0);
             Ok(self.0)
         }
 
@@ -849,14 +729,6 @@ mod tests {
 
     #[async_trait::async_trait]
     impl SwarmSettlementProvider for RecordingProvider {
-        fn pre_allow(
-            &self,
-            _peer: OverlayAddress,
-            _state: &dyn vertex_swarm_api::SwarmPeerState,
-        ) -> Au {
-            Au::ZERO
-        }
-
         async fn settle(
             &self,
             _peer: OverlayAddress,
@@ -873,9 +745,9 @@ mod tests {
 
     #[tokio::test]
     async fn settle_all_reaches_every_provider_while_debt_remains() {
-        // Payment threshold 1000. A 5000 debt, of which the first provider settles
-        // only 1000 (leaving -4000, still past the threshold), so the fan-out must
-        // run the second provider.
+        // Payment threshold 1000. A 5000 debt stays past the threshold while the
+        // first provider settles only part of it, so the fan-out must run the
+        // second provider too.
         let ran_second = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let accounting = Accounting::with_providers(
             small_config(),
@@ -896,8 +768,6 @@ mod tests {
             ran_second.load(std::sync::atomic::Ordering::SeqCst),
             "the second provider must run while debt remains past the threshold"
         );
-        // The first provider credited 1000, leaving -4000.
-        assert_eq!(handle.balance(), au(-4000));
     }
 
     #[test]

--- a/crates/swarm/accounting/core/src/accounting/peer.rs
+++ b/crates/swarm/accounting/core/src/accounting/peer.rs
@@ -2,7 +2,6 @@
 
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
-use serde::{Deserialize, Serialize};
 use vertex_swarm_api::{Au, SwarmPeerState};
 
 /// Add `delta` to an atomic balance, saturating at the [`i64`] bounds.
@@ -36,7 +35,7 @@ fn saturating_fetch_sub(atomic: &AtomicU64, delta: u64) {
     }
 }
 
-/// Atomic per-peer balance state (serializable for persistence).
+/// Atomic per-peer balance state.
 ///
 /// - Positive balance: peer owes us (we provided service)
 /// - Negative balance: we owe peer (we received service)
@@ -47,10 +46,8 @@ pub struct PeerState {
     balance: AtomicI64,
     reserved_balance: AtomicU64,
     shadow_reserved_balance: AtomicU64,
-    surplus_balance: AtomicI64,
     payment_threshold: Au,
     disconnect_threshold: Au,
-    last_refresh: AtomicU64,
 }
 
 impl PeerState {
@@ -60,20 +57,9 @@ impl PeerState {
             balance: AtomicI64::new(0),
             reserved_balance: AtomicU64::new(0),
             shadow_reserved_balance: AtomicU64::new(0),
-            surplus_balance: AtomicI64::new(0),
             payment_threshold,
             disconnect_threshold,
-            last_refresh: AtomicU64::new(0),
         }
-    }
-
-    /// Create peer state with scaled thresholds for a client-only node.
-    pub fn new_client_only(payment_threshold: Au, disconnect_threshold: Au, factor: u64) -> Self {
-        let factor = factor.max(1);
-        Self::new(
-            Au::from_amount(payment_threshold.as_amount() / factor),
-            Au::from_amount(disconnect_threshold.as_amount() / factor),
-        )
     }
 
     /// Get the current balance in AU.
@@ -85,11 +71,6 @@ impl PeerState {
     /// adversarial price or settlement sequence cannot wrap and flip owed/owes.
     pub fn add_balance(&self, amount: Au) {
         saturating_fetch_add(&self.balance, amount.get());
-    }
-
-    /// Set the balance atomically.
-    pub fn set_balance(&self, amount: Au) {
-        self.balance.store(amount.get(), Ordering::Relaxed);
     }
 
     /// Get the reserved balance in AU.
@@ -124,16 +105,6 @@ impl PeerState {
         saturating_fetch_sub(&self.shadow_reserved_balance, amount.as_amount());
     }
 
-    /// Get the surplus balance in AU.
-    pub fn surplus_balance(&self) -> Au {
-        Au::new(self.surplus_balance.load(Ordering::Relaxed))
-    }
-
-    /// Add to surplus balance, saturating at the [`i64`] bounds.
-    pub fn add_surplus(&self, amount: Au) {
-        saturating_fetch_add(&self.surplus_balance, amount.get());
-    }
-
     /// Get the payment threshold in AU.
     pub fn payment_threshold(&self) -> Au {
         self.payment_threshold
@@ -143,80 +114,11 @@ impl PeerState {
     pub fn disconnect_threshold(&self) -> Au {
         self.disconnect_threshold
     }
-
-    /// Get the last refresh timestamp.
-    pub fn last_refresh(&self) -> u64 {
-        self.last_refresh.load(Ordering::Relaxed)
-    }
-
-    /// Set the last refresh timestamp.
-    pub fn set_last_refresh(&self, timestamp: u64) {
-        self.last_refresh.store(timestamp, Ordering::Relaxed);
-    }
 }
 
 impl SwarmPeerState for PeerState {
     fn balance(&self) -> Au {
         Au::new(self.balance.load(Ordering::Relaxed))
-    }
-
-    fn add_balance(&self, amount: Au) {
-        saturating_fetch_add(&self.balance, amount.get());
-    }
-
-    fn last_refresh(&self) -> u64 {
-        self.last_refresh.load(Ordering::Relaxed)
-    }
-
-    fn set_last_refresh(&self, timestamp: u64) {
-        self.last_refresh.store(timestamp, Ordering::Relaxed);
-    }
-
-    fn payment_threshold(&self) -> Au {
-        self.payment_threshold
-    }
-
-    fn disconnect_threshold(&self) -> Au {
-        self.disconnect_threshold
-    }
-}
-
-/// Snapshot of peer state for serialization/persistence.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PeerStateSnapshot {
-    pub balance: i64,
-    pub surplus_balance: i64,
-    pub payment_threshold: u64,
-    pub disconnect_threshold: u64,
-    pub last_refresh: u64,
-}
-
-impl PeerState {
-    /// Create a snapshot for persistence.
-    ///
-    /// The snapshot stores plain integers so the persisted bytes are
-    /// unchanged by the AU typing.
-    pub fn snapshot(&self) -> PeerStateSnapshot {
-        PeerStateSnapshot {
-            balance: self.balance.load(Ordering::Relaxed),
-            surplus_balance: self.surplus_balance.load(Ordering::Relaxed),
-            payment_threshold: self.payment_threshold.as_amount(),
-            disconnect_threshold: self.disconnect_threshold.as_amount(),
-            last_refresh: self.last_refresh.load(Ordering::Relaxed),
-        }
-    }
-
-    /// Restore from a snapshot.
-    pub fn from_snapshot(snapshot: PeerStateSnapshot) -> Self {
-        Self {
-            balance: AtomicI64::new(snapshot.balance),
-            reserved_balance: AtomicU64::new(0),
-            shadow_reserved_balance: AtomicU64::new(0),
-            surplus_balance: AtomicI64::new(snapshot.surplus_balance),
-            payment_threshold: Au::from_amount(snapshot.payment_threshold),
-            disconnect_threshold: Au::from_amount(snapshot.disconnect_threshold),
-            last_refresh: AtomicU64::new(snapshot.last_refresh),
-        }
     }
 }
 
@@ -239,23 +141,20 @@ mod tests {
 
         state.add_balance(au(-50));
         assert_eq!(state.balance(), au(50));
-
-        state.set_balance(au(200));
-        assert_eq!(state.balance(), au(200));
     }
 
     #[test]
     fn test_add_balance_saturates_instead_of_wrapping() {
-        let state = PeerState::new(au(1000), au(10000));
-
         // Adding into the positive bound saturates rather than wrapping to a
         // negative balance (which would flip owed/owes).
-        state.set_balance(Au::new(i64::MAX));
+        let state = PeerState::new(au(1000), au(10000));
+        state.add_balance(Au::new(i64::MAX));
         state.add_balance(au(1000));
         assert_eq!(state.balance(), Au::new(i64::MAX));
 
         // The negative bound saturates too.
-        state.set_balance(Au::new(i64::MIN));
+        let state = PeerState::new(au(1000), au(10000));
+        state.add_balance(Au::new(i64::MIN));
         state.add_balance(au(-1000));
         assert_eq!(state.balance(), Au::new(i64::MIN));
     }
@@ -290,28 +189,10 @@ mod tests {
     }
 
     #[test]
-    fn test_client_node_thresholds() {
-        let state = PeerState::new_client_only(au(1000), au(10000), 5);
-
-        // Thresholds should be scaled down by client_factor
-        assert_eq!(state.payment_threshold(), au(200));
-        assert_eq!(state.disconnect_threshold(), au(2000));
-    }
-
-    #[test]
-    fn test_snapshot_roundtrip() {
+    fn test_thresholds() {
         let state = PeerState::new(au(1000), au(10000));
-        state.add_balance(au(500));
-        state.add_surplus(au(100));
-        state.set_last_refresh(12345);
 
-        let snapshot = state.snapshot();
-        let restored = PeerState::from_snapshot(snapshot);
-
-        assert_eq!(restored.balance(), au(500));
-        assert_eq!(restored.surplus_balance(), au(100));
-        assert_eq!(restored.last_refresh(), 12345);
-        assert_eq!(restored.payment_threshold(), au(1000));
-        assert_eq!(restored.disconnect_threshold(), au(10000));
+        assert_eq!(state.payment_threshold(), au(1000));
+        assert_eq!(state.disconnect_threshold(), au(10000));
     }
 }

--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -31,8 +31,7 @@ mod noop;
 mod settlement;
 
 pub use accounting::{
-    Accounting, AccountingError, AccountingPeerHandle, PeerState, PeerStateSnapshot, ProvideAction,
-    ReceiveAction,
+    Accounting, AccountingError, AccountingPeerHandle, PeerState, ProvideAction, ReceiveAction,
 };
 pub use args::BandwidthArgs;
 pub use builder::{AccountingBuilder, NoAccountingBuilder};

--- a/crates/swarm/accounting/core/src/noop.rs
+++ b/crates/swarm/accounting/core/src/noop.rs
@@ -29,10 +29,6 @@ pub struct NoPeerBandwidth {
 impl SwarmPeerBandwidth for NoPeerBandwidth {
     fn record(&self, _amount: Au, _direction: Direction) {}
 
-    fn allow(&self, _amount: Au) -> bool {
-        true
-    }
-
     fn balance(&self) -> Au {
         Au::ZERO
     }

--- a/crates/swarm/accounting/core/src/settlement.rs
+++ b/crates/swarm/accounting/core/src/settlement.rs
@@ -9,10 +9,6 @@ pub struct NoSettlement;
 
 #[async_trait::async_trait]
 impl SwarmSettlementProvider for NoSettlement {
-    fn pre_allow(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> Au {
-        Au::ZERO
-    }
-
     async fn settle(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> SwarmResult<Au> {
         Ok(Au::ZERO)
     }
@@ -25,15 +21,10 @@ impl SwarmSettlementProvider for NoSettlement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PeerState;
-    use vertex_swarm_test_utils::test_peer;
 
     #[test]
     fn test_no_settlement_provider() {
         let provider = NoSettlement;
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-
-        assert_eq!(provider.pre_allow(test_peer(), &state), Au::ZERO);
         assert_eq!(provider.name(), "none");
     }
 }

--- a/crates/swarm/accounting/pseudosettle/src/lib.rs
+++ b/crates/swarm/accounting/pseudosettle/src/lib.rs
@@ -41,9 +41,8 @@ pub use vertex_swarm_client_protocol::PseudosettleEvent;
 ///
 /// `settle()` sends a pseudosettle to the peer offering our debt; the peer
 /// forgives up to its time-based allowance and acks the accepted amount, which
-/// the service credits back. `pre_allow()` is a no-op: a debtor must not forgive
-/// its own debt on elapsed time, or our balance would understate the debt the
-/// peer records and we would under-settle.
+/// the service credits back. A debtor never forgives its own debt locally: our
+/// balance drops only when the peer acks a settle we sent.
 pub struct PseudosettleProvider<C> {
     config: C,
     /// Optional handle for delegating to the service.
@@ -83,15 +82,6 @@ impl<C: SwarmAccountingConfig> PseudosettleProvider<C> {
 
 #[async_trait::async_trait]
 impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for PseudosettleProvider<C> {
-    fn pre_allow(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> Au {
-        // A debtor never forgives its own debt locally. The peer reduces its view
-        // of our debt only when it acks a settle we sent; crediting our balance
-        // on elapsed time here would mask a debt that has actually climbed at the
-        // peer, suppressing the settle that recovers it and letting the peer drop
-        // us. Debt recovers only through the network ack credited in the service.
-        Au::ZERO
-    }
-
     async fn settle(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> SwarmResult<Au> {
         // If we have a handle, delegate to the service
         if let Some(handle) = &self.handle {
@@ -190,23 +180,6 @@ mod tests {
 
         handle.record(Au::from_amount(500), Direction::Download);
         assert_eq!(handle.balance(), Au::from_amount(500));
-    }
-
-    #[test]
-    fn pre_allow_never_forgives_debt_locally() {
-        // A debtor's balance must track the debt the peer records; only a network
-        // ack reduces it. `pre_allow` leaves the balance untouched however much
-        // time has elapsed, so the debt cannot look settled locally while the peer
-        // still counts it.
-        let provider = PseudosettleProvider::new(BandwidthConfig::default());
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
-        state.add_balance(Au::new(-10_000));
-        state.set_last_refresh(vertex_util_runtime::time::now_unix_secs() - 10);
-
-        let credit = provider.pre_allow(test_peer(), &state);
-
-        assert_eq!(credit, Au::ZERO);
-        assert_eq!(state.balance(), Au::new(-10_000));
     }
 
     #[tokio::test]

--- a/crates/swarm/accounting/swap/src/lib.rs
+++ b/crates/swarm/accounting/swap/src/lib.rs
@@ -93,12 +93,6 @@ impl<C: SwarmAccountingConfig> SwapProvider<C> {
 
 #[async_trait::async_trait]
 impl<C: SwarmAccountingConfig + 'static> SwarmSettlementProvider for SwapProvider<C> {
-    fn pre_allow(&self, _peer: OverlayAddress, _state: &dyn SwarmPeerState) -> Au {
-        // SWAP does not modify the balance during the allow check; payment is
-        // driven by `settle()` once debt crosses the threshold.
-        Au::ZERO
-    }
-
     async fn settle(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> SwarmResult<Au> {
         let balance = state.balance();
         // Positive balance means the peer owes us; nothing for us to pay.

--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -26,45 +26,24 @@ pub enum Direction {
     Download,
 }
 
-/// Abstract peer balance state for settlement providers.
+/// Abstract peer balance state read by settlement providers.
 ///
-/// Positive balance = peer owes us, negative = we owe peer.
-/// The peer address is passed separately to settlement methods.
+/// Positive balance = peer owes us, negative = we owe peer. The peer address is
+/// passed separately to `settle`.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait SwarmPeerState: Send + Sync {
     /// Get the current balance (positive = peer owes us).
     fn balance(&self) -> Au;
-
-    /// Add to the balance atomically.
-    fn add_balance(&self, amount: Au);
-
-    /// Get the last refresh timestamp (for pseudosettle).
-    fn last_refresh(&self) -> u64;
-
-    /// Set the last refresh timestamp.
-    fn set_last_refresh(&self, timestamp: u64);
-
-    /// Get the payment threshold for this peer.
-    fn payment_threshold(&self) -> Au;
-
-    /// Get the disconnect threshold for this peer.
-    fn disconnect_threshold(&self) -> Au;
 }
 
 /// Settlement provider for bandwidth accounting.
 ///
-/// Providers are called at `pre_allow()` (before allowing transfers) and
-/// `settle()` (when explicit settlement is requested).
-///
-/// Injected into the accounting core as `Box<dyn SwarmSettlementProvider>`, so
-/// the trait stays object-safe via `async_trait`.
+/// `settle()` runs when explicit settlement is requested. Injected into the
+/// accounting core as `Box<dyn SwarmSettlementProvider>`, so the trait stays
+/// object-safe via `async_trait`.
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, Arc, Box)]
 pub trait SwarmSettlementProvider: Send + Sync + 'static {
-    /// Called before checking if a transfer is allowed.
-    /// Returns the amount of balance adjustment (positive = credit added).
-    fn pre_allow(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> Au;
-
     /// Called when explicit settlement is requested.
     /// Returns the amount settled, or an error if settlement failed.
     async fn settle(&self, peer: OverlayAddress, state: &dyn SwarmPeerState) -> SwarmResult<Au>;
@@ -141,10 +120,6 @@ pub trait AccountingAction: Send {
 pub trait SwarmPeerBandwidth: Send + Sync {
     /// Record a priced amount of bandwidth usage (lock-free, must not block).
     fn record(&self, amount: Au, direction: Direction);
-
-    /// Check if a transfer of `amount` is allowed (false if over disconnect
-    /// threshold).
-    fn allow(&self, amount: Au) -> bool;
 
     /// Get current balance (positive = peer owes us).
     fn balance(&self) -> Au;
@@ -235,19 +210,6 @@ pub trait SwarmClientAccounting: Send + Sync {
     /// Get the pricer.
     fn pricing(&self) -> &Self::Pricing;
 
-    /// Get the node's identity.
-    fn identity(&self) -> &<Self::Bandwidth as SwarmBandwidthAccounting>::Identity {
-        self.bandwidth().identity()
-    }
-
-    /// Get or create accounting for a peer.
-    fn for_peer(
-        &self,
-        peer: OverlayAddress,
-    ) -> <Self::Bandwidth as SwarmBandwidthAccounting>::Peer {
-        self.bandwidth().for_peer(peer)
-    }
-
     /// Prepare to receive a chunk (we pay, balance decreases).
     fn prepare_receive_chunk(
         &self,
@@ -267,15 +229,5 @@ pub trait SwarmClientAccounting: Send + Sync {
     ) -> SwarmResult<<Self::Bandwidth as SwarmBandwidthAccounting>::ProvideAction> {
         let price = self.pricing().peer_price(&peer, chunk);
         self.bandwidth().prepare_provide(peer, price)
-    }
-
-    /// Calculate price for receiving a chunk from a peer.
-    fn receive_price(&self, peer: &OverlayAddress, chunk: &ChunkAddress) -> Au {
-        self.pricing().peer_price(peer, chunk)
-    }
-
-    /// Calculate price for providing a chunk to a peer.
-    fn provide_price(&self, peer: &OverlayAddress, chunk: &ChunkAddress) -> Au {
-        self.pricing().peer_price(peer, chunk)
     }
 }

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -535,9 +535,6 @@ mod tests {
 
     impl SwarmPeerBandwidth for MockPeerBandwidth {
         fn record(&self, _amount: Au, _direction: Direction) {}
-        fn allow(&self, _amount: Au) -> bool {
-            true
-        }
         fn balance(&self) -> Au {
             Au::ZERO
         }


### PR DESCRIPTION
## What

Removes dead bandwidth-accounting code with no live (non-test) caller, and collapses the `SwarmPeerState` trait to the one read that survives. Net -347 lines, no behaviour change; the settlement provider signature is unchanged.

Removed: the debtor-side time-refresh seam (`pre_allow`/`allow`/`pre_allow_all`); the unused `SwarmClientAccounting` price forwarders and default `for_peer`/`identity` methods; `Accounting::config()`/`providers()` accessors; `get_or_create_client_peer`/`PeerState::new_client_only` (client scaling lives in `BandwidthConfig::for_client`); and the `PeerState` `surplus`/`set_balance`/`last_refresh`/snapshot fields and path.

## Why

Closes #552.

The deletion half of the accounting-seam reshape (`docs/design/accounting-seam.md`), part of the client retrieval hardening spine (epic #526). The `pre_allow` chain became fully dead once the client settled its own debt reliably (#549). Removing it first keeps the following reth-shaped trait reshape reviewable against a clean surface.

## Testing

`cargo nextest run --all-features` across api + the three accounting crates + builder + node: 239 pass (dead-path tests removed; the kept settlement fan-out test still asserts the second provider runs while debt remains). `cargo clippy --all-targets --all-features -- -D warnings` clean on all touched crates plus a swap-off pass.

## AI Assistance

Claude Code used for the dead-code census, deletions, and verification.
