### PR TITLE
perf(swarm-node): enforce the per-peer inflight cap on mid-walk legs

### DIFF
--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -190,11 +190,17 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     /// an originated retrieval that reserves the per-peer in-flight permit riding
     /// its future. Shared by the single-flight primary route and the staggered
     /// fallback; `legs` accumulates the metered legs across both phases.
+    ///
+    /// With `enforce_cap`, a peer that filled its in-flight slot since the
+    /// skip-busy snapshot is declined at dispatch (no leg, no budget unit) so the
+    /// cap holds on live state; without it (no limiter, or the all-busy
+    /// fall-through) the leg runs best-effort even with no permit.
     async fn walk_legs(
         &self,
         candidates: Vec<SwarmAddress>,
         chunk_address: SwarmAddress,
         bounds: WalkBounds,
+        enforce_cap: bool,
         legs: &AtomicUsize,
     ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
         race_walk(
@@ -204,20 +210,26 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
             bounds.deadline,
             bounds.stagger,
             |peer_overlay| {
-                legs.fetch_add(1, Ordering::Relaxed);
                 let permit = self
                     .inflight
                     .as_ref()
                     .and_then(|limiter| limiter.try_acquire(&peer_overlay));
+                // A peer that filled since the skip-busy snapshot is declined so
+                // the cap holds on live state, spending no budget; best-effort
+                // (no limiter or all-busy fall-through) attempts without a permit.
+                if enforce_cap && permit.is_none() {
+                    return None;
+                }
+                legs.fetch_add(1, Ordering::Relaxed);
                 // `originated = true`: our own retrieval, so the client service
                 // debits the serving peer on delivery.
                 let request = self
                     .client_handle
                     .retrieve_chunk(peer_overlay, chunk_address, true);
-                async move {
+                Some(async move {
                     let _permit = permit;
                     request.await
-                }
+                })
             },
         )
         .await
@@ -253,7 +265,7 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         // Skip-busy: drop peers at their in-flight cap so the route leads with an
         // in-headroom peer. The cap is the non-economic muxer guard, composed
         // after the accounting band, never merged with it.
-        let bin_candidates = skip_busy(bin_candidates, self.inflight.as_deref());
+        let (bin_candidates, enforce_cap) = skip_busy(bin_candidates, self.inflight.as_deref());
 
         if !bin_candidates.is_empty() {
             let primary = self
@@ -268,6 +280,7 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
                         deadline: PRIMARY_ROUTE_DEADLINE,
                         stagger: PRIMARY_ROUTE_SINGLE_FLIGHT,
                     },
+                    enforce_cap,
                     &legs,
                 )
                 .await;
@@ -300,7 +313,7 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         // result falls through to the no-connected-peers path below, the same
         // generic transient error a no-peers failure yields.
         let closest_peers = self.select_or_wait(closest_peers, &chunk_address).await;
-        let candidates = skip_busy(closest_peers, self.inflight.as_deref());
+        let (candidates, enforce_cap) = skip_busy(closest_peers, self.inflight.as_deref());
 
         let outcome = self
             .walk_legs(
@@ -312,6 +325,7 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
                     deadline: RETRIEVE_WALK_DEADLINE,
                     stagger: RETRIEVAL_STAGGER,
                 },
+                enforce_cap,
                 &legs,
             )
             .await;
@@ -518,28 +532,34 @@ fn spill_bins(b: u8, max_bin: u8) -> Vec<u8> {
     bins
 }
 
-/// Filter proximity-ordered `candidates` to those with a free retrieval slot.
+/// Filter proximity-ordered `candidates` to those with a free retrieval slot,
+/// returning the survivors and whether the walk should enforce the cap.
 ///
-/// With no limiter the list is unchanged. When every close candidate is at its
-/// in-flight cap the full list is returned (fall through, since degraded service
-/// beats failing the request). Skip-busy happens here, at selection time, so a
-/// busy head peer is never raced and the next-closest free peer leads instead.
+/// With no limiter the list is unchanged and `enforce_cap` is false. When every
+/// close candidate is at its in-flight cap the full list is returned with
+/// `enforce_cap` false (fall through, since degraded service beats failing the
+/// request, so legs run best-effort). Only when free-slot peers are found is
+/// `enforce_cap` true, so a peer that fills between this snapshot and dispatch is
+/// declined rather than run uncapped. Skip-busy happens here, at selection time,
+/// so a busy head peer is never raced and the next-closest free peer leads.
 fn skip_busy(
     candidates: Vec<SwarmAddress>,
     inflight: Option<&PeerInflightLimiter>,
-) -> Vec<SwarmAddress> {
+) -> (Vec<SwarmAddress>, bool) {
     let Some(limiter) = inflight else {
-        return candidates;
+        return (candidates, false);
     };
     let survivors: Vec<SwarmAddress> = candidates
         .iter()
         .copied()
         .filter(|peer| limiter.has_free_slot(peer))
         .collect();
+    // `enforce_cap` only when free-slot peers were found: the all-busy
+    // fall-through returns the full list so the walk still attempts, best-effort.
     if survivors.is_empty() {
-        candidates
+        (candidates, false)
     } else {
-        survivors
+        (survivors, true)
     }
 }
 
