### PR TITLE
feat(swarm-demo): OPFS-worker download sink for off-thread out-of-order writes

### DIFF
--- a/bin/swarm-demo/assets/download-sink.js
+++ b/bin/swarm-demo/assets/download-sink.js
@@ -1,26 +1,40 @@
 // Browser download sink factory.
 //
 // `createDownloadSink(filename, sizeHintOrNull)` returns a sink the Rust wasm
-// streaming download writes ordered segments to:
+// streaming download writes to:
 //
-//   { write(Uint8Array): Promise, setTotal(n), close(): Promise, abort(reason) }
+//   { seekable, setTotal(n), close(): Promise, abort(reason),
+//     write(Uint8Array): Promise,                                  // ordered
+//     setLen(n): Promise, writeAt(offset, Uint8Array): Promise }   // seekable
 //
-// Two implementations, feature-detected at call time:
+// Three implementations, feature-detected at call time. `seekable` tells the
+// Rust side whether it may deliver leaves out of order (positional writes) or
+// must stream in file order.
+//
+//   * OPFS worker (Chromium/Firefox/Safari, preferred): a dedicated worker owns
+//     an Origin Private File System scratch file via a sync access handle and
+//     writes each leaf at its offset off the fetch thread; on close the finished
+//     file is delivered to Downloads as a disk-backed Blob. `seekable`. Needs no
+//     user gesture, so it is tried first.
 //
 //   * File System Access (Chromium/Edge): `showSaveFilePicker` opens the native
 //     save dialog and streams straight to a `FileSystemWritableFileStream`. The
 //     picker REQUIRES a user gesture, so this factory must be called inside the
-//     download click handler, before any awaiting.
+//     download click handler, before any awaiting. Ordered.
 //
 //   * Service worker (Firefox/Safari): a StreamSaver-style worker answers a
 //     navigation to a synthetic URL with a streamed attachment Response fed from
 //     a MessagePort. Backpressure flows back over the port as `pull` signals.
+//     Ordered.
 //
 // Keeping all browser-specific plumbing here lets the Rust side stay a plain
-// `extern` binding with async write/close/abort/setTotal and no unstable cfgs.
+// `extern` binding with no unstable cfgs.
 
 const SW_URL = resolveRootUrl('download-sw.js');
+const WORKER_URL = resolveRootUrl('download-worker.js');
 const DL_PREFIX = '__stream_dl__';
+// Prefix for the OPFS scratch files the worker writes to before delivery.
+const SCRATCH_PREFIX = '__swarm_dl__';
 
 // Resolve a path relative to the demo root (one level up from assets/), so the
 // worker is registered at root scope and can control the synthetic download URL.
