### PR TITLE
feat(swarm-node): reserve origin debt at dispatch and gate admission on the band

### DIFF
--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -196,6 +196,57 @@ impl<B: SwarmBandwidthAccounting> BandwidthDebit for B {
     }
 }
 
+/// Object-safe held receive reservation: reserve at dispatch, commit on
+/// delivery, release on drop.
+///
+/// The origin retrieval and pushsync legs reserve the price before sending and
+/// carry the hold across the in-flight leg behind a trait object (the dispatch
+/// site cannot name the concrete `ReceiveAction`). Calling [`apply`](Self::apply)
+/// commits the debit; dropping the box releases the reservation, so any
+/// non-delivery exit (failure, timeout, a dropped request future) never leaks.
+pub trait HeldReceive: Send {
+    /// Commit the reserved receive debit.
+    fn apply(self: Box<Self>);
+}
+
+impl<T: Commit + 'static> HeldReceive for T {
+    fn apply(self: Box<Self>) {
+        Commit::apply(*self);
+    }
+}
+
+/// Object-safe reserve-at-dispatch for callers that hold accounting behind a
+/// trait object.
+///
+/// Reserves the receive leg and returns the hold to carry across the in-flight
+/// leg. An `Err` is the band refusing at the disconnect line (the same hard gate
+/// [`SwarmBandwidthAccounting::prepare_receive`] applies): sending would cross
+/// the creditor's line, so the caller routes elsewhere.
+pub trait BandwidthReserve: Send + Sync {
+    /// Reserve `price` for an in-flight receive leg from `peer`. Apply the
+    /// returned hold on delivery; drop it to release.
+    fn reserve_received(
+        &self,
+        peer: OverlayAddress,
+        price: Au,
+        originated: bool,
+    ) -> SwarmResult<Box<dyn HeldReceive>>;
+}
+
+impl<B: SwarmBandwidthAccounting> BandwidthReserve for B
+where
+    B::ReceiveAction: 'static,
+{
+    fn reserve_received(
+        &self,
+        peer: OverlayAddress,
+        price: Au,
+        originated: bool,
+    ) -> SwarmResult<Box<dyn HeldReceive>> {
+        Ok(Box::new(self.prepare_receive(peer, price, originated)?))
+    }
+}
+
 /// Combined pricing and bandwidth accounting for client operations.
 ///
 /// Unifies chunk pricing and bandwidth accounting so callers don't need

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -9,9 +9,9 @@ mod reserve;
 mod topology;
 
 pub use self::bandwidth::{
-    BandwidthDebit, Commit, CommitOnWrite, Direction, SwarmAccountingConfig,
-    SwarmBandwidthAccounting, SwarmClientAccounting, SwarmPeerBandwidth, SwarmPeerState,
-    SwarmSettlementProvider,
+    BandwidthDebit, BandwidthReserve, Commit, CommitOnWrite, Direction, HeldReceive,
+    SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmPeerBandwidth,
+    SwarmPeerState, SwarmSettlementProvider,
 };
 pub use self::localstore::{SwarmLocalStore, SwarmLocalStoreConfig};
 pub use self::peers::SwarmPeerResolver;

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -38,14 +38,15 @@ mod types;
 
 pub use self::accounting::{Admission, Au, AuConversionError, Debt, Threshold};
 pub use self::components::{
-    BandwidthDebit, BinCursorStore, BinScanItem, BootnodeComponents, ClientComponents, Commit,
-    CommitOnWrite, Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology,
-    IntervalStore, PullChunkVerifier, PullStorage, ReserveStore, SettableRadius, StorerComponents,
-    SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore,
-    SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing,
-    SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
-    SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting,
-    SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats, VerifyError, construct,
+    BandwidthDebit, BandwidthReserve, BinCursorStore, BinScanItem, BootnodeComponents,
+    ClientComponents, Commit, CommitOnWrite, Direction, HasChunkClient, HasIdentity, HasReserve,
+    HasStore, HasTopology, HeldReceive, IntervalStore, PullChunkVerifier, PullStorage,
+    ReserveStore, SettableRadius, StorerComponents, SwarmAccountingConfig,
+    SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig,
+    SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder,
+    SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins,
+    SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting,
+    SwarmTopologyState, SwarmTopologyStats, VerifyError, construct,
 };
 pub use self::config::{
     DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN,

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -733,15 +733,22 @@ mod tests {
         assert_eq!(after, baseline, "a receive breach must not score the peer");
     }
 
-    /// The shared accounting wired into the client service via `with_accounting`
-    /// debits the serving peer for an own-request delivery. This proves the
-    /// builder's wiring expression activates the origin debit, not just that the
-    /// service supports it.
+    /// The origin gate wired onto the client handle reserves the price at
+    /// dispatch and commits it exactly once on delivery, debiting the serving
+    /// peer by the per-chunk price. This mirrors the `with_origin_gate` wiring
+    /// `assemble_client_core` builds, proving an end-to-end origin retrieval
+    /// debits the serving peer exactly once through the reservation path.
     #[tokio::test]
     async fn builder_wiring_debits_an_origin_delivery() {
         use nectar_primitives::{AnyChunk, ChunkAddress, ContentChunk};
-        use vertex_swarm_api::{SwarmBandwidthAccounting, SwarmPeerBandwidth, SwarmPricing};
-        use vertex_swarm_node::{ClientEvent, ClientService};
+        use tokio::sync::mpsc;
+        use vertex_swarm_api::{
+            AdmissionControl, BandwidthReserve, SwarmBandwidthAccounting, SwarmPeerBandwidth,
+            SwarmPricing,
+        };
+        use vertex_swarm_node::{
+            AccountingSettlement, ClientCommand, ClientHandle, RetrievalResult, SettlementTrigger,
+        };
 
         let identity = test_identity_arc();
         let config = DefaultBandwidthConfig::default();
@@ -759,33 +766,35 @@ mod tests {
         let price = accounting.pricing().peer_price(&overlay, &address);
         assert!(price > Au::ZERO, "the per-chunk price is non-zero");
 
-        // The same wiring expression `build_client_backed_node` uses.
-        let (service, event_tx, _handle) = ClientService::new();
-        let service = service.with_accounting(
+        // The same gate `assemble_client_core` wires onto the throttled handle.
+        let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+        let settlement: Arc<dyn SettlementTrigger> =
+            Arc::new(AccountingSettlement::new(accounting.bandwidth().clone()));
+        let handle = ClientHandle::new(tx).with_origin_gate(
             Arc::new(accounting.pricing().clone()),
-            accounting.bandwidth().clone(),
+            accounting.bandwidth().clone() as Arc<dyn BandwidthReserve>,
+            accounting.bandwidth().clone() as Arc<dyn AdmissionControl>,
+            settlement,
         );
 
-        let manager = TaskManager::current();
-        let handle = manager
-            .executor()
-            .spawn_service("test.client_service", service);
+        let request = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.retrieve_chunk(overlay, address, true).await }
+        });
 
-        event_tx
-            .send(ClientEvent::ChunkReceived {
-                peer: overlay,
-                address,
+        // The reservation is held the moment the command is dispatched.
+        let response = match rx.recv().await.expect("origin retrieval dispatched") {
+            ClientCommand::RetrieveChunk { response, .. } => response,
+            other => panic!("unexpected command: {other:?}"),
+        };
+        response
+            .send(Ok(RetrievalResult {
                 chunk,
                 stamp: None,
-                latency: std::time::Duration::from_millis(1),
-                originated: true,
-            })
-            .await
-            .expect("service is running");
-        // Dropping the sender closes the channel, so the run loop drains the one
-        // queued event and then exits.
-        drop(event_tx);
-        handle.await.expect("service task joins cleanly");
+                peer: overlay,
+            }))
+            .expect("receiver alive");
+        request.await.unwrap().expect("delivery ok");
 
         assert_eq!(
             accounting.bandwidth().for_peer(overlay).balance(),

--- a/crates/swarm/client-protocol/src/lib.rs
+++ b/crates/swarm/client-protocol/src/lib.rs
@@ -92,18 +92,28 @@ pub enum ChunkTransferError {
     /// Retrieval only.
     #[error("Chunk not found: {0}")]
     NotFound(ChunkAddress),
+
+    /// The local credit gate refused the request at the peer's disconnect line.
+    /// No bytes were sent and a settle was triggered so the peer drains; another
+    /// candidate should be tried.
+    #[error("Admission refused at the disconnect line")]
+    Refused,
 }
 
 impl ChunkTransferError {
     /// Whether retrying the request against another candidate may succeed.
     ///
-    /// Timeout, remote failure, transient protocol error, and not-found are
-    /// retryable (another candidate may hold the chunk); a cancelled or
-    /// channel-closed request reflects a local teardown that another attempt
-    /// cannot fix.
+    /// Timeout, remote failure, transient protocol error, not-found, and a local
+    /// credit refusal are retryable (another candidate may hold the chunk or be
+    /// affordable); a cancelled or channel-closed request reflects a local
+    /// teardown that another attempt cannot fix.
     pub fn is_retryable(&self) -> bool {
         match self {
-            Self::TimedOut | Self::Remote | Self::Protocol(_) | Self::NotFound(_) => true,
+            Self::TimedOut
+            | Self::Remote
+            | Self::Protocol(_)
+            | Self::NotFound(_)
+            | Self::Refused => true,
             Self::ChannelClosed | Self::NotConnected | Self::Cancelled => false,
         }
     }

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -134,7 +134,7 @@ alloy-signer-local.workspace = true
 # native-only and would drag native-only transitive crates (mio, errno) into the
 # wasm test build, so they stay off wasm32.
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync", "test-util"] }
 vertex-swarm-test-utils = { workspace = true, features = ["cluster"] }
 vertex-swarm-topology.workspace = true
 eyre.workspace = true

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -12,6 +12,9 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
 use vertex_swarm_topology::TopologyHandle;
+// `Instant` is portable (the browser performance clock on wasm); only timer
+// sleeps are `!Send`, and the gated-set wait awaits a settle completion instead.
+use vertex_tasks::time::{Duration, Instant};
 
 use crate::{
     ClientHandle, PeerInflightLimiter, PeerSelector, RETRIEVAL_STAGGER, RaceFailure,
@@ -39,6 +42,14 @@ const RETRIEVE_CANDIDATE_WIDTH: usize = 8;
 /// does not amplify paid bandwidth: the wider pool only supplies free-slot
 /// alternatives, the race still meters at most this many legs (the prior bound).
 const RETRIEVE_MAX_ATTEMPTS: usize = 3;
+
+/// Bound on the settle-and-await for a fully gated close set: the request's own
+/// retrieval lifetime, matching the client-behaviour outbound retrieval timeout.
+/// Accounting-timing back-pressure blocks within the request rather than failing
+/// early to the consumer, and only a genuine lifetime expiry falls through to the
+/// generic transient failure. The wait is progress-aware, so it paces on
+/// settlement RTT and returns at once when no settle is in flight to drain debt.
+const GATE_SETTLE_BUDGET: Duration = Duration::from_secs(30);
 
 /// Chunk provider using ClientHandle for network retrieval.
 #[derive(Clone)]
@@ -73,10 +84,27 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         self
     }
 
-    /// Order proximity-sorted `candidates` for a request on `chunk`.
-    fn select(&self, candidates: Vec<SwarmAddress>, chunk: &ChunkAddress) -> Vec<SwarmAddress> {
+    /// Order proximity-sorted `candidates` for a request on `chunk`, settling
+    /// and awaiting a fully gated close set.
+    ///
+    /// With a selector this delegates to the score- and affordability-aware
+    /// ordering. A non-empty order returns at once (the fast path); a fully
+    /// gated close set awaits its in-flight settles up to the retrieval-lifetime
+    /// [`GATE_SETTLE_BUDGET`], returning at the deadline or promptly once no
+    /// settle is in flight to drain debt, with whatever is admissible (possibly
+    /// empty). An empty result falls through to the caller's generic transient
+    /// failure, never an accounting-specific error. The wait is `Send` on every
+    /// platform. With no selector the proximity order is returned unchanged.
+    async fn select_or_wait(
+        &self,
+        candidates: Vec<SwarmAddress>,
+        chunk: &ChunkAddress,
+    ) -> Vec<SwarmAddress> {
         match &self.selector {
-            Some(selector) => selector.order(candidates, chunk),
+            Some(selector) => {
+                let deadline = Instant::now() + GATE_SETTLE_BUDGET;
+                selector.order_or_wait(candidates, chunk, deadline).await
+            }
             None => candidates,
         }
     }
@@ -89,7 +117,11 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         let closest_peers = self
             .topology
             .closest_to(&chunk_address, RETRIEVE_CANDIDATE_WIDTH);
-        let closest_peers = self.select(closest_peers, &chunk_address);
+        // Settle-and-await when every close peer is gated, so a fully gated set
+        // recovers instead of failing; if still gated at the budget the empty
+        // result falls through to the no-connected-peers path below, the same
+        // generic transient error a no-peers failure yields.
+        let closest_peers = self.select_or_wait(closest_peers, &chunk_address).await;
 
         // Skip-busy: prefer close peers with a free retrieval slot so a hot peer
         // at its in-flight cap is skipped at selection time rather than
@@ -166,7 +198,10 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     async fn push_to_closest(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
         let address = *chunk.address();
         let closest = self.topology.closest_to(&address, PUSH_CANDIDATE_COUNT);
-        let closest = self.select(closest, &address);
+        // Settle-and-await an all-gated closest set rather than immediately
+        // falling through to a farther peer or failing; if still gated at the
+        // budget the empty result yields the generic no-storer outcome below.
+        let closest = self.select_or_wait(closest, &address).await;
         let attempts = closest.len();
 
         // The required custody depth is derived from our locally observed
@@ -851,6 +886,157 @@ mod tests {
                 limiter.try_acquire(&head).is_some(),
                 "the freed head slot is reservable again"
             );
+        }
+    }
+
+    mod gated_fallback {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use nectar_primitives::SwarmAddress;
+        use vertex_swarm_api::{Au, ChunkAddress, Ledger, SwarmError, SwarmPricing, Threshold};
+        use vertex_tasks::time::Instant;
+
+        use crate::{PeerScores, PeerSelector, SettlementTrigger};
+
+        use super::address;
+
+        fn overlay(n: u8) -> SwarmAddress {
+            SwarmAddress::from([n; 32])
+        }
+
+        struct NoScores;
+        impl PeerScores for NoScores {
+            fn peer_score(&self, _overlay: &SwarmAddress) -> Option<f64> {
+                None
+            }
+        }
+
+        struct UnitPricer;
+        impl SwarmPricing for UnitPricer {
+            fn price(&self, _chunk: &ChunkAddress) -> Au {
+                Au::from_amount(1)
+            }
+            fn peer_price(&self, _peer: &SwarmAddress, _chunk: &ChunkAddress) -> Au {
+                Au::from_amount(1)
+            }
+        }
+
+        /// Refuses every peer at the unit price while `gated`; admits once clear.
+        struct GatedLedger(Arc<AtomicBool>);
+        impl Ledger for GatedLedger {
+            fn balance(&self, _o: &SwarmAddress) -> Au {
+                Au::ZERO
+            }
+            fn reserved(&self, _o: &SwarmAddress) -> Au {
+                Au::ZERO
+            }
+            fn headroom(&self, _o: &SwarmAddress, _t: Threshold) -> Au {
+                Au::from_amount(1000)
+            }
+            fn disconnect_line(&self, _o: &SwarmAddress) -> Au {
+                if self.0.load(Ordering::SeqCst) {
+                    Au::ZERO
+                } else {
+                    Au::from_amount(1000)
+                }
+            }
+            fn settle_trigger(&self, _o: &SwarmAddress) -> Au {
+                Au::from_amount(1000)
+            }
+        }
+
+        /// `settled` resolves at once; when `drains` it clears the gate first
+        /// (modelling a completed in-flight settle that drops the peer's debt
+        /// under its line) and reports `true`. Otherwise it reports `false`: no
+        /// settle is draining debt, so the wait loop stops without spinning.
+        struct DrainSettlement {
+            gate: Arc<AtomicBool>,
+            drains: bool,
+        }
+        impl SettlementTrigger for DrainSettlement {
+            fn trigger_settlement(&self, _peer: SwarmAddress) {}
+            fn settled(
+                &self,
+                _peers: &[SwarmAddress],
+            ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+                if self.drains {
+                    self.gate.store(false, Ordering::SeqCst);
+                }
+                Box::pin(std::future::ready(self.drains))
+            }
+        }
+
+        fn selector(gate: Arc<AtomicBool>, drains: bool) -> PeerSelector {
+            PeerSelector::new(
+                Arc::new(NoScores),
+                Arc::new(GatedLedger(Arc::clone(&gate))),
+                Arc::new(UnitPricer),
+                Arc::new(DrainSettlement { gate, drains }),
+            )
+        }
+
+        #[tokio::test]
+        async fn a_recovering_gated_set_returns_the_admissible_peers() {
+            // Every close peer is gated on the first order; the awaited settle
+            // drains the debt (the gate clears) and the re-order returns them.
+            let gate = Arc::new(AtomicBool::new(true));
+            let sel = selector(Arc::clone(&gate), true);
+            let deadline = Instant::now() + std::time::Duration::from_secs(5);
+            let ordered = sel
+                .order_or_wait(
+                    vec![overlay(1), overlay(2)],
+                    &ChunkAddress::zero(),
+                    deadline,
+                )
+                .await;
+            assert_eq!(
+                ordered,
+                vec![overlay(1), overlay(2)],
+                "recovers once the settle drains"
+            );
+        }
+
+        #[tokio::test]
+        async fn a_fully_gated_set_with_no_draining_settle_returns_empty() {
+            // The gate never clears and no settle is draining debt: the
+            // no-progress guard terminates the wait with an empty result, so the
+            // dispatch falls through to its generic transient error rather than
+            // hanging or spinning to the far deadline.
+            let gate = Arc::new(AtomicBool::new(true));
+            let sel = selector(Arc::clone(&gate), false);
+            let deadline = Instant::now() + std::time::Duration::from_secs(30);
+            let ordered = sel
+                .order_or_wait(
+                    vec![overlay(1), overlay(2)],
+                    &ChunkAddress::zero(),
+                    deadline,
+                )
+                .await;
+            assert!(ordered.is_empty(), "still gated, no settle draining");
+        }
+
+        #[test]
+        fn an_empty_close_set_surfaces_a_generic_transient_error() {
+            // What a fully gated (empty) selection falls through to is the same
+            // generic transient failure a genuine no-peers/no-storer case yields:
+            // retrieval a `Network` error, push a `NoStorer` error. Neither is an
+            // accounting-specific variant, so the accounting concern never reaches
+            // the consumer.
+            let retrieval = SwarmError::network_msg("no connected peers available for retrieval");
+            assert!(matches!(retrieval, SwarmError::Network { .. }));
+            assert!(
+                retrieval.is_retryable(),
+                "a no-peers retrieval is transient"
+            );
+
+            let push = SwarmError::NoStorer {
+                chunk_address: address(0xaa),
+            };
+            assert!(matches!(push, SwarmError::NoStorer { .. }));
+            assert!(push.is_retryable(), "a no-storer push is transient");
         }
     }
 }

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -8,8 +8,8 @@ use nectar_primitives::ChunkAddress;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use vertex_swarm_api::{
-    AdmissionControl, Au, BandwidthDebit, PeerReporter, ReportSource, SwarmLocalStore,
-    SwarmPricing, SwarmScoringEvent,
+    Admission, AdmissionControl, Au, BandwidthReserve, HeldReceive, PeerReporter, ReportSource,
+    SwarmLocalStore, SwarmPricing, SwarmScoringEvent,
 };
 use vertex_swarm_client_protocol::PseudosettleAck;
 pub use vertex_swarm_client_protocol::{ChunkTransferError, RetrievalResult};
@@ -40,6 +40,24 @@ pub struct ClientHandle {
     /// When set, requests pace themselves under the peer's pseudosettle
     /// allowance before dispatch.
     throttle: Option<Arc<SelfThrottle>>,
+    /// When set, an origin request reserves its price at dispatch, gates on the
+    /// admission band, and commits the reserved debit on delivery. Absent on the
+    /// lightweight launcher, where origin dispatch neither reserves nor gates.
+    origin: Option<OriginGate>,
+}
+
+/// Reserve-at-dispatch and the admission band for origin requests.
+///
+/// All four read the one shared accounting the selector and throttle use, so the
+/// dispatch gate, the candidate selector, and the in-flight reservation agree on
+/// one ledger. The settlement trigger is the selector's, so settles dedup across
+/// both paths.
+#[derive(Clone)]
+struct OriginGate {
+    pricing: Arc<dyn SwarmPricing>,
+    reserve: Arc<dyn BandwidthReserve>,
+    admission: Arc<dyn AdmissionControl>,
+    settlement: Arc<dyn SettlementTrigger>,
 }
 
 impl ClientHandle {
@@ -48,6 +66,7 @@ impl ClientHandle {
         Self {
             command_tx,
             throttle: None,
+            origin: None,
         }
     }
 
@@ -57,6 +76,77 @@ impl ClientHandle {
     pub fn with_throttle(mut self, throttle: Arc<SelfThrottle>) -> Self {
         self.throttle = Some(throttle);
         self
+    }
+
+    /// Attach the origin credit gate so an own-request dispatch reserves its
+    /// price, bands the request, and commits the debit on delivery.
+    ///
+    /// `pricing`, `reserve`, and `admission` must read the one shared accounting
+    /// the selector and throttle use, and `settlement` must be the selector's so
+    /// the in-flight settle dedup is shared. Relay legs (`originated == false`)
+    /// are accounted by the forwarder and bypass this gate.
+    #[must_use]
+    pub fn with_origin_gate(
+        mut self,
+        pricing: Arc<dyn SwarmPricing>,
+        reserve: Arc<dyn BandwidthReserve>,
+        admission: Arc<dyn AdmissionControl>,
+        settlement: Arc<dyn SettlementTrigger>,
+    ) -> Self {
+        self.origin = Some(OriginGate {
+            pricing,
+            reserve,
+            admission,
+            settlement,
+        });
+        self
+    }
+
+    /// Gate and reserve an origin request before dispatch.
+    ///
+    /// Returns the hold to carry across the in-flight leg (`Ok(Some(_))`), or
+    /// `Ok(None)` for a relay leg or when no origin gate is attached. An
+    /// [`Admit`](Admission::Admit) band reserves and sends; a
+    /// [`SettleAndAdmit`](Admission::SettleAndAdmit) triggers a settle and sends
+    /// anyway (the band keeps us under the disconnect line whichever order the
+    /// storer applies them); a [`Refuse`](Admission::Refuse) at the disconnect
+    /// line triggers a settle and refuses, so the caller routes elsewhere.
+    fn reserve_origin(
+        &self,
+        peer: OverlayAddress,
+        address: &ChunkAddress,
+        originated: bool,
+    ) -> Result<Option<Box<dyn HeldReceive>>, ChunkTransferError> {
+        let Some(gate) = &self.origin else {
+            return Ok(None);
+        };
+        if !originated {
+            return Ok(None);
+        }
+
+        let price = gate.pricing.peer_price(&peer, address);
+        match gate.admission.admit(&peer, price) {
+            Admission::Refuse => {
+                gate.settlement.trigger_settlement(peer);
+                return Err(ChunkTransferError::Refused);
+            }
+            admission => {
+                if admission.settles() {
+                    gate.settlement.trigger_settlement(peer);
+                }
+            }
+        }
+
+        // The reserve shares the admit boundary, so it refuses at the disconnect
+        // line too; a concurrent burst that crossed it between the band check and
+        // here surfaces as a refusal, handled identically.
+        match gate.reserve.reserve_received(peer, price, true) {
+            Ok(held) => Ok(Some(held)),
+            Err(_) => {
+                gate.settlement.trigger_settlement(peer);
+                Err(ChunkTransferError::Refused)
+            }
+        }
     }
 
     /// Send a command to the network layer.
@@ -92,6 +182,11 @@ impl ClientHandle {
                 .await;
         }
 
+        // Reserve the origin debit and gate on the band before sending. The hold
+        // rides this future: applied on delivery, released on any other exit
+        // (failure, cancel, a dropped losing race leg).
+        let reservation = self.reserve_origin(peer, &address, originated)?;
+
         let (tx, rx) = oneshot::channel();
 
         self.send_command(ClientCommand::RetrieveChunk {
@@ -101,7 +196,13 @@ impl ClientHandle {
             originated,
         })?;
 
-        rx.await.map_err(|_| ChunkTransferError::Cancelled)?
+        let result = rx.await.map_err(|_| ChunkTransferError::Cancelled)?;
+        if result.is_ok()
+            && let Some(held) = reservation
+        {
+            held.apply();
+        }
+        result
     }
 
     /// Push a stamped chunk to a specific peer.
@@ -124,6 +225,11 @@ impl ClientHandle {
                 .await;
         }
 
+        // Pushsync reserves the origin debit and gates like retrieval. A
+        // `SettleAndAdmit` peer is still sent to (closeness preserved); only a
+        // `Refuse` at the disconnect line refuses here.
+        let reservation = self.reserve_origin(peer, &address, originated)?;
+
         let (tx, rx) = oneshot::channel();
 
         self.send_command(ClientCommand::PushChunk {
@@ -134,7 +240,13 @@ impl ClientHandle {
             originated,
         })?;
 
-        rx.await.map_err(|_| ChunkTransferError::Cancelled)?
+        let result = rx.await.map_err(|_| ChunkTransferError::Cancelled)?;
+        if result.is_ok()
+            && let Some(held) = reservation
+        {
+            held.apply();
+        }
+        result
     }
 }
 
@@ -154,31 +266,6 @@ pub struct ClientService {
     /// Per-peer retrieval in-flight limiter shared with the chunk provider;
     /// the peer entry is forgotten on disconnect.
     inflight: Option<Arc<PeerInflightLimiter>>,
-    /// Per-peer chunk pricer and the receive-debit half of the shared
-    /// accounting. Present only on the full builder; absent on the lightweight
-    /// launcher, where the origin debit is a no-op.
-    accounting: Option<OriginAccounting>,
-    /// Debtor-initiated settlement over the shared accounting. Present whenever
-    /// accounting is. The selector drives settlement on the candidate-selection
-    /// path, which the shared retrieval path the client drives never runs, so the
-    /// service settles after an own delivery instead.
-    settlement: Option<ClientSettlement>,
-}
-
-/// The pricing and debit handles the service needs to debit own-request
-/// deliveries. Both halves come from the one shared accounting instance.
-struct OriginAccounting {
-    pricing: Arc<dyn SwarmPricing>,
-    bandwidth: Arc<dyn BandwidthDebit>,
-}
-
-/// The affordability query and settlement trigger the service needs to settle
-/// after an own-request delivery. Both read the same shared accounting the origin
-/// debit, the selector, and the throttle use, and the trigger shares its
-/// in-flight set with the selector so overlapping settles are deduped.
-struct ClientSettlement {
-    admission: Arc<dyn AdmissionControl>,
-    trigger: Arc<dyn SettlementTrigger>,
 }
 
 impl ClientService {
@@ -197,8 +284,6 @@ impl ClientService {
             store: None,
             throttle: None,
             inflight: None,
-            accounting: None,
-            settlement: None,
         };
 
         (service, event_tx, handle)
@@ -219,8 +304,6 @@ impl ClientService {
             store: None,
             throttle: None,
             inflight: None,
-            accounting: None,
-            settlement: None,
         };
 
         (service, handle)
@@ -269,77 +352,9 @@ impl ClientService {
         self
     }
 
-    /// Attach the shared accounting so own-request deliveries debit the serving
-    /// peer by the per-chunk price.
-    ///
-    /// `pricing` and `bandwidth` are the two halves of the one accounting
-    /// instance the selector, throttle, and forwarder also share. Only origin
-    /// (own-request) completions are debited here; relay legs are accounted by
-    /// the forwarder, so debiting them here would double-charge.
-    #[must_use]
-    pub fn with_accounting(
-        mut self,
-        pricing: Arc<dyn SwarmPricing>,
-        bandwidth: Arc<dyn BandwidthDebit>,
-    ) -> Self {
-        self.accounting = Some(OriginAccounting { pricing, bandwidth });
-        self
-    }
-
-    /// Attach debtor-initiated settlement so each own-request delivery that
-    /// leaves us past the early-payment trigger settles the serving peer.
-    ///
-    /// `admission` and `trigger` must read the same shared accounting the origin
-    /// debit uses, and `trigger` must be the selector's so the in-flight dedup is
-    /// shared. The selector drives settlement on the candidate-selection path; the
-    /// shared retrieval path never runs the selector, so without this a client's
-    /// debt only ever climbs until peers drop it.
-    #[must_use]
-    pub fn with_settlement(
-        mut self,
-        admission: Arc<dyn AdmissionControl>,
-        trigger: Arc<dyn SettlementTrigger>,
-    ) -> Self {
-        self.settlement = Some(ClientSettlement { admission, trigger });
-        self
-    }
-
     /// Get a handle for sending commands.
     pub fn handle(&self) -> ClientHandle {
         self.handle.clone()
-    }
-
-    /// Debit the serving peer by the per-chunk price for a completed
-    /// own-request delivery. A no-op when no accounting handle is attached.
-    ///
-    /// The chunk is already in hand, so the debit commits immediately. A
-    /// disconnect-threshold breach is already reported to peer scoring inside
-    /// accounting; this only logs it.
-    fn debit_origin(&self, peer: &OverlayAddress, address: &ChunkAddress) {
-        let Some(accounting) = &self.accounting else {
-            return;
-        };
-        let price = accounting.pricing.peer_price(peer, address);
-        if let Err(error) = accounting.bandwidth.debit_received(*peer, price, true) {
-            debug!(%peer, %address, %error, "origin debit refused at disconnect threshold");
-        }
-    }
-
-    /// Settle the serving peer when the own-request debit just committed has
-    /// pushed our debt past the payment threshold. A no-op without settlement.
-    ///
-    /// The trigger self-gates (a settle already in flight to this peer is skipped)
-    /// and `admit(..).settles()` gates on the committed-plus-reserved debt at a
-    /// zero incremental price (the debit already landed), so polling every in-debt
-    /// delivery is cheap. The accepted amount is credited back by the pseudosettle
-    /// service on the ack.
-    fn settle_origin(&self, peer: &OverlayAddress) {
-        let Some(settlement) = &self.settlement else {
-            return;
-        };
-        if settlement.admission.admit(peer, Au::ZERO).settles() {
-            settlement.trigger.trigger_settlement(*peer);
-        }
     }
 
     fn report(&self, peer: &OverlayAddress, event: SwarmScoringEvent, source: ReportSource) {
@@ -401,18 +416,15 @@ impl ClientService {
                 chunk,
                 stamp,
                 latency,
-                originated,
+                originated: _,
             } => {
                 // The requester is resolved by the handler; this event exists for
-                // accounting, scoring, and caching. Content chunks are cached by
-                // address (immutable); SOCs are not (no version signal). The
-                // debit is origin-gated (a relay leg is debited by the
-                // forwarder); cache and scoring apply to every delivery.
+                // scoring and caching. Content chunks are cached by address
+                // (immutable); SOCs are not (no version signal). The origin debit
+                // is committed by the dispatch reservation, not here; a relay leg
+                // is accounted by the forwarder. Cache and scoring apply to every
+                // delivery.
                 debug!(%peer, %address, ?latency, "Chunk received");
-                if originated {
-                    self.debit_origin(&peer, &address);
-                    self.settle_origin(&peer);
-                }
                 if let Some(store) = &self.store
                     && chunk.is_content()
                 {
@@ -459,16 +471,13 @@ impl ClientService {
                 peer,
                 address,
                 latency,
-                originated,
+                originated: _,
             } => {
                 // The pusher is resolved by the handler; this event exists for
-                // accounting and scoring. The debit is origin-gated; a relay leg
-                // is debited by the forwarder.
+                // scoring. The origin debit is committed by the dispatch
+                // reservation, not here; a relay leg is accounted by the
+                // forwarder.
                 debug!(%peer, %address, ?latency, "Receipt received");
-                if originated {
-                    self.debit_origin(&peer, &address);
-                    self.settle_origin(&peer);
-                }
                 self.report(
                     &peer,
                     SwarmScoringEvent::PushSuccess { latency },
@@ -794,138 +803,318 @@ mod tests {
         assert_eq!(source, ReportSource::Protocol("pushsync"));
     }
 
-    /// A fixed per-chunk price for the origin-debit tests.
-    const ORIGIN_PRICE: u64 = 7;
-
-    /// Records every receive debit so a test can assert exactly which peer was
-    /// charged, how much, and that the `originated` flag carried through.
-    #[derive(Default)]
-    struct RecordingDebit {
-        debits: Mutex<Vec<(OverlayAddress, Au, bool)>>,
-    }
-
-    impl vertex_swarm_api::BandwidthDebit for RecordingDebit {
-        fn debit_received(
-            &self,
-            peer: OverlayAddress,
-            price: Au,
-            originated: bool,
-        ) -> vertex_swarm_api::SwarmResult<()> {
-            self.debits.lock().unwrap().push((peer, price, originated));
-            Ok(())
-        }
-    }
-
-    /// A pricer charging `ORIGIN_PRICE` for every peer and chunk.
-    struct FixedPricer;
-    impl vertex_swarm_api::SwarmPricing for FixedPricer {
-        fn price(&self, _chunk: &ChunkAddress) -> Au {
-            Au::from_amount(ORIGIN_PRICE)
-        }
-        fn peer_price(&self, _peer: &OverlayAddress, _chunk: &ChunkAddress) -> Au {
-            Au::from_amount(ORIGIN_PRICE)
-        }
-    }
-
-    fn service_with_accounting() -> (ClientService, Arc<RecordingDebit>) {
-        let debit = Arc::new(RecordingDebit::default());
-        let (service, _event_tx, _handle) = ClientService::new();
-        let service = service.with_accounting(
-            Arc::new(FixedPricer) as Arc<dyn SwarmPricing>,
-            Arc::clone(&debit) as Arc<dyn BandwidthDebit>,
-        );
-        (service, debit)
-    }
-
     fn content_chunk() -> nectar_primitives::AnyChunk {
-        nectar_primitives::ContentChunk::new(&b"origin-debit-test"[..])
+        nectar_primitives::ContentChunk::new(&b"origin-reserve-test"[..])
             .expect("valid content chunk")
             .into()
     }
 
-    #[test]
-    fn origin_retrieval_debits_serving_peer_exactly_once() {
-        let (service, debit) = service_with_accounting();
-        service.process_event(ClientEvent::ChunkReceived {
-            peer: peer(1),
-            address: ChunkAddress::zero(),
-            chunk: content_chunk(),
-            stamp: None,
-            latency: Duration::from_millis(1),
-            originated: true,
-        });
-        let debits = debit.debits.lock().unwrap();
-        assert_eq!(
-            *debits,
-            vec![(peer(1), Au::from_amount(ORIGIN_PRICE), true)],
-            "an origin retrieval debits the serving peer once by the per-chunk price"
-        );
+    // Reserve-at-dispatch lifecycle over a real `Accounting`. The origin gate on
+    // the handle reserves the price before sending, commits it on delivery, and
+    // releases it on every other exit.
+    use vertex_swarm_accounting::{Accounting, FixedPricingConfig};
+
+    /// Records the peers a settle was triggered for.
+    #[derive(Default)]
+    struct RecordingSettlement {
+        triggered: std::sync::Mutex<Vec<OverlayAddress>>,
     }
 
-    #[test]
-    fn relay_retrieval_is_not_debited_by_the_service() {
-        // The forwarder accounts a relay leg itself; the service must not also
-        // debit it, or the transfer is charged twice.
-        let (service, debit) = service_with_accounting();
-        service.process_event(ClientEvent::ChunkReceived {
-            peer: peer(2),
-            address: ChunkAddress::zero(),
-            chunk: content_chunk(),
-            stamp: None,
-            latency: Duration::from_millis(1),
-            originated: false,
+    impl SettlementTrigger for RecordingSettlement {
+        fn trigger_settlement(&self, peer: OverlayAddress) {
+            self.triggered.lock().unwrap().push(peer);
+        }
+
+        fn settled(
+            &self,
+            _peers: &[OverlayAddress],
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
+            Box::pin(std::future::ready(false))
+        }
+    }
+
+    /// A pricer charging a fixed price for every peer and chunk.
+    struct FixedPeerPricer(u64);
+
+    impl SwarmPricing for FixedPeerPricer {
+        fn price(&self, _chunk: &ChunkAddress) -> Au {
+            Au::from_amount(self.0)
+        }
+        fn peer_price(&self, _peer: &OverlayAddress, _chunk: &ChunkAddress) -> Au {
+            Au::from_amount(self.0)
+        }
+    }
+
+    type GatedAccounting = Accounting<DefaultBandwidthConfig, MockIdentity>;
+
+    /// Build a handle whose origin gate reserves against a real `Accounting`.
+    /// The config bands at payment 1000 (settle trigger 400, floored at refresh
+    /// 10) and disconnect 1250, so a `price` of 100 admits, 800 lands in the
+    /// tolerance band, and 2000 refuses. Returns the handle, the shared
+    /// accounting (to observe balance and reserved), the recording settle
+    /// trigger, and the command receiver.
+    fn gated_handle(
+        price: u64,
+    ) -> (
+        ClientHandle,
+        Arc<GatedAccounting>,
+        Arc<RecordingSettlement>,
+        mpsc::Receiver<ClientCommand>,
+    ) {
+        let config =
+            DefaultBandwidthConfig::new(1000, 25, 10, 60, 1, 50, FixedPricingConfig::default());
+        let accounting = Arc::new(Accounting::new(config, MockIdentity::with_first_byte(0)));
+        let settlement = Arc::new(RecordingSettlement::default());
+        let (tx, rx) = mpsc::channel::<ClientCommand>(16);
+        let handle = ClientHandle::new(tx).with_origin_gate(
+            Arc::new(FixedPeerPricer(price)) as Arc<dyn SwarmPricing>,
+            accounting.clone() as Arc<dyn BandwidthReserve>,
+            accounting.clone() as Arc<dyn AdmissionControl>,
+            settlement.clone() as Arc<dyn SettlementTrigger>,
+        );
+        (handle, accounting, settlement, rx)
+    }
+
+    #[tokio::test]
+    async fn origin_dispatch_reserves_then_applies_on_delivery() {
+        let (handle, accounting, settlement, mut rx) = gated_handle(100);
+        let peer = peer(1);
+
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                handle
+                    .retrieve_chunk(peer, ChunkAddress::zero(), true)
+                    .await
+            }
         });
+
+        // The dispatched command means the reservation is held: the price is
+        // reserved and the committed balance is still zero.
+        let response = match rx.recv().await.expect("dispatched") {
+            ClientCommand::RetrieveChunk {
+                peer: p, response, ..
+            } => {
+                assert_eq!(p, peer);
+                response
+            }
+            other => panic!("unexpected command: {other:?}"),
+        };
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::from_amount(100));
+        assert_eq!(Ledger::balance(&*accounting, &peer), Au::ZERO);
+
+        // Delivery applies the reservation: debited once, reserve cleared.
+        response
+            .send(Ok(RetrievalResult {
+                chunk: content_chunk(),
+                stamp: None,
+                peer,
+            }))
+            .expect("receiver alive");
+        task.await.unwrap().expect("delivery ok");
+        assert_eq!(Ledger::balance(&*accounting, &peer), Au::new(-100));
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::ZERO);
+        // An in-band Admit needs no settle.
+        assert!(settlement.triggered.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn origin_dispatch_releases_reservation_on_failure() {
+        let (handle, accounting, _settlement, mut rx) = gated_handle(100);
+        let peer = peer(2);
+
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                handle
+                    .retrieve_chunk(peer, ChunkAddress::zero(), true)
+                    .await
+            }
+        });
+        let response = match rx.recv().await.expect("dispatched") {
+            ClientCommand::RetrieveChunk { response, .. } => response,
+            other => panic!("unexpected command: {other:?}"),
+        };
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::from_amount(100));
+
+        // A remote failure releases the reservation, leaving the balance untouched.
+        response
+            .send(Err(ChunkTransferError::Remote))
+            .expect("receiver alive");
+        assert!(matches!(
+            task.await.unwrap(),
+            Err(ChunkTransferError::Remote)
+        ));
+        assert_eq!(Ledger::balance(&*accounting, &peer), Au::ZERO);
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::ZERO);
+    }
+
+    #[tokio::test]
+    async fn origin_dispatch_releases_reservation_on_dropped_response() {
+        // The cancel path: the response oneshot is dropped without an answer, so
+        // the request returns `Cancelled` and the held reservation releases. No
+        // leak, no debit.
+        let (handle, accounting, _settlement, mut rx) = gated_handle(100);
+        let peer = peer(3);
+
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                handle
+                    .retrieve_chunk(peer, ChunkAddress::zero(), true)
+                    .await
+            }
+        });
+        let response = match rx.recv().await.expect("dispatched") {
+            ClientCommand::RetrieveChunk { response, .. } => response,
+            other => panic!("unexpected command: {other:?}"),
+        };
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::from_amount(100));
+
+        drop(response);
+        assert!(matches!(
+            task.await.unwrap(),
+            Err(ChunkTransferError::Cancelled)
+        ));
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::ZERO);
+        assert_eq!(Ledger::balance(&*accounting, &peer), Au::ZERO);
+    }
+
+    #[tokio::test]
+    async fn origin_dispatch_in_the_band_still_sends_and_triggers_settle() {
+        // A price landing the projected debt in the tolerance band sends anyway
+        // (closeness preserved) and triggers a settle.
+        let (handle, _accounting, settlement, mut rx) = gated_handle(800);
+        let peer = peer(4);
+
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                handle
+                    .retrieve_chunk(peer, ChunkAddress::zero(), true)
+                    .await
+            }
+        });
+        let response = match rx.recv().await.expect("dispatched anyway in the band") {
+            ClientCommand::RetrieveChunk { response, .. } => response,
+            other => panic!("unexpected command: {other:?}"),
+        };
+        assert_eq!(*settlement.triggered.lock().unwrap(), vec![peer]);
+        response.send(Err(ChunkTransferError::Remote)).ok();
+        let _ = task.await;
+    }
+
+    #[tokio::test]
+    async fn origin_dispatch_refused_at_the_disconnect_line_skips_and_settles() {
+        // A price past the disconnect line refuses: no bytes are sent, nothing is
+        // reserved, and a settle is triggered so the peer drains.
+        let (handle, accounting, settlement, mut rx) = gated_handle(2000);
+        let peer = peer(5);
+
+        let outcome = handle
+            .retrieve_chunk(peer, ChunkAddress::zero(), true)
+            .await;
+        assert!(matches!(outcome, Err(ChunkTransferError::Refused)));
         assert!(
-            debit.debits.lock().unwrap().is_empty(),
-            "a relay retrieval is debited by the forwarder, never by the service"
+            rx.try_recv().is_err(),
+            "no bytes are sent to a refused peer"
         );
+        assert_eq!(*settlement.triggered.lock().unwrap(), vec![peer]);
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::ZERO);
+        assert_eq!(Ledger::balance(&*accounting, &peer), Au::ZERO);
     }
 
