### PR TITLE
perf(swarm-node): batch-drain the central command poll and snapshot closest_to

### DIFF
--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -289,9 +289,22 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
 
                 Some(command) = self.client_command_rx.recv() => {
                     self.handle_client_command(command);
+                    // Admit a bounded burst of already-queued commands in this
+                    // wake, preserving FIFO order, then yield to the swarm poll.
+                    let mut drained = 0;
+                    while drained < super::CHANNEL_DRAIN_BUDGET {
+                        match self.client_command_rx.try_recv() {
+                            Ok(command) => {
+                                self.handle_client_command(command);
+                                drained += 1;
+                            }
+                            Err(_) => break,
+                        }
+                    }
                 }
 
                 result = topo_events.recv() => {
+                    let mut closed = false;
                     match result {
                         Ok(event) => self.handle_topology_service_event(event),
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
@@ -299,8 +312,34 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                             info!("Topology event channel closed, shutting down client node");
-                            break;
+                            closed = true;
                         }
+                    }
+                    if !closed {
+                        let mut drained = 0;
+                        while drained < super::CHANNEL_DRAIN_BUDGET {
+                            match topo_events.try_recv() {
+                                Ok(event) => {
+                                    self.handle_topology_service_event(event);
+                                    drained += 1;
+                                }
+                                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(skipped)) => {
+                                    warn!(skipped, "Client node lagged behind topology events");
+                                    drained += 1;
+                                }
+                                Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
+                                Err(tokio::sync::broadcast::error::TryRecvError::Closed) => {
+                                    info!(
+                                        "Topology event channel closed, shutting down client node"
+                                    );
+                                    closed = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if closed {
+                        break;
                     }
                 }
             }

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -48,3 +48,12 @@ pub use launch::LauncherSwapConfig;
 pub use launch::{ClientLauncher, LaunchedClient};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storer"))]
 pub use storer::{StorerNode, StorerNodeBuilder, StorerPullsyncControl};
+
+/// Upper bound on queued items drained from a single channel per central-loop
+/// wake, after the first item the `select!` already delivered. Bounding the
+/// burst keeps the swarm poll from being starved: once the budget is spent the
+/// loop returns to `select!`, which polls the swarm again before the next drain.
+/// A bulk download fans many retrieval legs, settles, and acks into the command
+/// channel at once, so admitting a burst per wake (rather than one per full
+/// select pass) keeps the single central task from serialising on wake latency.
+pub(crate) const CHANNEL_DRAIN_BUDGET: usize = 32;

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -358,13 +358,36 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
 
                 Some(command) = self.client_command_rx.recv() => {
                     self.handle_client_command(command);
+                    // Admit a bounded burst of already-queued commands in this
+                    // wake, preserving FIFO order, then yield to the swarm poll.
+                    let mut drained = 0;
+                    while drained < super::CHANNEL_DRAIN_BUDGET {
+                        match self.client_command_rx.try_recv() {
+                            Ok(command) => {
+                                self.handle_client_command(command);
+                                drained += 1;
+                            }
+                            Err(_) => break,
+                        }
+                    }
                 }
 
                 Some(command) = self.pullsync_command_rx.recv() => {
                     self.handle_pullsync_command(command);
+                    let mut drained = 0;
+                    while drained < super::CHANNEL_DRAIN_BUDGET {
+                        match self.pullsync_command_rx.try_recv() {
+                            Ok(command) => {
+                                self.handle_pullsync_command(command);
+                                drained += 1;
+                            }
+                            Err(_) => break,
+                        }
+                    }
                 }
 
                 result = topo_events.recv() => {
+                    let mut closed = false;
                     match result {
                         Ok(event) => self.handle_topology_service_event(event),
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
@@ -372,8 +395,34 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                             info!("Topology event channel closed, shutting down storer node");
-                            break;
+                            closed = true;
                         }
+                    }
+                    if !closed {
+                        let mut drained = 0;
+                        while drained < super::CHANNEL_DRAIN_BUDGET {
+                            match topo_events.try_recv() {
+                                Ok(event) => {
+                                    self.handle_topology_service_event(event);
+                                    drained += 1;
+                                }
+                                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(skipped)) => {
+                                    warn!(skipped, "Storer node lagged behind topology events");
+                                    drained += 1;
+                                }
+                                Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
+                                Err(tokio::sync::broadcast::error::TryRecvError::Closed) => {
+                                    info!(
+                                        "Topology event channel closed, shutting down storer node"
+                                    );
+                                    closed = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if closed {
+                        break;
                     }
                 }
             }

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -689,12 +689,16 @@ impl<I: SwarmIdentity> KademliaRouting<I> {
     }
 
     /// Top `count` connected peers closest to `address` by proximity.
+    ///
+    /// Reads the generation-cached membership snapshot (one `Arc` clone on the
+    /// hot path, no per-bin relock and no fresh membership `Vec`), then scores
+    /// each peer against `address` and partitions the top-k. The snapshot's bin
+    /// order matches a full membership walk, so the selection is unchanged.
     pub(crate) fn closest_to(&self, address: &ChunkAddress, count: usize) -> Vec<OverlayAddress> {
         let mut peers_with_distance: Vec<_> = self
             .connected_peers
-            .all_peers()
-            .into_iter()
-            .map(|peer| {
+            .iter_by_proximity()
+            .map(|(_, peer)| {
                 let proximity = address.proximity(&peer);
                 (peer, proximity)
             })


### PR DESCRIPTION
Closes #584

## What

Two node-side, no-wire, behaviour-preserving changes to raise the single-node download ceiling, which a capacity sweep pinned at roughly 89 useful chunks/s (0.35 MB/s) bound by the single-threaded central Swarm-task poll at about 82% of one core.

1. Batch-drain the central command poll. The central `tokio::select!` loop in the client and storer event loops serviced exactly one queued command per loop iteration, interleaved with the swarm poll, so the bounded command channel drained one item per full select pass. After the `select!` delivers the first command, admit a bounded burst (budget 32) of already-queued items via `try_recv`, preserving FIFO order, then fall back to `select!` once the budget is spent. The same bounded drain is applied to the client and pullsync command channels and the topology-event broadcast in both node loops.

2. `closest_to` reads the cached snapshot. The Kademlia `closest_to` walked every routing bin under a read lock and allocated a fresh membership `Vec` per chunk. It now reads the generation-cached membership snapshot (one `Arc` clone on the hot path, no per-bin relock, no fresh `Vec`) and scores and partitions the top-k from it. The snapshot bin order matches a full membership walk, so the selection is identical.

## Why

The wall after client-side concurrency landed is node-side: the central single-threaded poll serialises command admission. Bounding the per-wake drain keeps the swarm-poll progress guarantee (after the budget the loop returns to `select!`, which polls the swarm before the next drain) while admitting a burst of legs, settles and acks in one wake instead of one per iteration. See #584.

## Testing

- `cargo test -p vertex-swarm-node -p vertex-swarm-topology --all-features` (all pass)
- `cargo clippy -p vertex-swarm-node -p vertex-swarm-topology --all-targets --all-features -- -D warnings` (clean)
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (clean)
- `cargo fmt --all`
- Live mainnet single-node download benchmark at download concurrency 128 and 256, before/after, measuring useful chunks/s off the node delivery log and node CPU.

## AI Assistance

AI Assistance: Claude Code used for implementation and benchmarking.