### PR TITLE
fix(swarm-node): backpressure the settlement bridge instead of dropping

### DIFF
--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -170,6 +170,24 @@ impl ClientHandle {
         })
     }
 
+    /// Send a command, awaiting room when the channel is full instead of dropping.
+    ///
+    /// For the settlement command bridge: a dedicated task (not the libp2p event
+    /// loop) whose job is to move a settle command into the node channel without
+    /// losing it. Dropping one would strand the originating service's per-peer
+    /// pending entry, so the peer never settles again. Backpressure here instead;
+    /// the upstream service channel buffers under the wait, bounded by the
+    /// service's one-settle-per-peer dedup. Errors only when the channel is closed.
+    pub async fn send_command_buffered(
+        &self,
+        command: ClientCommand,
+    ) -> Result<(), ChunkTransferError> {
+        self.command_tx
+            .send(command)
+            .await
+            .map_err(|_| ChunkTransferError::ChannelClosed)
+    }
+
     /// Retrieve a chunk from a specific peer.
     ///
     /// Any failure on the path resolves or drops the response channel, so this
@@ -1379,5 +1397,61 @@ mod tests {
             error: "x".into(),
             kind: FailureKind::InvalidChunk,
         });
+    }
+
+    #[tokio::test]
+    async fn send_command_buffered_backpressures_instead_of_dropping() {
+        // A full node command channel must not drop a settle command: a dropped
+        // SendPseudosettle/SendCheque strands the originating service's per-peer
+        // pending entry (no Sent/Failed event ever clears it), so the peer never
+        // settles again. The buffered send awaits room and delivers the command
+        // rather than losing it, which the non-blocking send_command would.
+        use alloy_primitives::U256;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let handle = ClientHandle::new(tx);
+
+        // Fill the single channel slot.
+        handle
+            .send_command_buffered(ClientCommand::SendPseudosettle {
+                peer: peer(1),
+                amount: U256::from(1u64),
+            })
+            .await
+            .expect("first send fits");
+
+        // A second buffered send blocks while the channel is full rather than
+        // dropping the command.
+        let queued = {
+            let handle = handle.clone();
+            tokio::spawn(async move {
+                handle
+                    .send_command_buffered(ClientCommand::SendPseudosettle {
+                        peer: peer(2),
+                        amount: U256::from(2u64),
+                    })
+                    .await
+            })
+        };
+        tokio::task::yield_now().await;
+        assert!(
+            !queued.is_finished(),
+            "the buffered send awaits room, it does not drop"
+        );
+
+        // Draining a slot lets the queued send complete: both commands delivered,
+        // none lost.
+        assert!(matches!(
+            rx.recv().await,
+            Some(ClientCommand::SendPseudosettle { .. })
+        ));
+        queued
+            .await
+            .expect("task joins")
+            .expect("queued send delivers once room frees");
+        assert!(matches!(
+            rx.recv().await,
+            Some(ClientCommand::SendPseudosettle { .. })
+        ));
     }
 }

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -499,8 +499,15 @@ pub fn spawn_client_command_bridge(
                 }
                 command = command_rx.recv() => {
                     let Some(command) = command else { break };
-                    if let Err(e) = client_handle.send_command(command) {
-                        warn!(error = %e, "Failed to forward settlement command to node");
+                    // Backpressure, never drop: a dropped settle command strands
+                    // the originating service's per-peer pending entry, so that
+                    // peer never settles again and is eventually dropped at its
+                    // line. Awaiting the bounded node channel buffers the wait on
+                    // the upstream service channel, which the service's
+                    // one-settle-per-peer dedup keeps bounded. Errors only on a
+                    // closed channel (node shutting down).
+                    if let Err(e) = client_handle.send_command_buffered(command).await {
+                        warn!(error = %e, "settlement command bridge stopped: node channel closed");
                     }
                 }
             }


### PR DESCRIPTION
## What

The settlement command bridge (`spawn_client_command_bridge`) forwarded a service's outbound settle command into the node's bounded command channel with a non-blocking `try_send`, dropping it on `Full` and logging a warning. This change makes the bridge **await** the bounded send instead, so a settle command is never dropped.

- New `ClientHandle::send_command_buffered`: awaits room on the bounded node channel, errors only when the channel is closed.
- The bridge (a dedicated task, not the libp2p event loop) awaits it rather than calling the non-blocking `send_command`. The existing `send_command` is unchanged for the event-loop-adjacent callers that must not block.

## Why

Part of #606 (Phase 2). A dropped `SendPseudosettle`/`SendCheque` opens no substream, so the originating service never sees a `Sent` or `Failed` event and its per-peer `pending` entry is never cleared. Every later settle to that peer then short-circuits as `SettlementInProgress` for the connection's lifetime: the peer's debt never drains and it is eventually dropped at its disconnect line. The trigger is node-channel saturation, exactly the bulk-download regime the retrieval path is tuned for, so this is not a rare edge.

Awaiting eliminates the drop at the source, so the service always sees its terminal event and clears `pending` (no service change needed). The wait backpressures onto the service's unbounded channel, which the service's one-settle-per-peer dedup keeps bounded (at most one in-flight settle command per peer). Shutdown is safe: the node loop drops the command receiver on shutdown, so an in-flight awaited send returns a closed-channel error and the bridge unwinds.

## Testing

`cargo fmt --all`, `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean), `cargo nextest run -p vertex-swarm-node --all-features` (151 pass, including a new `send_command_buffered_backpressures_instead_of_dropping` that fills the channel and asserts a second send awaits room and then delivers, rather than dropping), and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (clean). No wire change.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8) used for the diagnosis, implementation, the test, and verification.

Closes #598. Part of #606.
