### PR TITLE
perf(swarm-node): cap concurrent retrieval walk legs at a width

### DIFF
--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -50,6 +50,18 @@ const RETRIEVE_WALK_WIDTH: usize = 32;
 /// only on the residual-failure metric below.
 const RETRIEVE_LEG_BUDGET: usize = 8;
 
+/// Maximum legs the staggered fallback keeps concurrently in flight, bounding the
+/// metered over-fetch independently of [`RETRIEVE_LEG_BUDGET`].
+///
+/// A losing race leg is not cancelled downstream: the serving chain forwards and
+/// delivers regardless, so every overlapping leg is real duplicate bandwidth and
+/// cost. The stagger grows the in-flight set one leg per tick, so a withhold-storm
+/// would otherwise reach the full budget concurrently. This caps the simultaneous
+/// legs at a handful while [`RETRIEVE_LEG_BUDGET`] still bounds the lifetime total;
+/// a failed leg refills at once, replacing a freed slot rather than widening, so
+/// the walk keeps its reach.
+const RETRIEVE_WALK_MAX_IN_FLIGHT: usize = 3;
+
 /// Wall-clock bound on the whole retrieval walk across its refilled legs, so a
 /// run of slow or withholding entry points cannot hold a download-pipeline slot
 /// indefinitely. Matches the per-request retrieval lifetime.
@@ -93,6 +105,16 @@ const PRIMARY_ROUTE_DEADLINE: Duration = Duration::from_secs(2);
 /// staggered fan-out that trades a second metered leg for failover latency is
 /// reserved for that fallback, never the primary.
 const PRIMARY_ROUTE_SINGLE_FLIGHT: Duration = Duration::from_secs(3600);
+
+/// Tuning for one staggered walk phase: the lifetime leg `budget`, the
+/// concurrent-leg width `max_in_flight`, the wall-clock `deadline`, and the
+/// per-leg `stagger`.
+struct WalkBounds {
+    budget: usize,
+    max_in_flight: usize,
+    deadline: Duration,
+    stagger: Duration,
+}
 
 /// Chunk provider using ClientHandle for network retrieval.
 #[derive(Clone)]
@@ -172,27 +194,32 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         &self,
         candidates: Vec<SwarmAddress>,
         chunk_address: SwarmAddress,
-        budget: usize,
-        deadline: Duration,
-        stagger: Duration,
+        bounds: WalkBounds,
         legs: &AtomicUsize,
     ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
-        race_walk(candidates, budget, deadline, stagger, |peer_overlay| {
-            legs.fetch_add(1, Ordering::Relaxed);
-            let permit = self
-                .inflight
-                .as_ref()
-                .and_then(|limiter| limiter.try_acquire(&peer_overlay));
-            // `originated = true`: our own retrieval, so the client service
-            // debits the serving peer on delivery.
-            let request = self
-                .client_handle
-                .retrieve_chunk(peer_overlay, chunk_address, true);
-            async move {
-                let _permit = permit;
-                request.await
-            }
-        })
+        race_walk(
+            candidates,
+            bounds.budget,
+            bounds.max_in_flight,
+            bounds.deadline,
+            bounds.stagger,
+            |peer_overlay| {
+                legs.fetch_add(1, Ordering::Relaxed);
+                let permit = self
+                    .inflight
+                    .as_ref()
+                    .and_then(|limiter| limiter.try_acquire(&peer_overlay));
+                // `originated = true`: our own retrieval, so the client service
+                // debits the serving peer on delivery.
+                let request = self
+                    .client_handle
+                    .retrieve_chunk(peer_overlay, chunk_address, true);
+                async move {
+                    let _permit = permit;
+                    request.await
+                }
+            },
+        )
         .await
     }
 }
@@ -233,9 +260,14 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
                 .walk_legs(
                     bin_candidates,
                     chunk_address,
-                    PRIMARY_ROUTE_BUDGET,
-                    PRIMARY_ROUTE_DEADLINE,
-                    PRIMARY_ROUTE_SINGLE_FLIGHT,
+                    WalkBounds {
+                        budget: PRIMARY_ROUTE_BUDGET,
+                        // Single-flight: at most one metered leg in flight,
+                        // advancing the bin spill only on an explicit failure.
+                        max_in_flight: 1,
+                        deadline: PRIMARY_ROUTE_DEADLINE,
+                        stagger: PRIMARY_ROUTE_SINGLE_FLIGHT,
+                    },
                     &legs,
                 )
                 .await;
@@ -274,9 +306,12 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
             .walk_legs(
                 candidates,
                 chunk_address,
-                RETRIEVE_LEG_BUDGET,
-                RETRIEVE_WALK_DEADLINE,
-                RETRIEVAL_STAGGER,
+                WalkBounds {
+                    budget: RETRIEVE_LEG_BUDGET,
+                    max_in_flight: RETRIEVE_WALK_MAX_IN_FLIGHT,
+                    deadline: RETRIEVE_WALK_DEADLINE,
+                    stagger: RETRIEVAL_STAGGER,
+                },
                 &legs,
             )
             .await;
