### PR TITLE
fix(swarm-node): raise the retrieval stagger above the mainnet round trip

### DIFF
--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -47,7 +47,22 @@ use futures_timer::Delay;
 /// remote answers is paid for in accounting units, so further candidates only
 /// start while no response has arrived. A failed attempt starts the next
 /// candidate immediately instead of waiting out the stagger.
-pub const RETRIEVAL_STAGGER: Duration = Duration::from_millis(500);
+///
+/// The value sits comfortably above a typical live-network retrieval round
+/// trip, which spans several forwarding hops and runs in the hundreds of
+/// milliseconds. A stagger below that round trip dispatches the second
+/// candidate before the first leg has had a chance to answer, so both entry
+/// points forward and deliver the same chunk and both legs are metered: a near
+/// twofold over-fetch on the bulk path. Pacing the second leg past the round
+/// trip keeps the race single-leg whenever the head is merely in flight, and
+/// reserves the fan-out for a head that is genuinely slow or withholding. The
+/// failover cost is that a withholding head is now overtaken after this stagger
+/// rather than within a few hundred milliseconds; that is acceptable because the
+/// stagger stays far below the per-request `retrieval_timeout`, the failed-leg
+/// path still starts the next candidate immediately on an explicit error, and
+/// the difficult-chunk walk's wall-clock deadline still admits its full leg
+/// budget at this pace.
+pub const RETRIEVAL_STAGGER: Duration = Duration::from_millis(1200);
 
 /// Outcome of a candidate race that produced no success.
 #[derive(Debug)]


### PR DESCRIPTION
## What

Raise `RETRIEVAL_STAGGER` (the staggered retrieval race's inter-candidate delay) from 500ms to 1200ms, comfortably above a typical mainnet retrieval round trip.

## Why

Closes #578.

Chunk retrieval races interchangeable candidates: the closest entry point is queried immediately, and the next joins the race after `RETRIEVAL_STAGGER` if the first has not answered. Live-network retrieval round trips span several forwarding hops and commonly run in the 400-800ms range, so at a 500ms stagger the second leg fired before the first answered for a large share of chunks. Both entry points then forwarded and delivered the same chunk, and both legs were metered (the retrieval debit is booked at dispatch), giving a near twofold over-fetch on the bulk download path: double the bandwidth and double the pseudosettle-forgiveness cost per useful chunk, roughly halving effective goodput.

Pacing the second leg past the round trip keeps the race single-leg whenever the head is merely in flight, and reserves the fan-out for a head that is genuinely slow or withholding.

## Tradeoff (this is a proposed value, tune or reject)

The const is consumed by both the simple `race_candidates` retrieve path and the bounded-refill `race_walk` difficult-chunk walk, so raising it slows two things:

- Withholding-head failover: a withholding head is overtaken after the stagger (~1200ms) rather than within a few hundred ms. This stays far below the per-request `retrieval_timeout` (30s), and the failed-leg path still starts the next candidate immediately on an explicit error (only a silent withhold waits out the stagger).
- Difficult-chunk walk leg pacing: the walk's 30s wall-clock deadline still admits its full 8-leg budget at 1200ms pacing (8 legs dispatch by ~8.4s), so hard-chunk rescue is unchanged in reach, just paced more patiently.

The exact knee is worth tuning; the maintainer may prefer a different value.

## Benchmark (mainnet)

Same dipper download stack against the same target reference, one node binary at 500ms (baseline) and one at 1200ms. Dup factor and throughput are reconstructed from the node's timestamped per-delivery log (`Received chunk`), since the joiner buffers out-of-order chunks in memory and writes the output file only as the in-order prefix advances (on-disk slope understates rate). A chunk is 4096 wire bytes.

Mainnet, target `0x00850a14...e8a0bf`, identical dipper stack, ~360s window each (steady window [20,~350]s). Chunk = 4096 wire bytes. Goodput counts distinct chunk addresses; wire throughput counts every delivery.

| metric | 500ms (baseline) | 1200ms (this PR) |
|---|---|---|
| dup factor (deliveries / distinct addr) | 2.082 | 1.012 |
| duplicated addresses | 3256 of 3266 | 38 of 3334 |
| ... by distinct delivering peers | 3256 (99.7%) | 37 |
| ... same-peer repeats | 0 | 1 |
| useful goodput (distinct chunks) | 0.0356 MB/s | 0.0363 MB/s |
| wire throughput (all deliveries) | 0.0741 MB/s | 0.0368 MB/s |
| pseudosettle forgiveness | 7.11M AU/s | 2.97M AU/s |
| distinct delivering peers | 148 | 143 |
| node `Retrieval failed` legs | 389 | 6 |

The ~2x over-fetch is confirmed and isolated: at 500ms, 99.7% of duplicated addresses were delivered by two *distinct* peers with zero same-peer repeats, the signature of the second race leg firing before the first answered. Raising the stagger drops the dup factor to ~1.0.

The decisive finding is that **useful goodput is unchanged** (0.0356 vs 0.0363 MB/s) while wire bandwidth and pseudosettle forgiveness both roughly halve. The over-fetch was buying nothing: it delivered the same useful chunks per second at double the metered cost. The fix keeps the goodput and discards the waste.

Honest caveat on absolute numbers: this harness used dipper over crates.io `nectar` 0.3.0, not the joiner-concurrency frontload branch, so absolute goodput (~0.036 MB/s) is bottlenecked on joiner concurrency and is far below the ~0.12 MB/s @N=32 figure from earlier high-concurrency runs. The stagger is orthogonal to that bottleneck, which is why useful goodput is flat across the two runs here rather than rising. The win this benchmark proves is cost: half the wire traffic and half the forgiveness for the same delivered file. On a path where bandwidth or forgiveness is the binding constraint (the real concern under sustained mainnet load with the dispatch-time debit), removing that 2x waste is what converts into higher sustained goodput; this low-concurrency harness simply was not bandwidth-bound, so it shows the saving as cost rather than speed.

## Testing

- `cargo test -p vertex-swarm-node --all-features` (staggered_race + provider race tests pass; the timing-bound tests assert `<2s` / `<5s` windows that the 1200ms stagger sits inside, so no test-side timing edits were needed)
- `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings`
- `cargo build --release -p vertex` and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`

## AI Assistance

Claude Code (Opus 4.8) used for the diagnosis, the one-line change plus rustdoc, the benchmark harness, and drafting this PR.
