### PR TITLE
fix(swarm-node): walk farther to rescue difficult chunks on retrieval

### DIFF
--- a/bin/swarm-demo/src/client/network.rs
+++ b/bin/swarm-demo/src/client/network.rs
@@ -214,6 +214,13 @@ impl BrowserChunkProvider {
                     last_failure = Some(e);
                     wave += 1;
                 }
+                // `race_candidates` carries no wall-clock deadline, so this is
+                // unreachable here; advance to the next wave for forward
+                // compatibility rather than abandoning the walk.
+                Err(RaceFailure::TimedOut) => {
+                    attempted += wave_size;
+                    wave += 1;
+                }
             }
         }
 

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -1,8 +1,10 @@
 //! RPC provider implementations for Swarm nodes.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
+use metrics::{counter, histogram};
 use nectar_primitives::SwarmAddress;
 use tracing::warn;
 use vertex_swarm_api::{
@@ -17,8 +19,7 @@ use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::time::{Duration, Instant};
 
 use crate::{
-    ClientHandle, PeerInflightLimiter, PeerSelector, RETRIEVAL_STAGGER, RaceFailure,
-    race_candidates,
+    ClientHandle, PeerInflightLimiter, PeerSelector, RETRIEVAL_STAGGER, RaceFailure, race_walk,
 };
 
 /// Report source for shallow/malformed receipts caught on the origin upload
@@ -28,20 +29,30 @@ const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
 /// Number of closest peers to try when pushing a chunk before giving up.
 const PUSH_CANDIDATE_COUNT: usize = 5;
 
-/// Pool of closest connected peers scanned for a free retrieval slot before
-/// skip-busy filtering.
+/// Proximity-ordered pool of closest connected peers the retrieval walk draws
+/// from.
 ///
-/// Intentionally wider than [`RETRIEVE_MAX_ATTEMPTS`] so that when address
-/// proximity clusters onto a few close peers and one is at its in-flight cap,
-/// skip-busy still has next-closest alternatives with a free slot rather than
-/// overrunning the hot peer's per-connection substream budget. This is only a
-/// selection pool: the race is bounded separately by [`RETRIEVE_MAX_ATTEMPTS`].
-const RETRIEVE_CANDIDATE_WIDTH: usize = 8;
+/// Wider than [`RETRIEVE_LEG_BUDGET`] so that, after skip-busy removes peers at
+/// their in-flight cap, the walk still has next-closest free-slot entry points to
+/// refill a failed leg with rather than overrunning a hot peer. Retrieval is
+/// forwarding-based, so these are connected peers only; the walk never dials.
+const RETRIEVE_WALK_WIDTH: usize = 32;
 
-/// Maximum retrieval legs raced per chunk, so widening the skip-busy pool
-/// does not amplify paid bandwidth: the wider pool only supplies free-slot
-/// alternatives, the race still meters at most this many legs (the prior bound).
-const RETRIEVE_MAX_ATTEMPTS: usize = 3;
+/// Maximum real retrieval legs the walk dispatches per chunk before giving up.
+///
+/// A chunk whose closest few entry points miss is not absent: each leg is a
+/// distinct peer whose own forwarding chain may still reach the chunk's storers,
+/// so a sparse-bin chunk needs more than the closest few tries. Peers skipped for
+/// back-pressure before dispatch do not count against this budget, so it bounds
+/// only genuine coverage attempts and the metered bandwidth they cost. The
+/// reference node's origin ceiling is 32; this starts conservative and is raised
+/// only on the residual-failure metric below.
+const RETRIEVE_LEG_BUDGET: usize = 8;
+
+/// Wall-clock bound on the whole retrieval walk across its refilled legs, so a
+/// run of slow or withholding entry points cannot hold a download-pipeline slot
+/// indefinitely. Matches the per-request retrieval lifetime.
+const RETRIEVE_WALK_DEADLINE: Duration = Duration::from_secs(30);
 
 /// Bound on the settle-and-await for a fully gated close set: the request's own
 /// retrieval lifetime, matching the client-behaviour outbound retrieval timeout.
@@ -116,55 +127,67 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         let chunk_address = SwarmAddress::new(address.0.into());
         let closest_peers = self
             .topology
-            .closest_to(&chunk_address, RETRIEVE_CANDIDATE_WIDTH);
+            .closest_to(&chunk_address, RETRIEVE_WALK_WIDTH);
         // Settle-and-await when every close peer is gated, so a fully gated set
         // recovers instead of failing; if still gated at the budget the empty
         // result falls through to the no-connected-peers path below, the same
         // generic transient error a no-peers failure yields.
         let closest_peers = self.select_or_wait(closest_peers, &chunk_address).await;
 
-        // Skip-busy: prefer close peers with a free retrieval slot so a hot peer
-        // at its in-flight cap is skipped at selection time rather than
-        // overrun. When every close candidate is at its cap, fall through to the
+        // Skip-busy: drop peers at their in-flight cap so a hot peer is never
+        // overrun and a busy peer never spends a leg of the difficulty budget
+        // below. When every close candidate is at its cap, fall through to the
         // full list rather than failing the request: degraded service beats
         // failure. The cap is non-economic and composed after the economic
         // selector above; the admission band paces each chosen request below.
-        let mut candidates = skip_busy(closest_peers, self.inflight.as_deref());
-        // Bound the raced legs so the wider skip-busy pool only supplies
-        // free-slot alternatives and never amplifies metered bandwidth: the
-        // survivor list is proximity-ordered and skip-busy preserves order, so
-        // this keeps the closest free-slot peers (or, in the all-busy
-        // fall-through, the closest few, the prior bound).
-        candidates.truncate(RETRIEVE_MAX_ATTEMPTS);
-        let attempts = candidates.len();
+        let candidates = skip_busy(closest_peers, self.inflight.as_deref());
 
-        // Race the candidates with a staggered start, resolving on the first
-        // success, so a withholding head candidate is overtaken by the next one
-        // within the stagger instead of stalling this slot for a full
-        // per-attempt deadline and blocking every later chunk behind it. Each
-        // attempt carries its own pacing (the admission band and affordability
-        // check run inside `retrieve_chunk` before it dispatches), so the
-        // staggered starts preserve the per-peer pacing. The per-peer
-        // in-flight permit is reserved lazily as each leg starts and rides its
-        // request future, releasing the slot on drop including a cancelled
-        // losing leg.
-        match race_candidates(candidates, RETRIEVAL_STAGGER, |peer_overlay| {
-            let permit = self
-                .inflight
-                .as_ref()
-                .and_then(|limiter| limiter.try_acquire(&peer_overlay));
-            // `originated = true`: our own retrieval, so the client service
-            // debits the serving peer on delivery.
-            let request = self
-                .client_handle
-                .retrieve_chunk(peer_overlay, chunk_address, true);
-            async move {
-                let _permit = permit;
-                request.await
-            }
-        })
-        .await
-        {
+        // Walk the proximity-ordered free-slot pool, staggering one leg in at a
+        // time and refilling a failed leg with the next-closest peer. Retrieval
+        // is forwarding-Kademlia with no authoritative negative on the wire: a
+        // failed or slow leg means "this entry point could not serve it", never
+        // "the chunk is absent", so the walk keeps going to the next peer and
+        // only gives up on a real bound (the leg budget, the pool, or the
+        // deadline). Each leg meters one request and reserves the per-peer
+        // in-flight permit that rides its future, released on drop including a
+        // cancelled losing leg, so the walk stays a patient handful of in-flight
+        // legs rather than a wide paid fan-out.
+        let legs = AtomicUsize::new(0);
+        let outcome = race_walk(
+            candidates,
+            RETRIEVE_LEG_BUDGET,
+            RETRIEVE_WALK_DEADLINE,
+            RETRIEVAL_STAGGER,
+            |peer_overlay| {
+                legs.fetch_add(1, Ordering::Relaxed);
+                let permit = self
+                    .inflight
+                    .as_ref()
+                    .and_then(|limiter| limiter.try_acquire(&peer_overlay));
+                // `originated = true`: our own retrieval, so the client service
+                // debits the serving peer on delivery.
+                let request = self
+                    .client_handle
+                    .retrieve_chunk(peer_overlay, chunk_address, true);
+                async move {
+                    let _permit = permit;
+                    request.await
+                }
+            },
+        )
+        .await;
+
+        let legs = legs.load(Ordering::Relaxed);
+        histogram!("retrieval_walk_legs").record(legs as f64);
+        let outcome_label = match &outcome {
+            Ok(_) => "hit",
+            Err(RaceFailure::NoCandidates) => "no_peers",
+            Err(RaceFailure::AllFailed(_)) => "exhausted",
+            Err(RaceFailure::TimedOut) => "timed_out",
+        };
+        counter!("retrieval_walk_total", "outcome" => outcome_label).increment(1);
+
+        match outcome {
             Ok(result) => Ok(ChunkRetrievalResult {
                 chunk: result.chunk,
                 stamp: result.stamp,
@@ -175,9 +198,16 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
             )),
             Err(RaceFailure::AllFailed(e)) => Err(SwarmError::AllPeersFailed {
                 address: *address,
-                attempts,
+                attempts: legs,
                 source: Box::new(e),
             }),
+            // The walk ran out of wall-clock time with legs still slow rather
+            // than failed: a transient condition, surfaced like a no-peers miss
+            // so the consumer re-streams the address rather than treating it as a
+            // hard not-found.
+            Err(RaceFailure::TimedOut) => Err(SwarmError::network_msg(
+                "retrieval walk deadline elapsed before any peer served the chunk",
+            )),
         }
     }
 
@@ -557,7 +587,9 @@ mod tests {
         use nectar_primitives::ContentChunk;
         use tokio::sync::mpsc;
 
-        use super::super::{RETRIEVAL_STAGGER, RaceFailure, race_candidates};
+        use crate::race_candidates;
+
+        use super::super::{RETRIEVAL_STAGGER, RaceFailure};
         use super::*;
 
         fn test_chunk() -> nectar_primitives::AnyChunk {
@@ -679,14 +711,19 @@ mod tests {
         use std::time::{Duration, Instant};
 
         use nectar_primitives::ContentChunk;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
         use tokio::sync::mpsc;
 
         use crate::{
             ChunkTransferError, ClientCommand, ClientHandle, PeerInflightLimiter, RetrievalResult,
         };
 
+        use crate::race_candidates;
+
         use super::super::{
-            RETRIEVAL_STAGGER, RETRIEVE_MAX_ATTEMPTS, RaceFailure, race_candidates, skip_busy,
+            RETRIEVAL_STAGGER, RETRIEVE_LEG_BUDGET, RETRIEVE_WALK_DEADLINE, RaceFailure, race_walk,
+            skip_busy,
         };
         use super::*;
 
@@ -760,23 +797,45 @@ mod tests {
             );
         }
 
-        #[test]
-        fn skip_busy_pool_is_truncated_to_the_attempts_bound() {
-            // A wide pool of free-slot peers must not race every leg: the
-            // production path truncates the skip-busy survivors to the attempts
-            // bound, so the wider pool only supplies free-slot alternatives
-            // without amplifying metered bandwidth.
-            let limiter = PeerInflightLimiter::new(CAP_ONE);
-            let pool: Vec<SwarmAddress> = (1..=8).map(overlay).collect();
+        #[tokio::test]
+        async fn walk_budget_caps_metered_legs_below_the_free_slot_pool() {
+            // A wide pool of free-slot peers must not meter a leg each: the walk
+            // dispatches at most the leg budget, refilling a failed leg from the
+            // next-closest peer, so the wider pool supplies coverage alternatives
+            // without amplifying paid bandwidth.
+            let (tx, rx) = mpsc::channel::<ClientCommand>(64);
+            drop(rx); // every retrieval fails at once: the walk spends its budget.
+            let handle = ClientHandle::new(tx);
+            let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
 
-            let mut candidates = skip_busy(pool, Some(&limiter));
-            candidates.truncate(RETRIEVE_MAX_ATTEMPTS);
+            let pool: Vec<SwarmAddress> = (1..=16).map(overlay).collect();
+            let candidates = skip_busy(pool, Some(&limiter));
+            assert_eq!(candidates.len(), 16, "all 16 peers have a free slot");
 
-            assert_eq!(candidates.len(), RETRIEVE_MAX_ATTEMPTS);
-            assert_eq!(
+            let legs = Arc::new(AtomicUsize::new(0));
+            let counted = Arc::clone(&legs);
+            let outcome = race_walk(
                 candidates,
-                vec![overlay(1), overlay(2), overlay(3)],
-                "the closest attempts-bound free-slot peers are kept in order"
+                RETRIEVE_LEG_BUDGET,
+                RETRIEVE_WALK_DEADLINE,
+                RETRIEVAL_STAGGER,
+                move |peer| {
+                    counted.fetch_add(1, Ordering::SeqCst);
+                    let permit = limiter.try_acquire(&peer);
+                    let handle = handle.clone();
+                    async move {
+                        let _permit = permit;
+                        handle.retrieve_chunk(peer, address(0xaa), true).await
+                    }
+                },
+            )
+            .await;
+
+            assert!(matches!(outcome, Err(RaceFailure::AllFailed(_))));
+            assert_eq!(
+                legs.load(Ordering::SeqCst),
+                RETRIEVE_LEG_BUDGET,
+                "the walk meters at most the leg budget across the wider free-slot pool"
             );
         }
 

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -54,7 +54,7 @@ pub use protocol::{
 
 pub use inflight::{DEFAULT_PEER_INFLIGHT_CAP, PeerInflightLimiter};
 pub use selection::{AccountingSettlement, PeerScores, PeerSelector, SettlementTrigger};
-pub use staggered_race::{RETRIEVAL_STAGGER, RaceFailure, race_candidates};
+pub use staggered_race::{RETRIEVAL_STAGGER, RaceFailure, race_candidates, race_walk};
 
 pub use bootnodes::BootnodeProvider;
 pub use chunks::{ChunkVerifyConfig, NetworkChunkProvider, VerifyingChunkProvider};

--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -56,6 +56,10 @@ pub enum RaceFailure<E> {
     NoCandidates,
     /// Every candidate was attempted and failed; carries the last failure.
     AllFailed(E),
+    /// The walk's wall-clock deadline elapsed before any candidate succeeded.
+    /// Distinct from [`AllFailed`](Self::AllFailed) because the walk may still
+    /// have had legs in flight or untried candidates when the clock ran out.
+    TimedOut,
 }
 
 /// Race `candidates` for the first success, dispatching each through `attempt`
@@ -109,6 +113,91 @@ where
                     in_flight.push(attempt(candidate));
                     stagger_tick = Delay::new(stagger).fuse();
                 }
+            }
+        }
+    }
+}
+
+/// Like [`race_candidates`], but bounded to at most `budget` dispatched legs and
+/// an overall wall-clock `deadline`.
+///
+/// This is the difficult-chunk retrieval walk. Retrieval is forwarding-Kademlia
+/// with no authoritative negative response: a leg that errors or times out means
+/// "this entry point could not serve it", never "the chunk is absent". So the
+/// walk keeps trying the next candidate on every failure and only gives up on a
+/// real bound: `budget` legs dispatched, the candidate source exhausted, or the
+/// `deadline`. The caller filters back-pressured peers out of `candidates`
+/// beforehand (skip-busy), so a busy peer is never dispatched and never spends a
+/// budget unit; `budget` therefore counts only genuine coverage attempts.
+///
+/// Each leg is still staggered and losers are dropped on resolve, so true
+/// concurrency stays a handful regardless of `budget`: this is a patient walk,
+/// not a wide simultaneous fan-out.
+pub async fn race_walk<C, T, E, I, F, Fut>(
+    candidates: I,
+    budget: usize,
+    deadline: Duration,
+    stagger: Duration,
+    mut attempt: F,
+) -> Result<T, RaceFailure<E>>
+where
+    I: IntoIterator<Item = C>,
+    F: FnMut(C) -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let mut candidates = candidates.into_iter();
+    let mut in_flight = FuturesUnordered::new();
+    let mut dispatched = 0usize;
+    let mut last_error: Option<E> = None;
+
+    // Dispatch the next candidate while the leg budget allows. Returns whether a
+    // leg was pushed (false once the budget is spent or the source is drained).
+    let mut dispatch_next = |in_flight: &mut FuturesUnordered<Fut>, dispatched: &mut usize| {
+        if *dispatched >= budget {
+            return false;
+        }
+        match candidates.next() {
+            Some(candidate) => {
+                in_flight.push(attempt(candidate));
+                *dispatched += 1;
+                true
+            }
+            None => false,
+        }
+    };
+
+    if !dispatch_next(&mut in_flight, &mut dispatched) {
+        return Err(RaceFailure::NoCandidates);
+    }
+
+    let mut stagger_tick = Delay::new(stagger).fuse();
+    let mut deadline_tick = Delay::new(deadline).fuse();
+
+    loop {
+        futures::select! {
+            result = in_flight.select_next_some() => match result {
+                Ok(value) => return Ok(value),
+                Err(error) => {
+                    // A failed leg frees its slot: dispatch the next candidate at
+                    // once. When the budget and the source are both spent and no
+                    // leg is in flight, this failure is the walk's last word.
+                    if !dispatch_next(&mut in_flight, &mut dispatched) && in_flight.is_empty() {
+                        return Err(RaceFailure::AllFailed(error));
+                    }
+                    last_error = Some(error);
+                }
+            },
+            _ = stagger_tick => {
+                dispatch_next(&mut in_flight, &mut dispatched);
+                stagger_tick = Delay::new(stagger).fuse();
+            },
+            _ = deadline_tick => {
+                // Out of wall-clock time. Surface the last real failure if one
+                // landed, else the legs were merely slow: a distinct TimedOut.
+                return match last_error.take() {
+                    Some(error) => Err(RaceFailure::AllFailed(error)),
+                    None => Err(RaceFailure::TimedOut),
+                };
             }
         }
     }
@@ -289,5 +378,118 @@ mod tests {
             Err(RaceFailure::AllFailed(last)) => assert_eq!(last, "last"),
             _ => panic!("expected AllFailed with the last error"),
         }
+    }
+
+    /// The walk reaches a chunk whose closest few entry points miss: the legs
+    /// before the holder fail, and the walk refills to the next-closest until the
+    /// holder serves it, well within the budget.
+    #[tokio::test]
+    async fn walk_reaches_a_holder_past_missing_close_peers() {
+        // Candidates 0..10 in proximity order; the first four miss, the fifth
+        // serves. A bound of 3 would have failed here.
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let counted = attempts.clone();
+        let outcome = race_walk(
+            0..10u32,
+            8,
+            Duration::from_secs(30),
+            RETRIEVAL_STAGGER,
+            |i| {
+                counted.fetch_add(1, Ordering::SeqCst);
+                async move { if i < 4 { Err("miss") } else { Ok(i) } }
+            },
+        )
+        .await;
+
+        assert_eq!(
+            outcome.ok(),
+            Some(4),
+            "the fifth candidate serves the chunk"
+        );
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            5,
+            "exactly the five legs up to and including the holder were dispatched"
+        );
+    }
+
+    /// An all-miss walk gives up after exactly `budget` legs, never the whole
+    /// pool: the bound caps paid coverage attempts even when far more candidates
+    /// are available.
+    #[tokio::test]
+    async fn walk_spends_exactly_the_budget_then_fails() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let counted = attempts.clone();
+        let outcome = race_walk(
+            0..100u32,
+            6,
+            Duration::from_secs(30),
+            RETRIEVAL_STAGGER,
+            |_| {
+                counted.fetch_add(1, Ordering::SeqCst);
+                async move { Err::<u32, _>("miss") }
+            },
+        )
+        .await;
+
+        assert!(matches!(outcome, Err(RaceFailure::AllFailed("miss"))));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            6,
+            "the budget caps dispatched legs at 6 of the 100 available"
+        );
+    }
+
+    /// A walk whose legs all merely withhold (never an explicit failure) is
+    /// bounded by the wall clock, surfacing TimedOut rather than hanging.
+    #[tokio::test]
+    async fn walk_deadline_bounds_withholding_legs() {
+        let start = Instant::now();
+        // Every leg withholds for far longer than the deadline; none ever errors.
+        let outcome = race_walk(
+            0..8u32,
+            8,
+            Duration::from_millis(300),
+            Duration::from_millis(50),
+            |_| async {
+                Delay::new(Duration::from_secs(30)).await;
+                Ok::<u32, &str>(0)
+            },
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(outcome, Err(RaceFailure::TimedOut)),
+            "withholding legs surface TimedOut"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "the deadline bounded the walk ({elapsed:?})"
+        );
+    }
+
+    /// An empty pool and a zero budget both attempt nothing.
+    #[tokio::test]
+    async fn walk_with_nothing_to_try_yields_no_candidates() {
+        let empty = race_walk(
+            Vec::<u32>::new(),
+            8,
+            Duration::from_secs(1),
+            RETRIEVAL_STAGGER,
+            |_| async { Ok::<u32, &str>(0) },
+        )
+        .await;
+        assert!(matches!(empty, Err(RaceFailure::NoCandidates)));
+
+        let zero_budget = race_walk(
+            0..4u32,
+            0,
+            Duration::from_secs(1),
+            RETRIEVAL_STAGGER,
+            |_| async { Ok::<u32, &str>(0) },
+        )
+        .await;
+        assert!(matches!(zero_budget, Err(RaceFailure::NoCandidates)));
     }
 }