-    #[test]
-    fn origin_push_debits_serving_peer_exactly_once() {
-        let (service, debit) = service_with_accounting();
-        service.process_event(ClientEvent::ReceiptReceived {
-            peer: peer(3),
-            address: ChunkAddress::zero(),
-            latency: Duration::from_millis(1),
-            originated: true,
+    #[tokio::test]
+    async fn relay_leg_bypasses_the_origin_gate() {
+        // A relay leg (`originated = false`) neither reserves nor settles; the
+        // forwarder accounts its own legs.
+        let (handle, accounting, settlement, mut rx) = gated_handle(100);
+        let peer = peer(6);
+
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                handle
+                    .retrieve_chunk(peer, ChunkAddress::zero(), false)
+                    .await
+            }
         });
-        let debits = debit.debits.lock().unwrap();
+        let response = match rx.recv().await.expect("dispatched") {
+            ClientCommand::RetrieveChunk {
+                originated,
+                response,
+                ..
+            } => {
+                assert!(!originated, "a relay leg is not an origin request");
+                response
+            }
+            other => panic!("unexpected command: {other:?}"),
+        };
         assert_eq!(
-            *debits,
-            vec![(peer(3), Au::from_amount(ORIGIN_PRICE), true)],
-            "an origin push debits the storer once by the per-chunk price"
+            Ledger::reserved(&*accounting, &peer),
+            Au::ZERO,
+            "a relay leg holds no reservation"
         );
+        response
+            .send(Ok(RetrievalResult {
+                chunk: content_chunk(),
+                stamp: None,
+                peer,
+            }))
+            .ok();
+        let _ = task.await;
+        assert_eq!(
+            Ledger::balance(&*accounting, &peer),
+            Au::ZERO,
+            "a relay leg is not debited by the origin gate"
+        );
+        assert!(settlement.triggered.lock().unwrap().is_empty());
     }
 
