### PR TITLE
perf(swarm-node): spill a gated retrieval close set to headroom peers

### DIFF
--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -76,6 +76,20 @@ const RETRIEVE_WALK_DEADLINE: Duration = Duration::from_secs(30);
 /// settlement RTT and returns at once when no settle is in flight to drain debt.
 const GATE_SETTLE_BUDGET: Duration = Duration::from_secs(30);
 
+/// Wider topology slice the retrieval fallback spills to when the close set is
+/// fully gated.
+///
+/// The closest peers to a chunk carry a download's debt and gate first; a far
+/// larger set of slightly-farther peers still holds forgiveness headroom and
+/// forwards the chunk just the same. Routing a gated chunk there keeps the
+/// pipeline slot moving instead of parking it while the close set's debt drains.
+const RETRIEVE_SPILL_WIDTH: usize = 128;
+
+/// Bound on the settle-and-await once even the wider spill slice is fully gated.
+/// Short because, by then, every nearby peer is at its line and waiting buys
+/// little; failing fast to the consumer to re-stream beats holding the slot.
+const GATE_SPILL_SETTLE_BUDGET: Duration = Duration::from_secs(5);
+
 /// Legs the bin-bucket primary route dispatches before handing off to the
 /// staggered fallback.
 ///
@@ -182,6 +196,40 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
             }
             None => candidates,
         }
+    }
+
+    /// Order the close set, spilling to a wider in-headroom slice before blocking
+    /// on a settle drain.
+    ///
+    /// A non-empty band over the close set returns at once (the fast path). When
+    /// every close peer is refused, the closest few have spent their forgiveness
+    /// on this download while a far larger ring of slightly-farther peers still
+    /// carries headroom; banding [`RETRIEVE_SPILL_WIDTH`] peers and routing the
+    /// chunk to an admissible one there forwards it just the same, at one extra
+    /// hop, without parking the pipeline slot for the seconds a close-set debt
+    /// takes to drain. Only when even the wider slice is fully gated does it fall
+    /// back to a bounded [`GATE_SPILL_SETTLE_BUDGET`] settle wait. Disconnect-safe:
+    /// the band still hard-skips every refused peer, so no peer is sent a request
+    /// past its line. With no selector the proximity order is returned unchanged.
+    async fn select_or_spill(
+        &self,
+        candidates: Vec<SwarmAddress>,
+        chunk: &ChunkAddress,
+    ) -> Vec<SwarmAddress> {
+        let Some(selector) = &self.selector else {
+            return candidates;
+        };
+        let ordered = selector.order(candidates, chunk);
+        if !ordered.is_empty() {
+            return ordered;
+        }
+        let wide = self.topology.closest_to(chunk, RETRIEVE_SPILL_WIDTH);
+        let spilled = selector.order(wide.clone(), chunk);
+        if !spilled.is_empty() {
+            return spilled;
+        }
+        let deadline = Instant::now() + GATE_SPILL_SETTLE_BUDGET;
+        selector.order_or_wait(wide, chunk, deadline).await
     }
 
     /// Order `candidates` through the accounting band without awaiting a settle.
@@ -320,11 +368,12 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         let closest_peers = self
             .topology
             .closest_to(&chunk_address, RETRIEVE_WALK_WIDTH);
-        // Settle-and-await when every close peer is gated, so a fully gated set
-        // recovers instead of failing; if still gated at the budget the empty
-        // result falls through to the no-connected-peers path below, the same
-        // generic transient error a no-peers failure yields.
-        let closest_peers = self.select_or_wait(closest_peers, &chunk_address).await;
+        // Spill to a wider in-headroom slice when every close peer is gated, so a
+        // fully gated close set routes around its spent peers rather than blocking;
+        // if even the wide slice is gated at the short budget the empty result
+        // falls through to the no-connected-peers path below, the same generic
+        // transient error a no-peers failure yields.
+        let closest_peers = self.select_or_spill(closest_peers, &chunk_address).await;
         let (candidates, enforce_cap) = skip_busy(closest_peers, self.inflight.as_deref());
 
         // Pace the staggered fan-out to the live round trip rather than a fixed

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -1,20 +1,30 @@
 //! Score- and credit-aware peer selection for retrieval and pushsync.
 //!
 //! Topology returns candidate storers in proximity order. [`PeerSelector`]
-//! reorders them with two additional signals before a request goes out:
+//! reorders them with three additional signals before a request goes out:
 //!
 //! - A peer the admission band refuses (the per-chunk debit would cross its
 //!   disconnect line) is hard-skipped, so the request routes to the next-closest
 //!   affordable peer while a background settle drains the skipped one.
 //! - Peers whose score is in the warned range are excluded among the admissible,
 //!   so a peer that is being scored down is not asked again while it misbehaves.