### PR DESCRIPTION
## What

Replaces the fixed three-leg retrieval race in `NetworkChunkProvider::retrieve_chunk` with a bounded-refill proximity walk, so a chunk whose closest few connected peers miss is no longer spuriously failed when a farther peer's forwarding chain could still serve it.

- New `race_walk` in `staggered_race.rs`: like `race_candidates`, but bounded to at most `budget` dispatched legs and an overall wall-clock `deadline`. It staggers one leg in at a time and refills a failed leg with the next candidate, dropping losers on resolve. A new `RaceFailure::TimedOut` distinguishes "the clock ran out with legs still slow" from "every leg failed".
- `retrieve_chunk` now widens the connected pool, applies the existing skip-busy filter, and drives `race_walk` over the survivors.
- A `retrieval_walk_legs` histogram and a `retrieval_walk_total{outcome}` counter make the legs-per-retrieval distribution and the residual sparse tail observable.

## Why

Retrieval is forwarding-Kademlia: each connected peer the client races is an independent forwarding chain, and a chunk in a sparse proximity bin is reachable through a farther chain even when the closest few miss. The reference node walks a skiplist of up to 32 next-closest peers within a 30s deadline; vertex raced only 3 then surfaced `AllPeersFailed`, roughly a tenth of that reach, so the genuinely-sparse tail failed spuriously and killed whole downloads. There is no authoritative negative on the Swarm wire (a peer that lacks a chunk times out or errors, never asserts absence), so the terminal condition must be a real bound, never a single negative.

