### PR TITLE
fix(swarm-client-behaviour): release a pending settle when its substream fails

### DIFF
--- a/crates/swarm/accounting/pseudosettle/src/service.rs
+++ b/crates/swarm/accounting/pseudosettle/src/service.rs
@@ -272,6 +272,19 @@ impl<A: SwarmBandwidthAccounting + 'static> PseudosettleService<A> {
                     warn!(%peer, error = ?e, "Failed to send pseudosettle ack");
                 }
             }
+            PseudosettleEvent::Failed { peer } => {
+                // The substream died or the peer disconnected before acking, so
+                // resolve the pending settle with an error rather than leaking it.
+                if let Some(pending) = self.pending.remove(&peer) {
+                    debug!(%peer, "Pseudosettle substream failed; releasing pending settle");
+                    let _ =
+                        pending
+                            .response_tx
+                            .send(Err(PseudosettleSettlementError::NetworkError(
+                                "substream failed".into(),
+                            )));
+                }
+            }
         }
     }
 
@@ -557,6 +570,32 @@ mod tests {
         assert_eq!(rx.try_recv().unwrap().unwrap(), Au::from_amount(100));
         let handle = svc.accounting.for_peer(peer);
         assert_eq!(handle.balance(), Au::from_amount(100));
+    }
+
+    #[tokio::test]
+    async fn failed_event_releases_pending_settle() {
+        let mut svc = build_service();
+        let peer = test_peer();
+
+        // A settle is pending its ack when the substream dies.
+        let mut rx = insert_pending(&mut svc, peer, Au::from_amount(100));
+        svc.handle_event(PseudosettleEvent::Failed { peer }).await;
+
+        // The caller is released with an error rather than left hanging.
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            Err(PseudosettleSettlementError::NetworkError(_))
+        ));
+        // The pending entry is cleared so a later settle starts fresh.
+        assert!(!svc.pending.contains_key(&peer));
+    }
+
+    #[tokio::test]
+    async fn failed_event_for_unknown_peer_is_noop() {
+        let mut svc = build_service();
+        // No pending settle for this peer: the failure is simply ignored.
+        svc.handle_event(PseudosettleEvent::Failed { peer: test_peer() })
+            .await;
     }
 
     #[tokio::test]

--- a/crates/swarm/accounting/swap/src/service.rs
+++ b/crates/swarm/accounting/swap/src/service.rs
@@ -351,6 +351,22 @@ where
                     }
                 }
             }
+            SwapEvent::Failed { peer } => {
+                // The substream died or the peer disconnected before the
+                // cheque-sent ack, so resolve the pending settle with an error.
+                // The cheque may already be on the wire, so the cumulative payout
+                // is left advanced: a retry issues a higher payout the peer still
+                // credits by delta, whereas rolling back risks a non-increasing
+                // re-issue the peer would reject.
+                if let Some(pending) = self.pending.remove(&peer) {
+                    debug!(%peer, "Swap substream failed; releasing pending settle");
+                    let _ = pending
+                        .response_tx
+                        .send(Err(SwapSettlementError::NetworkError(
+                            "substream failed".into(),
+                        )));
+                }
+            }
         }
     }
 
@@ -884,6 +900,39 @@ mod tests {
         assert!(reporter.reports.lock().unwrap().is_empty());
         let handle = svc.accounting.for_peer(peer);
         assert_eq!(handle.balance(), Au::new(-1_000));
+    }
+
+    #[tokio::test]
+    async fn failed_event_releases_pending_settle() {
+        let mut svc = build_service(PrivateKeySigner::random());
+        let peer = test_peer();
+
+        // A cheque is pending its sent-ack when the substream dies.
+        let (response_tx, mut response_rx) = oneshot::channel();
+        svc.pending.insert(
+            peer,
+            PendingSettlement {
+                amount: Au::from_amount(100),
+                response_tx,
+            },
+        );
+
+        svc.handle_event(SwapEvent::Failed { peer }).await;
+
+        // The caller is released with an error rather than left hanging.
+        assert!(matches!(
+            response_rx.try_recv().unwrap(),
+            Err(SwapSettlementError::NetworkError(_))
+        ));
+        assert!(!svc.pending.contains_key(&peer));
+    }
+
+    #[tokio::test]
+    async fn failed_event_for_unknown_peer_is_noop() {
+        let mut svc = build_service(PrivateKeySigner::random());
+        // No pending settle for this peer: the failure is simply ignored.
+        svc.handle_event(SwapEvent::Failed { peer: test_peer() })
+            .await;
     }
 
     #[test]