+//! - The admissible peers split into two affordability tiers: those with full
+//!   forgiveness headroom (the band still [`Admit`]s) lead those already past the
+//!   settle trigger (the band [`SettleAndAdmit`]s). A bulk download therefore
+//!   spreads its debt across the closest headroom peers before it leans on a
+//!   near-threshold one, so no single close peer's free allowance saturates while
+//!   the aggregate forgiveness across the neighbourhood stays untapped.
 //!
-//! Proximity stays the primary key. If every admissible candidate is warned, the
-//! warned peers are returned in proximity order so a degraded request can still
-//! go out; a refused peer is never resurrected this way. Every candidate not
-//! plainly admitted is settled (a peer in the tolerance band to stay there, a
-//! refused peer to drain back under its line); the settlement providers
-//! themselves decide whether any payment is actually due.
+//! Proximity is the secondary key within each tier; the headroom split orders the
+//! admissible above it. If every admissible candidate is warned, the warned peers
+//! are returned in proximity order so a degraded request can still go out; a
+//! refused peer is never resurrected this way. Every candidate not plainly
+//! admitted is settled (a peer in the tolerance band to stay there, a refused
+//! peer to drain back under its line); the settlement providers themselves decide
+//! whether any payment is actually due.
+//!
+//! [`Admit`]: Admission::Admit
+//! [`SettleAndAdmit`]: Admission::SettleAndAdmit
 //!
 //! The price consulted per candidate is [`SwarmPricing::peer_price`], the same
 //! per-peer chunk price the accounting layer debits when the request is
