### PR TITLE
perf(swarm-node): measure retrieval over-fetch

### DIFF
--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -705,11 +705,19 @@ impl ClientHandler {
                     latency,
                     originated,
                 });
-                let _ = response.send(Ok(RetrievalResult {
+                let delivered = response.send(Ok(RetrievalResult {
                     chunk,
                     stamp,
                     peer: overlay,
                 }));
+                // An originated delivery whose receiver is gone: the race leg that
+                // asked for it already lost (or the request was abandoned), so the
+                // chunk was fetched and metered but is discarded. Retrieval is not
+                // cancellable downstream, so this is the delivery-side over-fetch
+                // the staggered race trades for failover latency.
+                if originated && delivered.is_err() {
+                    metrics::counter!("swarm.client.retrieval_overfetch_delivered").increment(1);
+                }
             }
         }
     }

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -285,9 +285,11 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
                 )
                 .await;
             if let Ok(result) = primary {
-                histogram!("retrieval_walk_legs").record(legs.load(Ordering::Relaxed) as f64);
+                let walked = legs.load(Ordering::Relaxed);
+                histogram!("retrieval_walk_legs").record(walked as f64);
                 counter!("retrieval_walk_total", "outcome" => "hit", "path" => "bin_route")
                     .increment(1);
+                record_overfetch_legs(walked, "bin_route");
                 return Ok(ChunkRetrievalResult {
                     chunk: result.chunk,
                     stamp: result.stamp,
@@ -340,6 +342,11 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         };
         counter!("retrieval_walk_total", "outcome" => outcome_label, "path" => "fallback")
             .increment(1);
+        if outcome.is_ok() {
+            // `legs` spans both phases, so a fallback win also counts the primary
+            // legs the missed bin route already spent.
+            record_overfetch_legs(legs, "fallback");
+        }
 
         match outcome {
             Ok(result) => Ok(ChunkRetrievalResult {
@@ -530,6 +537,19 @@ fn spill_bins(b: u8, max_bin: u8) -> Vec<u8> {
         delta += 1;
     }
     bins
+}
+
+/// Record the metered legs a successful retrieval spent beyond the one that won.
+///
+/// Each extra leg is a failed refill or a concurrent loser the race dropped; a
+/// dropped loser is not cancelled downstream, so it still fetches and meters a
+/// duplicate. This is the dispatch-side over-fetch signal (an upper bound). The
+/// delivery-side count of duplicates that actually arrived is
+/// `swarm.client.retrieval_overfetch_delivered`, emitted by the handler.
+fn record_overfetch_legs(legs: usize, path: &'static str) {
+    if let Some(extra) = legs.checked_sub(1).filter(|extra| *extra > 0) {
+        counter!("retrieval_overfetch_legs", "path" => path).increment(extra as u64);
+    }
 }
 
 /// Filter proximity-ordered `candidates` to those with a free retrieval slot,


### PR DESCRIPTION
## What

Add two over-fetch observability signals to the retrieval path:

- `retrieval_overfetch_legs{path}` (in `NetworkChunkProvider`): on a successful retrieval, the metered legs spent beyond the one that won (`legs - 1`), labelled by the winning phase (`bin_route`/`fallback`). The dispatch-side upper bound on over-fetch.
- `swarm.client.retrieval_overfetch_delivered` (in the client handler): an originated delivery whose receiver was already gone when it arrived, so the chunk was fetched and metered but discarded. The delivery-side actual cost.

Together they bracket the structural over-fetch the staggered race trades for failover latency.

## Why

Part of #606 (Phase 1). The retrieval race meters every leg beyond the winner, and a losing leg is not cancelled downstream: the remote forwards through its full chain, fetches the chunk, and delivers it into a dropped receiver (the debit committed at dispatch is not refunded on a cancelled one-shot). That over-fetch is structural, not cosmetic, and was not directly observable, so the stagger (#578) and the concurrency-width bound (#610) were tuned by inference. These metrics give them a real signal to calibrate against, and let the adaptive-hedge follow-up (#607) be measured rather than guessed.

A wire-level retrieval-cancel frame is deliberately not added: each forwarding hop awaits its own upstream fetch before writing back, so cancelling our outbound substream would at best save the final write-back while the recursive upstream fetch has already happened. The no-wire levers (stagger, width bound, adaptive hedge) are what stop the second fetch from happening at all.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node -p vertex-swarm-client-behaviour --all-targets --all-features -- -D warnings` (clean), `cargo nextest run -p vertex-swarm-node -p vertex-swarm-client-behaviour --all-features` (168 pass), and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (clean). Observability-only; no behaviour or wire change. Metric emission is not unit-tested, consistent with the existing retrieval metrics.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the implementation and the local verification.

Closes #605. Part of #606.