--- a/crates/swarm/client-behaviour/src/behaviour.rs
+++ b/crates/swarm/client-behaviour/src/behaviour.rs
@@ -415,6 +415,24 @@ impl ClientBehaviour {
                 protocol,
                 error,
             } => {
+                // A dead settlement substream must release the service's pending
+                // settle, else the settle oneshot leaks and the caller hangs past
+                // its deadline.
+                if let Some(peer) = overlay
+                    && protocol == "pseudosettle"
+                    && let Some(tx) = &self.pseudosettle_event_tx
+                    && tx.send(PseudosettleEvent::Failed { peer }).is_err()
+                {
+                    warn!(%peer, "Pseudosettle event channel closed");
+                }
+                #[cfg(feature = "swap")]
+                if let Some(peer) = overlay
+                    && protocol == "swap"
+                    && let Some(tx) = &self.swap_event_tx
+                    && tx.send(SwapEvent::Failed { peer }).is_err()
+                {
+                    warn!(%peer, "Swap event channel closed");
+                }
                 self.pending_events
                     .push_back(ToSwarm::GenerateEvent(ClientEvent::ProtocolError {
                         peer: overlay,
@@ -539,6 +557,21 @@ impl NetworkBehaviour for ClientBehaviour {
         {
             self.overlay_peers.remove(&overlay);
             debug!(peer_id = %info.peer_id, %overlay, "Peer disconnected");
+            // A full disconnect may never surface as a substream error, so
+            // release any pending settle for this peer here too.
+            if let Some(tx) = &self.pseudosettle_event_tx
+                && tx
+                    .send(PseudosettleEvent::Failed { peer: overlay })
+                    .is_err()
+            {
+                warn!(%overlay, "Pseudosettle event channel closed");
+            }
+            #[cfg(feature = "swap")]
+            if let Some(tx) = &self.swap_event_tx
+                && tx.send(SwapEvent::Failed { peer: overlay }).is_err()
+            {
+                warn!(%overlay, "Swap event channel closed");
+            }
             self.pending_events
                 .push_back(ToSwarm::GenerateEvent(ClientEvent::PeerDisconnected {
                     peer_id: info.peer_id,
@@ -585,5 +618,104 @@ fn domain_ack(ack: PaymentAck) -> PseudosettleAck {
     PseudosettleAck {
         accepted: Au::saturating_from_u256(ack.amount),
         timestamp: ack.timestamp,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::PeerId;
+    use vertex_swarm_api::{ChunkAddress, SwarmResult};
+    use vertex_swarm_primitives::CachedChunk;
+    use vertex_swarm_test_utils::test_peer;
+
+    use super::*;
+    use crate::forward::StubForwarder;
+
+    struct NoopStore;
+
+    impl SwarmLocalStore for NoopStore {
+        fn put(&self, _chunk: CachedChunk) -> SwarmResult<()> {
+            Ok(())
+        }
+        fn get(&self, _address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
+            Ok(None)
+        }
+        fn contains(&self, _address: &ChunkAddress) -> bool {
+            false
+        }
+        fn remove(&self, _address: &ChunkAddress) -> SwarmResult<()> {
+            Ok(())
+        }
+    }
+
+    fn build_behaviour() -> ClientBehaviour {
+        ClientBehaviour::new(
+            Config::default(),
+            Arc::new(NoopStore),
+            Arc::new(StubForwarder),
+        )
+    }
+
+    #[test]
+    fn pseudosettle_substream_error_routes_failed() {
+        let mut behaviour = build_behaviour();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        behaviour.route_pseudosettle_events(tx);
+
+        let peer = test_peer();
+        behaviour.on_handler_event(
+            PeerId::random(),
+            HandlerEvent::Error {
+                overlay: Some(peer),
+                protocol: "pseudosettle",
+                error: "substream timed out".into(),
+            },
+        );
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(PseudosettleEvent::Failed { peer: p }) if p == peer
+        ));
+    }
+
+    #[test]
+    fn non_settlement_error_does_not_route_failed() {
+        let mut behaviour = build_behaviour();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        behaviour.route_pseudosettle_events(tx);
+
+        behaviour.on_handler_event(
+            PeerId::random(),
+            HandlerEvent::Error {
+                overlay: Some(test_peer()),
+                protocol: "pricing",
+                error: "boom".into(),
+            },
+        );
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[cfg(feature = "swap")]
+    #[test]
+    fn swap_substream_error_routes_failed() {
+        let mut behaviour = build_behaviour();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        behaviour.route_swap_events(tx);
+
+        let peer = test_peer();
+        behaviour.on_handler_event(
+            PeerId::random(),
+            HandlerEvent::Error {
+                overlay: Some(peer),
+                protocol: "swap",
+                error: "substream timed out".into(),
+            },
+        );
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(SwapEvent::Failed { peer: p }) if p == peer
+        ));
     }
 }

--- a/crates/swarm/client-protocol/src/lib.rs
+++ b/crates/swarm/client-protocol/src/lib.rs
@@ -432,6 +432,12 @@ pub enum PseudosettleEvent {
         /// Request ID for sending ack.
         request_id: u64,
     },
+    /// An outbound pseudosettle substream failed or the peer disconnected before
+    /// an ack arrived; any pending settle for this peer must be released.
+    Failed {
+        /// The peer whose pending settle can no longer complete.
+        peer: OverlayAddress,
+    },
 }
 
 /// Events extracted from [`ClientEvent`] and routed to the swap settlement service.
@@ -453,5 +459,11 @@ pub enum SwapEvent {
         cheque: SignedCheque,
         /// The peer's advertised exchange rate, from the headers exchange.
         peer_rate: U256,
+    },
+    /// An outbound swap substream failed or the peer disconnected before the
+    /// cheque-sent ack arrived; any pending settle for this peer must be released.
+    Failed {
+        /// The peer whose pending settle can no longer complete.
+        peer: OverlayAddress,
     },
 }


### PR DESCRIPTION
## What

Release a pending pseudosettle/swap settle when its libp2p substream fails, instead of leaking it.

## Why

The pseudosettle and swap outbound settle substreams already carry the handler's `Config::timeout` (30s), but when that timeout, any substream error, or a peer disconnect fired, the handler's `HandlerEvent::Error` was mapped to a `ClientEvent::ProtocolError` that no consumer acted on. The settle service never learned the substream had died, so its pending settle completion was leaked and `handle.settle()` blocked forever. That pinned the client all-gated wait (`PeerSelector::order_or_wait`) past its deadline whenever a peer accepted a settle stream and never acknowledged it.

This wires the libp2p substream bound that already exists through to the settle, rather than layering a second, redundant timer on top of it.

## How

A `Failed { peer }` event variant on `PseudosettleEvent` and, swap-gated, `SwapEvent`. The client behaviour routes a settle-protocol `HandlerEvent::Error`, and a peer disconnect, onto the matching service channel. Each service resolves that peer's pending settle with a network error and clears the entry, so `handle.settle()` returns within the existing deadline, the in-flight guard drops, and the wait unwinds.

## Testing

`cargo nextest run --all-features` across the pseudosettle, swap, client-behaviour, and node crates (185 pass, including the new routing and release tests). `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings` on the touched crates, the wasm32 build of the client cone, and a swap-off build confirming the swap cone stays out of the default client.

## AI Assistance

Claude Code used for the red-team analysis and implementation.

Closes #555