This is a prerequisite for raising download concurrency: higher concurrency drives more per-peer back-pressure and more transient misses, which is exactly what slams the three-leg wall today.

Closes #345.

## Design notes for review

The choices the independent review should scrutinise:

- **Real-leg vs busy-bounce.** A peer at its in-flight cap must NOT spend a budget unit (else a busy window falsely declares a present chunk absent). This is realised by filtering busy peers out at selection (`skip_busy`) so they never enter the walk; `budget` is spent only on dispatched (real) legs over free-slot survivors. Deliberate simplification vs the prototype's per-leg `Busy` accounting: a peer that becomes busy mid-walk is still attempted best-effort (the permit rides the future if available), as on the prior path. Re-acquiring per leg to free-skip a peer that turned busy mid-walk is a possible follow-up; flagged for review.
- **No cap bypass.** `skip_busy` keeps its existing all-busy fall-through (attempt the closest few rather than fail), and each leg still reserves the per-peer in-flight permit that rides and releases on drop. The walk never dispatches a wide simultaneous fan-out: the 500ms stagger plus drop-on-resolve keep true concurrency to a handful regardless of budget. This is the explicit `#519`/`#520`/`#544` lesson and the reason the closed wide-race PR was rejected.
- **Constants (conservative, calibrated by the new metric):** `RETRIEVE_WALK_WIDTH = 32` (connected pool, never dials), `RETRIEVE_LEG_BUDGET = 8` (real legs; reference ceiling is 32, starts low), `RETRIEVE_WALK_DEADLINE = 30s` (matches the per-request retrieval lifetime).
- **TimedOut handling:** surfaced as a transient network error (like a no-peers miss) so the consumer re-streams the address rather than treating it as a hard not-found.
- **Timer:** `futures_timer::Delay`, the wasm-safe timer already used by `race_candidates` in this module; confirmed by the wasm32 build.

## Testing

`cargo build`, `cargo nextest run -p vertex-swarm-node --all-features` (141 tests pass), `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`, and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` all clean.

New tests: the walk reaches a holder past missing close peers; spends exactly the budget then fails; the deadline bounds withholding legs (TimedOut); empty/zero-budget yield NoCandidates; and a provider-level test that the budget caps metered legs below a wider free-slot pool. Existing staggered-race and skip-busy tests are unchanged and pass.

Not browser- or live-network verified; the metric is intended to confirm the residual tail and calibrate the budget on a real download.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the reference/bee + prototype investigation that scoped this, the implementation, the tests, and the local verification.