-    #[test]
-    fn relay_push_is_not_debited_by_the_service() {
-        let (service, debit) = service_with_accounting();
-        service.process_event(ClientEvent::ReceiptReceived {
-            peer: peer(4),
-            address: ChunkAddress::zero(),
-            latency: Duration::from_millis(1),
-            originated: false,
+    #[tokio::test]
+    async fn origin_push_reserves_then_releases_on_failure() {
+        // Pushsync reserves at dispatch like retrieval and releases on failure.
+        let (handle, accounting, _settlement, mut rx) = gated_handle(100);
+        let peer = peer(7);
+        let stamped = test_stamped_chunk();
+
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.push_chunk(peer, stamped, true).await }
         });
-        assert!(
-            debit.debits.lock().unwrap().is_empty(),
-            "a relay push is debited by the forwarder, never by the service"
-        );
+        let response = match rx.recv().await.expect("dispatched") {
+            ClientCommand::PushChunk { response, .. } => response,
+            other => panic!("unexpected command: {other:?}"),
+        };
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::from_amount(100));
+
+        response.send(Err(ChunkTransferError::Remote)).ok();
+        let _ = task.await;
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::ZERO);
+        assert_eq!(Ledger::balance(&*accounting, &peer), Au::ZERO);
     }
 
-    #[test]
-    fn origin_delivery_without_accounting_is_a_noop() {
-        // The lightweight launcher attaches no accounting; an origin delivery
-        // must not panic and simply skips the debit.
-        let (service, _event_tx, _handle) = ClientService::new();
-        service.process_event(ClientEvent::ChunkReceived {
-            peer: peer(5),
-            address: ChunkAddress::zero(),
-            chunk: content_chunk(),
-            stamp: None,
-            latency: Duration::from_millis(1),
-            originated: true,
+    #[tokio::test]
+    async fn origin_dispatch_without_a_gate_is_a_noop() {
+        // The lightweight launcher attaches no origin gate; an origin dispatch
+        // must still send and never panic.
+        let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+        let handle = ClientHandle::new(tx);
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                handle
+                    .retrieve_chunk(peer(8), ChunkAddress::zero(), true)
+                    .await
+            }
         });
+        match rx.recv().await.expect("dispatched without a gate") {
+            ClientCommand::RetrieveChunk { response, .. } => {
+                response.send(Err(ChunkTransferError::Remote)).ok();
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+        let _ = task.await;
     }
 
     // Throttle wiring at the outbound API boundary.

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -168,7 +168,21 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     // peer's pseudosettle allowance so a burst never crosses the settlement
     // trigger.
     let throttle = Arc::new(SelfThrottle::new(&accounting, &bandwidth));
-    let throttled_handle = client_handle.clone().with_throttle(Arc::clone(&throttle));
+    // The throttled handle the chunk provider dispatches through also carries the
+    // origin credit gate: each own-request leg reserves its price (so `reserved`
+    // matches the storer's shadow reserve), bands on the same admission boundary
+    // the selector uses, commits the debit on delivery, and releases it on any
+    // other exit. The settle trigger is the selector's, so settles dedup across
+    // both paths.
+    let throttled_handle = client_handle
+        .clone()
+        .with_throttle(Arc::clone(&throttle))
+        .with_origin_gate(
+            Arc::new(accounting.pricing().clone()),
+            accounting.bandwidth().clone(),
+            admission.clone(),
+            settlement_trigger.clone(),
+        );
 
     // Per-peer retrieval substream cap: the non-economic overrun guard the chunk
     // provider consults at selection time. One shared instance so a disconnect on
@@ -177,18 +191,13 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
 
     // The service reports through the same peer-manager authority accounting
     // uses, shares the handle's throttle so a disconnect clears that peer's
-    // bucket, forgets that peer's in-flight slots on disconnect, and debits the
-    // serving peer for our own-request deliveries through the same shared
-    // accounting the selector, throttle, and forwarder use.
+    // bucket, and forgets that peer's in-flight slots on disconnect. The origin
+    // debit is reserved and committed by the dispatch gate on the throttled
+    // handle, not by the service.
     let client_service = client_service
         .with_reporter(reporter)
         .with_throttle(Arc::clone(&throttle))
-        .with_inflight_limiter(Arc::clone(&inflight))
-        .with_accounting(
-            Arc::new(accounting.pricing().clone()),
-            accounting.bandwidth().clone(),
-        )
-        .with_settlement(admission, settlement_trigger);
+        .with_inflight_limiter(Arc::clone(&inflight));
 
     ClientCore {
         accounting,

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -1,38 +1,49 @@
-//! Score- and affordability-aware peer selection for retrieval and pushsync.
+//! Score- and credit-aware peer selection for retrieval and pushsync.
 //!
 //! Topology returns candidate storers in proximity order. [`PeerSelector`]
 //! reorders them with two additional signals before a request goes out:
 //!
-//! - Peers whose score is in the warned range are excluded, so a peer that is
-//!   being scored down is not asked again while it misbehaves.
-//! - Peers we cannot afford (the per-chunk debit would cross their disconnect
-//!   threshold) rank behind affordable ones.
+//! - A peer the admission band refuses (the per-chunk debit would cross its
+//!   disconnect line) is hard-skipped, so the request routes to the next-closest
+//!   affordable peer while a background settle drains the skipped one.
+//! - Peers whose score is in the warned range are excluded among the admissible,
+//!   so a peer that is being scored down is not asked again while it misbehaves.
 //!
-//! Proximity stays the primary key within each group. When every candidate is
-//! warned or unaffordable, the original proximity order is used unchanged:
-//! degraded service beats failing the request outright. When a request is
-//! blocked on balance (no affordable candidate at all), a best-effort
-//! settlement is triggered for the unaffordable candidates so they become
-//! usable again; the settlement providers themselves decide whether any
-//! payment is actually due.
+//! Proximity stays the primary key. If every admissible candidate is warned, the
+//! warned peers are returned in proximity order so a degraded request can still
+//! go out; a refused peer is never resurrected this way. Every candidate not
+//! plainly admitted is settled (a peer in the tolerance band to stay there, a
+//! refused peer to drain back under its line); the settlement providers
+//! themselves decide whether any payment is actually due.
 //!
 //! The price consulted per candidate is [`SwarmPricing::peer_price`], the same
 //! per-peer chunk price the accounting layer debits when the request is
 //! served.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
+use futures::FutureExt;
+use futures::future::Shared;
 use nectar_primitives::ChunkAddress;
 use parking_lot::Mutex;
+use tokio::sync::oneshot;
 use tracing::debug;
 use vertex_swarm_api::{
-    AdmissionControl, DEFAULT_PEER_WARN_THRESHOLD, SwarmBandwidthAccounting, SwarmIdentity,
-    SwarmPeerBandwidth, SwarmPricing,
+    Admission, AdmissionControl, DEFAULT_PEER_WARN_THRESHOLD, SwarmBandwidthAccounting,
+    SwarmIdentity, SwarmPeerBandwidth, SwarmPricing,
 };
 use vertex_swarm_primitives::OverlayAddress;
 use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::TaskExecutor;
+use vertex_tasks::time::Instant;
+
+/// A shareable handle that resolves when an in-flight settle for a peer
+/// completes (the settle's [`InFlightGuard`] fires it on drop), so a waiter can
+/// re-evaluate admission as soon as the network settle acks.
+type SettleCompletion = Shared<oneshot::Receiver<()>>;
 
 /// Source of live peer scores for candidate selection.
 ///
@@ -50,7 +61,7 @@ impl<I: SwarmIdentity> PeerScores for TopologyHandle<I> {
     }
 }
 
-/// Best-effort settlement trigger for requests blocked on balance.
+/// Best-effort settlement trigger for a peer whose debt has reached the band.
 ///
 /// Implemented over bandwidth accounting (see [`AccountingSettlement`]) and by
 /// test mocks.
@@ -58,6 +69,16 @@ impl<I: SwarmIdentity> PeerScores for TopologyHandle<I> {
 pub trait SettlementTrigger: Send + Sync {
     /// Start settlement with `peer` without waiting for the outcome.
     fn trigger_settlement(&self, peer: OverlayAddress);
+
+    /// Resolve once any in-flight settle for the subset of `peers` currently
+    /// settling has completed, yielding whether one was actually awaited.
+    ///
+    /// Returns `true` after awaiting a real in-flight settle completion (paced by
+    /// network RTT), `false` immediately when none of `peers` is in flight. The
+    /// `bool` keeps the future `Send` and lets a gated-set wait loop both pace on
+    /// the settle ack and detect when no progress is possible (nothing draining
+    /// debt), so it returns rather than spinning to the deadline.
+    fn settled(&self, peers: &[OverlayAddress]) -> Pin<Box<dyn Future<Output = bool> + Send + '_>>;
 }
 
 /// [`SettlementTrigger`] over a bandwidth accounting instance.
@@ -66,13 +87,14 @@ pub trait SettlementTrigger: Send + Sync {
 /// selection never blocks on settlement I/O. Failures are logged at debug
 /// level; the next request retries naturally.
 ///
-/// A shared in-flight set keeps at most one settle per peer running at a time:
+/// A shared in-flight map keeps at most one settle per peer running at a time:
 /// the second trigger for a peer with a settle still outstanding is dropped, so
-/// the set is both the dedup and the per-peer rate limit (the next settle cannot
-/// start until the prior one is acked).
+/// the map is both the dedup and the per-peer rate limit (the next settle cannot
+/// start until the prior one is acked). The stored [`SettleCompletion`] lets a
+/// waiter await that ack.
 pub struct AccountingSettlement<B> {
     bandwidth: B,
-    in_flight: Arc<Mutex<HashSet<OverlayAddress>>>,
+    in_flight: Arc<Mutex<HashMap<OverlayAddress, SettleCompletion>>>,
 }
 
 impl<B> AccountingSettlement<B> {
@@ -80,21 +102,29 @@ impl<B> AccountingSettlement<B> {
     pub fn new(bandwidth: B) -> Self {
         Self {
             bandwidth,
-            in_flight: Arc::new(Mutex::new(HashSet::new())),
+            in_flight: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
 
-/// Removes a peer from the in-flight set on drop, so a panic or cancellation of
-/// the settle future cannot pin the peer and starve its settlement.
+/// Removes a peer from the in-flight map on drop and fires its completion, so a
+/// panic or cancellation of the settle future cannot pin the peer (which would
+/// starve its settlement) and any waiter on the settle is woken either way.
 struct InFlightGuard {
-    in_flight: Arc<Mutex<HashSet<OverlayAddress>>>,
+    in_flight: Arc<Mutex<HashMap<OverlayAddress, SettleCompletion>>>,
     peer: OverlayAddress,
+    done: Option<oneshot::Sender<()>>,
 }
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
         self.in_flight.lock().remove(&self.peer);
+        // Fulfil the completion; dropping the sender would also resolve the
+        // shared receiver, so a waiter is woken on completion, cancellation, and
+        // panic alike.
+        if let Some(done) = self.done.take() {
+            let _ = done.send(());
+        }
     }
 }
 
@@ -111,13 +141,19 @@ where
         // Skip if a settle to this peer is already running; the entry is cleared
         // when the spawned settle completes, so the next trigger can start a fresh
         // one.
-        if !self.in_flight.lock().insert(peer) {
-            return;
+        let (done, completion) = oneshot::channel();
+        {
+            let mut in_flight = self.in_flight.lock();
+            if in_flight.contains_key(&peer) {
+                return;
+            }
+            in_flight.insert(peer, completion.shared());
         }
         let handle = self.bandwidth.for_peer(peer);
         let guard = InFlightGuard {
             in_flight: Arc::clone(&self.in_flight),
             peer,
+            done: Some(done),
         };
         executor.spawn(async move {
             let _guard = guard;
@@ -126,13 +162,32 @@ where
             }
         });
     }
+
+    fn settled(&self, peers: &[OverlayAddress]) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+        let waiters: Vec<SettleCompletion> = {
+            let in_flight = self.in_flight.lock();
+            peers
+                .iter()
+                .filter_map(|peer| in_flight.get(peer).cloned())
+                .collect()
+        };
+        Box::pin(async move {
+            if waiters.is_empty() {
+                return false;
+            }
+            // The first completion is enough to re-evaluate admission.
+            let _ = futures::future::select_all(waiters).await;
+            true
+        })
+    }
 }
 
-/// Reorders proximity-ordered candidates by score and affordability.
+/// Reorders proximity-ordered candidates by the admission band and score.
 ///
 /// Built by the node assembly from the topology handle (scores), bandwidth
-/// accounting (affordability and settlement), and the pricer (per-peer chunk
-/// price). Consumed by the retrieval and pushsync candidate-selection paths.
+/// accounting (the admission band and settlement), and the pricer (per-peer
+/// chunk price). Consumed by the retrieval and pushsync candidate-selection
+/// paths.
 pub struct PeerSelector {
     scores: Arc<dyn PeerScores>,
     admission: Arc<dyn AdmissionControl>,
@@ -158,102 +213,122 @@ impl PeerSelector {
 
     /// Order `candidates` (in proximity order) for a request on `chunk`.
     ///
-    /// Applies the ranking described at the module level. Triggers best-effort
-    /// settlement for any candidate whose debt has reached the early-payment
-    /// trigger, so the peer's view of our debt drops before it reaches the
-    /// disconnect threshold. When the request is blocked on balance (candidates
-    /// exist but none is affordable), the unaffordable candidates are settled too,
-    /// so a debt that built without crossing the early trigger is still settled
-    /// before the request gives up on the peer. A single pass triggers each peer
-    /// at most once; the in-flight set dedups across repeated calls.
+    /// Applies the ranking described at the module level: a [`Refuse`] candidate
+    /// is hard-skipped (sending would cross its disconnect line), warned peers are
+    /// excluded, and the rest keep proximity order. Every candidate not plainly
+    /// [`Admit`]ted is settled (a [`SettleAndAdmit`] peer to stay in the band, a
+    /// refused peer to drain back under its line), so its view of our debt drops.
+    /// A single pass triggers each peer at most once; the in-flight set dedups
+    /// across repeated calls.
+    ///
+    /// [`Refuse`]: Admission::Refuse
+    /// [`Admit`]: Admission::Admit
+    /// [`SettleAndAdmit`]: Admission::SettleAndAdmit
     pub fn order(
         &self,
         candidates: Vec<OverlayAddress>,
         chunk: &ChunkAddress,
     ) -> Vec<OverlayAddress> {
-        // One admission band per candidate drives both the affordability ranking
-        // (`admits`) and the proactive settle trigger (`settles`).
+        // One admission band per candidate drives both the hard-skip (a refused
+        // peer leaves `ordered`) and the settle trigger (anything not plainly
+        // admitted).
         let admit = |peer: &OverlayAddress| {
             self.admission
                 .admit(peer, self.pricing.peer_price(peer, chunk))
         };
 
-        let ranked = rank_candidates(
-            &candidates,
-            |peer| self.scores.peer_score(peer),
-            |peer| admit(peer).admits(),
-        );
+        let ranked = rank_candidates(&candidates, |peer| self.scores.peer_score(peer), admit);
 
-        let blocked = ranked.blocked_on_balance();
         for peer in &candidates {
-            if admit(peer).settles() || (blocked && ranked.unaffordable.contains(peer)) {
+            if !matches!(admit(peer), Admission::Admit) {
                 self.settlement.trigger_settlement(*peer);
             }
         }
 
         ranked.ordered
     }
+
+    /// Order `candidates`, settling and awaiting a fully gated close set until a
+    /// peer becomes admissible or the wait is exhausted.
+    ///
+    /// The first [`order`](Self::order) is the fast path: a non-empty result
+    /// returns at once. Only when every candidate is gated (the result is empty)
+    /// does the loop wait: each gated `order` already triggered a settle per
+    /// peer, so it awaits those settles completing (paced by network RTT, no
+    /// timer) and re-orders. The bound is `deadline`, the request's retrieval
+    /// lifetime, so accounting-timing back-pressure blocks within the request.
+    /// The loop is progress-aware: if no settle is in flight to drain debt
+    /// ([`settled`](SettlementTrigger::settled) returns `false`) it returns an
+    /// empty result at once rather than spinning, since no re-order can change.
+    /// Each awaited settle is RTT-paced, so the loop cannot busy-spin. An empty
+    /// result leaves the caller to surface its generic transient failure; an
+    /// accounting concern never reaches the consumer. The wait is `Send` on every
+    /// platform: awaiting a settle completion and reading [`Instant`] are both
+    /// `Send`.
+    pub async fn order_or_wait(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        chunk: &ChunkAddress,
+        deadline: Instant,
+    ) -> Vec<OverlayAddress> {
+        loop {
+            let ordered = self.order(candidates.clone(), chunk);
+            if !ordered.is_empty() {
+                return ordered;
+            }
+            if Instant::now() >= deadline {
+                return Vec::new();
+            }
+            // No in-flight settle means nothing is draining debt, so no re-order
+            // can admit a peer: give up now rather than spin to the deadline.
+            if !self.settlement.settled(&candidates).await {
+                return Vec::new();
+            }
+        }
+    }
 }
 
 /// Outcome of ranking a candidate set.
 struct RankedCandidates {
-    /// Candidates to attempt, best first.
+    /// Candidates to attempt, best first. Never includes a refused peer.
     ordered: Vec<OverlayAddress>,
-    /// How many of `ordered` passed the affordability check.
-    affordable: usize,
-    /// Candidates that failed the affordability check, in proximity order.
-    unaffordable: Vec<OverlayAddress>,
 }
 
-impl RankedCandidates {
-    /// True when candidates exist but none is currently affordable.
-    fn blocked_on_balance(&self) -> bool {
-        self.affordable == 0 && !self.unaffordable.is_empty()
-    }
-}
-
-/// Rank proximity-ordered `candidates` by score and affordability.
+/// Rank proximity-ordered `candidates` by the admission band and score.
 ///
-/// Warned peers (score at or below [`DEFAULT_PEER_WARN_THRESHOLD`]) are
-/// excluded. Affordable peers keep their proximity order and rank before
-/// unaffordable ones, which also keep theirs. If every candidate is warned,
-/// the original proximity order is returned unchanged.
+/// A [`Refuse`](Admission::Refuse) candidate is hard-skipped:
+/// sending would cross its disconnect line, so it never appears in `ordered`.
+/// Warned peers (score at or below [`DEFAULT_PEER_WARN_THRESHOLD`]) are excluded
+/// among the admissible. If every admissible candidate is warned, those warned
+/// peers are returned in proximity order so a degraded request can still go out;
+/// a refused peer is never resurrected this way.
 fn rank_candidates(
     candidates: &[OverlayAddress],
     score: impl Fn(&OverlayAddress) -> Option<f64>,
-    can_afford: impl Fn(&OverlayAddress) -> bool,
+    admit: impl Fn(&OverlayAddress) -> Admission,
 ) -> RankedCandidates {
     let mut ordered = Vec::with_capacity(candidates.len());
-    let mut unaffordable = Vec::new();
+    let mut warned = Vec::new();
 
     for peer in candidates {
-        if score(peer).is_some_and(|s| s <= DEFAULT_PEER_WARN_THRESHOLD) {
+        if matches!(admit(peer), Admission::Refuse) {
             continue;
         }
-        if can_afford(peer) {
-            ordered.push(*peer);
-        } else {
-            unaffordable.push(*peer);
+        if score(peer).is_some_and(|s| s <= DEFAULT_PEER_WARN_THRESHOLD) {
+            warned.push(*peer);
+            continue;
         }
+        ordered.push(*peer);
     }
 
-    if ordered.is_empty() && unaffordable.is_empty() {
-        // Every candidate is warned. Fall back to plain proximity order so a
-        // degraded request can still be attempted.
-        return RankedCandidates {
-            ordered: candidates.to_vec(),
-            affordable: 0,
-            unaffordable: Vec::new(),
-        };
+    if ordered.is_empty() {
+        // Every admissible candidate is warned (or there are none). Fall back to
+        // the warned admissible peers so a degraded request can still be
+        // attempted; refused peers stay excluded.
+        ordered = warned;
     }
 
-    let affordable = ordered.len();
-    ordered.extend_from_slice(&unaffordable);
-    RankedCandidates {
-        ordered,
-        affordable,
-        unaffordable,
-    }
+    RankedCandidates { ordered }
 }
 
 #[cfg(test)]
@@ -357,6 +432,15 @@ mod tests {
         fn trigger_settlement(&self, peer: OverlayAddress) {
             self.triggered.lock().unwrap().push(peer);
         }
+
+        /// Records triggers but tracks no in-flight settle, so it reports `false`
+        /// (nothing awaited), modelling the no-progress case.
+        fn settled(
+            &self,
+            _peers: &[OverlayAddress],
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+            Box::pin(std::future::ready(false))
+        }
     }
 
     fn warned(peers: &[OverlayAddress]) -> impl Fn(&OverlayAddress) -> Option<f64> + '_ {
@@ -369,68 +453,79 @@ mod tests {
         }
     }
 
-    fn unaffordable(peers: &[OverlayAddress]) -> impl Fn(&OverlayAddress) -> bool + '_ {
-        move |p| !peers.contains(p)
+    /// Listed peers refuse at the disconnect line; everyone else admits.
+    fn refusing(peers: &[OverlayAddress]) -> impl Fn(&OverlayAddress) -> Admission + '_ {
+        move |p| {
+            if peers.contains(p) {
+                Admission::Refuse
+            } else {
+                Admission::Admit
+            }
+        }
     }
 
     #[test]
-    fn healthy_affordable_candidates_keep_proximity_order() {
+    fn healthy_admitted_candidates_keep_proximity_order() {
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(&candidates, warned(&[]), unaffordable(&[]));
+        let ranked = rank_candidates(&candidates, warned(&[]), refusing(&[]));
         assert_eq!(ranked.ordered, candidates);
-        assert_eq!(ranked.affordable, 3);
-        assert!(ranked.unaffordable.is_empty());
-        assert!(!ranked.blocked_on_balance());
     }
 
     #[test]
     fn warned_peer_is_excluded() {
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(&candidates, warned(&[peer(2)]), unaffordable(&[]));
+        let ranked = rank_candidates(&candidates, warned(&[peer(2)]), refusing(&[]));
         assert_eq!(ranked.ordered, vec![peer(1), peer(3)]);
     }
 
     #[test]
     fn unknown_peer_is_not_treated_as_warned() {
         let candidates = vec![peer(1), peer(2)];
-        let ranked = rank_candidates(&candidates, |_| None, unaffordable(&[]));
+        let ranked = rank_candidates(&candidates, |_| None, refusing(&[]));
         assert_eq!(ranked.ordered, candidates);
     }
 
     #[test]
-    fn unaffordable_peer_is_deprioritized() {
+    fn refused_peer_is_hard_skipped() {
+        // A refused peer is excluded entirely, not deprioritized: sending would
+        // cross its disconnect line.
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(&candidates, warned(&[]), unaffordable(&[peer(1)]));
-        assert_eq!(ranked.ordered, vec![peer(2), peer(3), peer(1)]);
-        assert_eq!(ranked.affordable, 2);
-        assert!(!ranked.blocked_on_balance());
+        let ranked = rank_candidates(&candidates, warned(&[]), refusing(&[peer(1)]));
+        assert_eq!(ranked.ordered, vec![peer(2), peer(3)]);
     }
 
     #[test]
-    fn all_unaffordable_falls_back_to_proximity_order() {
+    fn all_refused_yields_no_candidates() {
+        // Every candidate would cross its disconnect line, so none is sendable.
         let candidates = vec![peer(1), peer(2), peer(3)];
         let ranked = rank_candidates(
             &candidates,
             warned(&[]),
-            unaffordable(&[peer(1), peer(2), peer(3)]),
+            refusing(&[peer(1), peer(2), peer(3)]),
         );
-        assert_eq!(ranked.ordered, candidates);
-        assert!(ranked.blocked_on_balance());
+        assert!(ranked.ordered.is_empty());
     }
 
     #[test]
     fn all_warned_falls_back_to_proximity_order() {
         let candidates = vec![peer(1), peer(2)];
-        let ranked = rank_candidates(&candidates, warned(&[peer(1), peer(2)]), unaffordable(&[]));
+        let ranked = rank_candidates(&candidates, warned(&[peer(1), peer(2)]), refusing(&[]));
         assert_eq!(ranked.ordered, candidates);
-        assert!(!ranked.blocked_on_balance());
+    }
+
+    #[test]
+    fn refused_peer_is_not_resurrected_by_the_warned_fallback() {
+        // peer(1) is refused and peer(2) is warned: the fallback returns the
+        // warned admissible peer, never the refused one.
+        let candidates = vec![peer(1), peer(2)];
+        let ranked = rank_candidates(&candidates, warned(&[peer(2)]), refusing(&[peer(1)]));
+        assert_eq!(ranked.ordered, vec![peer(2)]);
     }
 
     #[test]
     fn empty_candidates_stay_empty() {
-        let ranked = rank_candidates(&[], warned(&[]), unaffordable(&[]));
+        let ranked = rank_candidates(&[], warned(&[]), refusing(&[]));
         assert!(ranked.ordered.is_empty());
-        assert!(!ranked.blocked_on_balance());
     }
 
     fn selector(
@@ -463,17 +558,24 @@ mod tests {
     }
 
     #[test]
-    fn selector_orders_and_skips_settlement_when_affordable_exists() {
+    fn selector_hard_skips_a_refused_peer_and_settles_it() {
+        // peer(1) is refused at the disconnect line: it is excluded from the
+        // ordered list (retrieval routes to peer(2)) and a settle is triggered so
+        // it drains back under its line.
         let settlement = Arc::new(RecordingSettlement::default());
         let sel = selector(HashMap::new(), vec![peer(1)], Arc::clone(&settlement));
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
-        assert_eq!(ordered, vec![peer(2), peer(1)]);
-        assert!(settlement.triggered.lock().unwrap().is_empty());
+        assert_eq!(ordered, vec![peer(2)], "the refused peer is hard-skipped");
+        assert_eq!(
+            *settlement.triggered.lock().unwrap(),
+            vec![peer(1)],
+            "the refused peer is settled so it drains"
+        );
     }
 
     #[test]
-    fn selector_triggers_settlement_when_blocked_on_balance() {
+    fn selector_settles_every_refused_candidate() {
         let settlement = Arc::new(RecordingSettlement::default());
         let sel = selector(
             HashMap::new(),
@@ -482,7 +584,7 @@ mod tests {
         );
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
-        assert_eq!(ordered, vec![peer(1), peer(2)]);
+        assert!(ordered.is_empty(), "all refused, nothing sendable");
         assert_eq!(
             *settlement.triggered.lock().unwrap(),
             vec![peer(1), peer(2)]
@@ -500,6 +602,27 @@ mod tests {
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
         assert_eq!(ordered, vec![peer(1), peer(2)]);
         assert_eq!(*settlement.triggered.lock().unwrap(), vec![peer(1)]);
+    }
+
+    #[test]
+    fn selector_keeps_a_settle_and_admit_peer_but_skips_a_refused_one() {
+        // Pushsync closeness: a peer in the tolerance band stays in the ordered
+        // list (and is settled in parallel), while only a peer refused at the
+        // disconnect line is dropped. peer(1) is in the band, peer(2) refuses.
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel = selector_with_settle_due(vec![peer(2)], vec![peer(1)], Arc::clone(&settlement));
+
+        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
+        assert_eq!(
+            ordered,
+            vec![peer(1)],
+            "the band peer is kept (closeness preserved), the refused peer skipped"
+        );
+        assert_eq!(
+            *settlement.triggered.lock().unwrap(),
+            vec![peer(1), peer(2)],
+            "both the band peer and the refused peer settle"
+        );
     }
 
     #[test]
@@ -522,6 +645,180 @@ mod tests {
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
         assert_eq!(ordered, vec![peer(2)]);
+    }
+
+    /// A ledger gated by a shared flag: while gated every peer refuses; once the
+    /// flag clears every peer admits. Models a settle draining a peer's debt.
+    struct FlipLedger(Arc<std::sync::atomic::AtomicBool>);
+
+    impl Ledger for FlipLedger {
+        fn balance(&self, _overlay: &OverlayAddress) -> Au {
+            Au::ZERO
+        }
+        fn reserved(&self, _overlay: &OverlayAddress) -> Au {
+            Au::ZERO
+        }
+        fn headroom(&self, _overlay: &OverlayAddress, _to: Threshold) -> Au {
+            Au::from_amount(1000)
+        }
+        fn disconnect_line(&self, _overlay: &OverlayAddress) -> Au {
+            if self.0.load(std::sync::atomic::Ordering::SeqCst) {
+                Au::ZERO
+            } else {
+                Au::from_amount(1000)
+            }
+        }
+        fn settle_trigger(&self, _overlay: &OverlayAddress) -> Au {
+            Au::from_amount(1000)
+        }
+    }
+
+    /// A settlement whose `settled` clears the shared gate and resolves at once,
+    /// modelling a completed settle that drains the peer's debt.
+    struct FlipSettlement(Arc<std::sync::atomic::AtomicBool>);
+
+    impl SettlementTrigger for FlipSettlement {
+        fn trigger_settlement(&self, _peer: OverlayAddress) {}
+        fn settled(
+            &self,
+            _peers: &[OverlayAddress],
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+            // Models an in-flight settle that completes and drains the debt:
+            // reports `true` (a real completion was awaited).
+            self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(std::future::ready(true))
+        }
+    }
+
+    /// A ledger that always refuses every peer at the unit price, modelling a
+    /// close set that stays fully gated for the whole wait.
+    struct AlwaysGatedLedger;
+
+    impl Ledger for AlwaysGatedLedger {
+        fn balance(&self, _overlay: &OverlayAddress) -> Au {
+            Au::ZERO
+        }
+        fn reserved(&self, _overlay: &OverlayAddress) -> Au {
+            Au::ZERO
+        }
+        fn headroom(&self, _overlay: &OverlayAddress, _to: Threshold) -> Au {
+            Au::ZERO
+        }
+        fn disconnect_line(&self, _overlay: &OverlayAddress) -> Au {
+            Au::ZERO
+        }
+        fn settle_trigger(&self, _overlay: &OverlayAddress) -> Au {
+            Au::from_amount(1000)
+        }
+    }
+
+    /// A settlement whose `settled` reports an in-flight completion that never
+    /// drains debt, RTT-paced by a short sleep so the wait loop cannot busy-spin.
+    struct StallSettlement;
+
+    impl SettlementTrigger for StallSettlement {
+        fn trigger_settlement(&self, _peer: OverlayAddress) {}
+        fn settled(
+            &self,
+            _peers: &[OverlayAddress],
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+            Box::pin(async {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                true
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn order_or_wait_returns_a_peer_once_a_settle_makes_it_admissible() {
+        // Every peer is gated on the first order; the awaited settle drains one
+        // (the flag flips) and the re-order returns the now-admissible peers.
+        let gated = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let sel = PeerSelector::new(
+            Arc::new(FixedScores(HashMap::new())),
+            Arc::new(FlipLedger(Arc::clone(&gated))),
+            Arc::new(UnitPricer),
+            Arc::new(FlipSettlement(Arc::clone(&gated))),
+        );
+
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        let ordered = sel
+            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
+            .await;
+        assert_eq!(ordered, vec![peer(1), peer(2)], "recovers after the settle");
+    }
+
+    #[tokio::test]
+    async fn order_or_wait_returns_empty_at_the_deadline_when_settles_never_drain() {
+        // Every order stays empty and each awaited (in-flight) settle resolves
+        // without draining debt: the loop runs to `deadline` and then returns
+        // empty, never hanging, so the caller raises its generic transient
+        // failure. A short deadline keeps the test fast.
+        let sel = PeerSelector::new(
+            Arc::new(FixedScores(HashMap::new())),
+            Arc::new(AlwaysGatedLedger),
+            Arc::new(UnitPricer),
+            Arc::new(StallSettlement),
+        );
+
+        let wait = std::time::Duration::from_millis(120);
+        let started = Instant::now();
+        let deadline = started + wait;
+        let ordered = sel
+            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
+            .await;
+        let elapsed = started.elapsed();
+        assert!(ordered.is_empty(), "still gated at the deadline");
+        assert!(
+            elapsed >= wait,
+            "the in-flight wait runs to the deadline, not short of it"
+        );
+        assert!(
+            elapsed < wait + std::time::Duration::from_secs(2),
+            "the wait terminates at the deadline and does not hang"
+        );
+    }
+
+    #[tokio::test]
+    async fn order_or_wait_returns_empty_promptly_when_no_settle_is_in_flight() {
+        // Every order stays empty and no settle is in flight to drain debt
+        // (`settled` reports `false`): no re-order can ever admit a peer, so the
+        // loop returns at once rather than spinning to a far-off deadline.
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel = selector(
+            HashMap::new(),
+            vec![peer(1), peer(2)],
+            Arc::clone(&settlement),
+        );
+
+        let started = Instant::now();
+        let deadline = started + std::time::Duration::from_secs(30);
+        let ordered = sel
+            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
+            .await;
+        assert!(ordered.is_empty(), "no peer is admissible");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(1),
+            "the no-progress guard returns promptly, well before the deadline"
+        );
+    }
+
+    #[tokio::test]
+    async fn order_or_wait_returns_the_first_order_without_awaiting_a_settle() {
+        // An admissible close set returns on the first order: no settle is
+        // triggered and the settle wait is never entered.
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel = selector(HashMap::new(), Vec::new(), Arc::clone(&settlement));
+
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        let ordered = sel
+            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
+            .await;
+        assert_eq!(ordered, vec![peer(1), peer(2)], "fast path");
+        assert!(
+            settlement.triggered.lock().unwrap().is_empty(),
+            "no settle on the fast path"
+        );
     }
 
     // Dedup of `AccountingSettlement` over a mock bandwidth accounting whose
@@ -681,21 +978,59 @@ mod tests {
     }
 
     #[test]
+    fn settled_resolves_when_the_in_flight_settle_completes() {
+        // A waiter on a peer's in-flight settle resolves once that settle acks,
+        // which is what paces the gated-set wait loop.
+        settlement_runtime().block_on(async {
+            let for_peer_calls = Arc::new(AtomicUsize::new(0));
+            let started = Arc::new(AtomicUsize::new(0));
+            let finished = Arc::new(AtomicUsize::new(0));
+            let gate = Arc::new(Notify::new());
+            let bandwidth = Arc::new(MockBandwidth {
+                for_peer_calls,
+                started: Arc::clone(&started),
+                finished,
+                gate: Arc::clone(&gate),
+            });
+            let trigger = AccountingSettlement::new(bandwidth);
+
+            // No settle in flight: the waiter resolves immediately.
+            trigger.settled(&[peer(1)]).await;
+
+            // Start a settle that parks on the gate, then take a waiter on it.
+            trigger.trigger_settlement(peer(1));
+            while started.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+            let waiter = trigger.settled(&[peer(1)]);
+
+            // Release the parked settle; the guard fires the completion on drop,
+            // so the waiter resolves. A bounded timeout proves it does not hang.
+            gate.notify_one();
+            vertex_tasks::time::timeout(std::time::Duration::from_secs(5), waiter)
+                .await
+                .expect("settled resolves once the in-flight settle completes");
+        });
+    }
+
+    #[test]
     fn in_flight_guard_clears_the_peer_on_drop() {
         // The guard removes the peer in Drop, which runs on normal completion,
         // unwind (a panicking settle), and cancellation alike, so a settle that
         // never completes cleanly cannot pin the peer and starve its settlement.
-        let in_flight = Arc::new(parking_lot::Mutex::new(HashSet::new()));
-        in_flight.lock().insert(peer(1));
+        let in_flight = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let (done, completion) = oneshot::channel();
+        in_flight.lock().insert(peer(1), completion.shared());
         {
             let _guard = InFlightGuard {
                 in_flight: Arc::clone(&in_flight),
                 peer: peer(1),
+                done: Some(done),
             };
-            assert!(in_flight.lock().contains(&peer(1)));
+            assert!(in_flight.lock().contains_key(&peer(1)));
         }
         assert!(
-            !in_flight.lock().contains(&peer(1)),
+            !in_flight.lock().contains_key(&peer(1)),
             "the guard must clear the peer when dropped"
         );
     }


### PR DESCRIPTION
## What

Origin retrieval and origin pushsync now reserve the per-chunk price at dispatch instead of committing the debit on delivery, and the dispatch gates on the admission band.

- Reserve-at-dispatch: `ClientHandle::retrieve_chunk`/`push_chunk` reserve the price (a held `Reservation<Receive>`), apply it on delivery, and release it on every other exit (failure, cancellation, race-loser). So `reserved` is non-zero in-flight and matches the storer's shadow reserve, and a wide prefetch burst is bounded, not just committed debt.
- The band gate: at dispatch the path consults `admit(peer, price)`. `Admit` sends; `SettleAndAdmit` triggers a settle and sends anyway (in-band, still under the disconnect line); `Refuse` skips the peer and triggers a settle so the scheduler routes elsewhere. `PeerSelector::order` hard-skips `Refuse` candidates while keeping `SettleAndAdmit` peers in proximity order, so pushsync placement is preserved except at the genuine disconnect line.
- All-gated fallback: when every close peer is gated, the dispatch settles and retries within a bounded window (the background settles plus time-based refresh drain debt), and only after that surfaces a distinct retryable `AllPeersGated` error rather than deadlocking or conflating with a genuinely empty neighbourhood.

The old commit-on-delivery `debit_origin`/`settle_origin` are removed; the relay/forwarder two-leg path is unchanged. The self-throttle and the per-peer in-flight cap are retained (their removal is a separate change).

## Why

Closes #514. Closes #516.

Our per-peer debt view must match the creditor's shadow-reserved view, and the only conformance brake under sustained retrieval is keeping that debt under the storer's disconnect line. Reserving at dispatch makes the in-flight debt visible to admission, and the band gate keeps it under the line while settling, so a sustained or wide download does not cross the line and get blocklisted.

## Testing

`cargo nextest run --all-features` across api, accounting, builder, node: 224 pass. New tests cover reserve-then-apply-on-delivery, release on failure and on the dropped-response cancel path (no double-debit, no leak), in-band send-and-settle, refuse-at-line skip-and-settle, relay-leg bypass, pushsync closeness under `SettleAndAdmit`, the byte-exact single-debit end to end, and the all-gated fallback (recovers after a settle, and a bounded retryable error with no hang when gated for the whole window). `cargo clippy --all-targets --all-features -- -D warnings` clean plus a swap-off pass.

A correctness red-team of the reservation lifecycle, the removed debit, the admit/reserve double boundary, pushsync closeness, and settle coverage found them sound; it surfaced the missing all-gated fallback, which this change adds.

## AI Assistance

Claude Code used for the design, implementation, an adversarial correctness review, and the fallback fix.

