### PR TITLE
perf(swarm-node): pace the retrieval stagger by per-PO latency

### DIFF
--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -18,6 +18,7 @@ use vertex_swarm_topology::TopologyHandle;
 // sleeps are `!Send`, and the gated-set wait awaits a settle completion instead.
 use vertex_tasks::time::{Duration, Instant};
 
+use crate::retrieval_latency::{RetrievalLatency, adaptive_stagger};
 use crate::{
     ChunkTransferError, ClientHandle, PeerInflightLimiter, PeerSelector, RETRIEVAL_STAGGER,
     RaceFailure, RetrievalResult, race_walk,
@@ -123,6 +124,7 @@ pub struct NetworkChunkProvider<I: SwarmIdentity> {
     topology: TopologyHandle<I>,
     selector: Option<Arc<PeerSelector>>,
     inflight: Option<Arc<PeerInflightLimiter>>,
+    retrieval_latency: Option<Arc<RetrievalLatency>>,
 }
 
 impl<I: SwarmIdentity> NetworkChunkProvider<I> {
@@ -132,7 +134,15 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
             topology,
             selector: None,
             inflight: None,
+            retrieval_latency: None,
         }
+    }
+
+    /// Pace the staggered fallback to the live round trip via the shared per-PO
+    /// latency estimate. The same instance the client service records into.
+    pub(crate) fn with_retrieval_latency(mut self, latency: Arc<RetrievalLatency>) -> Self {
+        self.retrieval_latency = Some(latency);
+        self
     }
 
     /// Order retrieval and pushsync candidates with `selector` (score- and
@@ -317,6 +327,21 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         let closest_peers = self.select_or_wait(closest_peers, &chunk_address).await;
         let (candidates, enforce_cap) = skip_busy(closest_peers, self.inflight.as_deref());
 
+        // Pace the staggered fan-out to the live round trip rather than a fixed
+        // constant. Each candidate's expected latency is read from the per-PO
+        // estimate at its proximity to the chunk (the forwarding distance that
+        // dominates retrieval latency), so a near neighbourhood walks far below
+        // the ceiling and a far one stays at it. Cold buckets fall back to the
+        // constant, so this is never slower, only faster on low-RTT distances.
+        let stagger = match &self.retrieval_latency {
+            Some(latency) => adaptive_stagger(
+                candidates
+                    .iter()
+                    .map(|peer| latency.estimate(chunk_address.proximity(peer).get())),
+            ),
+            None => RETRIEVAL_STAGGER,
+        };
+
         let outcome = self
             .walk_legs(
                 candidates,
@@ -325,7 +350,7 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
                     budget: RETRIEVE_LEG_BUDGET,
                     max_in_flight: RETRIEVE_WALK_MAX_IN_FLIGHT,
                     deadline: RETRIEVE_WALK_DEADLINE,
-                    stagger: RETRIEVAL_STAGGER,
+                    stagger,
                 },
                 enforce_cap,
                 &legs,

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -19,6 +19,7 @@ use vertex_tasks::{GracefulShutdown, MaybeSend, SpawnableTask};
 
 use crate::inflight::PeerInflightLimiter;
 use crate::protocol::{ClientCommand, ClientEvent, FailureKind};
+use crate::retrieval_latency::RetrievalLatency;
 use crate::selection::SettlementTrigger;
 
 const RETRIEVAL_SOURCE: ReportSource = ReportSource::Protocol("retrieval");
