### PR TITLE
perf(swarm-node): settle the dispatched peer only, drop the in-request gate

### DIFF
--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -14,9 +14,7 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
 use vertex_swarm_topology::TopologyHandle;
-// `Instant` is portable (the browser performance clock on wasm); only timer
-// sleeps are `!Send`, and the gated-set wait awaits a settle completion instead.
-use vertex_tasks::time::{Duration, Instant};
+use vertex_tasks::time::Duration;
 
 use crate::retrieval_latency::{RetrievalLatency, adaptive_stagger};
 use crate::{
@@ -68,14 +66,6 @@ const RETRIEVE_WALK_MAX_IN_FLIGHT: usize = 3;
 /// indefinitely. Matches the per-request retrieval lifetime.
 const RETRIEVE_WALK_DEADLINE: Duration = Duration::from_secs(30);
 
-/// Bound on the settle-and-await for a fully gated close set: the request's own
-/// retrieval lifetime, matching the client-behaviour outbound retrieval timeout.
-/// Accounting-timing back-pressure blocks within the request rather than failing
-/// early to the consumer, and only a genuine lifetime expiry falls through to the
-/// generic transient failure. The wait is progress-aware, so it paces on
-/// settlement RTT and returns at once when no settle is in flight to drain debt.
-const GATE_SETTLE_BUDGET: Duration = Duration::from_secs(30);
-
 /// Wider topology slice the retrieval fallback spills to when the close set is
 /// fully gated.
 ///
@@ -84,11 +74,6 @@ const GATE_SETTLE_BUDGET: Duration = Duration::from_secs(30);
 /// forwards the chunk just the same. Routing a gated chunk there keeps the
 /// pipeline slot moving instead of parking it while the close set's debt drains.
 const RETRIEVE_SPILL_WIDTH: usize = 128;
-
-/// Bound on the settle-and-await once even the wider spill slice is fully gated.
-/// Short because, by then, every nearby peer is at its line and waiting buys
-/// little; failing fast to the consumer to re-stream beats holding the slot.
-const GATE_SPILL_SETTLE_BUDGET: Duration = Duration::from_secs(5);
 
 /// Legs the bin-bucket primary route dispatches before handing off to the
 /// staggered fallback.
@@ -173,33 +158,8 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         self
     }
 
-    /// Order proximity-sorted `candidates` for a request on `chunk`, settling
-    /// and awaiting a fully gated close set.
-    ///
-    /// With a selector this delegates to the score- and affordability-aware
-    /// ordering. A non-empty order returns at once (the fast path); a fully
-    /// gated close set awaits its in-flight settles up to the retrieval-lifetime
-    /// [`GATE_SETTLE_BUDGET`], returning at the deadline or promptly once no
-    /// settle is in flight to drain debt, with whatever is admissible (possibly
-    /// empty). An empty result falls through to the caller's generic transient
-    /// failure, never an accounting-specific error. The wait is `Send` on every
-    /// platform. With no selector the proximity order is returned unchanged.
-    async fn select_or_wait(
-        &self,
-        candidates: Vec<SwarmAddress>,
-        chunk: &ChunkAddress,
-    ) -> Vec<SwarmAddress> {
-        match &self.selector {
-            Some(selector) => {
-                let deadline = Instant::now() + GATE_SETTLE_BUDGET;
-                selector.order_or_wait(candidates, chunk, deadline).await
-            }
-            None => candidates,
-        }
-    }
-
     /// Order the close set, spilling to the closest admissible peers of a wider
-    /// slice before blocking on a settle drain.
+    /// slice when the close set is fully gated.
     ///
     /// A non-empty band over the close set returns at once (the fast path), keeping
     /// the close set's headroom-first debt spread. When every close peer is
@@ -210,12 +170,12 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     /// seconds a close-set debt takes to drain. The spill orders that wider slice
     /// by plain proximity among the admissible (not headroom-first), so the closest
     /// admissible peer leads and the chunk travels the minimum extra distance to
-    /// find capacity rather than scattering to a far headroom peer and paying more
-    /// forwarding hops. Only when even the wider slice is fully gated does it fall
-    /// back to a bounded [`GATE_SPILL_SETTLE_BUDGET`] settle wait. Disconnect-safe:
-    /// the band still hard-skips every refused peer, so no peer is sent a request
-    /// past its line. With no selector the proximity order is returned unchanged.
-    async fn select_or_spill(
+    /// find capacity. If even the wider slice is fully gated the result is empty and
+    /// the caller falls through to its generic transient failure, leaving the
+    /// consumer to re-stream rather than blocking the slot on a settle drain.
+    /// Disconnect-safe: the band still hard-skips every refused peer. With no
+    /// selector the proximity order is returned unchanged.
+    fn select_or_spill(
         &self,
         candidates: Vec<SwarmAddress>,
         chunk: &ChunkAddress,
@@ -228,19 +188,14 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
             return ordered;
         }
         let wide = self.topology.closest_to(chunk, RETRIEVE_SPILL_WIDTH);
-        let spilled = selector.order_closest_admissible(wide.clone(), chunk);
-        if !spilled.is_empty() {
-            return spilled;
-        }
-        let deadline = Instant::now() + GATE_SPILL_SETTLE_BUDGET;
-        selector.order_or_wait(wide, chunk, deadline).await
+        selector.order_closest_admissible(wide, chunk)
     }
 
-    /// Order `candidates` through the accounting band without awaiting a settle.
+    /// Order `candidates` through the accounting band.
     ///