@@ -1058,7 +1078,7 @@ mod tests {
             candidates: Vec<SwarmAddress>,
             address: ChunkAddress,
         ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
-            let candidates = skip_busy(candidates, Some(&limiter));
+            let (candidates, _enforce_cap) = skip_busy(candidates, Some(&limiter));
             race_candidates(candidates, RETRIEVAL_STAGGER, move |peer| {
                 let permit = limiter.try_acquire(&peer);
                 let handle = handle.clone();
@@ -1073,7 +1093,7 @@ mod tests {
         #[test]
         fn skip_busy_without_a_limiter_keeps_every_candidate() {
             let candidates = vec![overlay(1), overlay(2), overlay(3)];
-            assert_eq!(skip_busy(candidates.clone(), None), candidates);
+            assert_eq!(skip_busy(candidates.clone(), None), (candidates, false));
         }
 
         #[test]
@@ -1082,12 +1102,14 @@ mod tests {
             let busy = overlay(1);
             let _held = limiter.try_acquire(&busy).expect("first slot");
 
-            let survivors = skip_busy(vec![busy, overlay(2), overlay(3)], Some(&limiter));
+            let (survivors, enforce_cap) =
+                skip_busy(vec![busy, overlay(2), overlay(3)], Some(&limiter));
             assert_eq!(
                 survivors,
                 vec![overlay(2), overlay(3)],
                 "the capped head is skipped, the next-closest free peers remain"
             );
+            assert!(enforce_cap, "free-slot peers found, so the cap is enforced");
         }
 
         #[test]
@@ -1097,10 +1119,14 @@ mod tests {
             let _h1 = limiter.try_acquire(&overlay(1)).expect("slot a");
             let _h2 = limiter.try_acquire(&overlay(2)).expect("slot b");
 
+            let (survivors, enforce_cap) = skip_busy(candidates.clone(), Some(&limiter));
             assert_eq!(
-                skip_busy(candidates.clone(), Some(&limiter)),
-                candidates,
+                survivors, candidates,
                 "all-busy falls through to the full list rather than failing"
+            );
+            assert!(
+                !enforce_cap,
+                "the all-busy fall-through is best-effort, not cap-enforced"
             );
         }
 
@@ -1116,7 +1142,7 @@ mod tests {
             let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
 
             let pool: Vec<SwarmAddress> = (1..=16).map(overlay).collect();
-            let candidates = skip_busy(pool, Some(&limiter));
+            let (candidates, _enforce_cap) = skip_busy(pool, Some(&limiter));
             assert_eq!(candidates.len(), 16, "all 16 peers have a free slot");
 
             let legs = Arc::new(AtomicUsize::new(0));
@@ -1131,10 +1157,10 @@ mod tests {
                     counted.fetch_add(1, Ordering::SeqCst);
                     let permit = limiter.try_acquire(&peer);
                     let handle = handle.clone();
-                    async move {
+                    Some(async move {
                         let _permit = permit;
                         handle.retrieve_chunk(peer, address(0xaa), true).await
-                    }
+                    })
                 },
             )
             .await;
@@ -1144,6 +1170,82 @@ mod tests {
                 legs.load(Ordering::SeqCst),
                 RETRIEVE_LEG_BUDGET,
                 "the walk meters at most the leg budget across the wider free-slot pool"
+            );
+        }
+
+        #[tokio::test]
+        async fn enforce_cap_declines_a_peer_that_filled_since_the_snapshot() {
+            // A peer free at the skip-busy snapshot but saturated before its leg
+            // dispatches is declined under enforce_cap: no command reaches it and
+            // it spends no leg, so the cap holds on live state, not the stale
+            // snapshot. The next free peer serves instead.
+            let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
+            let handle = ClientHandle::new(tx);
+            let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
+
+            let filled = overlay(1);
+            let free = overlay(2);
+
+            // Skip-busy sees both peers free, so the walk enforces the cap.
+            let (candidates, enforce_cap) = skip_busy(vec![filled, free], Some(&limiter));
+            assert_eq!(candidates, vec![filled, free]);
+            assert!(enforce_cap, "free-slot peers found, so the cap is enforced");
+
+            // Between the snapshot and dispatch the first peer's slot is taken.
+            let _held = limiter
+                .try_acquire(&filled)
+                .expect("saturate the first peer");
+
+            let address = address(0xac);
+            let legs = Arc::new(AtomicUsize::new(0));
+            let counted = Arc::clone(&legs);
+            let lim = Arc::clone(&limiter);
+            let race = tokio::spawn(async move {
+                race_walk(
+                    candidates,
+                    RETRIEVE_LEG_BUDGET,
+                    RETRIEVE_WALK_MAX_IN_FLIGHT,
+                    RETRIEVE_WALK_DEADLINE,
+                    RETRIEVAL_STAGGER,
+                    move |peer| {
+                        let permit = lim.try_acquire(&peer);
+                        // The enforce-cap decline: a peer with no live slot spends
+                        // no leg and is skipped for the next candidate.
+                        if enforce_cap && permit.is_none() {
+                            return None;
+                        }
+                        counted.fetch_add(1, Ordering::SeqCst);
+                        let handle = handle.clone();
+                        Some(async move {
+                            let _permit = permit;
+                            handle.retrieve_chunk(peer, address, true).await
+                        })
+                    },
+                )
+                .await
+            });
+
+            // The only command is for the free peer: the saturated peer is declined.
+            match rx.recv().await.expect("a command for the free peer") {
+                ClientCommand::RetrieveChunk { peer, response, .. } => {
+                    assert_eq!(peer, free, "the saturated peer is declined, not contacted");
+                    response
+                        .send(Ok(RetrievalResult {
+                            chunk: test_chunk(),
+                            stamp: None,
+                            peer: free,
+                        }))
+                        .expect("receiver alive");
+                }
+                other => panic!("unexpected command: {other:?}"),
+            }
+
+            let result = race.await.unwrap().expect("race resolves");
+            assert_eq!(result.peer, free, "the free peer serves the chunk");
+            assert_eq!(
+                legs.load(Ordering::SeqCst),
+                1,
+                "only the free peer spent a leg; the saturated peer was declined"
             );
         }
 

--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -143,7 +143,11 @@ where
 /// real bound: `budget` legs dispatched, the candidate source exhausted, or the
 /// `deadline`. The caller filters back-pressured peers out of `candidates`
 /// beforehand (skip-busy), so a busy peer is never dispatched and never spends a
-/// budget unit; `budget` therefore counts only genuine coverage attempts.
+/// budget unit; `budget` therefore counts only genuine coverage attempts. The
+/// `attempt` closure may also decline a candidate at dispatch by returning
+/// `None` (a peer that filled since the skip-busy snapshot), which is skipped for
+/// the next candidate without spending a budget unit, so the cap holds on the
+/// live state rather than the stale snapshot.
 ///
 /// Each leg is staggered, at most `max_in_flight` run concurrently, and losers
 /// are dropped on resolve, so true concurrency is bounded by `max_in_flight`
@@ -162,7 +166,7 @@ pub async fn race_walk<C, T, E, I, F, Fut>(
 ) -> Result<T, RaceFailure<E>>
 where
     I: IntoIterator<Item = C>,
-    F: FnMut(C) -> Fut,
+    F: FnMut(C) -> Option<Fut>,
     Fut: std::future::Future<Output = Result<T, E>>,
 {
     let mut candidates = candidates.into_iter();
@@ -170,20 +174,23 @@ where
     let mut dispatched = 0usize;
     let mut last_error: Option<E> = None;
 
-    // Dispatch the next candidate while the leg budget allows. Returns whether a
-    // leg was pushed (false once the budget is spent or the source is drained).
+    // Dispatch the next dispatchable candidate while the leg budget allows. A
+    // candidate the closure declines (returns `None`, e.g. a peer found busy at
+    // dispatch) is skipped without spending a budget unit, so only a pushed leg
+    // counts. Returns whether a leg was pushed (false once the budget is spent or
+    // the source is drained, declines included).
     let mut dispatch_next = |in_flight: &mut FuturesUnordered<Fut>, dispatched: &mut usize| {
         if *dispatched >= budget {
             return false;
         }
-        match candidates.next() {
-            Some(candidate) => {
-                in_flight.push(attempt(candidate));
+        for candidate in candidates.by_ref() {
+            if let Some(leg) = attempt(candidate) {
+                in_flight.push(leg);
                 *dispatched += 1;
-                true
+                return true;
             }
-            None => false,
         }
+        false
     };
 
     if !dispatch_next(&mut in_flight, &mut dispatched) {
@@ -422,7 +429,7 @@ mod tests {
             RETRIEVAL_STAGGER,
             |i| {
                 counted.fetch_add(1, Ordering::SeqCst);
-                async move { if i < 4 { Err("miss") } else { Ok(i) } }
+                Some(async move { if i < 4 { Err("miss") } else { Ok(i) } })
             },
         )
         .await;
@@ -454,7 +461,7 @@ mod tests {
             RETRIEVAL_STAGGER,
             |_| {
                 counted.fetch_add(1, Ordering::SeqCst);
-                async move { Err::<u32, _>("miss") }
+                Some(async move { Err::<u32, _>("miss") })
             },
         )
         .await;
@@ -464,6 +471,39 @@ mod tests {
             attempts.load(Ordering::SeqCst),
             6,
             "the budget caps dispatched legs at 6 of the 100 available"
+        );
+    }
+
+    /// A candidate the closure declines (returns `None`, a peer busy at dispatch)
+    /// is skipped for the next without spending a budget unit, so the budget is
+    /// spent only on dispatched legs.
+    #[tokio::test]
+    async fn walk_skips_declined_candidates_without_spending_budget() {
+        // Budget 2. The first three candidates decline; the budget must survive
+        // them so the fourth (a miss) and fifth (a hit) are still reached.
+        let dispatched = Arc::new(AtomicUsize::new(0));
+        let counted = dispatched.clone();
+        let outcome = race_walk(
+            0..10u32,
+            2,
+            3,
+            Duration::from_secs(30),
+            RETRIEVAL_STAGGER,
+            move |i| {
+                if i < 3 {
+                    return None; // busy at dispatch: skipped, no budget spent
+                }
+                counted.fetch_add(1, Ordering::SeqCst);
+                Some(async move { if i == 3 { Err("miss") } else { Ok(i) } })
+            },
+        )
+        .await;
+
+        assert_eq!(outcome.ok(), Some(4), "the holder past the declines serves");
+        assert_eq!(
+            dispatched.load(Ordering::SeqCst),
+            2,
+            "budget spent only on the two dispatched legs, not the three declines"
         );
     }
 
@@ -485,10 +525,10 @@ mod tests {
             Duration::from_millis(20),
             |_| {
                 counted.fetch_add(1, Ordering::SeqCst);
-                async {
+                Some(async {
                     Delay::new(Duration::from_secs(30)).await;
                     Ok::<u32, &str>(0)
-                }
+                })
             },
         )
         .await;
@@ -513,9 +553,11 @@ mod tests {
             3,
             Duration::from_millis(300),
             Duration::from_millis(50),
-            |_| async {
-                Delay::new(Duration::from_secs(30)).await;
-                Ok::<u32, &str>(0)
+            |_| {
+                Some(async {
+                    Delay::new(Duration::from_secs(30)).await;
+                    Ok::<u32, &str>(0)
+                })
             },
         )
         .await;
@@ -540,7 +582,7 @@ mod tests {
             3,
             Duration::from_secs(1),
             RETRIEVAL_STAGGER,
-            |_| async { Ok::<u32, &str>(0) },
+            |_| Some(async { Ok::<u32, &str>(0) }),
         )
         .await;
         assert!(matches!(empty, Err(RaceFailure::NoCandidates)));
@@ -551,7 +593,7 @@ mod tests {
             3,
             Duration::from_secs(1),
             RETRIEVAL_STAGGER,
-            |_| async { Ok::<u32, &str>(0) },
+            |_| Some(async { Ok::<u32, &str>(0) }),
         )
         .await;
         assert!(matches!(zero_budget, Err(RaceFailure::NoCandidates)));


### PR DESCRIPTION
## What

Make the per-peer in-flight cap enforced on the retrieval walk rather than advisory. `race_walk`'s `attempt` closure now returns `Option<Fut>`: a candidate the closure declines (returns `None`) is skipped for the next one without spending a budget unit. `skip_busy` returns an `enforce_cap` flag alongside its survivors, and the walk leg closure declines a peer whose live in-flight slot is gone when `enforce_cap` is set.

The `enforce_cap` flag preserves the two best-effort cases: `skip_busy`'s all-busy degraded fall-through (it returns the full list so the walk still attempts) and the no-limiter case both report `enforce_cap = false`, so legs there still run without a permit as before. Only when `skip_busy` actually filtered to free-slot peers is the cap enforced, so a peer that fills between the snapshot and dispatch is declined instead of run uncapped.

## Why

Part of #606 (Phase 1). `skip_busy` filters peers once, before a walk that can run up to 30s. The per-leg permit was optional (`let _permit = limiter.try_acquire(peer); ... run regardless`), so a peer that filled its slot between the snapshot and dispatch still ran a leg with no permit: it could exceed its in-flight cap, and a busy peer could consume a walk leg (and a budget unit) that a free-slot peer should have had. This was pre-flagged in the walk's introducing PR and never filed until #602.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean), `cargo nextest run -p vertex-swarm-node --all-features` (150 pass, including two new tests: `walk_skips_declined_candidates_without_spending_budget` at the `race_walk` level, and `enforce_cap_declines_a_peer_that_filled_since_the_snapshot` at the provider level; the existing `skip_busy_*` tests updated for the new return), and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (clean). No wire change.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the implementation, the tests, and the local verification.

Closes #602. Part of #606.