@@ -53,6 +67,7 @@ function randomId() {
 // File System Access sink: stream to a picked file. Must be created in-gesture.
 class FsaSink {
   constructor(writable) {
+    this.seekable = false;
     this.writable = writable;
     this.written = 0;
     this.total = null;
@@ -80,6 +95,7 @@ class FsaSink {
 // pace sends against the stream's pull signal for backpressure.
 class SwSink {
   constructor(id, port) {
+    this.seekable = false;
     this.id = id;
     this.port = port;
     this.written = 0;
@@ -139,6 +155,183 @@ class SwSink {
   }
 }
 
+// OPFS sync access handles live only in a dedicated worker, so OPFS support
+// plus Worker support is the signal for the seekable path.
+function opfsSupported() {
+  return (
+    typeof navigator !== 'undefined' &&
+    navigator.storage &&
+    typeof navigator.storage.getDirectory === 'function' &&
+    typeof Worker !== 'undefined' &&
+    typeof document !== 'undefined'
+  );
+}
+
+// Remove scratch files left by earlier downloads, never the current one. The
+// just-finished file is left in place (it is the anchor download's source) and
+// swept on the next download instead, so a remove never races the browser
+// reading the delivered Blob.
+async function sweepOldScratch(keepName) {
+  try {
+    const root = await navigator.storage.getDirectory();
+    const stale = [];
+    for await (const [name, handle] of root.entries()) {
+      if (name.startsWith(SCRATCH_PREFIX) && name !== keepName && handle.kind === 'file') {
+        stale.push(name);
+      }
+    }
+    for (const name of stale) {
+      try {
+        await root.removeEntry(name);
+      } catch (_) {}
+    }
+  } catch (_) {}
+}
+
+// OPFS-worker sink: out-of-order positional writes to a scratch file owned by a
+// dedicated worker, then delivery to Downloads as a disk-backed Blob. One write
+// is in flight at a time (the Rust side awaits each `writeAt`), so the worker's
+// queue and peak memory stay bounded.
+class OpfsWorkerSink {
+  constructor(worker, scratchName, filename) {
+    this.seekable = true;
+    this.worker = worker;
+    this.scratchName = scratchName;
+    this.filename = filename || 'swarm-download.bin';
+    this.written = 0;
+    this.total = null;
+    this.seq = 0;
+    this.pending = new Map(); // seq -> { resolve, reject }
+    this.lifecycle = null; // { resolve, reject } for opened/closed/aborted
+    worker.onmessage = (ev) => this._onMessage(ev.data);
+    worker.onerror = (e) =>
+      this._failAll(new Error('download worker error: ' + ((e && e.message) || e)));
+  }
+  _onMessage(msg) {
+    if (!msg) return;
+    if (msg.type === 'opened' || msg.type === 'closed' || msg.type === 'aborted') {
+      const w = this.lifecycle;
+      this.lifecycle = null;
+      if (w) w.resolve();
+      return;
+    }
+    if (msg.type === 'ack') {
+      const p = this.pending.get(msg.seq);
+      if (p) {
+        this.pending.delete(msg.seq);
+        p.resolve();
+      }
+      return;
+    }
+    if (msg.type === 'error') {
+      const err = new Error(msg.message || 'download worker error');
+      if (msg.seq != null && this.pending.has(msg.seq)) {
+        const p = this.pending.get(msg.seq);
+        this.pending.delete(msg.seq);
+        p.reject(err);
+      } else {
+        this._failAll(err);
+      }
+    }
+  }
+  _failAll(err) {
+    if (this.lifecycle) {
+      const w = this.lifecycle;
+      this.lifecycle = null;
+      w.reject(err);
+    }
+    for (const [, p] of this.pending) p.reject(err);
+    this.pending.clear();
+  }
+  _lifecycle() {
+    return new Promise((resolve, reject) => {
+      this.lifecycle = { resolve, reject };
+    });
+  }
+  _request(type, payload, transfer) {
+    const seq = ++this.seq;
+    return new Promise((resolve, reject) => {
+      this.pending.set(seq, { resolve, reject });
+      this.worker.postMessage({ type, seq, ...payload }, transfer || []);
+    });
+  }
+  setTotal(n) {
+    this.total = n;
+    notifyProgress(this.written, this.total);
+  }
+  async setLen(len) {
+    // Fail clearly before writing if the origin quota cannot hold the file,
+    // rather than surfacing a mid-stream ENOSPC.
+    try {
+      if (navigator.storage && typeof navigator.storage.estimate === 'function') {
+        const { quota, usage } = await navigator.storage.estimate();
+        if (quota != null && usage != null && quota - usage < len) {
+          throw new Error(
+            'insufficient browser storage for this download (' +
+              len +
+              ' bytes needed, ' +
+              (quota - usage) +
+              ' available)',
+          );
+        }
+      }
+    } catch (e) {
+      // Re-throw a real quota shortfall; ignore an estimate that simply failed.
+      if (e instanceof Error && e.message.startsWith('insufficient browser storage')) throw e;
+    }
+    await this._request('truncate', { len });
+  }
+  async writeAt(offset, chunk) {
+    // Copy out of wasm memory into a transferable buffer so the worker owns it.
+    const buf = chunk.slice().buffer;
+    await this._request('write', { offset, buffer: buf }, [buf]);
+    this.written += chunk.length;
+    notifyProgress(this.written, this.total);
+  }
+  // Ordered interface, unused on the seekable path but kept for parity.
+  async write(chunk) {
+    await this.writeAt(this.written, chunk);
+  }
+  async close() {
+    const closed = this._lifecycle();
+    this.worker.postMessage({ type: 'close' });
+    await closed;
+    await this._deliver();
+    try {
+      this.worker.terminate();
+    } catch (_) {}
+  }
+  abort(reason) {
+    try {
+      this.worker.postMessage({ type: 'abort' });
+    } catch (_) {}
+    try {
+      this.worker.terminate();
+    } catch (_) {}
+  }
+  // Read the finished scratch file (its sync handle is now closed) and hand it
+  // to the browser as a download. The File is a disk-backed snapshot, so this
+  // never loads the whole file into memory.
+  async _deliver() {
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle(this.scratchName);
+    const file = await handle.getFile();
+    const url = URL.createObjectURL(file);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = this.filename;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => {
+      try {
+        URL.revokeObjectURL(url);
+      } catch (_) {}
+    }, 120000);
+  }
+}
+
 // Progress is surfaced through a window-level hook the UI installs; absent that
 // it is a no-op, so the sink stays usable from a bare page.
 function notifyProgress(written, total) {
@@ -148,6 +341,30 @@ function notifyProgress(written, total) {
 }
 
 export async function createDownloadSink(filename, sizeHint) {
+  // PREFERRED: OPFS worker sink. Seekable, off the fetch thread, and needs no
+  // user gesture, so it is safe to try first even though it awaits. A present
+  // but unusable OPFS falls through to the service worker, which also needs no
+  // gesture; the File System Access picker is only reached when OPFS was never
+  // attempted, so its gesture is intact.
+  if (opfsSupported()) {
+    try {
+      const scratchName = SCRATCH_PREFIX + randomId();
+      await sweepOldScratch(scratchName);
+      const worker = new Worker(WORKER_URL);
+      const sink = new OpfsWorkerSink(worker, scratchName, filename);
+      const opened = sink._lifecycle();
+      worker.postMessage({ type: 'open', name: scratchName });
+      await opened;
+      if (sizeHint != null && !Number.isNaN(sizeHint)) {
+        sink.setTotal(sizeHint);
+      }
+      return sink;
+    } catch (e) {
+      console.warn('[download] OPFS sink unavailable, falling back', e);
+      return createSwSink(filename, sizeHint);
+    }
+  }
+
   // FAST PATH: File System Access. Call the picker synchronously here (still in
   // the gesture), then await the writable.
   if (typeof window !== 'undefined' && typeof window.showSaveFilePicker === 'function') {
@@ -162,9 +379,13 @@ export async function createDownloadSink(filename, sizeHint) {
     return sink;
   }
 
-  // FALLBACK: service worker stream. Register (idempotent), open a port, tell
-  // the worker about this download, then navigate a hidden iframe to the
-  // synthetic URL so the browser treats the streamed Response as a download.
+  return createSwSink(filename, sizeHint);
+}
+
+// Service worker stream sink. Register (idempotent), open a port, tell the
+// worker about this download, then navigate a hidden iframe to the synthetic URL
+// so the browser treats the streamed Response as a download.
+async function createSwSink(filename, sizeHint) {
   const reg = await ensureServiceWorker();
   if (!reg) {
     throw new Error('no streaming download path: missing File System Access and service workers');

--- a/bin/swarm-demo/download-worker.js
+++ b/bin/swarm-demo/download-worker.js
@@ -1,0 +1,79 @@
+// OPFS download worker.
+//
+// Owns a sandboxed Origin Private File System scratch file through a synchronous
+// access handle, which the spec exposes only in a dedicated worker. That lets
+// the random-access, out-of-order positional writes the joiner emits run off the
+// page's fetch thread: the synchronous OPFS write blocks this worker, never the
+// thread driving libp2p retrieval. The main thread posts one write at a time and
+// awaits an ack, so peak memory is one chunk and the file lives on disk, not the
+// heap.
+//
+// Protocol, main -> worker:
+//   { type: 'open',     name }
+//   { type: 'truncate', seq, len }
+//   { type: 'write',    seq, offset, buffer }   // buffer transferred
+//   { type: 'close' }
+//   { type: 'abort' }
+// worker -> main:
+//   { type: 'opened' } | { type: 'ack', seq } | { type: 'closed' }
+//   | { type: 'aborted' } | { type: 'error', seq, message }
+
+let access = null;
+
+self.onmessage = async (ev) => {
+  const msg = ev.data;
+  if (!msg) return;
+  try {
+    switch (msg.type) {
+      case 'open': {
+        const root = await navigator.storage.getDirectory();
+        const handle = await root.getFileHandle(msg.name, { create: true });
+        // createSyncAccessHandle is dedicated-worker only; this is why the sink
+        // needs a worker rather than a main-thread OPFS writable.
+        access = await handle.createSyncAccessHandle();
+        self.postMessage({ type: 'opened' });
+        break;
+      }
+      case 'truncate': {
+        if (!access) throw new Error('truncate before open');
+        // Pre-size so every in-range positional write lands in a sparse file.
+        access.truncate(msg.len);
+        self.postMessage({ type: 'ack', seq: msg.seq });
+        break;
+      }
+      case 'write': {
+        if (!access) throw new Error('write before open');
+        const view = new Uint8Array(msg.buffer);
+        const wrote = access.write(view, { at: msg.offset });
+        // A short write (e.g. quota exhaustion) must fail loudly rather than
+        // leave a silently truncated file.
+        if (wrote !== view.byteLength) {
+          throw new Error('short write at ' + msg.offset + ': ' + wrote + '/' + view.byteLength);
+        }
+        self.postMessage({ type: 'ack', seq: msg.seq });
+        break;
+      }
+      case 'close': {
+        if (access) {
+          access.flush();
+          access.close();
+          access = null;
+        }
+        self.postMessage({ type: 'closed' });
+        break;
+      }
+      case 'abort': {
+        if (access) {
+          try {
+            access.close();
+          } catch (_) {}
+          access = null;
+        }
+        self.postMessage({ type: 'aborted' });
+        break;
+      }
+    }
+  } catch (e) {
+    self.postMessage({ type: 'error', seq: msg.seq, message: String((e && e.message) || e) });
+  }
+};

--- a/bin/swarm-demo/index.html
+++ b/bin/swarm-demo/index.html
@@ -15,8 +15,11 @@
     <!-- The stream-to-disk service worker must sit at the demo root so it can
          take root scope and control the synthetic download URL. -->
     <link data-trunk rel="copy-file" href="download-sw.js" />
+    <!-- The OPFS download worker sits at the demo root so it loads by a stable
+         same-origin URL; it owns the scratch file's sync access handle. -->
+    <link data-trunk rel="copy-file" href="download-worker.js" />
 
-    <!-- Download sink factory (File System Access fast path + service-worker
+    <!-- Download sink factory (OPFS worker, File System Access, service-worker
          fallback). Loaded as a module so its `createDownloadSink` export is
          registered on `window` before the wasm download path calls it. -->
     <script type="module" src="assets/download-sink.js"></script>

--- a/bin/swarm-demo/src/client/download.rs
+++ b/bin/swarm-demo/src/client/download.rs
@@ -11,6 +11,7 @@ use futures::StreamExt;
 use js_sys::Uint8Array;
 use nectar_mantaray::error::MantarayError;
 use nectar_mantaray::{Entry, PlainManifest};
+use nectar_primitives::file::WriteAt;
 use nectar_primitives::store::ChunkStoreError;
 use nectar_primitives::{ChunkAddress, DEFAULT_BODY_SIZE, Joiner};
 use vertex_swarm_api::SwarmChunkProvider;
@@ -22,9 +23,9 @@ use super::net_get::NetworkChunkGet;
 
 #[wasm_bindgen]
 extern "C" {
-    /// A browser download sink (see `assets/download-sink.js`): ordered segment
-    /// writes with backpressure, streamed to disk via the File System Access API
-    /// or a service worker. The Rust side never inspects the chosen path.
+    /// A browser download sink (see `assets/download-sink.js`): an OPFS-worker
+    /// sink that accepts out-of-order positional writes, or an ordered sink
+    /// (File System Access or a service worker). `seekable` distinguishes them.
     #[wasm_bindgen(js_name = DownloadSink)]
     pub type DownloadSink;
 
@@ -32,9 +33,26 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setTotal)]
     fn set_total(this: &DownloadSink, total: f64);
 
+    /// Whether the sink accepts positional `write_at`, so leaves may be written
+    /// out of order; an ordered sink must instead be fed in file order.
+    #[wasm_bindgen(method, getter)]
+    fn seekable(this: &DownloadSink) -> bool;
+
     /// Write one ordered segment; resolves when the sink can accept more.
     #[wasm_bindgen(method, catch)]
     async fn write(this: &DownloadSink, chunk: Uint8Array) -> Result<JsValue, JsValue>;
+
+    /// Pre-size a seekable sink so every in-range `write_at` lands.
+    #[wasm_bindgen(method, catch, js_name = setLen)]
+    async fn set_len(this: &DownloadSink, len: f64) -> Result<JsValue, JsValue>;
+
+    /// Write `chunk` at absolute byte `offset` (seekable sinks only).
+    #[wasm_bindgen(method, catch, js_name = writeAt)]
+    async fn write_at(
+        this: &DownloadSink,
+        offset: f64,
+        chunk: Uint8Array,
+    ) -> Result<JsValue, JsValue>;
 
     /// Finish the download, flushing and closing the underlying stream.
     #[wasm_bindgen(method, catch)]
@@ -43,6 +61,46 @@ extern "C" {
     /// Cancel the download with a human-readable reason.
     #[wasm_bindgen(method)]
     fn abort(this: &DownloadSink, reason: &str);
+}
+
+/// Error from a browser sink operation, carrying the JS message as a string.
+#[derive(Debug)]
+struct SinkError(String);
+
+impl std::fmt::Display for SinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SinkError {}
+
+/// Adapts a seekable browser [`DownloadSink`] as a nectar [`WriteAt`], so the
+/// joiner writes each leaf at its offset out of order, straight to the OPFS
+/// worker. Wasm-only: the sink futures are `!Send`, which the demo never needs.
+struct JsWriteSink<'a> {
+    sink: &'a DownloadSink,
+}
+
+impl WriteAt for JsWriteSink<'_> {
+    type Error = SinkError;
+
+    async fn write_at(&self, offset: u64, buf: &[u8]) -> Result<(), SinkError> {
+        let view = Uint8Array::from(buf);
+        self.sink
+            .write_at(offset as f64, view)
+            .await
+            .map(|_| ())
+            .map_err(|e| SinkError(format!("write_at: {e:?}")))
+    }
+
+    async fn set_len(&self, len: u64) -> Result<(), SinkError> {
+        self.sink
+            .set_len(len as f64)
+            .await
+            .map(|_| ())
+            .map_err(|e| SinkError(format!("set_len: {e:?}")))
+    }
 }
 
 /// Maximum prefetch round trips before giving up on a manifest op.
@@ -89,10 +147,11 @@ pub async fn stream_reference(
     stream_file(file_root, provider, cache, sink).await
 }
 
-/// Stream the file at `file_root` to `sink` in order, driving the joiner over
-/// the network getter. A bounded window pipelines chunk fetches at the configured
-/// width while emitting in file order; each segment is dropped after its write
-/// resolves, so peak wasm buffering is the window, not the file size.
+/// Stream the file at `file_root` to `sink`, driving the joiner over the network
+/// getter at full width. A seekable sink (the OPFS worker) takes positional
+/// writes so leaves land out of order as they resolve; an ordered sink takes a
+/// windowed in-order stream. Either way peak wasm buffering is bounded by the
+/// in-flight width, not the file size.
 pub async fn stream_file(
     file_root: ChunkAddress,
     provider: Arc<dyn SwarmChunkProvider>,
@@ -113,10 +172,21 @@ pub async fn stream_file(
         return finish(sink).await;
     }
 
-    // The sink is a sequential disk stream (File System Access append or a
-    // service-worker download body), so delivery must stay in file order. The
-    // windowed reader fetches the tree at full width but reorders to in-order
-    // emission, bounding held leaf bodies to the window.
+    if sink.seekable() {
+        // Out-of-order positional writes: the joiner writes each leaf at its
+        // offset the moment it resolves, off the fetch thread, so a slow chunk
+        // never gates the writes already in hand.
+        if let Err(e) = joiner.download_into(JsWriteSink { sink }).await {
+            sink.abort(&format!("download: {e}"));
+            return Err(JsValue::from_str(&format!("download: {e}")));
+        }
+        return finish(sink).await;
+    }
+
+    // Ordered fallback: a sequential disk stream (File System Access append or a
+    // service-worker download body) must be fed in file order. The windowed
+    // reader fetches the tree at full width but reorders to in-order emission,
+    // bounding held leaf bodies to the window.
     let mut reader = joiner.into_windowed_reader(STREAM_WINDOW);
     let stream = reader.stream();
     futures::pin_mut!(stream);


### PR DESCRIPTION
## What

Adds an OPFS-worker download sink to the browser demo. A dedicated Web Worker owns an Origin Private File System scratch file through a `FileSystemSyncAccessHandle` (worker-only by spec) and writes each leaf at its byte offset. The Rust side exposes the sink as a nectar `WriteAt` and drives `joiner.download_into` when the sink reports `seekable`, so the joiner writes leaves out of order as they resolve, off the fetch thread. On completion the finished OPFS file is delivered to Downloads as a disk-backed `Blob` via an anchor download. When OPFS or `Worker` is unavailable, the existing ordered sink (File System Access append or the service worker) drives the windowed reader exactly as before.

Files: a new `download-worker.js`, the sink factory in `download-sink.js` (OPFS preferred, then FSA, then service worker), a `WriteAt` adapter plus a `seekable` branch in `src/client/download.rs`, and the Trunk wiring in `index.html`.

## Why

The wasm streaming download wrote to disk on the same thread as libp2p retrieval, and both browser sinks are sequential, so a slow chunk gated every ready write behind it and the writes contended with the fetch thread. OPFS sync access handles give positional, out-of-order writes but only inside a worker, so a worker is the natural home for the decoupling this issue asks for. This subsumes the wasm out-of-order residual from the now-closed #522, keeps peak memory bounded (OPFS is on disk, not the heap), and finally gives out-of-order writes on Firefox and Safari, which lack `showSaveFilePicker`.

Closes #525.

## Plan and red-team

- Backpressure and memory: the Rust download loop awaits each `write_at`, so at most one write is in flight; the worker queue cannot grow and the transferred buffer is not duplicated. The joiner's offset stream holds at most the in-flight width (32) of small leaf bodies. Peak memory is bounded and independent of file size.
- Failure and abort: a worker `error` rejects the in-flight write (or fails the open), surfacing as a Rust error that aborts the download; `worker.onerror` fails all pending. Abort terminates the worker and leaves the scratch file for the next sweep. A short write (quota exhaustion) throws in the worker rather than truncating silently.
- Wasm `!Send`: the sink futures are `!Send`, which is fine because the demo is a wasm-only cdylib (verified by the wasm build); this is not the shared client cone.
- Quota and ENOSPC: `setLen` checks `navigator.storage.estimate()` and fails clearly before any write rather than mid-stream.
- Delivery and lifecycle: the scratch file is read on the main thread after the worker closes its sync handle; the current file is left in place and swept on the next download, so an in-flight anchor read is never invalidated by an early remove.
- Always-OPFS vs branch: write to OPFS whenever it is available (positional, off-thread, gesture-free) and fall back to the ordered sinks otherwise. On Chromium this means the download lands in the Downloads folder rather than via the save picker; that is the deliberate trade for decoupling and out-of-order writes.

## Testing

`cargo build --target wasm32-unknown-unknown` and `cargo fmt --check` for `swarm-demo` on the pinned toolchain: clean. `node --check` passes on both JS files. `cargo clippy --target wasm32-unknown-unknown` is clean for the changed code; the one warning is a pre-existing `large_enum_variant` in `client/network.rs`, unrelated to this change.

Real OPFS and download behaviour is browser-only and is the acceptance gate. Needs manual verification:

- Chromium: download lands in Downloads, byte-exact; main thread stays responsive during a large download (out-of-order writes visible as offsets stepping backwards).
- Firefox: OPFS path is used (no `showSaveFilePicker`), file delivered byte-exact via the anchor Blob.
- Quota: a download larger than the origin quota fails with a clear message, not a mid-stream error.
- Fallback: with OPFS forced off, the ordered FSA/service-worker path still works.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the design, red-team, implementation, and build verification.
