### PR TITLE
test(swarm-node): grind receipt overlay to an exact depth to de-flake

### DIFF
--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -661,11 +661,16 @@ mod tests {
     }
 
     /// A storer-verified receipt as the decode boundary produces it, with the
-    /// storer ground to sit at least `min_depth` bits deep relative to `address`.
+    /// storer ground to sit exactly `proximity` bits deep relative to `address`.
+    ///
+    /// The grind targets an exact proximity, not a lower bound: the depth verdict
+    /// turns on the observed proximity, so a lower bound would leave it dependent
+    /// on the random overlay and flake (a shallow case occasionally grinding deep
+    /// enough to verify). An exact target makes every verdict deterministic.
     fn signed_receipt(
         signer: &PrivateKeySigner,
         address: &ChunkAddress,
-        min_depth: u8,
+        proximity: u8,
         storage_radius: StorageRadius,
     ) -> Receipt {
         let eth = signer.address();
@@ -678,7 +683,7 @@ mod tests {
             nonce_bytes[..8].copy_from_slice(&counter.to_le_bytes());
             let nonce = Nonce::from(nonce_bytes);
             let overlay = compute_overlay(&eth, NET, &nonce);
-            if address.proximity(&overlay).get() >= min_depth {
+            if address.proximity(&overlay).get() == proximity {
                 let wire = WireReceipt::new(*address, signature, nonce, storage_radius);
                 return Receipt::reconstruct(wire, NET).expect("reconstructs");
             }


### PR DESCRIPTION
## What

Grind the storer overlay in `signed_receipt` (the origin custody-receipt test helper) for an *exact* proximity instead of a lower bound, so the depth verdicts under test are deterministic. The four caller values are unchanged (8 for the deep-accept case, 0 for the shallow and unverifiable cases); they now pin the observed proximity rather than setting a floor.

## Why

`signed_receipt` ground for proximity `>= min_depth`. The shallow-receipt tests passed `min_depth = 0`, satisfied by the first nonce, so the storer's actual proximity to the chunk was random. `verify_depth` decides `Shallow` vs `Verified` on that observed proximity against the floor (`local_depth - SHALLOW_RECEIPT_TOLERANCE = 11`), so roughly one run in two hundred the random overlay sat at proximity >= 11 and the verdict flipped to `Verified`, failing the assertion. This bit CI on an unrelated PR. The fix is behaviour-preserving for the deterministic cases and removes the non-determinism.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean), and the `origin_*` receipt tests run 50x with 0 failures (deterministic by construction: observed proximity is now pinned). No wire change; test-only.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the diagnosis, the fix, and the verification.

Closes #612.
