### PR TITLE
perf(swarm-demo): spread download load via nectar ttfb-streaming-frontload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4891,7 +4891,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 [[package]]
 name = "nectar-contracts"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13#dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13"
+source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "nectar-postage"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13#dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13"
+source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4916,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "nectar-primitives"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13#dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13"
+source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4944,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "nectar-swarms"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13#dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13"
+source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
 dependencies = [
  "alloy-chains",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,13 +146,13 @@ indexing_slicing = "warn"
 # BatchStore/StoreValidator/SnapshotStore conversion plus nectar-mantaray and
 # nectar-postage-usage's `client`/`issuer`/`seal` features that the browser
 # upload/download path (bin/swarm-demo) depends on.
-nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
-nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
+nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
 
 digest = "0.10"
 

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -58,18 +58,18 @@ async-trait = "0.1"
 # `parallel`/`wasm-threads`, keeping the single-threaded wasm profile (the demo
 # never calls `initThreadPool`, so there is no rayon worker pool and no shared
 # memory).
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
 # `local-signer` brings the alloy-signer-local re-export for the in-browser key.
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
 # `issuer` + `seal` give signed content stamps (SnapshotIssuer) and the
 # usage-persistence seal path; default `std` is implied.
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13", features = [
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341", features = [
     "issuer",
     "seal",
     "client",
 ] }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "dd8778fce2d87ecddf1e7b3cf730e5e8e9808b13" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
 
 # Chequebook address parsing for the optional SWAP config input and chain
 # types/signing for the browser. alloy-sol-types decodes the BatchCreated log

--- a/bin/swarm-demo/src/client/download.rs
+++ b/bin/swarm-demo/src/client/download.rs
@@ -62,6 +62,21 @@ extern "C" {
     fn abort(this: &DownloadSink, reason: &str);
 }
 
+/// Render an error and its full `source()` chain on one line. The joiner's
+/// `FileError::Getter`/`Sink` variants hide their cause behind `#[source]`, so a
+/// bare `Display` reads only "getter error"; the chain surfaces the underlying
+/// retrieval or accounting failure that actually aborted the download.
+fn error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut out = err.to_string();
+    let mut source = err.source();
+    while let Some(cause) = source {
+        out.push_str(": ");
+        out.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    out
+}
+
 /// Error from a browser sink operation, carrying the JS message as a string.
 #[derive(Debug)]
 struct SinkError(String);
@@ -103,6 +118,14 @@ impl WriteAt for JsWriteSink<'_> {
 }
 
 /// Chunk retrievals kept in flight while the joiner walks a file's chunk tree.
+///
+/// The browser is a light client racing only the closest connected peers, never
+/// dialling for a retrieval. The engine's per-peer in-flight cap bounds how many
+/// retrieval substreams land on any one peer, so a wide fan-out stays within a
+/// healthy neighbourhood's budget; the joiner's split of its budget between a
+/// small cap of intermediate-node fetches and the remaining data-leaf fetches is
+/// what makes the wide fan-out worthwhile, landing the first data leaf after a
+/// short descent rather than behind the whole intermediate frontier.
 const DOWNLOAD_CONCURRENCY: usize = 32;
 
 /// Leaf bodies held at once while streaming to a sequential sink: in-flight plus
@@ -173,8 +196,9 @@ pub async fn stream_file(
         // offset the moment it resolves, off the fetch thread, so a slow chunk
         // never gates the writes already in hand.
         if let Err(e) = joiner.download_into(JsWriteSink { sink }).await {
-            sink.abort(&format!("download: {e}"));
-            return Err(JsValue::from_str(&format!("download: {e}")));
+            let msg = format!("download: {}", error_chain(&e));
+            sink.abort(&msg);
+            return Err(JsValue::from_str(&msg));
         }
         return finish(sink).await;
     }
@@ -190,8 +214,9 @@ pub async fn stream_file(
         let segment = match segment {
             Ok(seg) => seg,
             Err(e) => {
-                sink.abort(&format!("joiner read: {e}"));
-                return Err(JsValue::from_str(&format!("joiner read: {e}")));
+                let msg = format!("joiner read: {}", error_chain(&e));
+                sink.abort(&msg);
+                return Err(JsValue::from_str(&msg));
             }
         };
         // Copy this segment into a JS view and write it; await applies the


### PR DESCRIPTION
## What

Bump the workspace nectar pin to nectar main (now carrying #128's streaming-walk intermediate/leaf budget split) and harden the browser download error path.

- Pin every nectar crate in both `Cargo.toml` (root workspace) and `bin/swarm-demo/Cargo.toml` to the merged nectar rev `8e8e8ae7`. The two locations move together so cargo resolves one nectar source rather than double-compiling.
- Add an `error_chain` helper in `bin/swarm-demo/src/client/download.rs` and use it at the two abort sites, so a failed download surfaces the real `source()` chain (the underlying retrieval or accounting failure) instead of the joiner's opaque "getter error".
- Rescope the `DOWNLOAD_CONCURRENCY` doc: flood-safety at the concurrency-32 fan-out is the engine's per-peer in-flight cap (already on main), and the joiner's budget split is what makes the wide fan-out worthwhile for time-to-first-byte.

## Why

Closes #629. Part of #606 (Phase 3).

On the older nectar rev the joiner walks breadth-first, so a download waits on the entire intermediate frontier before the first data leaf. #128's split resolves at most a small cap of intermediate fetches at once and spends the rest of the width on data leaves, so the first bytes arrive after a short descent. Flood-safety is a separate concern, now owned by the engine's per-peer cap (#622), so this PR is purely the TTFB win plus the error-surfacing fix; it no longer carries a flood-safety argument.

Measured earlier on the live mainnet browser demo against this nectar change: TTFB ~205s -> ~13.4s, throughput ~0.031 -> ~0.105 MB/s.

## Testing

- `cargo build --workspace` against the bumped nectar rev: clean.
- `cargo build --manifest-path bin/swarm-demo/Cargo.toml --target wasm32-unknown-unknown`: clean.
- `cargo clippy --manifest-path bin/swarm-demo/Cargo.toml --target wasm32-unknown-unknown -- -D warnings`: clean.
- `cargo fmt`.

## Notes

The browser 1-2 peer download overrun (the per-peer cap's all-busy fall-through lets a small neighbourhood exceed one peer's muxer) is out of scope here and tracked separately as #628.

## AI Assistance

Claude Code (Opus 4.8) used for the nectar pin bump, the download error-chain fix, the rescope, and the build/lint verification.