@@ -1089,6 +1124,7 @@ mod tests {
             let outcome = race_walk(
                 candidates,
                 RETRIEVE_LEG_BUDGET,
+                RETRIEVE_WALK_MAX_IN_FLIGHT,
                 RETRIEVE_WALK_DEADLINE,
                 RETRIEVAL_STAGGER,
                 move |peer| {

--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -145,12 +145,17 @@ where
 /// beforehand (skip-busy), so a busy peer is never dispatched and never spends a
 /// budget unit; `budget` therefore counts only genuine coverage attempts.
 ///
-/// Each leg is still staggered and losers are dropped on resolve, so true
-/// concurrency stays a handful regardless of `budget`: this is a patient walk,
-/// not a wide simultaneous fan-out.
+/// Each leg is staggered, at most `max_in_flight` run concurrently, and losers
+/// are dropped on resolve, so true concurrency is bounded by `max_in_flight`
+/// regardless of `budget`: this is a patient walk, not a wide simultaneous
+/// fan-out. A stagger tick adds a leg only while fewer than `max_in_flight` are
+/// live; a failed leg still refills at once, which replaces a freed slot rather
+/// than widening, so the walk keeps its reach without multiplying the metered
+/// over-fetch when legs merely withhold.
 pub async fn race_walk<C, T, E, I, F, Fut>(
     candidates: I,
     budget: usize,
+    max_in_flight: usize,
     deadline: Duration,
     stagger: Duration,
     mut attempt: F,
@@ -203,7 +208,12 @@ where
                 }
             },
             _ = stagger_tick => {
-                dispatch_next(&mut in_flight, &mut dispatched);
+                // Grow the in-flight set only up to the width: a stagger adds a
+                // leg, a withholding leg never does. Failure-refill above still
+                // replaces a freed slot, so reach is preserved without widening.
+                if in_flight.len() < max_in_flight {
+                    dispatch_next(&mut in_flight, &mut dispatched);
+                }
                 stagger_tick = Delay::new(stagger).fuse();
             },
             _ = deadline_tick => {
@@ -407,6 +417,7 @@ mod tests {
         let outcome = race_walk(
             0..10u32,
             8,
+            3,
             Duration::from_secs(30),
             RETRIEVAL_STAGGER,
             |i| {
@@ -438,6 +449,7 @@ mod tests {
         let outcome = race_walk(
             0..100u32,
             6,
+            3,
             Duration::from_secs(30),
             RETRIEVAL_STAGGER,
             |_| {
@@ -455,6 +467,40 @@ mod tests {
         );
     }
 
+    /// Under a withhold-storm (legs stall, never error) a stagger grows the
+    /// in-flight set only up to the width, never the budget: the metered
+    /// over-fetch is bounded by `max_in_flight` even when the budget and the
+    /// deadline would admit more legs.
+    #[tokio::test]
+    async fn walk_caps_concurrent_legs_at_the_width() {
+        let constructed = Arc::new(AtomicUsize::new(0));
+        let counted = constructed.clone();
+        // Budget 8 over a 300ms deadline at a 20ms stagger would dispatch eight
+        // legs without a width cap; max_in_flight = 3 holds it to three.
+        let outcome = race_walk(
+            0..100u32,
+            8,
+            3,
+            Duration::from_millis(300),
+            Duration::from_millis(20),
+            |_| {
+                counted.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Delay::new(Duration::from_secs(30)).await;
+                    Ok::<u32, &str>(0)
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(outcome, Err(RaceFailure::TimedOut)));
+        assert_eq!(
+            constructed.load(Ordering::SeqCst),
+            3,
+            "the width caps concurrent legs at 3, not the budget of 8"
+        );
+    }
+
     /// A walk whose legs all merely withhold (never an explicit failure) is
     /// bounded by the wall clock, surfacing TimedOut rather than hanging.
     #[tokio::test]
@@ -464,6 +510,7 @@ mod tests {
         let outcome = race_walk(
             0..8u32,
             8,
+            3,
             Duration::from_millis(300),
             Duration::from_millis(50),
             |_| async {
@@ -490,6 +537,7 @@ mod tests {
         let empty = race_walk(
             Vec::<u32>::new(),
             8,
+            3,
             Duration::from_secs(1),
             RETRIEVAL_STAGGER,
             |_| async { Ok::<u32, &str>(0) },
@@ -500,6 +548,7 @@ mod tests {
         let zero_budget = race_walk(
             0..4u32,
             0,
+            3,
             Duration::from_secs(1),
             RETRIEVAL_STAGGER,
             |_| async { Ok::<u32, &str>(0) },


### PR DESCRIPTION
## What

Add a concurrent-leg width bound to `race_walk`, separate from the total leg budget. A stagger tick now dispatches a new leg only while fewer than `max_in_flight` legs are live; the total `budget` still caps the lifetime legs. The staggered fallback caps at `RETRIEVE_WALK_MAX_IN_FLIGHT` (3) and the bin-bucket primary passes 1, making its single-flight property explicit rather than implied by an out-of-band stagger. The per-phase walk tuning (budget, width, deadline, stagger) is bundled into a small `WalkBounds` struct at the two call sites.

Failure-refill is deliberately left ungated: a failed leg frees its slot, so refilling replaces it rather than growing past the width. The walk therefore keeps its difficult-chunk reach while bounding the simultaneous metered legs.

## Why

Part of #606 (Phase 1). A difficult chunk whose close entry points withhold (stall rather than error) could put up to `RETRIEVE_LEG_BUDGET` legs concurrently in flight, one added per stagger tick and never removed until the deadline. A losing race leg is not cancelled downstream (the serving chain forwards and delivers regardless), so every overlapping leg is real duplicate bandwidth and real duplicate cost: the worst case was a roughly eightfold over-fetch and eightfold forwarding amplification for a single withheld chunk. The module docstring claimed "true concurrency stays a handful regardless of budget", which held only when legs fail fast and refill, not when they withhold. This makes that true.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean), `cargo nextest run -p vertex-swarm-node --all-features` (148 pass, including a new `walk_caps_concurrent_legs_at_the_width` that asserts a withhold-storm dispatches exactly the width, not the budget), and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (clean). No wire change.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the implementation, the test, and the local verification.

Closes #599. Part of #606.