@@ -223,9 +233,11 @@ impl PeerSelector {
     ///
     /// Applies the ranking described at the module level: a [`Refuse`] candidate
     /// is hard-skipped (sending would cross its disconnect line), warned peers are
-    /// excluded, and the rest keep proximity order. Every candidate not plainly
-    /// [`Admit`]ted is settled (a [`SettleAndAdmit`] peer to stay in the band, a
-    /// refused peer to drain back under its line), so its view of our debt drops.
+    /// excluded, and the admissible rest are tiered headroom-first (an [`Admit`]
+    /// peer leads a [`SettleAndAdmit`] one) with proximity the key within a tier.
+    /// Every candidate not plainly [`Admit`]ted is settled (a [`SettleAndAdmit`]
+    /// peer to stay in the band, a refused peer to drain back under its line), so
+    /// its view of our debt drops.
     /// A single pass triggers each peer at most once; the in-flight set dedups
     /// across repeated calls.
     ///
@@ -315,16 +327,22 @@ struct RankedCandidates {
 /// A [`Refuse`](Admission::Refuse) candidate is hard-skipped:
 /// sending would cross its disconnect line, so it never appears in `ordered`.
 /// Warned peers (score at or below [`DEFAULT_PEER_WARN_THRESHOLD`]) are excluded
-/// among the admissible. If every admissible candidate is warned, those warned
-/// peers are returned in proximity order so a degraded request can still go out;
-/// a refused peer is never resurrected this way. `admit` is invoked exactly once
-/// per candidate and the bands are returned for reuse.
+/// among the admissible. The admissible rest tier headroom-first: an
+/// [`Admit`](Admission::Admit) peer (debt below the settle trigger, full
+/// forgiveness headroom) leads a [`SettleAndAdmit`](Admission::SettleAndAdmit)
+/// peer (debt past the trigger), so debt spreads across the closest headroom
+/// peers before a near-threshold one is asked, and proximity stays the key within
+/// each tier. If every admissible candidate is warned, those warned peers are
+/// returned in proximity order so a degraded request can still go out; a refused
+/// peer is never resurrected this way. `admit` is invoked exactly once per
+/// candidate and the bands are returned for reuse.
 fn rank_candidates(
     candidates: &[OverlayAddress],
     score: impl Fn(&OverlayAddress) -> Option<f64>,
     admit: impl Fn(&OverlayAddress) -> Admission,
 ) -> RankedCandidates {
-    let mut ordered = Vec::with_capacity(candidates.len());
+    let mut headroom = Vec::with_capacity(candidates.len());
+    let mut near_threshold = Vec::new();
     let mut warned = Vec::new();
     let mut bands = Vec::with_capacity(candidates.len());
 
@@ -336,10 +354,16 @@ fn rank_candidates(
         }
         if score(peer).is_some_and(|s| s <= DEFAULT_PEER_WARN_THRESHOLD) {
             warned.push(*peer);
-            continue;
+        } else if matches!(band, Admission::SettleAndAdmit) {
+            near_threshold.push(*peer);
+        } else {
+            headroom.push(*peer);
         }
-        ordered.push(*peer);
     }
+
+    // Headroom peers first, near-threshold peers after, each in proximity order.
+    let mut ordered = headroom;
+    ordered.append(&mut near_threshold);
 
     if ordered.is_empty() {
         // Every admissible candidate is warned (or there are none). Fall back to
@@ -601,13 +625,36 @@ mod tests {
     fn selector_settles_proactively_when_debt_reaches_early_trigger() {
         // A still-affordable peer whose debt has reached the early-payment trigger
         // is settled before it becomes unaffordable, so its view of our debt drops
-        // before it would refuse or drop us.
+        // before it would refuse or drop us. The closer peer(1) is past the trigger
+        // (SettleAndAdmit), so the headroom peer(2) leads it: debt spreads to a
+        // peer with headroom before the near-threshold one is asked again.
         let settlement = Arc::new(RecordingSettlement::default());
         let sel = selector_with_settle_due(Vec::new(), vec![peer(1)], Arc::clone(&settlement));
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
-        assert_eq!(ordered, vec![peer(1), peer(2)]);
+        assert_eq!(ordered, vec![peer(2), peer(1)]);
         assert_eq!(*settlement.triggered.lock().unwrap(), vec![peer(1)]);
+    }
+
+    #[test]
+    fn headroom_peers_lead_near_threshold_peers() {
+        // peer(1) and peer(3) are past the settle trigger (SettleAndAdmit); peer(2)
+        // and peer(4) still have forgiveness headroom (Admit). The headroom tier
+        // leads, each tier in proximity order, so a bulk download spreads debt
+        // across headroom peers before leaning on a near-threshold one.
+        let settlement = Arc::new(RecordingSettlement::default());
+        let sel =
+            selector_with_settle_due(Vec::new(), vec![peer(1), peer(3)], Arc::clone(&settlement));
+
+        let ordered = sel.order(
+            vec![peer(1), peer(2), peer(3), peer(4)],
+            &ChunkAddress::zero(),
+        );
+        assert_eq!(
+            ordered,
+            vec![peer(2), peer(4), peer(1), peer(3)],
+            "headroom peers lead, proximity within each tier"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

When a chunk's closest-32 close set is fully refused by the admission band, the retrieval fallback now bands a wider 128-peer slice and routes the chunk to an admissible peer there instead of blocking the pipeline slot on the 30s gate-settle budget. Only when even the wider slice is fully gated does it fall back to a short 5s bounded settle wait. Pushsync and the upload path are untouched.

## Why

Closes #591.

A download's per-chunk retrieval debt concentrates on the few peers closest to each chunk, so under bulk concurrency those close peers reach their disconnect line and the band refuses the whole close set. The fallback then parked the slot in `order_or_wait` waiting for the close set's committed debt to drain at the per-peer pseudosettle forgiveness rate (450k AU/s for a client). Live mainnet instrumentation measured this gate firing on ~51% of chunks at 256 in-flight (mean 1.6s, tail to 29s), pinning goodput near 85 chunks/s.

The gate is settle latency and pacing, not a hard economic floor: no peer was saturated on average (busiest ~1.5 chunks/s, under its ~1.875 ceiling), and in 100% of fully-gated close sets a wider 128-peer slice held an admissible peer (mean 80 of 128). Any peer in that slice forwards the chunk to its storers at one extra hop. Disconnect-safe: the band still hard-skips every refused peer, so no peer is sent a request past its line.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings`, `cargo test -p vertex-swarm-node --all-features` all clean.

Live mainnet A/B (one node, combined dipper, 150s windows, same instrumented binary):

| metric | base 256 | spill 256 | base 512 | spill 512 |
|---|---|---|---|---|
| goodput | 85 ch/s | 151 ch/s | 98 ch/s | 216 ch/s |
| MB/s | 0.43 | 0.57 | 0.38 | 0.81 |
| gate_ms mean | 1570 | 14 | 4073 | 471 |
| accounting disconnects | 0 | 0 | 0 | 0 |

The gate collapsed and goodput roughly doubled, with zero accounting disconnects. The cost is a slightly higher forward floor (spill peers are one hop farther), but the slot is never parked.

## AI Assistance

Claude Code used for the live-mainnet diagnosis and instrumentation, the implementation, and the benchmark.