-    /// Used by the bin-bucket primary, where a gated route must fall through to
-    /// the staggered fallback (which does await) rather than block here. Drops
-    /// refused peers and ranks by score; with no selector the order is unchanged.
+    /// Used by the bin-bucket primary and the pushsync path. Drops refused peers
+    /// and ranks by score; with no selector the order is unchanged. The peer a
+    /// request dispatches to is settled at the origin credit gate.
     fn select_now(&self, candidates: Vec<SwarmAddress>, chunk: &ChunkAddress) -> Vec<SwarmAddress> {
         match &self.selector {
             Some(selector) => selector.order(candidates, chunk),
@@ -311,9 +266,9 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
         // over fewer hops than a peer picked by raw closeness alone: fewer hops
         // is lower per-chunk latency, the throughput lever. The route is
         // single-flight (no stagger), so the happy path delivers one chunk for
-        // one metered leg and over-fetches nothing. The accounting band is
-        // applied without awaiting a settle here; a gated route falls through to
-        // the fallback, which does await.
+        // one metered leg and over-fetches nothing. The accounting band ranks the
+        // route here; a gated route falls through to the staggered fallback, which
+        // spills to a wider headroom slice.
         let local = self.topology.overlay_address();
         let max_bin = self.topology.max_bin().get();
         let bin_candidates = bin_routed_order(
@@ -374,10 +329,10 @@ impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
             .closest_to(&chunk_address, RETRIEVE_WALK_WIDTH);
         // Spill to a wider in-headroom slice when every close peer is gated, so a
         // fully gated close set routes around its spent peers rather than blocking;
-        // if even the wide slice is gated at the short budget the empty result
-        // falls through to the no-connected-peers path below, the same generic
-        // transient error a no-peers failure yields.
-        let closest_peers = self.select_or_spill(closest_peers, &chunk_address).await;
+        // if even the wide slice is gated the empty result falls through to the
+        // no-connected-peers path below, the same generic transient error a
+        // no-peers failure yields, and the consumer re-streams.
+        let closest_peers = self.select_or_spill(closest_peers, &chunk_address);
         let (candidates, enforce_cap) = skip_busy(closest_peers, self.inflight.as_deref());
 
         // Pace the staggered fan-out to the live round trip rather than a fixed
@@ -467,10 +422,10 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     async fn push_to_closest(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
         let address = *chunk.address();
         let closest = self.topology.closest_to(&address, PUSH_CANDIDATE_COUNT);
-        // Settle-and-await an all-gated closest set rather than immediately
-        // falling through to a farther peer or failing; if still gated at the
-        // budget the empty result yields the generic no-storer outcome below.
-        let closest = self.select_or_wait(closest, &address).await;
+        // Rank by band and score, hard-skipping a refused peer; an all-gated set
+        // yields an empty result and the generic no-storer outcome below. The peer
+        // a push actually dispatches to is settled at the origin credit gate.
+        let closest = self.select_now(closest, &address);
         let attempts = closest.len();
 
         // The required custody depth is derived from our locally observed
@@ -1462,130 +1417,9 @@ mod tests {
     }
 
     mod gated_fallback {
-        use std::future::Future;
-        use std::pin::Pin;
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicBool, Ordering};
-
-        use nectar_primitives::SwarmAddress;
-        use vertex_swarm_api::{Au, ChunkAddress, Ledger, SwarmError, SwarmPricing};
-        use vertex_tasks::time::Instant;
-
-        use crate::{PeerScores, PeerSelector, SettlementTrigger};
+        use vertex_swarm_api::SwarmError;
 
         use super::address;
-
-        fn overlay(n: u8) -> SwarmAddress {
-            SwarmAddress::from([n; 32])
-        }
-
-        struct NoScores;
-        impl PeerScores for NoScores {
-            fn peer_score(&self, _overlay: &SwarmAddress) -> Option<f64> {
-                None
-            }
-        }
-
-        struct UnitPricer;
-        impl SwarmPricing for UnitPricer {
-            fn price(&self, _chunk: &ChunkAddress) -> Au {
-                Au::from_amount(1)
-            }
-            fn peer_price(&self, _peer: &SwarmAddress, _chunk: &ChunkAddress) -> Au {
-                Au::from_amount(1)
-            }
-        }
-
-        /// Refuses every peer at the unit price while `gated`; admits once clear.
-        struct GatedLedger(Arc<AtomicBool>);
-        impl Ledger for GatedLedger {
-            fn balance(&self, _o: &SwarmAddress) -> Au {
-                Au::ZERO
-            }
-            fn reserved(&self, _o: &SwarmAddress) -> Au {
-                Au::ZERO
-            }
-            fn disconnect_line(&self, _o: &SwarmAddress) -> Au {
-                if self.0.load(Ordering::SeqCst) {
-                    Au::ZERO
-                } else {
-                    Au::from_amount(1000)
-                }
-            }
-            fn settle_trigger(&self, _o: &SwarmAddress) -> Au {
-                Au::from_amount(1000)
-            }
-        }
-
-        /// `settled` resolves at once; when `drains` it clears the gate first
-        /// (modelling a completed in-flight settle that drops the peer's debt
-        /// under its line) and reports `true`. Otherwise it reports `false`: no
-        /// settle is draining debt, so the wait loop stops without spinning.
-        struct DrainSettlement {
-            gate: Arc<AtomicBool>,
-            drains: bool,
-        }
-        impl SettlementTrigger for DrainSettlement {
-            fn trigger_settlement(&self, _peer: SwarmAddress) {}
-            fn settled(
-                &self,
-                _peers: &[SwarmAddress],
-            ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-                if self.drains {
-                    self.gate.store(false, Ordering::SeqCst);
-                }
-                Box::pin(std::future::ready(self.drains))
-            }
-        }
-
-        fn selector(gate: Arc<AtomicBool>, drains: bool) -> PeerSelector {
-            PeerSelector::new(
-                Arc::new(NoScores),
-                Arc::new(GatedLedger(Arc::clone(&gate))),
-                Arc::new(UnitPricer),
-                Arc::new(DrainSettlement { gate, drains }),
-            )
-        }
-
-        #[tokio::test]
-        async fn a_recovering_gated_set_returns_the_admissible_peers() {
-            // Every close peer is gated on the first order; the awaited settle
-            // drains the debt (the gate clears) and the re-order returns them.
-            let gate = Arc::new(AtomicBool::new(true));
-            let sel = selector(Arc::clone(&gate), true);
-            let deadline = Instant::now() + std::time::Duration::from_secs(5);
-            let ordered = sel
-                .order_or_wait(
-                    vec![overlay(1), overlay(2)],
-                    &ChunkAddress::zero(),
-                    deadline,
-                )
-                .await;
-            assert_eq!(
-                ordered,
-                vec![overlay(1), overlay(2)],
-                "recovers once the settle drains"
-            );
-        }
-
-        #[tokio::test]
-        async fn a_fully_gated_set_with_no_draining_settle_returns_empty() {
-            // The gate never clears and no settle is draining debt: the
-            // no-progress guard terminates the wait with an empty result, so the
-            // dispatch falls through to its generic transient error rather than
-            // hanging or spinning to the far deadline.
-            let gate = Arc::new(AtomicBool::new(true));
-            let sel = selector(Arc::clone(&gate), false);
-            let deadline = Instant::now() + std::time::Duration::from_secs(30);
-            let ordered = sel
-                .order_or_wait(
-                    vec![overlay(1), overlay(2)],
-                    &ChunkAddress::zero(),
-                    deadline,
-                )
-                .await;
-            assert!(ordered.is_empty(), "still gated, no settle draining");
-        }
 
         #[test]
         fn an_empty_close_set_surfaces_a_generic_transient_error() {

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -827,13 +827,6 @@ mod tests {
         fn trigger_settlement(&self, peer: OverlayAddress) {
             self.triggered.lock().unwrap().push(peer);
         }
-
-        fn settled(
-            &self,
-            _peers: &[OverlayAddress],
-        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send + '_>> {
-            Box::pin(std::future::ready(false))
-        }
     }
 
     /// A pricer charging a fixed price for every peer and chunk.

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -160,11 +160,13 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     let admission = accounting.bandwidth().clone();
     let settlement_trigger = Arc::new(AccountingSettlement::new(accounting.bandwidth().clone()));
 
+    // Ranking only: the selector triggers no settlement. The origin credit gate
+    // settles the peer a request actually dispatches to (`settlement_trigger`),
+    // so the settle fan-out is the legs contacted, not the candidate window.
     let selector = Arc::new(PeerSelector::new(
         Arc::new(topology.clone()),
         admission.clone(),
         Arc::new(accounting.pricing().clone()),
-        settlement_trigger.clone(),
     ));
 
     // The origin-gated handle the chunk provider dispatches through: each
@@ -172,8 +174,8 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     // shadow reserve), bands on the same admission boundary the selector uses,
     // commits the debit on delivery, and releases it on any other exit. The band
     // is the synchronous brake on the outbound rate: an over-threshold request
-    // settles or refuses before it sends. The settle trigger is the selector's,
-    // so settles dedup across both paths.
+    // settles or refuses before it sends. This gate is the sole settle trigger:
+    // a request settles only the peer it dispatches to, not the whole window.
     let origin_handle = client_handle.clone().with_origin_gate(
         Arc::new(accounting.pricing().clone()),
         accounting.bandwidth().clone(),

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -1,11 +1,15 @@
 //! Score- and credit-aware peer selection for retrieval and pushsync.
 //!
 //! Topology returns candidate storers in proximity order. [`PeerSelector`]
-//! reorders them with three additional signals before a request goes out:
+//! reorders them with three additional signals before a request goes out. The
+//! reorder is a pure function: the selector never triggers settlement. A request
+//! settles the one peer it actually dispatches to, at the origin credit gate, so
+//! the settle fan-out is the legs contacted rather than the whole window.
 //!
 //! - A peer the admission band refuses (the per-chunk debit would cross its
 //!   disconnect line) is hard-skipped, so the request routes to the next-closest
-//!   affordable peer while a background settle drains the skipped one.
+//!   affordable peer. The dispatch that crossed its line triggers one settle to
+//!   draw that peer back under its line.
 //! - Peers whose score is in the warned range are excluded among the admissible,
 //!   so a peer that is being scored down is not asked again while it misbehaves.
 //! - The admissible peers split into two affordability tiers: those with full
@@ -18,10 +22,7 @@
 //! Proximity is the secondary key within each tier; the headroom split orders the
 //! admissible above it. If every admissible candidate is warned, the warned peers
 //! are returned in proximity order so a degraded request can still go out; a
-//! refused peer is never resurrected this way. Every candidate not plainly
-//! admitted is settled (a peer in the tolerance band to stay there, a refused
-//! peer to drain back under its line); the settlement providers themselves decide
-//! whether any payment is actually due.
+//! refused peer is never resurrected this way.
 //!
 //! [`Admit`]: Admission::Admit
 //! [`SettleAndAdmit`]: Admission::SettleAndAdmit
@@ -30,17 +31,12 @@
 //! per-peer chunk price the accounting layer debits when the request is
 //! served.
 
-use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use futures::FutureExt;
-use futures::future::Shared;
 use nectar_primitives::ChunkAddress;
 use parking_lot::Mutex;
 use rustc_hash::FxBuildHasher;
-use tokio::sync::oneshot;
 use tracing::debug;
 use vertex_swarm_api::{
     Admission, AdmissionControl, DEFAULT_PEER_WARN_THRESHOLD, SwarmBandwidthAccounting,
@@ -49,16 +45,12 @@ use vertex_swarm_api::{
 use vertex_swarm_primitives::OverlayAddress;
 use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::TaskExecutor;
-use vertex_tasks::time::Instant;
 
-/// A shareable handle that resolves when an in-flight settle for a peer
-/// completes (the settle's [`InFlightGuard`] fires it on drop), so a waiter can
-/// re-evaluate admission as soon as the network settle acks.
-type SettleCompletion = Shared<oneshot::Receiver<()>>;
-
-/// Per-peer in-flight settle map. Overlay keys are uniformly random, so a fast
-/// non-DoS hasher keeps the settle-trigger dedup off SipHash.
-type InFlightMap = HashMap<OverlayAddress, SettleCompletion, FxBuildHasher>;
+/// Per-peer in-flight settle set: a peer is present while a settle to it is
+/// running, so a second trigger for it is deduped (the per-peer rate limit, the
+/// next settle cannot start until the prior one clears). Overlay keys are
+/// uniformly random, so a fast non-DoS hasher keeps the dedup off SipHash.
+type InFlightSet = HashSet<OverlayAddress, FxBuildHasher>;
 
 /// Source of live peer scores for candidate selection.
 ///
@@ -84,16 +76,6 @@ impl<I: SwarmIdentity> PeerScores for TopologyHandle<I> {
 pub trait SettlementTrigger: Send + Sync {
     /// Start settlement with `peer` without waiting for the outcome.
     fn trigger_settlement(&self, peer: OverlayAddress);
-
-    /// Resolve once any in-flight settle for the subset of `peers` currently
-    /// settling has completed, yielding whether one was actually awaited.
-    ///
-    /// Returns `true` after awaiting a real in-flight settle completion (paced by
-    /// network RTT), `false` immediately when none of `peers` is in flight. The
-    /// `bool` keeps the future `Send` and lets a gated-set wait loop both pace on
-    /// the settle ack and detect when no progress is possible (nothing draining
-    /// debt), so it returns rather than spinning to the deadline.
-    fn settled(&self, peers: &[OverlayAddress]) -> Pin<Box<dyn Future<Output = bool> + Send + '_>>;
 }
 
 /// [`SettlementTrigger`] over a bandwidth accounting instance.
@@ -102,14 +84,13 @@ pub trait SettlementTrigger: Send + Sync {
 /// selection never blocks on settlement I/O. Failures are logged at debug
 /// level; the next request retries naturally.
 ///
-/// A shared in-flight map keeps at most one settle per peer running at a time:
+/// A shared in-flight set keeps at most one settle per peer running at a time:
 /// the second trigger for a peer with a settle still outstanding is dropped, so
-/// the map is both the dedup and the per-peer rate limit (the next settle cannot
-/// start until the prior one is acked). The stored [`SettleCompletion`] lets a
-/// waiter await that ack.
+/// the set is both the dedup and the per-peer rate limit (the next settle cannot
+/// start until the prior one clears on completion).
 pub struct AccountingSettlement<B> {
     bandwidth: B,
-    in_flight: Arc<Mutex<InFlightMap>>,
+    in_flight: Arc<Mutex<InFlightSet>>,
 }
 
 impl<B> AccountingSettlement<B> {
@@ -117,29 +98,21 @@ impl<B> AccountingSettlement<B> {
     pub fn new(bandwidth: B) -> Self {
         Self {
             bandwidth,
-            in_flight: Arc::new(Mutex::new(InFlightMap::default())),
+            in_flight: Arc::new(Mutex::new(InFlightSet::default())),
         }
     }
 }
 
-/// Removes a peer from the in-flight map on drop and fires its completion, so a
-/// panic or cancellation of the settle future cannot pin the peer (which would
-/// starve its settlement) and any waiter on the settle is woken either way.
+/// Removes a peer from the in-flight set on drop, so a panic or cancellation of
+/// the settle future cannot pin the peer (which would starve its settlement).
 struct InFlightGuard {
-    in_flight: Arc<Mutex<InFlightMap>>,
+    in_flight: Arc<Mutex<InFlightSet>>,
     peer: OverlayAddress,
-    done: Option<oneshot::Sender<()>>,
 }
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
         self.in_flight.lock().remove(&self.peer);
-        // Fulfil the completion; dropping the sender would also resolve the
-        // shared receiver, so a waiter is woken on completion, cancellation, and
-        // panic alike.
-        if let Some(done) = self.done.take() {
-            let _ = done.send(());
-        }
     }
 }
 
@@ -155,23 +128,17 @@ where
         };
         // Skip if a settle to this peer is already running; the entry is cleared
         // when the spawned settle completes, so the next trigger can start a fresh
-        // one. The common steady-state path re-triggers a peer whose settle is
-        // still in flight, so the dedup check happens before the oneshot/Shared
-        // allocation: a hit returns on a bare map probe with nothing allocated.
-        let done = {
+        // one.
+        {
             let mut in_flight = self.in_flight.lock();
-            if in_flight.contains_key(&peer) {
+            if !in_flight.insert(peer) {
                 return;
             }
-            let (done, completion) = oneshot::channel();
-            in_flight.insert(peer, completion.shared());
-            done
-        };
+        }
         let handle = self.bandwidth.for_peer(peer);
         let guard = InFlightGuard {
             in_flight: Arc::clone(&self.in_flight),
             peer,
-            done: Some(done),
         };
         executor.spawn(async move {
             let _guard = guard;
@@ -179,24 +146,6 @@ where
                 debug!(%peer, %error, "best-effort settlement failed");
             }
         });
-    }
-
-    fn settled(&self, peers: &[OverlayAddress]) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-        let waiters: Vec<SettleCompletion> = {
-            let in_flight = self.in_flight.lock();
-            peers
-                .iter()
-                .filter_map(|peer| in_flight.get(peer).cloned())
-                .collect()
-        };
-        Box::pin(async move {
-            if waiters.is_empty() {
-                return false;
-            }
-            // The first completion is enough to re-evaluate admission.
-            let _ = futures::future::select_all(waiters).await;
-            true
-        })
     }
 }
 
@@ -210,36 +159,34 @@ pub struct PeerSelector {
     scores: Arc<dyn PeerScores>,
     admission: Arc<dyn AdmissionControl>,
     pricing: Arc<dyn SwarmPricing>,
-    settlement: Arc<dyn SettlementTrigger>,
 }
 
 impl PeerSelector {
-    /// Compose a selector from its query and trigger surfaces.
+    /// Compose a selector from its query surfaces.
+    ///
+    /// Ranking only: the selector never triggers settlement. A request settles
+    /// the peer it actually dispatches to, at the origin credit gate, so the
+    /// fan-out is the legs contacted rather than the whole candidate window.
     pub fn new(
         scores: Arc<dyn PeerScores>,
         admission: Arc<dyn AdmissionControl>,
         pricing: Arc<dyn SwarmPricing>,
-        settlement: Arc<dyn SettlementTrigger>,
     ) -> Self {
         Self {
             scores,
             admission,
             pricing,
-            settlement,
         }
     }
 
     /// Order `candidates` (in proximity order) for a request on `chunk`.
     ///
-    /// Applies the ranking described at the module level: a [`Refuse`] candidate
-    /// is hard-skipped (sending would cross its disconnect line), warned peers are
-    /// excluded, and the admissible rest are tiered headroom-first (an [`Admit`]
-    /// peer leads a [`SettleAndAdmit`] one) with proximity the key within a tier.
-    /// Every candidate not plainly [`Admit`]ted is settled (a [`SettleAndAdmit`]
-    /// peer to stay in the band, a refused peer to drain back under its line), so
-    /// its view of our debt drops.
-    /// A single pass triggers each peer at most once; the in-flight set dedups
-    /// across repeated calls.
+    /// Pure ranking, no side effect: a [`Refuse`] candidate is hard-skipped
+    /// (sending would cross its disconnect line), warned peers are excluded, and
+    /// the admissible rest are tiered headroom-first (an [`Admit`] peer leads a
+    /// [`SettleAndAdmit`] one) with proximity the key within a tier. Settlement is
+    /// triggered by the dispatch path for the peer a request actually contacts,
+    /// not for the whole window here.
     ///
     /// [`Refuse`]: Admission::Refuse
     /// [`Admit`]: Admission::Admit
@@ -259,8 +206,8 @@ impl PeerSelector {
     /// forwarding hops rather than debt spread: the closest admissible peer leads
     /// even if it is past the settle trigger, so a gated close set spills the
     /// minimum distance instead of skipping near in-band peers for a far headroom
-    /// one. Refuse and warned handling, and the settle triggers, match
-    /// [`order`](Self::order).
+    /// one. Refuse and warned handling match [`order`](Self::order); like it, this
+    /// is pure ranking and triggers no settlement.
     pub fn order_closest_admissible(
         &self,
         candidates: Vec<OverlayAddress>,
@@ -275,12 +222,11 @@ impl PeerSelector {
         chunk: &ChunkAddress,
         tiering: Tiering,
     ) -> Vec<OverlayAddress> {
-        // One admission band per candidate drives both the hard-skip (a refused
-        // peer leaves `ordered`) and the settle trigger (anything not plainly
-        // admitted). The band is read once per candidate (a single ledger lock and
-        // key hash via `admit`) and reused for both, so the hot path never bands a
-        // peer twice.
-        let ranked = rank_candidates(
+        // Pure ranking: the band hard-skips a refused peer and tiers the rest, and
+        // nothing is settled here. A request settles only the peer it actually
+        // dispatches to, at the origin credit gate, so the settle fan-out is the
+        // legs contacted rather than the whole candidate window.
+        rank_candidates(
             &candidates,
             |peer| self.scores.peer_score(peer),
             |peer| {
@@ -288,65 +234,8 @@ impl PeerSelector {
                     .admit(peer, self.pricing.peer_price(peer, chunk))
             },
             tiering,
-        );
-
-        for (peer, band) in candidates.iter().zip(&ranked.bands) {
-            if !matches!(band, Admission::Admit) {
-                self.settlement.trigger_settlement(*peer);
-            }
-        }
-
-        ranked.ordered
+        )
     }
-
-    /// Order `candidates`, settling and awaiting a fully gated close set until a
-    /// peer becomes admissible or the wait is exhausted.
-    ///
-    /// The first [`order`](Self::order) is the fast path: a non-empty result
-    /// returns at once. Only when every candidate is gated (the result is empty)
-    /// does the loop wait: each gated `order` already triggered a settle per
-    /// peer, so it awaits those settles completing (paced by network RTT, no
-    /// timer) and re-orders. The bound is `deadline`, the request's retrieval
-    /// lifetime, so accounting-timing back-pressure blocks within the request.
-    /// The loop is progress-aware: if no settle is in flight to drain debt
-    /// ([`settled`](SettlementTrigger::settled) returns `false`) it returns an
-    /// empty result at once rather than spinning, since no re-order can change.
-    /// Each awaited settle is RTT-paced, so the loop cannot busy-spin. An empty
-    /// result leaves the caller to surface its generic transient failure; an
-    /// accounting concern never reaches the consumer. The wait is `Send` on every
-    /// platform: awaiting a settle completion and reading [`Instant`] are both
-    /// `Send`.
-    pub async fn order_or_wait(
-        &self,
-        candidates: Vec<OverlayAddress>,
-        chunk: &ChunkAddress,
-        deadline: Instant,
-    ) -> Vec<OverlayAddress> {
-        loop {
-            let ordered = self.order(candidates.clone(), chunk);
-            if !ordered.is_empty() {
-                return ordered;
-            }
-            if Instant::now() >= deadline {
-                return Vec::new();
-            }
-            // No in-flight settle means nothing is draining debt, so no re-order
-            // can admit a peer: give up now rather than spin to the deadline.
-            if !self.settlement.settled(&candidates).await {
-                return Vec::new();
-            }
-        }
-    }
-}
-
-/// Outcome of ranking a candidate set.
-struct RankedCandidates {
-    /// Candidates to attempt, best first. Never includes a refused peer.
-    ordered: Vec<OverlayAddress>,
-    /// The admission band of each input candidate, in input order. Returned so
-    /// the caller can drive the settle pass off the same single band read per
-    /// candidate rather than re-banding.
-    bands: Vec<Admission>,
 }
 
 /// How [`rank_candidates`] orders the admissible peers.
@@ -374,22 +263,19 @@ enum Tiering {
 /// within each tier), under [`Tiering::Proximity`] in plain proximity order. If
 /// every admissible candidate is warned, those warned peers are returned in
 /// proximity order so a degraded request can still go out; a refused peer is
-/// never resurrected this way. `admit` is invoked exactly once per candidate and
-/// the bands are returned for reuse.
+/// never resurrected this way. `admit` is invoked exactly once per candidate.
 fn rank_candidates(
     candidates: &[OverlayAddress],
     score: impl Fn(&OverlayAddress) -> Option<f64>,
     admit: impl Fn(&OverlayAddress) -> Admission,
     tiering: Tiering,
-) -> RankedCandidates {
+) -> Vec<OverlayAddress> {
     let mut headroom = Vec::with_capacity(candidates.len());
     let mut near_threshold = Vec::new();
     let mut warned = Vec::new();
-    let mut bands = Vec::with_capacity(candidates.len());
 
     for peer in candidates {
         let band = admit(peer);
-        bands.push(band);
         if matches!(band, Admission::Refuse) {
             continue;
         }
@@ -418,13 +304,12 @@ fn rank_candidates(
         ordered = warned;
     }
 
-    RankedCandidates { ordered, bands }
+    ordered
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Mutex;
 
     use vertex_swarm_api::{Au, Ledger};
 
@@ -499,26 +384,6 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct RecordingSettlement {
-        triggered: Mutex<Vec<OverlayAddress>>,
-    }
-
-    impl SettlementTrigger for RecordingSettlement {
-        fn trigger_settlement(&self, peer: OverlayAddress) {
-            self.triggered.lock().unwrap().push(peer);
-        }
-
-        /// Records triggers but tracks no in-flight settle, so it reports `false`
-        /// (nothing awaited), modelling the no-progress case.
-        fn settled(
-            &self,
-            _peers: &[OverlayAddress],
-        ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-            Box::pin(std::future::ready(false))
-        }
-    }
-
     fn warned(peers: &[OverlayAddress]) -> impl Fn(&OverlayAddress) -> Option<f64> + '_ {
         move |p| {
             if peers.contains(p) {
@@ -563,7 +428,7 @@ mod tests {
             settle_due(&[peer(1), peer(3)]),
             Tiering::SpreadDebt,
         );
-        assert_eq!(ranked.ordered, vec![peer(2), peer(4), peer(1), peer(3)]);
+        assert_eq!(ranked, vec![peer(2), peer(4), peer(1), peer(3)]);
     }
 
     #[test]
@@ -579,7 +444,7 @@ mod tests {
             settle_due(&[peer(1), peer(3)]),
             Tiering::Proximity,
         );
-        assert_eq!(ranked.ordered, candidates);
+        assert_eq!(ranked, candidates);
     }
 
     #[test]
@@ -593,14 +458,14 @@ mod tests {
             refusing(&[peer(1)]),
             Tiering::Proximity,
         );
-        assert_eq!(ranked.ordered, vec![peer(2)]);
+        assert_eq!(ranked, vec![peer(2)]);
     }
 
     #[test]
     fn healthy_admitted_candidates_keep_proximity_order() {
         let candidates = vec![peer(1), peer(2), peer(3)];
         let ranked = rank_candidates(&candidates, warned(&[]), refusing(&[]), Tiering::SpreadDebt);
-        assert_eq!(ranked.ordered, candidates);
+        assert_eq!(ranked, candidates);
     }
 
     #[test]
@@ -612,14 +477,14 @@ mod tests {
             refusing(&[]),
             Tiering::SpreadDebt,
         );
-        assert_eq!(ranked.ordered, vec![peer(1), peer(3)]);
+        assert_eq!(ranked, vec![peer(1), peer(3)]);
     }
 
     #[test]
     fn unknown_peer_is_not_treated_as_warned() {
         let candidates = vec![peer(1), peer(2)];
         let ranked = rank_candidates(&candidates, |_| None, refusing(&[]), Tiering::SpreadDebt);
-        assert_eq!(ranked.ordered, candidates);
+        assert_eq!(ranked, candidates);
     }
 
     #[test]
@@ -633,7 +498,7 @@ mod tests {
             refusing(&[peer(1)]),
             Tiering::SpreadDebt,
         );
-        assert_eq!(ranked.ordered, vec![peer(2), peer(3)]);
+        assert_eq!(ranked, vec![peer(2), peer(3)]);
     }
 
     #[test]
@@ -646,7 +511,7 @@ mod tests {
             refusing(&[peer(1), peer(2), peer(3)]),
             Tiering::SpreadDebt,
         );
-        assert!(ranked.ordered.is_empty());
+        assert!(ranked.is_empty());
     }
 
     #[test]
@@ -658,7 +523,7 @@ mod tests {
             refusing(&[]),
             Tiering::SpreadDebt,
         );
-        assert_eq!(ranked.ordered, candidates);
+        assert_eq!(ranked, candidates);
     }
 
     #[test]
@@ -672,32 +537,29 @@ mod tests {
             refusing(&[peer(1)]),
             Tiering::SpreadDebt,
         );
-        assert_eq!(ranked.ordered, vec![peer(2)]);
+        assert_eq!(ranked, vec![peer(2)]);
     }
 
     #[test]
     fn empty_candidates_stay_empty() {
         let ranked = rank_candidates(&[], warned(&[]), refusing(&[]), Tiering::SpreadDebt);
-        assert!(ranked.ordered.is_empty());
+        assert!(ranked.is_empty());
     }
 
     fn selector(
         scores: HashMap<OverlayAddress, f64>,
         unaffordable: Vec<OverlayAddress>,
-        settlement: Arc<RecordingSettlement>,
     ) -> PeerSelector {
         PeerSelector::new(
             Arc::new(FixedScores(scores)),
             Arc::new(FixedLedger::new(unaffordable)),
             Arc::new(UnitPricer),
-            settlement,
         )
     }
 
     fn selector_with_settle_due(
         unaffordable: Vec<OverlayAddress>,
         settle_due: Vec<OverlayAddress>,
-        settlement: Arc<RecordingSettlement>,
     ) -> PeerSelector {
         PeerSelector::new(
             Arc::new(FixedScores(HashMap::new())),
@@ -706,57 +568,18 @@ mod tests {
                 settle_due,
             }),
             Arc::new(UnitPricer),
-            settlement,
         )
     }
 
     #[test]
-    fn selector_hard_skips_a_refused_peer_and_settles_it() {
+    fn selector_hard_skips_a_refused_peer() {
         // peer(1) is refused at the disconnect line: it is excluded from the
-        // ordered list (retrieval routes to peer(2)) and a settle is triggered so
-        // it drains back under its line.
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel = selector(HashMap::new(), vec![peer(1)], Arc::clone(&settlement));
+        // ordered list, so retrieval routes to peer(2). Settling the peer a
+        // request dispatches to is the credit gate's job, not the selector's.
+        let sel = selector(HashMap::new(), vec![peer(1)]);
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
         assert_eq!(ordered, vec![peer(2)], "the refused peer is hard-skipped");
-        assert_eq!(
-            *settlement.triggered.lock().unwrap(),
-            vec![peer(1)],
-            "the refused peer is settled so it drains"
-        );
-    }
-
-    #[test]
-    fn selector_settles_every_refused_candidate() {
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel = selector(
-            HashMap::new(),
-            vec![peer(1), peer(2)],
-            Arc::clone(&settlement),
-        );
-
-        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
-        assert!(ordered.is_empty(), "all refused, nothing sendable");
-        assert_eq!(
-            *settlement.triggered.lock().unwrap(),
-            vec![peer(1), peer(2)]
-        );
-    }
-
-    #[test]
-    fn selector_settles_proactively_when_debt_reaches_early_trigger() {
-        // A still-affordable peer whose debt has reached the early-payment trigger
-        // is settled before it becomes unaffordable, so its view of our debt drops
-        // before it would refuse or drop us. The closer peer(1) is past the trigger
-        // (SettleAndAdmit), so the headroom peer(2) leads it: debt spreads to a
-        // peer with headroom before the near-threshold one is asked again.
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel = selector_with_settle_due(Vec::new(), vec![peer(1)], Arc::clone(&settlement));
-
-        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
-        assert_eq!(ordered, vec![peer(2), peer(1)]);
-        assert_eq!(*settlement.triggered.lock().unwrap(), vec![peer(1)]);
     }
 
     #[test]
@@ -765,9 +588,7 @@ mod tests {
         // and peer(4) still have forgiveness headroom (Admit). The headroom tier
         // leads, each tier in proximity order, so a bulk download spreads debt
         // across headroom peers before leaning on a near-threshold one.
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel =
-            selector_with_settle_due(Vec::new(), vec![peer(1), peer(3)], Arc::clone(&settlement));
+        let sel = selector_with_settle_due(Vec::new(), vec![peer(1), peer(3)]);
 
         let ordered = sel.order(
             vec![peer(1), peer(2), peer(3), peer(4)],
@@ -781,12 +602,11 @@ mod tests {
     }
 
     #[test]
-    fn selector_keeps_a_settle_and_admit_peer_but_skips_a_refused_one() {
-        // Pushsync closeness: a peer in the tolerance band stays in the ordered
-        // list (and is settled in parallel), while only a peer refused at the
-        // disconnect line is dropped. peer(1) is in the band, peer(2) refuses.
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel = selector_with_settle_due(vec![peer(2)], vec![peer(1)], Arc::clone(&settlement));
+    fn selector_keeps_a_band_peer_but_skips_a_refused_one() {
+        // A peer in the tolerance band stays in the ordered list (closeness
+        // preserved), while only a peer refused at the disconnect line is dropped.
+        // peer(1) is in the band, peer(2) refuses.
+        let sel = selector_with_settle_due(vec![peer(2)], vec![peer(1)]);
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
         assert_eq!(
@@ -794,201 +614,16 @@ mod tests {
             vec![peer(1)],
             "the band peer is kept (closeness preserved), the refused peer skipped"
         );
-        assert_eq!(
-            *settlement.triggered.lock().unwrap(),
-            vec![peer(1), peer(2)],
-            "both the band peer and the refused peer settle"
-        );
-    }
-
-    #[test]
-    fn selector_does_not_settle_below_the_early_trigger() {
-        // No candidate is over the trigger and all are affordable: no settle.
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel = selector_with_settle_due(Vec::new(), Vec::new(), Arc::clone(&settlement));
-
-        let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
-        assert_eq!(ordered, vec![peer(1), peer(2)]);
-        assert!(settlement.triggered.lock().unwrap().is_empty());
     }
 
     #[test]
     fn selector_excludes_warned_peers() {
-        let settlement = Arc::new(RecordingSettlement::default());
         let mut scores = HashMap::new();
         scores.insert(peer(1), DEFAULT_PEER_WARN_THRESHOLD - 1.0);
-        let sel = selector(scores, Vec::new(), Arc::clone(&settlement));
+        let sel = selector(scores, Vec::new());
 
         let ordered = sel.order(vec![peer(1), peer(2)], &ChunkAddress::zero());
         assert_eq!(ordered, vec![peer(2)]);
-    }
-
-    /// A ledger gated by a shared flag: while gated every peer refuses; once the
-    /// flag clears every peer admits. Models a settle draining a peer's debt.
-    struct FlipLedger(Arc<std::sync::atomic::AtomicBool>);
-
-    impl Ledger for FlipLedger {
-        fn balance(&self, _overlay: &OverlayAddress) -> Au {
-            Au::ZERO
-        }
-        fn reserved(&self, _overlay: &OverlayAddress) -> Au {
-            Au::ZERO
-        }
-        fn disconnect_line(&self, _overlay: &OverlayAddress) -> Au {
-            if self.0.load(std::sync::atomic::Ordering::SeqCst) {
-                Au::ZERO
-            } else {
-                Au::from_amount(1000)
-            }
-        }
-        fn settle_trigger(&self, _overlay: &OverlayAddress) -> Au {
-            Au::from_amount(1000)
-        }
-    }
-
-    /// A settlement whose `settled` clears the shared gate and resolves at once,
-    /// modelling a completed settle that drains the peer's debt.
-    struct FlipSettlement(Arc<std::sync::atomic::AtomicBool>);
-
-    impl SettlementTrigger for FlipSettlement {
-        fn trigger_settlement(&self, _peer: OverlayAddress) {}
-        fn settled(
-            &self,
-            _peers: &[OverlayAddress],
-        ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-            // Models an in-flight settle that completes and drains the debt:
-            // reports `true` (a real completion was awaited).
-            self.0.store(false, std::sync::atomic::Ordering::SeqCst);
-            Box::pin(std::future::ready(true))
-        }
-    }
-
-    /// A ledger that always refuses every peer at the unit price, modelling a
-    /// close set that stays fully gated for the whole wait.
-    struct AlwaysGatedLedger;
-
-    impl Ledger for AlwaysGatedLedger {
-        fn balance(&self, _overlay: &OverlayAddress) -> Au {
-            Au::ZERO
-        }
-        fn reserved(&self, _overlay: &OverlayAddress) -> Au {
-            Au::ZERO
-        }
-        fn disconnect_line(&self, _overlay: &OverlayAddress) -> Au {
-            Au::ZERO
-        }
-        fn settle_trigger(&self, _overlay: &OverlayAddress) -> Au {
-            Au::from_amount(1000)
-        }
-    }
-
-    /// A settlement whose `settled` reports an in-flight completion that never
-    /// drains debt, RTT-paced by a short sleep so the wait loop cannot busy-spin.
-    struct StallSettlement;
-
-    impl SettlementTrigger for StallSettlement {
-        fn trigger_settlement(&self, _peer: OverlayAddress) {}
-        fn settled(
-            &self,
-            _peers: &[OverlayAddress],
-        ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
-            Box::pin(async {
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-                true
-            })
-        }
-    }
-
-    #[tokio::test]
-    async fn order_or_wait_returns_a_peer_once_a_settle_makes_it_admissible() {
-        // Every peer is gated on the first order; the awaited settle drains one
-        // (the flag flips) and the re-order returns the now-admissible peers.
-        let gated = Arc::new(std::sync::atomic::AtomicBool::new(true));
-        let sel = PeerSelector::new(
-            Arc::new(FixedScores(HashMap::new())),
-            Arc::new(FlipLedger(Arc::clone(&gated))),
-            Arc::new(UnitPricer),
-            Arc::new(FlipSettlement(Arc::clone(&gated))),
-        );
-
-        let deadline = Instant::now() + std::time::Duration::from_secs(5);
-        let ordered = sel
-            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
-            .await;
-        assert_eq!(ordered, vec![peer(1), peer(2)], "recovers after the settle");
-    }
-
-    #[tokio::test]
-    async fn order_or_wait_returns_empty_at_the_deadline_when_settles_never_drain() {
-        // Every order stays empty and each awaited (in-flight) settle resolves
-        // without draining debt: the loop runs to `deadline` and then returns
-        // empty, never hanging, so the caller raises its generic transient
-        // failure. A short deadline keeps the test fast.
-        let sel = PeerSelector::new(
-            Arc::new(FixedScores(HashMap::new())),
-            Arc::new(AlwaysGatedLedger),
-            Arc::new(UnitPricer),
-            Arc::new(StallSettlement),
-        );
-
-        let wait = std::time::Duration::from_millis(120);
-        let started = Instant::now();
-        let deadline = started + wait;
-        let ordered = sel
-            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
-            .await;
-        let elapsed = started.elapsed();
-        assert!(ordered.is_empty(), "still gated at the deadline");
-        assert!(
-            elapsed >= wait,
-            "the in-flight wait runs to the deadline, not short of it"
-        );
-        assert!(
-            elapsed < wait + std::time::Duration::from_secs(2),
-            "the wait terminates at the deadline and does not hang"
-        );
-    }
-
-    #[tokio::test]
-    async fn order_or_wait_returns_empty_promptly_when_no_settle_is_in_flight() {
-        // Every order stays empty and no settle is in flight to drain debt
-        // (`settled` reports `false`): no re-order can ever admit a peer, so the
-        // loop returns at once rather than spinning to a far-off deadline.
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel = selector(
-            HashMap::new(),
-            vec![peer(1), peer(2)],
-            Arc::clone(&settlement),
-        );
-
-        let started = Instant::now();
-        let deadline = started + std::time::Duration::from_secs(30);
-        let ordered = sel
-            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
-            .await;
-        assert!(ordered.is_empty(), "no peer is admissible");
-        assert!(
-            started.elapsed() < std::time::Duration::from_secs(1),
-            "the no-progress guard returns promptly, well before the deadline"
-        );
-    }
-
-    #[tokio::test]
-    async fn order_or_wait_returns_the_first_order_without_awaiting_a_settle() {
-        // An admissible close set returns on the first order: no settle is
-        // triggered and the settle wait is never entered.
-        let settlement = Arc::new(RecordingSettlement::default());
-        let sel = selector(HashMap::new(), Vec::new(), Arc::clone(&settlement));
-
-        let deadline = Instant::now() + std::time::Duration::from_secs(5);
-        let ordered = sel
-            .order_or_wait(vec![peer(1), peer(2)], &ChunkAddress::zero(), deadline)
-            .await;
-        assert_eq!(ordered, vec![peer(1), peer(2)], "fast path");
-        assert!(
-            settlement.triggered.lock().unwrap().is_empty(),
-            "no settle on the fast path"
-        );
     }
 
     // Dedup of `AccountingSettlement` over a mock bandwidth accounting whose
@@ -1148,59 +783,21 @@ mod tests {
     }
 
     #[test]
-    fn settled_resolves_when_the_in_flight_settle_completes() {
-        // A waiter on a peer's in-flight settle resolves once that settle acks,
-        // which is what paces the gated-set wait loop.
-        settlement_runtime().block_on(async {
-            let for_peer_calls = Arc::new(AtomicUsize::new(0));
-            let started = Arc::new(AtomicUsize::new(0));
-            let finished = Arc::new(AtomicUsize::new(0));
-            let gate = Arc::new(Notify::new());
-            let bandwidth = Arc::new(MockBandwidth {
-                for_peer_calls,
-                started: Arc::clone(&started),
-                finished,
-                gate: Arc::clone(&gate),
-            });
-            let trigger = AccountingSettlement::new(bandwidth);
-
-            // No settle in flight: the waiter resolves immediately.
-            trigger.settled(&[peer(1)]).await;
-
-            // Start a settle that parks on the gate, then take a waiter on it.
-            trigger.trigger_settlement(peer(1));
-            while started.load(Ordering::SeqCst) == 0 {
-                tokio::task::yield_now().await;
-            }
-            let waiter = trigger.settled(&[peer(1)]);
-
-            // Release the parked settle; the guard fires the completion on drop,
-            // so the waiter resolves. A bounded timeout proves it does not hang.
-            gate.notify_one();
-            vertex_tasks::time::timeout(std::time::Duration::from_secs(5), waiter)
-                .await
-                .expect("settled resolves once the in-flight settle completes");
-        });
-    }
-
-    #[test]
     fn in_flight_guard_clears_the_peer_on_drop() {
         // The guard removes the peer in Drop, which runs on normal completion,
         // unwind (a panicking settle), and cancellation alike, so a settle that
         // never completes cleanly cannot pin the peer and starve its settlement.
-        let in_flight = Arc::new(parking_lot::Mutex::new(InFlightMap::default()));
-        let (done, completion) = oneshot::channel();
-        in_flight.lock().insert(peer(1), completion.shared());
+        let in_flight = Arc::new(parking_lot::Mutex::new(InFlightSet::default()));
+        in_flight.lock().insert(peer(1));
         {
             let _guard = InFlightGuard {
                 in_flight: Arc::clone(&in_flight),
                 peer: peer(1),
-                done: Some(done),
             };
-            assert!(in_flight.lock().contains_key(&peer(1)));
+            assert!(in_flight.lock().contains(&peer(1)));
         }
         assert!(
-            !in_flight.lock().contains_key(&peer(1)),
+            !in_flight.lock().contains(&peer(1)),
             "the guard must clear the peer when dropped"
         );
     }


### PR DESCRIPTION
## What

Two coupled changes that collapse the retrieval-to-settlement coordination, closing #600 and #601.

**#600 - settle only the dispatched peer.** `PeerSelector::order` (and `order_closest_admissible`) become pure ranking functions: selection triggers no settlement. A request settles only the peer it actually dispatches to, at the origin credit gate (which already triggered the dispatched peer). The settle fan-out drops from O(candidate window) to O(legs contacted). The selector loses its `SettlementTrigger` dependency entirely.

**#601 - drop the in-request settle-and-wait gate.** With `order` pure, the in-request wait has nothing to drive it, and the headroom spill (#588/#591/#595, already merged) routes a fully gated close set around its spent peers. So the gate is removed: `order_or_wait`, `SettlementTrigger::settled`, the `SettleCompletion` shared one-shot, and both gate-budget constants (`GATE_SETTLE_BUDGET`, `GATE_SPILL_SETTLE_BUDGET`) all go. The in-flight dedup map degrades from a one-shot-per-peer map to a presence set (`HashSet`), keeping the per-peer dedup/rate-limit. `select_or_spill` no longer awaits, and the push path uses the plain ranking.

Net: roughly 580 lines removed, mostly machinery and its tests.

## Why

Part of #606 (Phase 2). Settling the whole window on every retrieval was the root cause of the ~20% wasted settlement traffic observed on the live download path (#593 paced its symptom; #580 made each band cheaper; this removes the breadth). The in-request wait existed to recover a fully gated close set; the headroom spill now handles that case before the wait was ever reached, leaving the wait as dead weight.

## Behaviour change

A fully gated close set (every close peer at its disconnect line, and the wider spill slice too) now fails fast to a generic transient error and the consumer re-streams, rather than blocking the request up to a 30s in-request settle wait. A refused peer drains on a later dispatch to it (or via passive creditor forgiveness) rather than a proactive settle from selection. This is the accepted design (#601): the spill makes a fully gated set rare, and the dispatch-path trigger settles the peers actually used. Worth watching the fully-gated-set frequency and the settle-rate metrics on a live download.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean), `cargo nextest run -p vertex-swarm-node --all-features` (150 pass; the order-triggers-settlement, `order_or_wait`, and `settled` tests are removed as they covered removed behaviour, and the dispatch-path trigger stays covered by the client-service reserve_origin tests), and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (clean). No wire change; settlement still routes through `settle_all`.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the implementation, the test changes, and the local verification.

Closes #600. Closes #601. Part of #606.