@@ -261,6 +262,9 @@ pub struct ClientService {
     /// Per-peer retrieval in-flight limiter shared with the chunk provider;
     /// the peer entry is forgotten on disconnect.
     inflight: Option<Arc<PeerInflightLimiter>>,
+    /// Per-PO retrieval-latency estimate shared with the chunk provider; a
+    /// completed originated retrieval is recorded here keyed by its proximity.
+    retrieval_latency: Option<Arc<RetrievalLatency>>,
 }
 
 impl ClientService {
@@ -278,6 +282,7 @@ impl ClientService {
             reporter: None,
             store: None,
             inflight: None,
+            retrieval_latency: None,
         };
 
         (service, event_tx, handle)
@@ -297,6 +302,7 @@ impl ClientService {
             reporter: None,
             store: None,
             inflight: None,
+            retrieval_latency: None,
         };
 
         (service, handle)
@@ -331,6 +337,17 @@ impl ClientService {
     #[must_use]
     pub fn with_inflight_limiter(mut self, inflight: Arc<PeerInflightLimiter>) -> Self {
         self.inflight = Some(inflight);
+        self
+    }
+
+    /// Attach the per-PO retrieval-latency estimate so a completed originated
+    /// retrieval feeds the hedge the chunk provider paces its race with.
+    ///
+    /// Must be the same [`RetrievalLatency`] the chunk provider reads via
+    /// `NetworkChunkProvider::with_retrieval_latency`.
+    #[must_use]
+    pub(crate) fn with_retrieval_latency(mut self, latency: Arc<RetrievalLatency>) -> Self {
+        self.retrieval_latency = Some(latency);
         self
     }
 
@@ -398,7 +415,7 @@ impl ClientService {
                 chunk,
                 stamp,
                 latency,
-                originated: _,
+                originated,
             } => {
                 // The requester is resolved by the handler; this event exists for
                 // scoring and caching. Content chunks are cached by address
@@ -407,6 +424,13 @@ impl ClientService {
                 // is accounted by the forwarder. Cache and scoring apply to every
                 // delivery.
                 debug!(%peer, %address, ?latency, "Chunk received");
+                // Feed the per-PO latency estimate so the chunk provider can pace
+                // its staggered race to the forwarding distance. Only originated
+                // retrievals: a relay leg's latency is the requester's chain, not
+                // ours. Keyed by PO(serving_peer, chunk), the forwarding distance.
+                if originated && let Some(latency_estimate) = &self.retrieval_latency {
+                    latency_estimate.record(address.proximity(&peer).get(), latency);
+                }
                 if let Some(store) = &self.store
                     && chunk.is_content()
                 {

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -19,6 +19,7 @@ mod client_service;
 mod inflight;
 mod node;
 mod protocol;
+mod retrieval_latency;
 mod selection;
 mod staggered_race;
 

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -48,6 +48,7 @@ use vertex_swarm_accounting_swap::{SwapEvent, SwapHandle, SwapProvider, SwapServ
 #[cfg(feature = "swap")]
 use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 
+use crate::retrieval_latency::RetrievalLatency;
 use crate::{
     AccountingSettlement, ClientCommand, ClientHandle, ClientService, DEFAULT_PEER_INFLIGHT_CAP,
     PeerInflightLimiter, PeerSelector,
@@ -80,6 +81,10 @@ pub struct ClientCore {
     /// Per-peer retrieval in-flight cap shared by the chunk provider (reserves
     /// slots) and the service (forgets a peer on disconnect).
     pub inflight: Arc<PeerInflightLimiter>,
+    /// Per-PO retrieval-latency estimate shared by the service (records) and the
+    /// chunk provider (reads to pace its staggered race). Internal mechanism, so
+    /// crate-visible rather than part of the re-exported surface.
+    pub(crate) retrieval_latency: Arc<RetrievalLatency>,
     /// The origin-gated client handle the provider dispatches through; its
     /// admission band paces each own request before it sends.
     pub origin_handle: ClientHandle,
@@ -181,18 +186,26 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     // the service path forgets the same peer the provider reserves against.
     let inflight = Arc::new(PeerInflightLimiter::new(DEFAULT_PEER_INFLIGHT_CAP));
 
+    // Per-PO retrieval-latency estimate shared between the service (records a
+    // completed originated retrieval) and the chunk provider (reads it to pace
+    // the staggered race). One instance so the provider hedges on what the
+    // service has observed.
+    let retrieval_latency = Arc::new(RetrievalLatency::new());
+
     // The service reports through the same peer-manager authority accounting uses
     // and forgets a peer's in-flight slots on disconnect. The origin debit is
     // reserved and committed by the dispatch gate on the origin-gated handle, not
     // by the service.
     let client_service = client_service
         .with_reporter(reporter)
-        .with_inflight_limiter(Arc::clone(&inflight));
+        .with_inflight_limiter(Arc::clone(&inflight))
+        .with_retrieval_latency(Arc::clone(&retrieval_latency));
 
     ClientCore {
         accounting,
         selector,
         inflight,
+        retrieval_latency,
         origin_handle,
         topology,
         client_service,
@@ -733,7 +746,8 @@ where
 
     let chunk_provider = NetworkChunkProvider::new(core.origin_handle.clone(), topology.clone())
         .with_selector(Arc::clone(&core.selector))
-        .with_inflight_limiter(Arc::clone(&core.inflight));
+        .with_inflight_limiter(Arc::clone(&core.inflight))
+        .with_retrieval_latency(Arc::clone(&core.retrieval_latency));
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
     executor.spawn_service("swarm.client_service", core.client_service);

--- a/crates/swarm/node/src/retrieval_latency.rs
+++ b/crates/swarm/node/src/retrieval_latency.rs
@@ -1,0 +1,190 @@
+//! Per-proximity-order retrieval-latency estimate that paces the staggered race.
+//!
+//! Retrieval latency is dominated by the forwarding-chain length, which tracks
+//! how close the serving entry peer already is to the chunk: a chunk in the
+//! peer's neighbourhood returns in one hop, a sparse-bin chunk forwards several.
+//! Bucketing observed latency by `PO(serving_peer, chunk)` captures that, so the
+//! race paces its stagger to the distance actually being walked rather than to a
+//! single constant. Single-hop ping latency is deliberately not folded in: it
+//! reflects one connection, not a forwarding chain.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use crate::RETRIEVAL_STAGGER;
+
+/// Proximity-order buckets tracked. Proximity between two random addresses is
+/// geometric (mostly small); deeper observations clamp into the last bucket.
+const PO_BUCKETS: usize = 32;
+
+/// EWMA smoothing shift: each sample moves the estimate by `1 / 2^SHIFT` toward
+/// it, so the estimate tracks the recent distribution without chasing one outlier.
+const EWMA_SHIFT: u32 = 3;
+
+/// Multiplier on the observed round trip for the adaptive stagger: the next leg
+/// waits this many typical round trips, sitting above a head merely in flight
+/// while still tracking the real distribution.
+const HEDGE_RTT_MULTIPLIER: u32 = 2;
+
+/// Floor on the adaptive stagger, so even a very low-RTT neighbourhood keeps a
+/// hair of spacing between dispatched legs rather than fanning out at once.
+const HEDGE_STAGGER_FLOOR: Duration = Duration::from_millis(50);
+
+/// Per-PO EWMA of observed originated-retrieval latency, in nanoseconds.
+///
+/// Lock-free and shared between the client service (which records a completed
+/// retrieval keyed by `PO(serving_peer, chunk)`) and the chunk provider (which
+/// reads an estimate to pace its race). A zero bucket means no sample yet.
+#[derive(Debug)]
+pub(crate) struct RetrievalLatency {
+    buckets: [AtomicU64; PO_BUCKETS],
+}
+
+impl Default for RetrievalLatency {
+    fn default() -> Self {
+        Self {
+            buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+}
+
+impl RetrievalLatency {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    fn bucket(po: u8) -> usize {
+        (po as usize).min(PO_BUCKETS - 1)
+    }
+
+    /// Fold an observed retrieval `latency` for a chunk served at proximity `po`
+    /// into that bucket's EWMA.
+    pub(crate) fn record(&self, po: u8, latency: Duration) {
+        let sample = latency.as_nanos().min(u64::MAX as u128) as u64;
+        // `bucket` always indexes in range; the get is a non-panicking access.
+        let Some(cell) = self.buckets.get(Self::bucket(po)) else {
+            return;
+        };
+        // Relaxed read-blend-store: a racing sample at most drops one update,
+        // immaterial for a smoothed estimate that only paces a timer.
+        let prev = cell.load(Ordering::Relaxed);
+        let next = if prev == 0 {
+            sample
+        } else {
+            let delta = sample as i64 - prev as i64;
+            (prev as i64 + (delta >> EWMA_SHIFT)).max(0) as u64
+        };
+        cell.store(next, Ordering::Relaxed);
+    }
+
+    /// The current latency estimate for proximity `po`, or `None` if unsampled.
+    pub(crate) fn estimate(&self, po: u8) -> Option<Duration> {
+        match self.buckets.get(Self::bucket(po))?.load(Ordering::Relaxed) {
+            0 => None,
+            nanos => Some(Duration::from_nanos(nanos)),
+        }
+    }
+}
+
+/// Derive the staggered-race interval from the candidates' per-PO latency
+/// estimates: `clamp(k * median(estimates), floor, RETRIEVAL_STAGGER)`.
+///
+/// `RETRIEVAL_STAGGER` is the ceiling and the cold-start fallback, so the hedge
+/// is never slower than the fixed constant, only faster on a low-RTT
+/// neighbourhood. With no estimate (a cold node, or a chunk whose proximity has
+/// not been seen) every candidate yields `None` and the constant stands.
+pub(crate) fn adaptive_stagger(estimates: impl Iterator<Item = Option<Duration>>) -> Duration {
+    let mut known: Vec<Duration> = estimates.flatten().collect();
+    if known.is_empty() {
+        return RETRIEVAL_STAGGER;
+    }
+    known.sort_unstable();
+    match known.get(known.len() / 2) {
+        Some(median) => median
+            .saturating_mul(HEDGE_RTT_MULTIPLIER)
+            .clamp(HEDGE_STAGGER_FLOOR, RETRIEVAL_STAGGER),
+        None => RETRIEVAL_STAGGER,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn estimate_is_none_until_recorded_then_tracks_samples() {
+        let lat = RetrievalLatency::new();
+        assert_eq!(lat.estimate(8), None, "unsampled bucket is None");
+
+        lat.record(8, Duration::from_millis(100));
+        assert_eq!(
+            lat.estimate(8),
+            Some(Duration::from_millis(100)),
+            "the first sample seeds the bucket exactly"
+        );
+
+        // Further samples blend toward the new value, not jump to it.
+        lat.record(8, Duration::from_millis(900));
+        let est = lat.estimate(8).unwrap();
+        assert!(
+            est > Duration::from_millis(100) && est < Duration::from_millis(900),
+            "EWMA blends toward the new sample: {est:?}"
+        );
+    }
+
+    #[test]
+    fn buckets_are_keyed_by_proximity_order() {
+        let lat = RetrievalLatency::new();
+        lat.record(2, Duration::from_millis(800));
+        lat.record(20, Duration::from_millis(40));
+        // A near chunk (high PO) reads its own fast bucket; a far one its slow one.
+        assert_eq!(lat.estimate(20), Some(Duration::from_millis(40)));
+        assert_eq!(lat.estimate(2), Some(Duration::from_millis(800)));
+        // An out-of-range PO clamps into the last bucket rather than panicking.
+        assert_eq!(lat.estimate(255), lat.estimate((PO_BUCKETS - 1) as u8));
+    }
+
+    #[test]
+    fn adaptive_stagger_falls_back_to_the_constant_when_cold() {
+        let cold = adaptive_stagger([None, None].into_iter());
+        assert_eq!(cold, RETRIEVAL_STAGGER, "no estimate keeps the constant");
+    }
+
+    #[test]
+    fn adaptive_stagger_tracks_a_low_rtt_neighbourhood_down_to_the_floor() {
+        let fast = adaptive_stagger(
+            [
+                Some(Duration::from_millis(10)),
+                Some(Duration::from_millis(15)),
+            ]
+            .into_iter(),
+        );
+        assert_eq!(
+            fast, HEDGE_STAGGER_FLOOR,
+            "k * a few-ms median clamps up to the floor, far below the constant"
+        );
+    }
+
+    #[test]
+    fn adaptive_stagger_clamps_a_high_rtt_neighbourhood_to_the_constant() {
+        let slow = adaptive_stagger([Some(Duration::from_millis(900))].into_iter());
+        assert_eq!(
+            slow, RETRIEVAL_STAGGER,
+            "k * a high median clamps down to the ceiling, never slower than the constant"
+        );
+    }
+
+    #[test]
+    fn adaptive_stagger_hedges_at_the_multiplied_median_between_the_bounds() {
+        // Median 400ms, k = 2 -> 800ms, inside [50ms, 1200ms].
+        let mid = adaptive_stagger(
+            [
+                Some(Duration::from_millis(400)),
+                Some(Duration::from_millis(400)),
+                None,
+            ]
+            .into_iter(),
+        );
+        assert_eq!(mid, Duration::from_millis(800));
+    }
+}


### PR DESCRIPTION
## What

Replace the fixed 1200ms retrieval stagger with one paced by observed latency, bucketed by proximity order:

- New `RetrievalLatency`: a lock-free per-PO EWMA of observed originated-retrieval latency, keyed by `PO(serving_peer, chunk)`.
- The client service records a completed originated retrieval into the bucket for its proximity.
- The chunk provider's fallback walk derives its stagger from the candidates' per-PO estimates: `clamp(2 * median(estimates), 50ms, RETRIEVAL_STAGGER)`. `RETRIEVAL_STAGGER` is the ceiling and the cold-start fallback, so the hedge is never slower than the old constant, only faster on a low-RTT distance.
- One shared `Arc<RetrievalLatency>` wired into both the service (writer) and the provider (reader), mirroring the in-flight limiter.

The primary single-flight route is unchanged; only the staggered fallback adapts.

## Why

Part of #606 (Phase 1). The fixed constant is wrong in both directions, and a per-peer average is the wrong signal: retrieval latency is dominated by the forwarding-chain length, which tracks how close the serving entry peer already is to the chunk (a chunk in the peer's neighbourhood returns in one hop, a sparse-bin chunk forwards several). Bucketing by `PO(serving_peer, chunk)` captures that, so the race paces to the distance actually being walked. On a low-RTT or cluster network the difficult-chunk walk drops from 1200ms per leg toward the floor; on a high-RTT mainnet, or before any sample, it stays at the constant. Single-hop libp2p ping latency is deliberately excluded: it reflects one connection, not a forwarding chain. The over-fetch metrics from #605 are the calibration signal for the multiplier.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean), `cargo nextest run -p vertex-swarm-node --all-features` (156 pass, +6 new: per-PO record/estimate/EWMA-blend/bucket-keying, and the adaptive-stagger cold-fallback / floor-clamp / ceiling-clamp / mid-range cases), and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (clean). No wire change.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the design, implementation, and verification.

Closes #607. Part of #606.
