### PR TITLE
refactor(swarm-node): unify origin retrieval behind one RetrievalEngine (trait lattice)

### DIFF
--- a/bin/swarm-demo/src/client/network.rs
+++ b/bin/swarm-demo/src/client/network.rs
@@ -2,37 +2,28 @@
 
 use std::sync::Arc;
 
-use nectar_primitives::SwarmAddress;
 use vertex_swarm_api::{
     ChunkAddress, ChunkRetrievalResult, PushReceipt, StampedChunk, SwarmChunkProvider,
     SwarmChunkSender, SwarmError, SwarmResult, SwarmTopologyRouting,
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::{
-    ChunkTransferError, ClientHandle, RETRIEVAL_STAGGER, RaceFailure, race_candidates,
+    ClientHandle, NoInflightLimit, NoLatencyHint, ProximityOnly, RetrievalEngine,
 };
-use vertex_swarm_primitives::OverlayAddress;
 use vertex_swarm_topology::TopologyHandle;
 
 /// Closest peers to try when pushing a chunk before giving up.
 const PUSH_CANDIDATE_COUNT: usize = 5;
 
-/// Connected peers raced together in the first retrieval wave.
-const RETRIEVE_INITIAL_CANDIDATES: usize = 8;
-
-/// Additional connected peers admitted to the race on each later fallback wave.
-const RETRIEVE_WAVE_STEP: usize = 8;
-
-/// Hard ceiling on connected peers a retrieval races before it stops widening.
-///
-/// A retrieval never dials: it relies on the serving peer to forward the request
-/// toward the chunk's neighbourhood (the retrieval protocol is forwarding-based).
-/// Racing the closest connected peers is enough, so this is the only budget.
-const RETRIEVE_CLOSE_BUDGET: usize = 24;
-
 /// A proximity-routing chunk provider/sender over the browser client node.
+///
+/// Drives the shared [`RetrievalEngine`] with the null-object capabilities
+/// ([`ProximityOnly`], [`NoInflightLimit`], [`NoLatencyHint`]): no economic
+/// ordering, no per-peer cap, and the constant stagger. Every retrieval terminal
+/// surfaces as `RetrievalExhausted`.
 #[derive(Clone)]
 pub struct BrowserChunkProvider {
+    engine: RetrievalEngine<Arc<Identity>, ProximityOnly, NoInflightLimit, NoLatencyHint>,
     client: ClientHandle,
     topology: TopologyHandle<Arc<Identity>>,
 }
@@ -40,195 +31,29 @@ pub struct BrowserChunkProvider {
 impl BrowserChunkProvider {
     /// Build the provider from the launched client's handle and topology.
     pub fn new(client: ClientHandle, topology: TopologyHandle<Arc<Identity>>) -> Self {
-        Self { client, topology }
+        Self {
+            engine: RetrievalEngine::new(
+                client.clone(),
+                topology.clone(),
+                ProximityOnly,
+                NoInflightLimit,
+                NoLatencyHint,
+            ),
+            client,
+            topology,
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl SwarmChunkProvider for BrowserChunkProvider {
-    /// Retrieve a chunk by racing the closest connected peers in widening waves.
-    ///
-    /// The browser never dials on a retrieval. The retrieval protocol is
-    /// forwarding-based: a connected peer that does not hold the chunk relays the
-    /// request to a peer strictly closer to the chunk and returns the answer, so
-    /// racing the closest connected peers reaches the chunk's neighbourhood
-    /// without the client opening any new connection. A terminal absence surfaces
-    /// as `NotFound`.
     async fn retrieve_chunk(&self, address: &ChunkAddress) -> SwarmResult<ChunkRetrievalResult> {
-        let chunk_address = SwarmAddress::new(address.0.into());
-
-        // Rank the connected peers by proximity to the chunk, but only the
-        // closest `RETRIEVE_CLOSE_BUDGET` of them.
-        let ranked = self
-            .topology
-            .closest_to(&chunk_address, RETRIEVE_CLOSE_BUDGET);
-
-        if ranked.is_empty() {
-            tracing::warn!(
-                chunk = %chunk_address,
-                "retrieval: no connected peers available"
-            );
-            return Err(SwarmError::network_msg(
-                "no connected peers available for retrieval",
-            ));
-        }
-
-        match self.race_connected_waves(&ranked, chunk_address).await {
-            WaveOutcome::Hit(result) => {
-                tracing::debug!(
-                    chunk = %chunk_address,
-                    served_by = %result.served_by,
-                    server_po = chunk_address.proximity(&result.served_by).get(),
-                    close_peers = ranked.len(),
-                    "retrieval: succeeded over connected peers (forwarding)"
-                );
-                Ok(result)
-            }
-            WaveOutcome::NotFound => {
-                tracing::warn!(
-                    chunk = %chunk_address,
-                    close_peers = ranked.len(),
-                    "retrieval: not found across connected peers (forwarded-but-absent)"
-                );
-                Err(SwarmError::ChunkNotFound { address: *address })
-            }
-            WaveOutcome::Failed(e) => {
-                tracing::warn!(
-                    chunk = %chunk_address,
-                    close_peers = ranked.len(),
-                    error = %e,
-                    "retrieval: all connected peers failed"
-                );
-                Err(SwarmError::AllPeersFailed {
-                    address: *address,
-                    attempts: ranked.len(),
-                    source: Box::new(e),
-                })
-            }
-            WaveOutcome::NoCandidates => Err(SwarmError::network_msg(
-                "no connected peers available for retrieval",
-            )),
-        }
+        self.engine.retrieve(address).await
     }
 
     fn has_chunk(&self, _address: &ChunkAddress) -> bool {
         // Client nodes have no local storage.
         false
-    }
-}
-
-/// Outcome of the close-peer wave phase.
-enum WaveOutcome {
-    /// A connected peer served the chunk.
-    Hit(ChunkRetrievalResult),
-    /// Every attempted wave failed and the terminal failure was `NotFound`.
-    NotFound,
-    /// Every attempted wave failed with a retryable (non-`NotFound`) error.
-    Failed(ChunkTransferError),
-    /// The candidate slice was empty.
-    NoCandidates,
-}
-
-impl BrowserChunkProvider {
-    /// Race the proximity-ranked connected peers in widening waves to the first answer.
-    ///
-    /// Each attempt logs the serving peer's proximity to the chunk at debug: a
-    /// connected peer serving a chunk far from itself is the observable signature
-    /// of the remote forwarding the request onward.
-    async fn race_connected_waves(
-        &self,
-        ranked: &[OverlayAddress],
-        chunk_address: SwarmAddress,
-    ) -> WaveOutcome {
-        let available = ranked.len();
-        let mut attempted = 0usize;
-        let mut wave = 0usize;
-        let mut last_failure: Option<ChunkTransferError> = None;
-
-        while attempted < available {
-            let wave_len = if wave == 0 {
-                RETRIEVE_INITIAL_CANDIDATES
-            } else {
-                RETRIEVE_WAVE_STEP
-            };
-            let wave_end = (attempted + wave_len).min(available);
-            let slice: Vec<_> = ranked[attempted..wave_end].to_vec();
-            let wave_size = slice.len();
-            if wave_size == 0 {
-                break;
-            }
-
-            match race_candidates(slice, RETRIEVAL_STAGGER, |peer| {
-                let client = self.client.clone();
-                async move {
-                    let peer_po = chunk_address.proximity(&peer).get();
-                    let started = js_sys::Date::now();
-                    let outcome = client.retrieve_chunk(peer, chunk_address, true).await;
-                    let latency_ms = js_sys::Date::now() - started;
-                    match &outcome {
-                        Ok(_) => tracing::debug!(
-                            %peer,
-                            chunk = %chunk_address,
-                            peer_po,
-                            latency_ms,
-                            "retrieval attempt: Hit"
-                        ),
-                        Err(ChunkTransferError::NotFound(_)) => tracing::debug!(
-                            %peer,
-                            chunk = %chunk_address,
-                            peer_po,
-                            latency_ms,
-                            "retrieval attempt: NotFound"
-                        ),
-                        Err(ChunkTransferError::TimedOut) => tracing::debug!(
-                            %peer,
-                            chunk = %chunk_address,
-                            peer_po,
-                            latency_ms,
-                            "retrieval attempt: Timeout"
-                        ),
-                        Err(e) => tracing::debug!(
-                            %peer,
-                            chunk = %chunk_address,
-                            peer_po,
-                            latency_ms,
-                            error = %e,
-                            "retrieval attempt: transport-error"
-                        ),
-                    }
-                    outcome
-                }
-            })
-            .await
-            {
-                Ok(result) => {
-                    return WaveOutcome::Hit(ChunkRetrievalResult {
-                        chunk: result.chunk,
-                        stamp: result.stamp,
-                        served_by: result.peer,
-                    });
-                }
-                Err(RaceFailure::NoCandidates) => break,
-                Err(RaceFailure::AllFailed(e)) => {
-                    attempted += wave_size;
-                    last_failure = Some(e);
-                    wave += 1;
-                }
-                // `race_candidates` carries no wall-clock deadline, so this is
-                // unreachable here; advance to the next wave for forward
-                // compatibility rather than abandoning the walk.
-                Err(RaceFailure::TimedOut) => {
-                    attempted += wave_size;
-                    wave += 1;
-                }
-            }
-        }
-
-        match last_failure {
-            Some(ChunkTransferError::NotFound(_)) => WaveOutcome::NotFound,
-            Some(e) => WaveOutcome::Failed(e),
-            None => WaveOutcome::NoCandidates,
-        }
     }
 }
 

--- a/bin/swarm-demo/src/client/usage.rs
+++ b/bin/swarm-demo/src/client/usage.rs
@@ -56,8 +56,9 @@ impl SnapshotSource for BrowserUsageSource {
             // for a single-owner chunk). Its data payload is the snapshot payload
             // the codec parses; hand back a clone of it.
             Ok(result) => Ok(Some(result.chunk.data().clone())),
-            // A definitively-absent chunk: the network agrees it does not exist.
-            Err(e) if e.is_not_found() => Ok(None),
+            // Retrieval exhausted the reachable peers: best-effort snapshot, so
+            // treat the chunk as absent rather than failing the open.
+            Err(SwarmError::RetrievalExhausted { .. }) => Ok(None),
             // Any other error is a read that could not be completed.
             Err(e) => Err(UsageAdapterError::from(e)),
         }

--- a/crates/swarm/AGENTS.md
+++ b/crates/swarm/AGENTS.md
@@ -47,7 +47,7 @@ A per-node-type `#[derive(NetworkBehaviour)]` composite (modelled on `topology`)
 
 ## Retrieval dispatch ordering
 
-Retrieval fan-out is free to redirect a chunk to any close peer in any completion order because the consumer reorders (see `crates/swarm/stream/AGENTS.md`). Per-peer substream capping is a non-economic guard composed AFTER economic selection: the dispatch order is selector (who is eligible) then skip-busy (who has a free slot) then the origin credit gate (band the chosen request). The substream cap must never be merged with the affordability or debt signals.
+Retrieval fan-out is free to redirect a chunk to any close peer in any completion order because the consumer reorders (see `crates/swarm/stream/AGENTS.md`). Per-peer substream capping is a non-economic guard composed AFTER economic selection: the dispatch order is the candidate ordering (who is eligible) then the in-flight cap (who has a free slot) then the origin credit gate (band the chosen request). The substream cap must never be merged with the affordability or debt signals.
 
 ## Nectar boundary
 

--- a/crates/swarm/api/src/error.rs
+++ b/crates/swarm/api/src/error.rs
@@ -54,10 +54,15 @@ impl AccountingError {
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum SwarmError {
-    /// Chunk not found in the network.
-    #[error("chunk not found: {address}")]
-    ChunkNotFound {
-        /// The address of the chunk that wasn't found.
+    /// Retrieval exhausted every reachable peer without serving the chunk.
+    ///
+    /// Forwarding retrieval has no authoritative negative on the wire, so this is
+    /// not a claim of absence: the reachable entry points were tried and none
+    /// served it, so a later request after reconnection or a topology change may
+    /// still succeed.
+    #[error("retrieval exhausted all reachable peers for chunk: {address}")]
+    RetrievalExhausted {
+        /// The address of the chunk that could not be retrieved.
         address: ChunkAddress,
     },
 
@@ -244,11 +249,6 @@ impl SwarmError {
                 | Self::AllPeersFailed { .. }
                 | Self::UnconfirmedCustody { .. }
         )
-    }
-
-    /// Whether this error indicates the requested data does not exist.
-    pub fn is_not_found(&self) -> bool {
-        matches!(self, Self::ChunkNotFound { .. })
     }
 
     /// Whether this error indicates invalid input data.

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -710,7 +710,7 @@ impl ClientHandler {
                     stamp,
                     peer: overlay,
                 }));
-                // An originated delivery whose receiver is gone: the race leg that
+                // An originated delivery whose receiver is gone: the attempt that
                 // asked for it already lost (or the request was abandoned), so the
                 // chunk was fetched and metered but is discarded. Retrieval is not
                 // cancellable downstream, so this is the delivery-side over-fetch

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -1,26 +1,21 @@
 //! RPC provider implementations for Swarm nodes.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
-use metrics::{counter, histogram};
 use nectar_primitives::SwarmAddress;
 use tracing::warn;
 use vertex_swarm_api::{
-    Bin, ChunkAddress, ChunkRetrievalResult, PeerReporter, PushReceipt, ReportSource, StampedChunk,
+    ChunkAddress, ChunkRetrievalResult, PeerReporter, PushReceipt, ReportSource, StampedChunk,
     SwarmChunkProvider, SwarmChunkSender, SwarmError, SwarmIdentity, SwarmResult,
-    SwarmScoringEvent, SwarmTopologyPeers, SwarmTopologyRouting, SwarmTopologyState,
+    SwarmScoringEvent, SwarmTopologyRouting, SwarmTopologyState,
 };
 use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
 use vertex_swarm_topology::TopologyHandle;
-use vertex_tasks::time::Duration;
 
-use crate::retrieval_latency::{RetrievalLatency, adaptive_stagger};
-use crate::{
-    ChunkTransferError, ClientHandle, PeerInflightLimiter, PeerSelector, RETRIEVAL_STAGGER,
-    RaceFailure, RetrievalResult, race_walk,
-};
+use crate::retrieval_engine::RetrievalEngine;
+use crate::retrieval_latency::RetrievalLatency;
+use crate::{ClientHandle, PeerInflightLimiter, PeerSelector};
 
 /// Report source for shallow/malformed receipts caught on the origin upload
 /// path.
@@ -29,380 +24,49 @@ const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
 /// Number of closest peers to try when pushing a chunk before giving up.
 const PUSH_CANDIDATE_COUNT: usize = 5;
 
-/// Proximity-ordered pool of closest connected peers the retrieval walk draws
-/// from.
+/// The native client's concrete retrieval engine: the score- and
+/// affordability-aware selector, the per-peer in-flight cap, and the per-PO
+/// latency estimate, all shared by `Arc`.
+type NativeEngine<I> =
+    RetrievalEngine<I, Arc<PeerSelector>, Arc<PeerInflightLimiter>, Arc<RetrievalLatency>>;
+
+/// Chunk provider using a shared retrieval engine for network retrieval.
 ///
-/// Wider than [`RETRIEVE_LEG_BUDGET`] so that, after skip-busy removes peers at
-/// their in-flight cap, the walk still has next-closest free-slot entry points to
-/// refill a failed leg with rather than overrunning a hot peer. Retrieval is
-/// forwarding-based, so these are connected peers only; the walk never dials.
-const RETRIEVE_WALK_WIDTH: usize = 32;
-
-/// Maximum real retrieval legs the walk dispatches per chunk before giving up.
-///
-/// A chunk whose closest few entry points miss is not absent: each leg is a
-/// distinct peer whose own forwarding chain may still reach the chunk's storers,
-/// so a sparse-bin chunk needs more than the closest few tries. Peers skipped for
-/// back-pressure before dispatch do not count against this budget, so it bounds
-/// only genuine coverage attempts and the metered bandwidth they cost. The
-/// reference node's origin ceiling is 32; this starts conservative and is raised
-/// only on the residual-failure metric below.
-const RETRIEVE_LEG_BUDGET: usize = 8;
-
-/// Maximum legs the staggered fallback keeps concurrently in flight, bounding the
-/// metered over-fetch independently of [`RETRIEVE_LEG_BUDGET`].
-///
-/// A losing race leg is not cancelled downstream: the serving chain forwards and
-/// delivers regardless, so every overlapping leg is real duplicate bandwidth and
-/// cost. The stagger grows the in-flight set one leg per tick, so a withhold-storm
-/// would otherwise reach the full budget concurrently. This caps the simultaneous
-/// legs at a handful while [`RETRIEVE_LEG_BUDGET`] still bounds the lifetime total;
-/// a failed leg refills at once, replacing a freed slot rather than widening, so
-/// the walk keeps its reach.
-const RETRIEVE_WALK_MAX_IN_FLIGHT: usize = 3;
-
-/// Wall-clock bound on the whole retrieval walk across its refilled legs, so a
-/// run of slow or withholding entry points cannot hold a download-pipeline slot
-/// indefinitely. Matches the per-request retrieval lifetime.
-const RETRIEVE_WALK_DEADLINE: Duration = Duration::from_secs(30);
-
-/// Wider topology slice the retrieval fallback spills to when the close set is
-/// fully gated.
-///
-/// The closest peers to a chunk carry a download's debt and gate first; a far
-/// larger set of slightly-farther peers still holds forgiveness headroom and
-/// forwards the chunk just the same. Routing a gated chunk there keeps the
-/// pipeline slot moving instead of parking it while the close set's debt drains.
-const RETRIEVE_SPILL_WIDTH: usize = 128;
-
-/// Legs the bin-bucket primary route dispatches before handing off to the
-/// staggered fallback.
-///
-/// The primary routes a chunk to its Kademlia forwarding bin and tries the
-/// in-headroom connected peers there (then the adjacent bins) one at a time. A
-/// peer already sharing the chunk's prefix forwards over fewer hops, so the
-/// closest few are the high-probability entry points; past that the difficult
-/// chunk is better served by the wider staggered fallback than by more
-/// single-flight bin tries. Bounds the metered legs the primary spends.
-const PRIMARY_ROUTE_BUDGET: usize = 4;
-
-/// Wall-clock bound on the whole bin-bucket primary route.
-///
-/// The primary is single-flight, so a withholding head holds the one in-flight
-/// leg with no overlapping leg to overtake it. This deadline hands a stuck route
-/// off to the staggered fallback rather than stalling the chunk's pipeline slot;
-/// the forwarding bin's peers are close, so a genuine answer arrives well inside
-/// it and only a stuck route pays the full wait.
-const PRIMARY_ROUTE_DEADLINE: Duration = Duration::from_secs(2);
-
-/// Stagger for the primary route, set beyond [`PRIMARY_ROUTE_DEADLINE`] so it
-/// never fires: the primary is strict single-flight.
-///
-/// Exactly one metered leg is in flight at a time, so the happy path delivers a
-/// chunk with no concurrent second leg and over-fetches nothing. A leg advances
-/// only on an explicit failure (the bin spill), and a withholding head falls
-/// through to the staggered fallback at the deadline instead of being raced. The
-/// staggered fan-out that trades a second metered leg for failover latency is
-/// reserved for that fallback, never the primary.
-const PRIMARY_ROUTE_SINGLE_FLIGHT: Duration = Duration::from_secs(3600);
-
-/// Tuning for one staggered walk phase: the lifetime leg `budget`, the
-/// concurrent-leg width `max_in_flight`, the wall-clock `deadline`, and the
-/// per-leg `stagger`.
-struct WalkBounds {
-    budget: usize,
-    max_in_flight: usize,
-    deadline: Duration,
-    stagger: Duration,
-}
-
-/// Chunk provider using ClientHandle for network retrieval.
+/// Every retrieval terminal surfaces as [`SwarmError::RetrievalExhausted`];
+/// forwarding retrieval has no authoritative negative, so absence is never
+/// claimed.
 #[derive(Clone)]
 pub struct NetworkChunkProvider<I: SwarmIdentity> {
-    client_handle: ClientHandle,
-    topology: TopologyHandle<I>,
-    selector: Option<Arc<PeerSelector>>,
-    inflight: Option<Arc<PeerInflightLimiter>>,
-    retrieval_latency: Option<Arc<RetrievalLatency>>,
+    engine: NativeEngine<I>,
 }
 
 impl<I: SwarmIdentity> NetworkChunkProvider<I> {
-    pub fn new(client_handle: ClientHandle, topology: TopologyHandle<I>) -> Self {
+    /// Build the provider over the three retrieval capabilities the native
+    /// client always wires: the candidate `selector`, the per-peer `inflight`
+    /// cap, and the per-PO `retrieval_latency` estimate.
+    pub(crate) fn new(
+        client_handle: ClientHandle,
+        topology: TopologyHandle<I>,
+        selector: Arc<PeerSelector>,
+        inflight: Arc<PeerInflightLimiter>,
+        retrieval_latency: Arc<RetrievalLatency>,
+    ) -> Self {
         Self {
-            client_handle,
-            topology,
-            selector: None,
-            inflight: None,
-            retrieval_latency: None,
+            engine: RetrievalEngine::new(
+                client_handle,
+                topology,
+                selector,
+                inflight,
+                retrieval_latency,
+            ),
         }
-    }
-
-    /// Pace the staggered fallback to the live round trip via the shared per-PO
-    /// latency estimate. The same instance the client service records into.
-    pub(crate) fn with_retrieval_latency(mut self, latency: Arc<RetrievalLatency>) -> Self {
-        self.retrieval_latency = Some(latency);
-        self
-    }
-
-    /// Order retrieval and pushsync candidates with `selector` (score- and
-    /// affordability-aware) instead of plain proximity order.
-    pub fn with_selector(mut self, selector: Arc<PeerSelector>) -> Self {
-        self.selector = Some(selector);
-        self
-    }
-
-    /// Cap concurrent outbound retrieval substreams per peer, skipping a peer at
-    /// its cap in favour of the next-closest candidate with a free slot.
-    pub fn with_inflight_limiter(mut self, inflight: Arc<PeerInflightLimiter>) -> Self {
-        self.inflight = Some(inflight);
-        self
-    }
-
-    /// Order the close set, spilling to the closest admissible peers of a wider
-    /// slice when the close set is fully gated.
-    ///
-    /// A non-empty band over the close set returns at once (the fast path), keeping
-    /// the close set's headroom-first debt spread. When every close peer is
-    /// refused, the closest few have spent their forgiveness on this download while
-    /// a far larger ring of slightly-farther peers still carries headroom; banding
-    /// [`RETRIEVE_SPILL_WIDTH`] peers and routing the chunk to an admissible one
-    /// there forwards it just the same, without parking the pipeline slot for the
-    /// seconds a close-set debt takes to drain. The spill orders that wider slice
-    /// by plain proximity among the admissible (not headroom-first), so the closest
-    /// admissible peer leads and the chunk travels the minimum extra distance to
-    /// find capacity. If even the wider slice is fully gated the result is empty and
-    /// the caller falls through to its generic transient failure, leaving the
-    /// consumer to re-stream rather than blocking the slot on a settle drain.
-    /// Disconnect-safe: the band still hard-skips every refused peer. With no
-    /// selector the proximity order is returned unchanged.
-    fn select_or_spill(
-        &self,
-        candidates: Vec<SwarmAddress>,
-        chunk: &ChunkAddress,
-    ) -> Vec<SwarmAddress> {
-        let Some(selector) = &self.selector else {
-            return candidates;
-        };
-        let ordered = selector.order(candidates, chunk);
-        if !ordered.is_empty() {
-            return ordered;
-        }
-        let wide = self.topology.closest_to(chunk, RETRIEVE_SPILL_WIDTH);
-        selector.order_closest_admissible(wide, chunk)
-    }
-
-    /// Order `candidates` through the accounting band.
-    ///
-    /// Used by the bin-bucket primary and the pushsync path. Drops refused peers
-    /// and ranks by score; with no selector the order is unchanged. The peer a
-    /// request dispatches to is settled at the origin credit gate.
-    fn select_now(&self, candidates: Vec<SwarmAddress>, chunk: &ChunkAddress) -> Vec<SwarmAddress> {
-        match &self.selector {
-            Some(selector) => selector.order(candidates, chunk),
-            None => candidates,
-        }
-    }
-
-    /// Run one bounded staggered walk over `candidates`, dispatching each leg as
-    /// an originated retrieval that reserves the per-peer in-flight permit riding
-    /// its future. Shared by the single-flight primary route and the staggered
-    /// fallback; `legs` accumulates the metered legs across both phases.
-    ///
-    /// With `enforce_cap`, a peer that filled its in-flight slot since the
-    /// skip-busy snapshot is declined at dispatch (no leg, no budget unit) so the
-    /// cap holds on live state; without it (no limiter, or the all-busy
-    /// fall-through) the leg runs best-effort even with no permit.
-    async fn walk_legs(
-        &self,
-        candidates: Vec<SwarmAddress>,
-        chunk_address: SwarmAddress,
-        bounds: WalkBounds,
-        enforce_cap: bool,
-        legs: &AtomicUsize,
-    ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
-        race_walk(
-            candidates,
-            bounds.budget,
-            bounds.max_in_flight,
-            bounds.deadline,
-            bounds.stagger,
-            |peer_overlay| {
-                let permit = self
-                    .inflight
-                    .as_ref()
-                    .and_then(|limiter| limiter.try_acquire(&peer_overlay));
-                // A peer that filled since the skip-busy snapshot is declined so
-                // the cap holds on live state, spending no budget; best-effort
-                // (no limiter or all-busy fall-through) attempts without a permit.
-                if enforce_cap && permit.is_none() {
-                    return None;
-                }
-                legs.fetch_add(1, Ordering::Relaxed);
-                // `originated = true`: our own retrieval, so the client service
-                // debits the serving peer on delivery.
-                let request = self
-                    .client_handle
-                    .retrieve_chunk(peer_overlay, chunk_address, true);
-                Some(async move {
-                    let _permit = permit;
-                    request.await
-                })
-            },
-        )
-        .await
     }
 }
 
 #[async_trait]
 impl<I: SwarmIdentity> SwarmChunkProvider for NetworkChunkProvider<I> {
     async fn retrieve_chunk(&self, address: &ChunkAddress) -> SwarmResult<ChunkRetrievalResult> {
-        let chunk_address = SwarmAddress::new(address.0.into());
-        let legs = AtomicUsize::new(0);
-
-        // PRIMARY: bin-bucket proximity route. Route the chunk to its Kademlia
-        // forwarding bin b = PO(local, chunk) and dispatch the best in-headroom
-        // connected peer there, spilling to the adjacent bins on saturation. A
-        // peer in bin b already shares the chunk's first b bits, so it forwards
-        // over fewer hops than a peer picked by raw closeness alone: fewer hops
-        // is lower per-chunk latency, the throughput lever. The route is
-        // single-flight (no stagger), so the happy path delivers one chunk for
-        // one metered leg and over-fetches nothing. The accounting band ranks the
-        // route here; a gated route falls through to the staggered fallback, which
-        // spills to a wider headroom slice.
-        let local = self.topology.overlay_address();
-        let max_bin = self.topology.max_bin().get();
-        let bin_candidates = bin_routed_order(
-            &chunk_address,
-            &local,
-            max_bin,
-            RETRIEVE_WALK_WIDTH,
-            |bin| self.topology.connected_peers_in_bin(bin),
-        );
-        let bin_candidates = self.select_now(bin_candidates, &chunk_address);
-        // Skip-busy: drop peers at their in-flight cap so the route leads with an
-        // in-headroom peer. The cap is the non-economic muxer guard, composed
-        // after the accounting band, never merged with it.
-        let (bin_candidates, enforce_cap) = skip_busy(bin_candidates, self.inflight.as_deref());
-
-        if !bin_candidates.is_empty() {
-            let primary = self
-                .walk_legs(
-                    bin_candidates,
-                    chunk_address,
-                    WalkBounds {
-                        budget: PRIMARY_ROUTE_BUDGET,
-                        // Single-flight: at most one metered leg in flight,
-                        // advancing the bin spill only on an explicit failure.
-                        max_in_flight: 1,
-                        deadline: PRIMARY_ROUTE_DEADLINE,
-                        stagger: PRIMARY_ROUTE_SINGLE_FLIGHT,
-                    },
-                    enforce_cap,
-                    &legs,
-                )
-                .await;
-            if let Ok(result) = primary {
-                let walked = legs.load(Ordering::Relaxed);
-                histogram!("retrieval_walk_legs").record(walked as f64);
-                counter!("retrieval_walk_total", "outcome" => "hit", "path" => "bin_route")
-                    .increment(1);
-                record_overfetch_legs(walked, "bin_route");
-                return Ok(ChunkRetrievalResult {
-                    chunk: result.chunk,
-                    stamp: result.stamp,
-                    served_by: result.peer,
-                });
-            }
-        }
-
-        // FALLBACK: the staggered bounded-refill walk over the globally closest
-        // connected peers. Reached when the bin route is gated, saturated, or its
-        // entry points all miss. Retrieval is forwarding-Kademlia with no
-        // authoritative negative on the wire: a failed or slow leg means "this
-        // entry point could not serve it", never "the chunk is absent", so the
-        // walk keeps going and only gives up on a real bound (the leg budget, the
-        // pool, or the deadline). Staggering one leg in at a time bounds the paid
-        // fan-out; each leg reserves the per-peer in-flight permit that rides its
-        // future, released on drop including a cancelled losing leg.
-        let closest_peers = self
-            .topology
-            .closest_to(&chunk_address, RETRIEVE_WALK_WIDTH);
-        // Spill to a wider in-headroom slice when every close peer is gated, so a
-        // fully gated close set routes around its spent peers rather than blocking;
-        // if even the wide slice is gated the empty result falls through to the
-        // no-connected-peers path below, the same generic transient error a
-        // no-peers failure yields, and the consumer re-streams.
-        let closest_peers = self.select_or_spill(closest_peers, &chunk_address);
-        let (candidates, enforce_cap) = skip_busy(closest_peers, self.inflight.as_deref());
-
-        // Pace the staggered fan-out to the live round trip rather than a fixed
-        // constant. Each candidate's expected latency is read from the per-PO
-        // estimate at its proximity to the chunk (the forwarding distance that
-        // dominates retrieval latency), so a near neighbourhood walks far below
-        // the ceiling and a far one stays at it. Cold buckets fall back to the
-        // constant, so this is never slower, only faster on low-RTT distances.
-        let stagger = match &self.retrieval_latency {
-            Some(latency) => adaptive_stagger(
-                candidates
-                    .iter()
-                    .map(|peer| latency.estimate(chunk_address.proximity(peer).get())),
-            ),
-            None => RETRIEVAL_STAGGER,
-        };
-
-        let outcome = self
-            .walk_legs(
-                candidates,
-                chunk_address,
-                WalkBounds {
-                    budget: RETRIEVE_LEG_BUDGET,
-                    max_in_flight: RETRIEVE_WALK_MAX_IN_FLIGHT,
-                    deadline: RETRIEVE_WALK_DEADLINE,
-                    stagger,
-                },
-                enforce_cap,
-                &legs,
-            )
-            .await;
-
-        let legs = legs.load(Ordering::Relaxed);
-        histogram!("retrieval_walk_legs").record(legs as f64);
-        let outcome_label = match &outcome {
-            Ok(_) => "hit",
-            Err(RaceFailure::NoCandidates) => "no_peers",
-            Err(RaceFailure::AllFailed(_)) => "exhausted",
-            Err(RaceFailure::TimedOut) => "timed_out",
-        };
-        counter!("retrieval_walk_total", "outcome" => outcome_label, "path" => "fallback")
-            .increment(1);
-        if outcome.is_ok() {
-            // `legs` spans both phases, so a fallback win also counts the primary
-            // legs the missed bin route already spent.
-            record_overfetch_legs(legs, "fallback");
-        }
-
-        match outcome {
-            Ok(result) => Ok(ChunkRetrievalResult {
-                chunk: result.chunk,
-                stamp: result.stamp,
-                served_by: result.peer,
-            }),
-            Err(RaceFailure::NoCandidates) => Err(SwarmError::network_msg(
-                "no connected peers available for retrieval",
-            )),
-            Err(RaceFailure::AllFailed(e)) => Err(SwarmError::AllPeersFailed {
-                address: *address,
-                attempts: legs,
-                source: Box::new(e),
-            }),
-            // The walk ran out of wall-clock time with legs still slow rather
-            // than failed: a transient condition, surfaced like a no-peers miss
-            // so the consumer re-streams the address rather than treating it as a
-            // hard not-found.
-            Err(RaceFailure::TimedOut) => Err(SwarmError::network_msg(
-                "retrieval walk deadline elapsed before any peer served the chunk",
-            )),
-        }
+        self.engine.retrieve(address).await
     }
 
     fn has_chunk(&self, _address: &ChunkAddress) -> bool {
@@ -415,17 +79,20 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
     /// Push `chunk` to the storer peers closest to its address, returning the
     /// first receipt.
     ///
-    /// Walks the closest candidates in order and returns the first storer that
+    /// Tries the closest candidates in order and returns the first storer that
     /// accepts the chunk. The client handle correlates a push response to its
     /// request by chunk address alone, so the candidates are tried sequentially
     /// rather than raced.
     async fn push_to_closest(&self, chunk: StampedChunk) -> SwarmResult<PushReceipt> {
         let address = *chunk.address();
-        let closest = self.topology.closest_to(&address, PUSH_CANDIDATE_COUNT);
+        let closest = self
+            .engine
+            .topology()
+            .closest_to(&address, PUSH_CANDIDATE_COUNT);
         // Rank by band and score, hard-skipping a refused peer; an all-gated set
         // yields an empty result and the generic no-storer outcome below. The peer
         // a push actually dispatches to is settled at the origin credit gate.
-        let closest = self.select_now(closest, &address);
+        let closest = self.engine.order(closest, &address);
         let attempts = closest.len();
 
         // The required custody depth is derived from our locally observed
@@ -436,13 +103,13 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         // verdict. The receipt's signer was already recovered at the decode
         // boundary; a malformed receipt never reaches here (it surfaces as a push
         // error below).
-        let local_depth = self.topology.depth();
-        let neighbourhood_credible = self.topology.neighbourhood_credible();
-        let reporter = self.topology.peer_manager();
+        let local_depth = self.engine.topology().depth();
+        let neighbourhood_credible = self.engine.topology().neighbourhood_credible();
+        let reporter = self.engine.topology().peer_manager();
 
         // Try each closest peer in order and return the first receipt that
         // verifies. A shallow receipt is rejected, the responding peer scored
-        // adversely, and the walk continues to the next candidate: this is the
+        // adversely, and the loop continues to the next candidate: this is the
         // retry-via-different-route dynamic the depth check exists to engage (a
         // fabricated shallow receipt no longer convinces the uploader the push
         // succeeded). An unverifiable receipt (non-credible local view) is also
@@ -459,7 +126,8 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
             // `originated = true`: our own push, so the client service debits
             // the storer on receipt.
             match self
-                .client_handle
+                .engine
+                .client_handle()
                 .push_chunk(peer, chunk.clone(), true)
                 .await
             {
@@ -512,107 +180,6 @@ impl<I: SwarmIdentity> NetworkChunkProvider<I> {
         }
 
         outcome
-    }
-}
-
-/// Build the bin-bucket proximity-routed candidate order for `chunk`.
-///
-/// Routes to the Kademlia forwarding bin `b = PO(local, chunk)` first: a peer
-/// there shares the chunk's first `b` bits, so it is at least as close to the
-/// chunk as we are and forwards over fewer hops. When that bin yields too few
-/// peers the route spills outward to the adjacent bins (`b-1`, `b+1`, `b-2`, ...)
-/// up to `width` candidates, so a sparse forwarding bin still finds an entry
-/// point. Within every bin the peers are ordered closest-to-chunk first.
-/// `peers_in_bin` returns connected peers only; retrieval never dials.
-fn bin_routed_order(
-    chunk: &SwarmAddress,
-    local: &SwarmAddress,
-    max_bin: u8,
-    width: usize,
-    peers_in_bin: impl Fn(Bin) -> Vec<SwarmAddress>,
-) -> Vec<SwarmAddress> {
-    let b = chunk.proximity(local).get().min(max_bin);
-    let mut order: Vec<SwarmAddress> = Vec::with_capacity(width);
-    for bin_index in spill_bins(b, max_bin) {
-        if order.len() >= width {
-            break;
-        }
-        let bin = Bin::new(bin_index).unwrap_or(Bin::MAX);
-        let mut in_bin = peers_in_bin(bin);
-        in_bin.sort_by_key(|peer| std::cmp::Reverse(chunk.proximity(peer)));
-        order.extend(in_bin);
-    }
-    order.truncate(width);
-    order
-}
-
-/// Bin visiting order for the bin-bucket route: the forwarding bin `b`, then
-/// outward to the nearest bins on either side (`b-1`, `b+1`, `b-2`, `b+2`, ...)
-/// within `[0, max_bin]`.
-fn spill_bins(b: u8, max_bin: u8) -> Vec<u8> {
-    let mut bins = Vec::with_capacity(max_bin as usize + 1);
-    bins.push(b);
-    let mut delta = 1u8;
-    loop {
-        let mut pushed = false;
-        if let Some(lower) = b.checked_sub(delta) {
-            bins.push(lower);
-            pushed = true;
-        }
-        let upper = b.saturating_add(delta);
-        if upper > b && upper <= max_bin {
-            bins.push(upper);
-            pushed = true;
-        }
-        if !pushed {
-            break;
-        }
-        delta += 1;
-    }
-    bins
-}
-
-/// Record the metered legs a successful retrieval spent beyond the one that won.
-///
-/// Each extra leg is a failed refill or a concurrent loser the race dropped; a
-/// dropped loser is not cancelled downstream, so it still fetches and meters a
-/// duplicate. This is the dispatch-side over-fetch signal (an upper bound). The
-/// delivery-side count of duplicates that actually arrived is
-/// `swarm.client.retrieval_overfetch_delivered`, emitted by the handler.
-fn record_overfetch_legs(legs: usize, path: &'static str) {
-    if let Some(extra) = legs.checked_sub(1).filter(|extra| *extra > 0) {
-        counter!("retrieval_overfetch_legs", "path" => path).increment(extra as u64);
-    }
-}
-
-/// Filter proximity-ordered `candidates` to those with a free retrieval slot,
-/// returning the survivors and whether the walk should enforce the cap.
-///
-/// With no limiter the list is unchanged and `enforce_cap` is false. When every
-/// close candidate is at its in-flight cap the full list is returned with
-/// `enforce_cap` false (fall through, since degraded service beats failing the
-/// request, so legs run best-effort). Only when free-slot peers are found is
-/// `enforce_cap` true, so a peer that fills between this snapshot and dispatch is
-/// declined rather than run uncapped. Skip-busy happens here, at selection time,
-/// so a busy head peer is never raced and the next-closest free peer leads.
-fn skip_busy(
-    candidates: Vec<SwarmAddress>,
-    inflight: Option<&PeerInflightLimiter>,
-) -> (Vec<SwarmAddress>, bool) {
-    let Some(limiter) = inflight else {
-        return (candidates, false);
-    };
-    let survivors: Vec<SwarmAddress> = candidates
-        .iter()
-        .copied()
-        .filter(|peer| limiter.has_free_slot(peer))
-        .collect();
-    // `enforce_cap` only when free-slot peers were found: the all-busy
-    // fall-through returns the full list so the walk still attempts, best-effort.
-    if survivors.is_empty() {
-        (candidates, false)
-    } else {
-        (survivors, true)
     }
 }
 
@@ -833,9 +400,9 @@ mod tests {
 
     #[test]
     fn origin_treats_an_unverifiable_receipt_as_unconfirmed_without_reporting() {
-        // Regression for #316: with a non-credible local view (a fresh or sparse
-        // node, local_depth == 0) a shallow receipt declaring radius 0 must NOT
-        // be accepted, and the responder must NOT be penalised: the verdict is
+        // Regression for a non-credible local view (a fresh or sparse node,
+        // local_depth == 0): a shallow receipt declaring radius 0 must NOT be
+        // accepted, and the responder must NOT be penalised: the verdict is
         // unverifiable, not a finding of misbehaviour.
         let signer = PrivateKeySigner::random();
         let addr = address(0xff);
@@ -855,116 +422,6 @@ mod tests {
         );
     }
 
-    mod bin_route {
-        use std::collections::HashMap;
-
-        use super::super::{bin_routed_order, spill_bins};
-        use nectar_primitives::SwarmAddress;
-        use vertex_swarm_api::Bin;
-
-        /// An address with `byte0` set, the rest zero, so its proximity to the
-        /// zero local overlay is controllable.
-        fn addr(byte0: u8) -> SwarmAddress {
-            let mut bytes = [0u8; 32];
-            bytes[0] = byte0;
-            SwarmAddress::from(bytes)
-        }
-
-        #[test]
-        fn spill_visits_the_forwarding_bin_then_outward() {
-            // Mid bin: b, then b-1, b+1, b-2, b+2, ... clamped to [0, max].
-            assert_eq!(spill_bins(4, 8), vec![4, 3, 5, 2, 6, 1, 7, 0, 8]);
-        }
-
-        #[test]
-        fn spill_clamps_at_both_edges() {
-            // b == 0 never produces a negative bin; b == max never overshoots.
-            assert_eq!(spill_bins(0, 3), vec![0, 1, 2, 3]);
-            assert_eq!(spill_bins(3, 3), vec![3, 2, 1, 0]);
-            assert_eq!(spill_bins(0, 0), vec![0]);
-        }
-
-        #[test]
-        fn routes_to_the_forwarding_bin_first_then_spills() {
-            // local is the zero overlay; chunk 0x08 (0000_1000) shares its first
-            // four bits with local, so the forwarding bin is 4.
-            let local = addr(0x00);
-            let chunk = addr(0x08);
-            // One sentinel peer per bin, encoding the bin index in byte 1.
-            let peers = |bin: Bin| {
-                let mut bytes = [0u8; 32];
-                bytes[1] = bin.get();
-                bytes[2] = 0x01; // distinguish from local/chunk
-                vec![SwarmAddress::from(bytes)]
-            };
-
-            let order = bin_routed_order(&chunk, &local, 8, 32, peers);
-            let bins: Vec<u8> = order
-                .iter()
-                .map(|p| p.as_bytes().get(1).copied().unwrap())
-                .collect();
-            assert_eq!(
-                bins,
-                vec![4, 3, 5, 2, 6, 1, 7, 0, 8],
-                "the forwarding bin leads, then the route spills outward"
-            );
-        }
-
-        #[test]
-        fn orders_within_a_bin_by_closeness_to_the_chunk() {
-            let local = addr(0x00);
-            let chunk = addr(0x08);
-            let near = addr(0x08); // shares the chunk's prefix: high proximity
-            let far = addr(0xff); // diverges at the first bit: proximity 0
-            let b = chunk.proximity(&local).get();
-            let bin_b = b;
-            let peers = move |bin: Bin| {
-                if bin.get() == bin_b {
-                    vec![far, near]
-                } else {
-                    Vec::new()
-                }
-            };
-
-            let order = bin_routed_order(&chunk, &local, 31, 32, peers);
-            assert_eq!(
-                order,
-                vec![near, far],
-                "the closer-to-chunk peer leads its bin regardless of input order"
-            );
-        }
-
-        #[test]
-        fn respects_the_width_cap() {
-            let local = addr(0x00);
-            let chunk = addr(0x08);
-            // Three peers in every bin; a width of 5 takes only the first five.
-            let peers = |bin: Bin| {
-                (0u8..3)
-                    .map(|i| {
-                        let mut bytes = [0u8; 32];
-                        bytes[1] = bin.get();
-                        bytes[2] = i + 1;
-                        SwarmAddress::from(bytes)
-                    })
-                    .collect::<Vec<_>>()
-            };
-            let order = bin_routed_order(&chunk, &local, 8, 5, peers);
-            assert_eq!(order.len(), 5, "width caps the candidate count");
-        }
-
-        #[test]
-        fn empty_bins_yield_no_candidates() {
-            let local = addr(0x00);
-            let chunk = addr(0x08);
-            let empty: HashMap<u8, Vec<SwarmAddress>> = HashMap::new();
-            let order = bin_routed_order(&chunk, &local, 8, 32, |bin| {
-                empty.get(&bin.get()).cloned().unwrap_or_default()
-            });
-            assert!(order.is_empty(), "no connected peers yields no route");
-        }
-    }
-
     mod staggered_race {
         use std::time::{Duration, Instant};
 
@@ -974,8 +431,8 @@ mod tests {
 
         use crate::race_candidates;
 
-        use super::super::{RETRIEVAL_STAGGER, RaceFailure};
         use super::*;
+        use crate::{RETRIEVAL_STAGGER, RaceFailure};
 
         fn test_chunk() -> nectar_primitives::AnyChunk {
             ContentChunk::new(&b"provider-race-chunk"[..])
@@ -987,7 +444,7 @@ mod tests {
         /// attempt is `client_handle.retrieve_chunk(peer, address)`, raced with a
         /// staggered start. The per-candidate pacing (the admission band and
         /// affordability check) lives inside that call, so this exercises the
-        /// provider's retrieval leg and race wiring without standing up a
+        /// provider's retrieval attempt and race wiring without standing up a
         /// topology mock.
         async fn race_over_handle(
             handle: ClientHandle,
@@ -1090,7 +547,7 @@ mod tests {
         }
     }
 
-    mod skip_busy_scheduler {
+    mod inflight_scheduler {
         use std::num::NonZeroUsize;
         use std::sync::Arc;
         use std::time::{Duration, Instant};
@@ -1106,11 +563,11 @@ mod tests {
 
         use crate::race_candidates;
 
-        use super::super::{
-            RETRIEVAL_STAGGER, RETRIEVE_LEG_BUDGET, RETRIEVE_WALK_DEADLINE, RaceFailure, race_walk,
-            skip_busy,
-        };
         use super::*;
+        use crate::retrieval_engine::{
+            InflightLimit, RETRIEVE_ATTEMPT_BUDGET, RETRIEVE_DEADLINE, RETRIEVE_MAX_IN_FLIGHT,
+        };
+        use crate::{RETRIEVAL_STAGGER, RaceFailure, race_with_refill};
 
         const CAP_ONE: NonZeroUsize = match NonZeroUsize::new(1) {
             Some(cap) => cap,
@@ -1122,13 +579,13 @@ mod tests {
         }
 
         fn test_chunk() -> nectar_primitives::AnyChunk {
-            ContentChunk::new(&b"skip-busy-chunk"[..])
+            ContentChunk::new(&b"inflight-chunk"[..])
                 .expect("valid content chunk")
                 .into()
         }
 
-        /// Drive the exact composition the provider builds: skip-busy filtering
-        /// at selection time, then the staggered race whose legs reserve an
+        /// Drive the exact composition the provider builds: availability
+        /// filtering at selection time, then the staggered race whose attempts reserve an
         /// in-flight permit that rides the request future and releases on drop.
         async fn race_with_limiter(
             handle: ClientHandle,
@@ -1136,7 +593,7 @@ mod tests {
             candidates: Vec<SwarmAddress>,
             address: ChunkAddress,
         ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
-            let (candidates, _enforce_cap) = skip_busy(candidates, Some(&limiter));
+            let (candidates, _enforce_cap) = limiter.available(candidates);
             race_candidates(candidates, RETRIEVAL_STAGGER, move |peer| {
                 let permit = limiter.try_acquire(&peer);
                 let handle = handle.clone();
@@ -1148,68 +605,28 @@ mod tests {
             .await
         }
 
-        #[test]
-        fn skip_busy_without_a_limiter_keeps_every_candidate() {
-            let candidates = vec![overlay(1), overlay(2), overlay(3)];
-            assert_eq!(skip_busy(candidates.clone(), None), (candidates, false));
-        }
-
-        #[test]
-        fn skip_busy_drops_a_capped_head() {
-            let limiter = PeerInflightLimiter::new(CAP_ONE);
-            let busy = overlay(1);
-            let _held = limiter.try_acquire(&busy).expect("first slot");
-
-            let (survivors, enforce_cap) =
-                skip_busy(vec![busy, overlay(2), overlay(3)], Some(&limiter));
-            assert_eq!(
-                survivors,
-                vec![overlay(2), overlay(3)],
-                "the capped head is skipped, the next-closest free peers remain"
-            );
-            assert!(enforce_cap, "free-slot peers found, so the cap is enforced");
-        }
-
-        #[test]
-        fn skip_busy_falls_through_when_every_candidate_is_capped() {
-            let limiter = PeerInflightLimiter::new(CAP_ONE);
-            let candidates = vec![overlay(1), overlay(2)];
-            let _h1 = limiter.try_acquire(&overlay(1)).expect("slot a");
-            let _h2 = limiter.try_acquire(&overlay(2)).expect("slot b");
-
-            let (survivors, enforce_cap) = skip_busy(candidates.clone(), Some(&limiter));
-            assert_eq!(
-                survivors, candidates,
-                "all-busy falls through to the full list rather than failing"
-            );
-            assert!(
-                !enforce_cap,
-                "the all-busy fall-through is best-effort, not cap-enforced"
-            );
-        }
-
         #[tokio::test]
-        async fn walk_budget_caps_metered_legs_below_the_free_slot_pool() {
-            // A wide pool of free-slot peers must not meter a leg each: the walk
-            // dispatches at most the leg budget, refilling a failed leg from the
+        async fn race_budget_caps_metered_attempts_below_the_free_slot_pool() {
+            // A wide pool of free-slot peers must not meter an attempt each: the race
+            // dispatches at most the attempt budget, refilling a failed attempt from the
             // next-closest peer, so the wider pool supplies coverage alternatives
             // without amplifying paid bandwidth.
             let (tx, rx) = mpsc::channel::<ClientCommand>(64);
-            drop(rx); // every retrieval fails at once: the walk spends its budget.
+            drop(rx); // every retrieval fails at once: the race spends its budget.
             let handle = ClientHandle::new(tx);
             let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
 
             let pool: Vec<SwarmAddress> = (1..=16).map(overlay).collect();
-            let (candidates, _enforce_cap) = skip_busy(pool, Some(&limiter));
+            let (candidates, _enforce_cap) = limiter.available(pool);
             assert_eq!(candidates.len(), 16, "all 16 peers have a free slot");
 
-            let legs = Arc::new(AtomicUsize::new(0));
-            let counted = Arc::clone(&legs);
-            let outcome = race_walk(
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let counted = Arc::clone(&attempts);
+            let outcome = race_with_refill(
                 candidates,
-                RETRIEVE_LEG_BUDGET,
-                RETRIEVE_WALK_MAX_IN_FLIGHT,
-                RETRIEVE_WALK_DEADLINE,
+                RETRIEVE_ATTEMPT_BUDGET,
+                RETRIEVE_MAX_IN_FLIGHT,
+                RETRIEVE_DEADLINE,
                 RETRIEVAL_STAGGER,
                 move |peer| {
                     counted.fetch_add(1, Ordering::SeqCst);
@@ -1225,17 +642,17 @@ mod tests {
 
             assert!(matches!(outcome, Err(RaceFailure::AllFailed(_))));
             assert_eq!(
-                legs.load(Ordering::SeqCst),
-                RETRIEVE_LEG_BUDGET,
-                "the walk meters at most the leg budget across the wider free-slot pool"
+                attempts.load(Ordering::SeqCst),
+                RETRIEVE_ATTEMPT_BUDGET,
+                "the race meters at most the attempt budget across the wider free-slot pool"
             );
         }
 
         #[tokio::test]
         async fn enforce_cap_declines_a_peer_that_filled_since_the_snapshot() {
-            // A peer free at the skip-busy snapshot but saturated before its leg
-            // dispatches is declined under enforce_cap: no command reaches it and
-            // it spends no leg, so the cap holds on live state, not the stale
+            // A peer free at the availability snapshot but saturated before its
+            // attempt dispatches is declined under enforce_cap: no command reaches
+            // it and it spends no attempt, so the cap holds on live state, not the stale
             // snapshot. The next free peer serves instead.
             let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
             let handle = ClientHandle::new(tx);
@@ -1244,8 +661,8 @@ mod tests {
             let filled = overlay(1);
             let free = overlay(2);
 
-            // Skip-busy sees both peers free, so the walk enforces the cap.
-            let (candidates, enforce_cap) = skip_busy(vec![filled, free], Some(&limiter));
+            // Availability sees both peers free, so the race enforces the cap.
+            let (candidates, enforce_cap) = limiter.available(vec![filled, free]);
             assert_eq!(candidates, vec![filled, free]);
             assert!(enforce_cap, "free-slot peers found, so the cap is enforced");
 
@@ -1255,20 +672,20 @@ mod tests {
                 .expect("saturate the first peer");
 
             let address = address(0xac);
-            let legs = Arc::new(AtomicUsize::new(0));
-            let counted = Arc::clone(&legs);
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let counted = Arc::clone(&attempts);
             let lim = Arc::clone(&limiter);
             let race = tokio::spawn(async move {
-                race_walk(
+                race_with_refill(
                     candidates,
-                    RETRIEVE_LEG_BUDGET,
-                    RETRIEVE_WALK_MAX_IN_FLIGHT,
-                    RETRIEVE_WALK_DEADLINE,
+                    RETRIEVE_ATTEMPT_BUDGET,
+                    RETRIEVE_MAX_IN_FLIGHT,
+                    RETRIEVE_DEADLINE,
                     RETRIEVAL_STAGGER,
                     move |peer| {
                         let permit = lim.try_acquire(&peer);
                         // The enforce-cap decline: a peer with no live slot spends
-                        // no leg and is skipped for the next candidate.
+                        // no attempt and is skipped for the next candidate.
                         if enforce_cap && permit.is_none() {
                             return None;
                         }
@@ -1301,9 +718,9 @@ mod tests {
             let result = race.await.unwrap().expect("race resolves");
             assert_eq!(result.peer, free, "the free peer serves the chunk");
             assert_eq!(
-                legs.load(Ordering::SeqCst),
+                attempts.load(Ordering::SeqCst),
                 1,
-                "only the free peer spent a leg; the saturated peer was declined"
+                "only the free peer spent an attempt; the saturated peer was declined"
             );
         }
 
@@ -1350,9 +767,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn losing_leg_releases_its_permit_on_drop() {
-            // The head leg reserves a permit and then withholds; the staggered
-            // second wins and the head leg is dropped. Dropping it must release
+        async fn losing_attempt_releases_its_permit_on_drop() {
+            // The head attempt reserves a permit and then withholds; the staggered
+            // second wins and the head attempt is dropped. Dropping it must release
             // the head's in-flight slot, so the head is reservable again.
             let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
             let handle = ClientHandle::new(tx);
@@ -1370,13 +787,13 @@ mod tests {
                 address,
             ));
 
-            // The head leg dispatches first and reserves the head's only slot.
+            // The head attempt dispatches first and reserves the head's only slot.
             let _head_response = match rx.recv().await.expect("head command") {
                 ClientCommand::RetrieveChunk { peer, response, .. } => {
                     assert_eq!(peer, head);
                     assert!(
                         !limiter.has_free_slot(&head),
-                        "the in-flight head leg holds the head's slot"
+                        "the in-flight head attempt holds the head's slot"
                     );
                     response
                 }
@@ -1403,11 +820,11 @@ mod tests {
                 start.elapsed() < Duration::from_secs(5),
                 "resolved within the stagger, not a per-attempt deadline"
             );
-            // The losing head leg was dropped when the race resolved, releasing
+            // The losing head attempt was dropped when the race resolved, releasing
             // its permit: the head's slot is free again.
             assert!(
                 limiter.has_free_slot(&head),
-                "the cancelled head leg released its in-flight slot on drop"
+                "the cancelled head attempt released its in-flight slot on drop"
             );
             assert!(
                 limiter.try_acquire(&head).is_some(),
@@ -1422,18 +839,16 @@ mod tests {
         use super::address;
 
         #[test]
-        fn an_empty_close_set_surfaces_a_generic_transient_error() {
-            // What a fully gated (empty) selection falls through to is the same
-            // generic transient failure a genuine no-peers/no-storer case yields:
-            // retrieval a `Network` error, push a `NoStorer` error. Neither is an
+        fn a_fully_gated_set_surfaces_the_terminal_outcome() {
+            // What a fully gated (empty) selection falls through to: retrieval the
+            // honest `RetrievalExhausted` (no authoritative negative exists, so
+            // absence is never claimed), push a `NoStorer`. Neither is an
             // accounting-specific variant, so the accounting concern never reaches
             // the consumer.
-            let retrieval = SwarmError::network_msg("no connected peers available for retrieval");
-            assert!(matches!(retrieval, SwarmError::Network { .. }));
-            assert!(
-                retrieval.is_retryable(),
-                "a no-peers retrieval is transient"
-            );
+            let retrieval = SwarmError::RetrievalExhausted {
+                address: address(0xaa),
+            };
+            assert!(matches!(retrieval, SwarmError::RetrievalExhausted { .. }));
 
             let push = SwarmError::NoStorer {
                 chunk_address: address(0xaa),

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -106,7 +106,7 @@ impl ClientHandle {
     /// is refunded only when the request provably reaches no charge. Every chunk
     /// the server serves thus corresponds to a request we already committed, so
     /// our debt-view stays at or above the server's and our band refuses before
-    /// the server's disconnect line. A losing race leg dropped mid-flight cannot
+    /// the server's disconnect line. A losing attempt dropped mid-flight cannot
     /// un-book, because the commit already happened synchronously here.
     fn reserve_origin(
         &self,
@@ -349,9 +349,7 @@ impl ClientService {
     /// peer's slot accounting on disconnect.
     ///
     /// Must be the same [`PeerInflightLimiter`] the chunk provider reserves
-    /// against via [`NetworkChunkProvider::with_inflight_limiter`].
-    ///
-    /// [`NetworkChunkProvider::with_inflight_limiter`]: crate::NetworkChunkProvider::with_inflight_limiter
+    /// against.
     #[must_use]
     pub fn with_inflight_limiter(mut self, inflight: Arc<PeerInflightLimiter>) -> Self {
         self.inflight = Some(inflight);
@@ -361,8 +359,8 @@ impl ClientService {
     /// Attach the per-PO retrieval-latency estimate so a completed originated
     /// retrieval feeds the hedge the chunk provider paces its race with.
     ///
-    /// Must be the same [`RetrievalLatency`] the chunk provider reads via
-    /// `NetworkChunkProvider::with_retrieval_latency`.
+    /// Must be the same [`RetrievalLatency`] the chunk provider reads to pace its
+    /// race.
     #[must_use]
     pub(crate) fn with_retrieval_latency(mut self, latency: Arc<RetrievalLatency>) -> Self {
         self.retrieval_latency = Some(latency);
@@ -1229,7 +1227,7 @@ mod tests {
 
     #[tokio::test]
     async fn dropped_race_loser_keeps_the_dispatch_commit() {
-        // The key guarantee over commit-on-failure: a losing race leg's future is
+        // The key guarantee over commit-on-failure: a losing attempt's future is
         // dropped mid-await (its result never arrives), yet the debit stays
         // committed because the commit happened synchronously at dispatch. Under
         // the old reserve-only design the hold would drop un-applied and release,

--- a/crates/swarm/node/src/inflight.rs
+++ b/crates/swarm/node/src/inflight.rs
@@ -11,7 +11,7 @@
 //! selection time so the next-closest peer with a free slot serves the chunk,
 //! never blocking on the head peer (which would reintroduce head-of-line
 //! blocking). The permit rides the chosen request future and releases the slot on
-//! drop, including a cancelled race leg.
+//! drop, including a cancelled attempt.
 
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
@@ -75,7 +75,7 @@ impl PeerInflightLimiter {
     /// cap.
     ///
     /// Non-blocking. The returned permit releases the slot on drop, including a
-    /// cancelled race leg, so a slot is held only for the lifetime of the request
+    /// cancelled attempt, so a slot is held only for the lifetime of the request
     /// future it rides.
     pub fn try_acquire(&self, peer: &OverlayAddress) -> Option<OwnedSemaphorePermit> {
         let semaphore = {
@@ -139,7 +139,7 @@ mod tests {
         assert!(limiter.try_acquire(&p).is_none(), "at the cap");
 
         // Releasing one permit frees exactly one slot, modelling a cancelled or
-        // completed race leg returning a slot for the next request.
+        // completed attempt returning a slot for the next request.
         drop(first);
         assert!(limiter.has_free_slot(&p), "a released slot is free again");
         let third = limiter.try_acquire(&p).expect("slot freed by the drop");

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -19,6 +19,7 @@ mod client_service;
 mod inflight;
 mod node;
 mod protocol;
+mod retrieval_engine;
 mod retrieval_latency;
 mod selection;
 mod staggered_race;
@@ -55,9 +56,13 @@ pub use protocol::{
 
 pub use inflight::{DEFAULT_PEER_INFLIGHT_CAP, PeerInflightLimiter};
 pub use selection::{AccountingSettlement, PeerScores, PeerSelector, SettlementTrigger};
-pub use staggered_race::{RETRIEVAL_STAGGER, RaceFailure, race_candidates, race_walk};
+pub use staggered_race::{RETRIEVAL_STAGGER, RaceFailure, race_candidates, race_with_refill};
 
 pub use bootnodes::BootnodeProvider;
 pub use chunks::{ChunkVerifyConfig, NetworkChunkProvider, VerifyingChunkProvider};
 pub use node::stats::StatsConfig;
 pub use node::task::spawn_stats_task;
+pub use retrieval_engine::{
+    CandidateOrdering, InflightLimit, LatencyHint, NoInflightLimit, NoLatencyHint, ProximityOnly,
+    RetrievalEngine,
+};

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -753,10 +753,13 @@ where
         core.client_handle.clone(),
     );
 
-    let chunk_provider = NetworkChunkProvider::new(core.origin_handle.clone(), topology.clone())
-        .with_selector(Arc::clone(&core.selector))
-        .with_inflight_limiter(Arc::clone(&core.inflight))
-        .with_retrieval_latency(Arc::clone(&core.retrieval_latency));
+    let chunk_provider = NetworkChunkProvider::new(
+        core.origin_handle.clone(),
+        topology.clone(),
+        Arc::clone(&core.selector),
+        Arc::clone(&core.inflight),
+        Arc::clone(&core.retrieval_latency),
+    );
     let chunks = VerifyingChunkProvider::new(chunk_provider, params.verify);
 
     executor.spawn_service("swarm.client_service", core.client_service);

--- a/crates/swarm/node/src/retrieval_engine.rs
+++ b/crates/swarm/node/src/retrieval_engine.rs
@@ -1,0 +1,806 @@
+//! Shared dispatch engine for origin chunk retrieval.
+//!
+//! Both the native and browser chunk providers build a [`RetrievalEngine`] and
+//! delegate their `retrieve_chunk` implementation to it, so the bin-route
+//! primary, staggered refilling race, in-flight cap, adaptive stagger, headroom
+//! spill, and over-fetch metrics live in one place. Each capability is a small
+//! trait the engine is generic over: the native client supplies
+//! [`PeerSelector`], [`PeerInflightLimiter`], and [`RetrievalLatency`]; the
+//! browser supplies the zero-sized null objects [`ProximityOnly`],
+//! [`NoInflightLimit`], and [`NoLatencyHint`].
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use metrics::{counter, histogram};
+use nectar_primitives::SwarmAddress;
+use tokio::sync::OwnedSemaphorePermit;
+use vertex_swarm_api::{
+    Bin, ChunkAddress, ChunkRetrievalResult, OverlayAddress, SwarmError, SwarmIdentity,
+    SwarmResult, SwarmTopologyPeers, SwarmTopologyRouting, SwarmTopologyState,
+};
+use vertex_swarm_topology::TopologyHandle;
+use vertex_tasks::time::Duration;
+
+use crate::retrieval_latency::{RetrievalLatency, adaptive_stagger};
+use crate::{
+    ChunkTransferError, ClientHandle, PeerInflightLimiter, PeerSelector, RaceFailure,
+    RetrievalResult, race_with_refill,
+};
+
+/// Proximity-ordered pool of closest connected peers the refilling race draws
+/// from.
+///
+/// Wider than [`RETRIEVE_ATTEMPT_BUDGET`] so that, after the in-flight cap
+/// removes peers at their limit, the race still has next-closest free-slot entry
+/// points to refill a failed attempt rather than overrunning a hot peer.
+/// Retrieval is forwarding-based, so these are connected peers only; the race
+/// never dials.
+const RETRIEVE_WIDTH: usize = 32;
+
+/// Maximum real retrieval attempts the race dispatches per chunk before giving
+/// up.
+///
+/// A chunk whose closest few entry points miss is not absent: each attempt is a
+/// distinct peer whose own forwarding chain may still reach the chunk's storers,
+/// so a sparse-bin chunk needs more than the closest few tries. Peers skipped
+/// for back-pressure before dispatch do not count against this budget, so it
+/// bounds only genuine coverage attempts and the metered bandwidth they cost.
+pub(crate) const RETRIEVE_ATTEMPT_BUDGET: usize = 8;
+
+/// Maximum attempts the staggered fallback keeps concurrently in flight,
+/// bounding the metered over-fetch independently of [`RETRIEVE_ATTEMPT_BUDGET`].
+///
+/// A losing race attempt is not cancelled downstream: the serving chain forwards
+/// and delivers regardless, so every overlapping attempt is real duplicate
+/// bandwidth and cost. This caps the simultaneous attempts at a handful while
+/// [`RETRIEVE_ATTEMPT_BUDGET`] still bounds the lifetime total.
+pub(crate) const RETRIEVE_MAX_IN_FLIGHT: usize = 3;
+
+/// Wall-clock bound on the whole refilling race across its refilled attempts.
+pub(crate) const RETRIEVE_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Wider topology slice the retrieval fallback spills to when the close set is
+/// fully gated.
+///
+/// The closest peers to a chunk carry a download's debt and gate first; a far
+/// larger set of slightly-farther peers still holds forgiveness headroom and
+/// forwards the chunk just the same.
+const RETRIEVE_SPILL_WIDTH: usize = 128;
+
+/// Attempts the bin-bucket primary route dispatches before handing off to the
+/// staggered fallback.
+///
+/// The primary routes a chunk to its Kademlia forwarding bin and tries the
+/// in-headroom connected peers there one at a time. Past that, the difficult
+/// chunk is better served by the wider staggered fallback than by more
+/// single-flight bin tries.
+const PRIMARY_ROUTE_BUDGET: usize = 4;
+
+/// Wall-clock bound on the whole bin-bucket primary route.
+///
+/// The primary is single-flight, so a withholding head holds the one in-flight
+/// attempt with no overlapping attempt to overtake it. This deadline hands a
+/// stuck route off to the staggered fallback rather than stalling the chunk's
+/// pipeline slot.
+const PRIMARY_ROUTE_DEADLINE: Duration = Duration::from_secs(2);
+
+/// Stagger for the primary route, set beyond [`PRIMARY_ROUTE_DEADLINE`] so it
+/// never fires: the primary is strict single-flight.
+///
+/// Exactly one metered attempt is in flight at a time on the primary path. The
+/// staggered fan-out is reserved for the fallback.
+const PRIMARY_ROUTE_SINGLE_FLIGHT: Duration = Duration::from_secs(3600);
+
+/// Economic ordering of retrieval and pushsync candidates.
+///
+/// The native client supplies [`PeerSelector`] (score- and affordability-aware);
+/// the browser supplies [`ProximityOnly`], which leaves the proximity order
+/// untouched.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait CandidateOrdering: Send + Sync {
+    /// Order `candidates` for a request on `chunk` (band- and score-aware).
+    fn order(&self, candidates: Vec<OverlayAddress>, chunk: &ChunkAddress) -> Vec<OverlayAddress>;
+
+    /// Order by closeness among the admissible, dropping the headroom tiering;
+    /// the close spill uses this to travel the fewest forwarding hops.
+    fn order_closest_admissible(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        chunk: &ChunkAddress,
+    ) -> Vec<OverlayAddress>;
+}
+
+impl CandidateOrdering for PeerSelector {
+    fn order(&self, candidates: Vec<OverlayAddress>, chunk: &ChunkAddress) -> Vec<OverlayAddress> {
+        PeerSelector::order(self, candidates, chunk)
+    }
+
+    fn order_closest_admissible(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        chunk: &ChunkAddress,
+    ) -> Vec<OverlayAddress> {
+        PeerSelector::order_closest_admissible(self, candidates, chunk)
+    }
+}
+
+/// Per-peer cap on concurrent outbound retrieval substreams.
+///
+/// The native client supplies [`PeerInflightLimiter`]; the browser supplies
+/// [`NoInflightLimit`], which never declines a peer.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait InflightLimit: Send + Sync {
+    /// Per-attempt reservation that releases the slot on drop, including a
+    /// cancelled losing attempt.
+    type Permit: vertex_tasks::MaybeSend + 'static;
+
+    /// Filter proximity-ordered `candidates` to those with a free slot,
+    /// returning the survivors and whether the race should enforce the cap. When
+    /// every candidate is at its cap the full list is returned with the cap not
+    /// enforced (degraded service beats failing the request).
+    fn available(&self, candidates: Vec<OverlayAddress>) -> (Vec<OverlayAddress>, bool);
+
+    /// Reserve a slot for `peer`, or `None` when it is at its cap.
+    fn try_acquire(&self, peer: &OverlayAddress) -> Option<Self::Permit>;
+}
+
+impl InflightLimit for PeerInflightLimiter {
+    type Permit = OwnedSemaphorePermit;
+
+    fn available(&self, candidates: Vec<OverlayAddress>) -> (Vec<OverlayAddress>, bool) {
+        let survivors: Vec<OverlayAddress> = candidates
+            .iter()
+            .copied()
+            .filter(|peer| self.has_free_slot(peer))
+            .collect();
+        // The cap is enforced only when free-slot peers were found: the all-busy
+        // fall-through returns the full list so the race still attempts,
+        // best-effort.
+        if survivors.is_empty() {
+            (candidates, false)
+        } else {
+            (survivors, true)
+        }
+    }
+
+    fn try_acquire(&self, peer: &OverlayAddress) -> Option<Self::Permit> {
+        PeerInflightLimiter::try_acquire(self, peer)
+    }
+}
+
+/// Per-proximity-order latency estimate that paces the staggered race.
+///
+/// The native client supplies [`RetrievalLatency`]; the browser supplies
+/// [`NoLatencyHint`], so the stagger falls back to the constant.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait LatencyHint: Send + Sync {
+    /// The latency estimate for proximity `po`, or `None` when unsampled.
+    fn estimate(&self, po: u8) -> Option<Duration>;
+}
+
+impl LatencyHint for RetrievalLatency {
+    fn estimate(&self, po: u8) -> Option<Duration> {
+        RetrievalLatency::estimate(self, po)
+    }
+}
+
+/// Proximity-only ordering: returns candidates unchanged, with no economic
+/// signal. The browser client's [`CandidateOrdering`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ProximityOnly;
+
+impl CandidateOrdering for ProximityOnly {
+    fn order(&self, candidates: Vec<OverlayAddress>, _chunk: &ChunkAddress) -> Vec<OverlayAddress> {
+        candidates
+    }
+
+    fn order_closest_admissible(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        _chunk: &ChunkAddress,
+    ) -> Vec<OverlayAddress> {
+        candidates
+    }
+}
+
+/// No per-peer cap: every candidate has a free slot. The browser client's
+/// [`InflightLimit`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoInflightLimit;
+
+impl InflightLimit for NoInflightLimit {
+    type Permit = ();
+
+    fn available(&self, candidates: Vec<OverlayAddress>) -> (Vec<OverlayAddress>, bool) {
+        (candidates, false)
+    }
+
+    fn try_acquire(&self, _peer: &OverlayAddress) -> Option<Self::Permit> {
+        Some(())
+    }
+}
+
+/// No latency estimate: the adaptive stagger falls back to the constant. The
+/// browser client's [`LatencyHint`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoLatencyHint;
+
+impl LatencyHint for NoLatencyHint {
+    fn estimate(&self, _po: u8) -> Option<Duration> {
+        None
+    }
+}
+
+/// Tuning for one staggered race phase: the lifetime attempt `budget`, the
+/// concurrent-attempt width `max_in_flight`, the wall-clock `deadline`, and the
+/// per-attempt `stagger`.
+struct RaceBounds {
+    budget: usize,
+    max_in_flight: usize,
+    deadline: Duration,
+    stagger: Duration,
+}
+
+/// Shared dispatch engine for origin chunk retrieval.
+///
+/// Generic over its three capabilities so a native client wires the concrete
+/// providers and the browser wires zero-sized null objects. Both build one and
+/// delegate `retrieve_chunk` to [`Self::retrieve`]. Every retrieval terminal
+/// (no candidates, all attempts failed, deadline) maps to
+/// [`SwarmError::RetrievalExhausted`]: forwarding retrieval has no authoritative
+/// negative, so the engine never adjudicates absence.
+#[derive(Clone)]
+pub struct RetrievalEngine<I: SwarmIdentity, O: CandidateOrdering, G: InflightLimit, L: LatencyHint>
+{
+    client_handle: ClientHandle,
+    topology: TopologyHandle<I>,
+    ordering: O,
+    inflight: G,
+    latency: L,
+}
+
+impl<I, O, G, L> RetrievalEngine<I, O, G, L>
+where
+    I: SwarmIdentity,
+    O: CandidateOrdering,
+    G: InflightLimit,
+    L: LatencyHint,
+{
+    /// Build an engine over its three capabilities.
+    pub fn new(
+        client_handle: ClientHandle,
+        topology: TopologyHandle<I>,
+        ordering: O,
+        inflight: G,
+        latency: L,
+    ) -> Self {
+        Self {
+            client_handle,
+            topology,
+            ordering,
+            inflight,
+            latency,
+        }
+    }
+
+    /// The topology handle, for the native push path's closest-storer dispatch;
+    /// retrieval reaches topology through the engine's own dispatch.
+    pub(crate) fn topology(&self) -> &TopologyHandle<I> {
+        &self.topology
+    }
+
+    /// The client handle, for dispatching a push on the native push path.
+    pub(crate) fn client_handle(&self) -> &ClientHandle {
+        &self.client_handle
+    }
+
+    /// Order `candidates` through the accounting band, for the native push path.
+    ///
+    /// Drops refused peers and ranks by score; with [`ProximityOnly`] the order
+    /// is unchanged.
+    pub(crate) fn order(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        chunk: &ChunkAddress,
+    ) -> Vec<OverlayAddress> {
+        self.ordering.order(candidates, chunk)
+    }
+
+    /// Order the close set, spilling to the closest admissible peers of a wider
+    /// slice when the close set is fully gated.
+    ///
+    /// A non-empty band over the close set returns at once (the fast path),
+    /// keeping the close set's headroom-first debt spread. When every close peer
+    /// is refused, the closest few have spent their forgiveness on this download
+    /// while a far larger ring of slightly-farther peers still carries headroom;
+    /// banding [`RETRIEVE_SPILL_WIDTH`] peers and routing the chunk to an
+    /// admissible one there forwards it just the same, without parking the
+    /// pipeline slot. If even the wider slice is fully gated the result is empty
+    /// and the caller falls through to its terminal failure. With
+    /// [`ProximityOnly`] the proximity order is returned unchanged.
+    fn order_with_spill(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        chunk: &ChunkAddress,
+    ) -> Vec<OverlayAddress> {
+        let ordered = self.ordering.order(candidates, chunk);
+        if !ordered.is_empty() {
+            return ordered;
+        }
+        let wide = self.topology.closest_to(chunk, RETRIEVE_SPILL_WIDTH);
+        self.ordering.order_closest_admissible(wide, chunk)
+    }
+
+    /// Run one bounded staggered race over `candidates`, dispatching each attempt
+    /// as an originated retrieval that reserves the per-peer in-flight permit
+    /// riding its future.
+    ///
+    /// With `enforce_cap`, a peer that filled its in-flight slot since the
+    /// availability snapshot is declined at dispatch (no attempt, no budget unit)
+    /// so the cap holds on live state; without it (no limiter, or the all-busy
+    /// fall-through) the attempt runs best-effort even with no permit.
+    async fn race_attempts(
+        &self,
+        candidates: Vec<OverlayAddress>,
+        chunk_address: SwarmAddress,
+        bounds: RaceBounds,
+        enforce_cap: bool,
+        attempts: &AtomicUsize,
+    ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
+        race_with_refill(
+            candidates,
+            bounds.budget,
+            bounds.max_in_flight,
+            bounds.deadline,
+            bounds.stagger,
+            |peer_overlay| {
+                let permit = self.inflight.try_acquire(&peer_overlay);
+                // A peer that filled since the availability snapshot is declined
+                // so the cap holds on live state, spending no budget; best-effort
+                // (no limiter or all-busy fall-through) attempts without a permit.
+                if enforce_cap && permit.is_none() {
+                    return None;
+                }
+                attempts.fetch_add(1, Ordering::Relaxed);
+                // `originated = true`: our own retrieval, so the client service
+                // debits the serving peer on delivery.
+                let request = self
+                    .client_handle
+                    .retrieve_chunk(peer_overlay, chunk_address, true);
+                Some(async move {
+                    let _permit = permit;
+                    request.await
+                })
+            },
+        )
+        .await
+    }
+
+    /// Retrieve a chunk by the full dispatch policy.
+    ///
+    /// Runs the bin-route primary (single-flight, in-bin peers first), then the
+    /// staggered bounded-refill fallback. Every retrieval terminal maps to
+    /// [`SwarmError::RetrievalExhausted`]; the attempt count and last error stay
+    /// in the metrics and debug log, never the error variant.
+    pub async fn retrieve(&self, address: &ChunkAddress) -> SwarmResult<ChunkRetrievalResult> {
+        let chunk_address = SwarmAddress::new(address.0.into());
+        let attempts = AtomicUsize::new(0);
+
+        // PRIMARY: bin-bucket proximity route. Route the chunk to its Kademlia
+        // forwarding bin b = PO(local, chunk) and dispatch the best in-headroom
+        // connected peer there, spilling to the adjacent bins on saturation. A
+        // peer in bin b already shares the chunk's first b bits, so it forwards
+        // over fewer hops than a peer picked by raw closeness alone: fewer hops
+        // is lower per-chunk latency, the throughput lever. The route is
+        // single-flight (no stagger), so the happy path delivers one chunk for
+        // one metered attempt and over-fetches nothing. The accounting band ranks
+        // the route here; a gated route falls through to the staggered fallback,
+        // which spills to a wider headroom slice.
+        let local = self.topology.overlay_address();
+        let max_bin = self.topology.max_bin().get();
+        let bin_candidates =
+            bin_routed_order(&chunk_address, &local, max_bin, RETRIEVE_WIDTH, |bin| {
+                self.topology.connected_peers_in_bin(bin)
+            });
+        let bin_candidates = self.ordering.order(bin_candidates, address);
+        // Availability: drop peers at their in-flight cap so the route leads with
+        // an in-headroom peer. The cap is the non-economic muxer guard, composed
+        // after the accounting band, never merged with it.
+        let (bin_candidates, enforce_cap) = self.inflight.available(bin_candidates);
+
+        if !bin_candidates.is_empty() {
+            let primary = self
+                .race_attempts(
+                    bin_candidates,
+                    chunk_address,
+                    RaceBounds {
+                        budget: PRIMARY_ROUTE_BUDGET,
+                        // Single-flight: at most one metered attempt in flight,
+                        // advancing the bin spill only on an explicit failure.
+                        max_in_flight: 1,
+                        deadline: PRIMARY_ROUTE_DEADLINE,
+                        stagger: PRIMARY_ROUTE_SINGLE_FLIGHT,
+                    },
+                    enforce_cap,
+                    &attempts,
+                )
+                .await;
+            if let Ok(result) = primary {
+                let dispatched = attempts.load(Ordering::Relaxed);
+                histogram!("swarm.client.retrieval_attempts").record(dispatched as f64);
+                counter!("swarm.client.retrieval_total", "outcome" => "hit", "path" => "bin_route")
+                    .increment(1);
+                record_overfetch(dispatched, "bin_route");
+                return Ok(ChunkRetrievalResult {
+                    chunk: result.chunk,
+                    stamp: result.stamp,
+                    served_by: result.peer,
+                });
+            }
+        }
+
+        // FALLBACK: the staggered bounded-refill race over the globally closest
+        // connected peers. Reached when the bin route is gated, saturated, or its
+        // entry points all miss. Retrieval is forwarding-Kademlia with no
+        // authoritative negative on the wire: a failed or slow attempt means
+        // "this entry point could not serve it", never "the chunk is absent", so
+        // the race keeps going and only gives up on a real bound (the attempt
+        // budget, the pool, or the deadline). Staggering one attempt in at a time
+        // bounds the paid fan-out; each attempt reserves the per-peer in-flight
+        // permit that rides its future, released on drop including a cancelled
+        // losing attempt.
+        let closest_peers = self.topology.closest_to(&chunk_address, RETRIEVE_WIDTH);
+        // Spill to a wider in-headroom slice when every close peer is gated, so a
+        // fully gated close set routes around its spent peers rather than
+        // blocking; if even the wide slice is gated the empty result falls through
+        // to the no-connected-peers path below, the same RetrievalExhausted a
+        // no-peers failure yields, and the consumer re-streams.
+        let closest_peers = self.order_with_spill(closest_peers, address);
+        let (candidates, enforce_cap) = self.inflight.available(closest_peers);
+
+        // Pace the staggered fan-out to the live round trip rather than a fixed
+        // constant. Each candidate's expected latency is read from the per-PO
+        // estimate at its proximity to the chunk (the forwarding distance that
+        // dominates retrieval latency). Cold buckets fall back to the constant, so
+        // this is never slower, only faster on low-RTT distances.
+        let stagger = adaptive_stagger(
+            candidates
+                .iter()
+                .map(|peer| self.latency.estimate(chunk_address.proximity(peer).get())),
+        );
+
+        let outcome = self
+            .race_attempts(
+                candidates,
+                chunk_address,
+                RaceBounds {
+                    budget: RETRIEVE_ATTEMPT_BUDGET,
+                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                    deadline: RETRIEVE_DEADLINE,
+                    stagger,
+                },
+                enforce_cap,
+                &attempts,
+            )
+            .await;
+
+        let dispatched = attempts.load(Ordering::Relaxed);
+        histogram!("swarm.client.retrieval_attempts").record(dispatched as f64);
+        let outcome_label = match &outcome {
+            Ok(_) => "hit",
+            Err(RaceFailure::NoCandidates) => "no_peers",
+            Err(RaceFailure::AllFailed(_)) => "exhausted",
+            Err(RaceFailure::TimedOut) => "timed_out",
+        };
+        counter!("swarm.client.retrieval_total", "outcome" => outcome_label, "path" => "fallback")
+            .increment(1);
+        if outcome.is_ok() {
+            // `dispatched` spans both phases, so a fallback win also counts the
+            // primary attempts the missed bin route already spent.
+            record_overfetch(dispatched, "fallback");
+        }
+
+        match outcome {
+            Ok(result) => Ok(ChunkRetrievalResult {
+                chunk: result.chunk,
+                stamp: result.stamp,
+                served_by: result.peer,
+            }),
+            // Forwarding retrieval has no authoritative negative, so every
+            // terminal is the same honest outcome: the reachable peers were
+            // exhausted without serving the chunk. The which-attempt and
+            // last-error detail lives in the metrics and debug log above.
+            Err(_) => Err(SwarmError::RetrievalExhausted { address: *address }),
+        }
+    }
+}
+
+/// Build the bin-bucket proximity-routed candidate order for `chunk`.
+///
+/// Routes to the Kademlia forwarding bin `b = PO(local, chunk)` first: a peer
+/// there shares the chunk's first `b` bits, so it is at least as close to the
+/// chunk as we are and forwards over fewer hops. When that bin yields too few
+/// peers the route spills outward to the adjacent bins (`b-1`, `b+1`, `b-2`,
+/// ...) up to `width` candidates, so a sparse forwarding bin still finds an
+/// entry point. Within every bin the peers are ordered closest-to-chunk first.
+/// `peers_in_bin` returns connected peers only; retrieval never dials.
+pub(crate) fn bin_routed_order(
+    chunk: &SwarmAddress,
+    local: &SwarmAddress,
+    max_bin: u8,
+    width: usize,
+    peers_in_bin: impl Fn(Bin) -> Vec<SwarmAddress>,
+) -> Vec<SwarmAddress> {
+    let b = chunk.proximity(local).get().min(max_bin);
+    let mut order: Vec<SwarmAddress> = Vec::with_capacity(width);
+    for bin_index in spill_bins(b, max_bin) {
+        if order.len() >= width {
+            break;
+        }
+        let bin = Bin::new(bin_index).unwrap_or(Bin::MAX);
+        let mut in_bin = peers_in_bin(bin);
+        in_bin.sort_by_key(|peer| std::cmp::Reverse(chunk.proximity(peer)));
+        order.extend(in_bin);
+    }
+    order.truncate(width);
+    order
+}
+
+/// Bin visiting order for the bin-bucket route: the forwarding bin `b`, then
+/// outward to the nearest bins on either side (`b-1`, `b+1`, `b-2`, `b+2`,
+/// ...) within `[0, max_bin]`.
+pub(crate) fn spill_bins(b: u8, max_bin: u8) -> Vec<u8> {
+    let mut bins = Vec::with_capacity(max_bin as usize + 1);
+    bins.push(b);
+    let mut delta = 1u8;
+    loop {
+        let mut pushed = false;
+        if let Some(lower) = b.checked_sub(delta) {
+            bins.push(lower);
+            pushed = true;
+        }
+        let upper = b.saturating_add(delta);
+        if upper > b && upper <= max_bin {
+            bins.push(upper);
+            pushed = true;
+        }
+        if !pushed {
+            break;
+        }
+        delta += 1;
+    }
+    bins
+}
+
+/// Record the metered attempts a successful retrieval spent beyond the one that
+/// won.
+///
+/// Each extra attempt is a failed refill or a concurrent loser the race dropped;
+/// a dropped loser is not cancelled downstream, so it still fetches and meters a
+/// duplicate. This is the dispatch-side over-fetch signal (an upper bound). The
+/// delivery-side count of duplicates that actually arrived is
+/// `swarm.client.retrieval_overfetch_delivered`, emitted by the handler.
+fn record_overfetch(attempts: usize, path: &'static str) {
+    if let Some(extra) = attempts.checked_sub(1).filter(|extra| *extra > 0) {
+        counter!("swarm.client.retrieval_overfetch_total", "path" => path).increment(extra as u64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod bin_route {
+        use std::collections::HashMap;
+
+        use super::super::{bin_routed_order, spill_bins};
+        use nectar_primitives::SwarmAddress;
+        use vertex_swarm_api::Bin;
+
+        /// An address with `byte0` set, the rest zero, so its proximity to the
+        /// zero local overlay is controllable.
+        fn addr(byte0: u8) -> SwarmAddress {
+            let mut bytes = [0u8; 32];
+            bytes[0] = byte0;
+            SwarmAddress::from(bytes)
+        }
+
+        #[test]
+        fn spill_visits_the_forwarding_bin_then_outward() {
+            // Mid bin: b, then b-1, b+1, b-2, b+2, ... clamped to [0, max].
+            assert_eq!(spill_bins(4, 8), vec![4, 3, 5, 2, 6, 1, 7, 0, 8]);
+        }
+
+        #[test]
+        fn spill_clamps_at_both_edges() {
+            // b == 0 never produces a negative bin; b == max never overshoots.
+            assert_eq!(spill_bins(0, 3), vec![0, 1, 2, 3]);
+            assert_eq!(spill_bins(3, 3), vec![3, 2, 1, 0]);
+            assert_eq!(spill_bins(0, 0), vec![0]);
+        }
+
+        #[test]
+        fn routes_to_the_forwarding_bin_first_then_spills() {
+            // local is the zero overlay; chunk 0x08 (0000_1000) shares its first
+            // four bits with local, so the forwarding bin is 4.
+            let local = addr(0x00);
+            let chunk = addr(0x08);
+            // One sentinel peer per bin, encoding the bin index in byte 1.
+            let peers = |bin: Bin| {
+                let mut bytes = [0u8; 32];
+                bytes[1] = bin.get();
+                bytes[2] = 0x01; // distinguish from local/chunk
+                vec![SwarmAddress::from(bytes)]
+            };
+
+            let order = bin_routed_order(&chunk, &local, 8, 32, peers);
+            let bins: Vec<u8> = order
+                .iter()
+                .map(|p| p.as_bytes().get(1).copied().unwrap())
+                .collect();
+            assert_eq!(
+                bins,
+                vec![4, 3, 5, 2, 6, 1, 7, 0, 8],
+                "the forwarding bin leads, then the route spills outward"
+            );
+        }
+
+        #[test]
+        fn orders_within_a_bin_by_closeness_to_the_chunk() {
+            let local = addr(0x00);
+            let chunk = addr(0x08);
+            let near = addr(0x08); // shares the chunk's prefix: high proximity
+            let far = addr(0xff); // diverges at the first bit: proximity 0
+            let b = chunk.proximity(&local).get();
+            let bin_b = b;
+            let peers = move |bin: Bin| {
+                if bin.get() == bin_b {
+                    vec![far, near]
+                } else {
+                    Vec::new()
+                }
+            };
+
+            let order = bin_routed_order(&chunk, &local, 31, 32, peers);
+            assert_eq!(
+                order,
+                vec![near, far],
+                "the closer-to-chunk peer leads its bin regardless of input order"
+            );
+        }
+
+        #[test]
+        fn respects_the_width_cap() {
+            let local = addr(0x00);
+            let chunk = addr(0x08);
+            // Three peers in every bin; a width of 5 takes only the first five.
+            let peers = |bin: Bin| {
+                (0u8..3)
+                    .map(|i| {
+                        let mut bytes = [0u8; 32];
+                        bytes[1] = bin.get();
+                        bytes[2] = i + 1;
+                        SwarmAddress::from(bytes)
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let order = bin_routed_order(&chunk, &local, 8, 5, peers);
+            assert_eq!(order.len(), 5, "width caps the candidate count");
+        }
+
+        #[test]
+        fn empty_bins_yield_no_candidates() {
+            let local = addr(0x00);
+            let chunk = addr(0x08);
+            let empty: HashMap<u8, Vec<SwarmAddress>> = HashMap::new();
+            let order = bin_routed_order(&chunk, &local, 8, 32, |bin| {
+                empty.get(&bin.get()).cloned().unwrap_or_default()
+            });
+            assert!(order.is_empty(), "no connected peers yields no route");
+        }
+    }
+
+    mod null_objects {
+        use nectar_primitives::SwarmAddress;
+        use vertex_swarm_api::ChunkAddress;
+        use vertex_tasks::time::Duration;
+
+        use super::super::{
+            CandidateOrdering, InflightLimit, LatencyHint, NoInflightLimit, NoLatencyHint,
+            ProximityOnly,
+        };
+
+        fn overlay(n: u8) -> SwarmAddress {
+            SwarmAddress::from([n; 32])
+        }
+
+        #[test]
+        fn proximity_only_leaves_the_order_untouched() {
+            let candidates = vec![overlay(3), overlay(1), overlay(2)];
+            let chunk = ChunkAddress::zero();
+            assert_eq!(
+                ProximityOnly.order(candidates.clone(), &chunk),
+                candidates,
+                "ordering is a no-op"
+            );
+            assert_eq!(
+                ProximityOnly.order_closest_admissible(candidates.clone(), &chunk),
+                candidates,
+                "the spill ordering is a no-op"
+            );
+        }
+
+        #[test]
+        fn no_inflight_limit_keeps_every_candidate_and_never_declines() {
+            let candidates = vec![overlay(1), overlay(2)];
+            assert_eq!(
+                NoInflightLimit.available(candidates.clone()),
+                (candidates, false),
+                "no peer is filtered and the cap is not enforced"
+            );
+            assert_eq!(
+                NoInflightLimit.try_acquire(&overlay(1)),
+                Some(()),
+                "a permit is always granted"
+            );
+        }
+
+        #[test]
+        fn no_latency_hint_is_always_cold() {
+            assert_eq!(
+                NoLatencyHint.estimate(8),
+                None::<Duration>,
+                "no estimate, so the stagger falls back to the constant"
+            );
+        }
+    }
+
+    mod inflight_available {
+        use std::num::NonZeroUsize;
+
+        use nectar_primitives::SwarmAddress;
+
+        use super::super::InflightLimit;
+        use crate::PeerInflightLimiter;
+
+        const CAP_ONE: NonZeroUsize = match NonZeroUsize::new(1) {
+            Some(cap) => cap,
+            None => unreachable!(),
+        };
+
+        fn overlay(n: u8) -> SwarmAddress {
+            SwarmAddress::from([n; 32])
+        }
+
+        #[test]
+        fn available_drops_a_capped_head() {
+            let limiter = PeerInflightLimiter::new(CAP_ONE);
+            let busy = overlay(1);
+            let _held = limiter.try_acquire(&busy).expect("first slot");
+
+            let (survivors, enforce_cap) = limiter.available(vec![busy, overlay(2), overlay(3)]);
+            assert_eq!(
+                survivors,
+                vec![overlay(2), overlay(3)],
+                "the capped head is skipped, the next-closest free peers remain"
+            );
+            assert!(enforce_cap, "free-slot peers found, so the cap is enforced");
+        }
+
+        #[test]
+        fn available_falls_through_when_every_candidate_is_capped() {
+            let limiter = PeerInflightLimiter::new(CAP_ONE);
+            let candidates = vec![overlay(1), overlay(2)];
+            let _h1 = limiter.try_acquire(&overlay(1)).expect("slot a");
+            let _h2 = limiter.try_acquire(&overlay(2)).expect("slot b");
+
+            let (survivors, enforce_cap) = limiter.available(candidates.clone());
+            assert_eq!(
+                survivors, candidates,
+                "all-busy falls through to the full list rather than failing"
+            );
+            assert!(
+                !enforce_cap,
+                "the all-busy fall-through is best-effort, not cap-enforced"
+            );
+        }
+    }
+}

--- a/crates/swarm/node/src/retrieval_latency.rs
+++ b/crates/swarm/node/src/retrieval_latency.rs
@@ -4,7 +4,7 @@
 //! how close the serving entry peer already is to the chunk: a chunk in the
 //! peer's neighbourhood returns in one hop, a sparse-bin chunk forwards several.
 //! Bucketing observed latency by `PO(serving_peer, chunk)` captures that, so the
-//! race paces its stagger to the distance actually being walked rather than to a
+//! race paces its stagger to the distance actually being traversed rather than to a
 //! single constant. Single-hop ping latency is deliberately not folded in: it
 //! reflects one connection, not a forwarding chain.
 
@@ -21,13 +21,13 @@ const PO_BUCKETS: usize = 32;
 /// it, so the estimate tracks the recent distribution without chasing one outlier.
 const EWMA_SHIFT: u32 = 3;
 
-/// Multiplier on the observed round trip for the adaptive stagger: the next leg
+/// Multiplier on the observed round trip for the adaptive stagger: the next attempt
 /// waits this many typical round trips, sitting above a head merely in flight
 /// while still tracking the real distribution.
 const HEDGE_RTT_MULTIPLIER: u32 = 2;
 
 /// Floor on the adaptive stagger, so even a very low-RTT neighbourhood keeps a
-/// hair of spacing between dispatched legs rather than fanning out at once.
+/// hair of spacing between dispatched attempts rather than fanning out at once.
 const HEDGE_STAGGER_FLOOR: Duration = Duration::from_millis(50);
 
 /// Per-PO EWMA of observed originated-retrieval latency, in nanoseconds.

--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -2,7 +2,7 @@
 //! first success.
 //!
 //! Some requests have several interchangeable candidates, any of which can
-//! satisfy the request. Walking them strictly in series lets one slow or
+//! satisfy the request. Trying them strictly in series lets one slow or
 //! withholding head candidate stall the whole request for a full per-attempt
 //! deadline, and where the caller streams a sequence of such requests that
 //! head-of-line stall blocks every later item behind it.
@@ -51,17 +51,17 @@ use futures_timer::Delay;
 /// The value sits comfortably above a typical live-network retrieval round
 /// trip, which spans several forwarding hops and runs in the hundreds of
 /// milliseconds. A stagger below that round trip dispatches the second
-/// candidate before the first leg has had a chance to answer, so both entry
-/// points forward and deliver the same chunk and both legs are metered: a near
-/// twofold over-fetch on the bulk path. Pacing the second leg past the round
-/// trip keeps the race single-leg whenever the head is merely in flight, and
-/// reserves the fan-out for a head that is genuinely slow or withholding. The
-/// failover cost is that a withholding head is now overtaken after this stagger
-/// rather than within a few hundred milliseconds; that is acceptable because the
-/// stagger stays far below the per-request `retrieval_timeout`, the failed-leg
-/// path still starts the next candidate immediately on an explicit error, and
-/// the difficult-chunk walk's wall-clock deadline still admits its full leg
-/// budget at this pace.
+/// candidate before the first attempt has had a chance to answer, so both entry
+/// points forward and deliver the same chunk and both attempts are metered: a
+/// near twofold over-fetch on the bulk path. Pacing the second attempt past the
+/// round trip keeps the race single-attempt whenever the head is merely in
+/// flight, and reserves the fan-out for a head that is genuinely slow or
+/// withholding. The failover cost is that a withholding head is now overtaken
+/// after this stagger rather than within a few hundred milliseconds; that is
+/// acceptable because the stagger stays far below the per-request
+/// `retrieval_timeout`, the failed-attempt path still starts the next candidate
+/// immediately on an explicit error, and the difficult-chunk retrieval's
+/// wall-clock deadline still admits its full attempt budget at this pace.
 pub const RETRIEVAL_STAGGER: Duration = Duration::from_millis(1200);
 
 /// Outcome of a candidate race that produced no success.
@@ -71,9 +71,9 @@ pub enum RaceFailure<E> {
     NoCandidates,
     /// Every candidate was attempted and failed; carries the last failure.
     AllFailed(E),
-    /// The walk's wall-clock deadline elapsed before any candidate succeeded.
-    /// Distinct from [`AllFailed`](Self::AllFailed) because the walk may still
-    /// have had legs in flight or untried candidates when the clock ran out.
+    /// The race's wall-clock deadline elapsed before any candidate succeeded.
+    /// Distinct from [`AllFailed`](Self::AllFailed) because the race may still
+    /// have had attempts in flight or untried candidates when the clock ran out.
     TimedOut,
 }
 
@@ -133,30 +133,30 @@ where
     }
 }
 
-/// Like [`race_candidates`], but bounded to at most `budget` dispatched legs and
-/// an overall wall-clock `deadline`.
+/// Like [`race_candidates`], but bounded to at most `budget` dispatched attempts
+/// and an overall wall-clock `deadline`.
 ///
-/// This is the difficult-chunk retrieval walk. Retrieval is forwarding-Kademlia
-/// with no authoritative negative response: a leg that errors or times out means
-/// "this entry point could not serve it", never "the chunk is absent". So the
-/// walk keeps trying the next candidate on every failure and only gives up on a
-/// real bound: `budget` legs dispatched, the candidate source exhausted, or the
-/// `deadline`. The caller filters back-pressured peers out of `candidates`
-/// beforehand (skip-busy), so a busy peer is never dispatched and never spends a
+/// This is the difficult-chunk retrieval race. Retrieval is forwarding-Kademlia
+/// with no authoritative negative response: an attempt that errors or times out
+/// means "this entry point could not serve it", never "the chunk is absent". So
+/// the race keeps trying the next candidate on every failure and only gives up
+/// on a real bound: `budget` attempts dispatched, the candidate source
+/// exhausted, or the `deadline`. The caller filters back-pressured peers out of
+/// `candidates` beforehand, so a busy peer is never dispatched and never spends a
 /// budget unit; `budget` therefore counts only genuine coverage attempts. The
 /// `attempt` closure may also decline a candidate at dispatch by returning
-/// `None` (a peer that filled since the skip-busy snapshot), which is skipped for
-/// the next candidate without spending a budget unit, so the cap holds on the
+/// `None` (a peer that filled since the availability snapshot), which is skipped
+/// for the next candidate without spending a budget unit, so the cap holds on the
 /// live state rather than the stale snapshot.
 ///
-/// Each leg is staggered, at most `max_in_flight` run concurrently, and losers
-/// are dropped on resolve, so true concurrency is bounded by `max_in_flight`
-/// regardless of `budget`: this is a patient walk, not a wide simultaneous
-/// fan-out. A stagger tick adds a leg only while fewer than `max_in_flight` are
-/// live; a failed leg still refills at once, which replaces a freed slot rather
-/// than widening, so the walk keeps its reach without multiplying the metered
-/// over-fetch when legs merely withhold.
-pub async fn race_walk<C, T, E, I, F, Fut>(
+/// Each attempt is staggered, at most `max_in_flight` run concurrently, and
+/// losers are dropped on resolve, so true concurrency is bounded by
+/// `max_in_flight` regardless of `budget`: this is a patient race, not a wide
+/// simultaneous fan-out. A stagger tick adds an attempt only while fewer than
+/// `max_in_flight` are live; a failed attempt still refills at once, which
+/// replaces a freed slot rather than widening, so the race keeps its reach
+/// without multiplying the metered over-fetch when attempts merely withhold.
+pub async fn race_with_refill<C, T, E, I, F, Fut>(
     candidates: I,
     budget: usize,
     max_in_flight: usize,
@@ -174,18 +174,18 @@ where
     let mut dispatched = 0usize;
     let mut last_error: Option<E> = None;
 
-    // Dispatch the next dispatchable candidate while the leg budget allows. A
+    // Dispatch the next dispatchable candidate while the attempt budget allows. A
     // candidate the closure declines (returns `None`, e.g. a peer found busy at
-    // dispatch) is skipped without spending a budget unit, so only a pushed leg
-    // counts. Returns whether a leg was pushed (false once the budget is spent or
-    // the source is drained, declines included).
+    // dispatch) is skipped without spending a budget unit, so only a pushed
+    // attempt counts. Returns whether an attempt was pushed (false once the
+    // budget is spent or the source is drained, declines included).
     let mut dispatch_next = |in_flight: &mut FuturesUnordered<Fut>, dispatched: &mut usize| {
         if *dispatched >= budget {
             return false;
         }
         for candidate in candidates.by_ref() {
-            if let Some(leg) = attempt(candidate) {
-                in_flight.push(leg);
+            if let Some(future) = attempt(candidate) {
+                in_flight.push(future);
                 *dispatched += 1;
                 return true;
             }
@@ -205,9 +205,9 @@ where
             result = in_flight.select_next_some() => match result {
                 Ok(value) => return Ok(value),
                 Err(error) => {
-                    // A failed leg frees its slot: dispatch the next candidate at
-                    // once. When the budget and the source are both spent and no
-                    // leg is in flight, this failure is the walk's last word.
+                    // A failed attempt frees its slot: dispatch the next candidate
+                    // at once. When the budget and the source are both spent and no
+                    // attempt is in flight, this failure is the race's last word.
                     if !dispatch_next(&mut in_flight, &mut dispatched) && in_flight.is_empty() {
                         return Err(RaceFailure::AllFailed(error));
                     }
@@ -215,9 +215,10 @@ where
                 }
             },
             _ = stagger_tick => {
-                // Grow the in-flight set only up to the width: a stagger adds a
-                // leg, a withholding leg never does. Failure-refill above still
-                // replaces a freed slot, so reach is preserved without widening.
+                // Grow the in-flight set only up to the width: a stagger adds an
+                // attempt, a withholding attempt never does. Failure-refill above
+                // still replaces a freed slot, so reach is preserved without
+                // widening.
                 if in_flight.len() < max_in_flight {
                     dispatch_next(&mut in_flight, &mut dispatched);
                 }
@@ -225,7 +226,7 @@ where
             },
             _ = deadline_tick => {
                 // Out of wall-clock time. Surface the last real failure if one
-                // landed, else the legs were merely slow: a distinct TimedOut.
+                // landed, else the attempts were merely slow: a distinct TimedOut.
                 return match last_error.take() {
                     Some(error) => Err(RaceFailure::AllFailed(error)),
                     None => Err(RaceFailure::TimedOut),
@@ -247,10 +248,10 @@ mod tests {
 
     use super::*;
 
-    /// A retrieval leg that records whether it was polled to completion or
+    /// A retrieval attempt that records whether it was polled to completion or
     /// dropped mid-flight, so a test can assert losing attempts are dropped (the
     /// reservation-release signal).
-    struct TrackedLeg {
+    struct TrackedAttempt {
         delay: Delay,
         result: Option<Result<u32, &'static str>>,
         completed: Arc<AtomicUsize>,
@@ -258,7 +259,7 @@ mod tests {
         done: bool,
     }
 
-    impl TrackedLeg {
+    impl TrackedAttempt {
         fn new(
             after: Duration,
             result: Result<u32, &'static str>,
@@ -275,7 +276,7 @@ mod tests {
         }
     }
 
-    impl std::future::Future for TrackedLeg {
+    impl std::future::Future for TrackedAttempt {
         type Output = Result<u32, &'static str>;
 
         fn poll(
@@ -294,7 +295,7 @@ mod tests {
         }
     }
 
-    impl Drop for TrackedLeg {
+    impl Drop for TrackedAttempt {
         fn drop(&mut self) {
             // Only count a drop that pre-empted completion: that is the
             // race-lost path whose resource release we care about.
@@ -323,25 +324,25 @@ mod tests {
         let completed = Arc::new(AtomicUsize::new(0));
         let dropped = Arc::new(AtomicUsize::new(0));
 
-        let legs = vec![
+        let outcomes = vec![
             // Head: would succeed, but only after ~5s.
             (Duration::from_secs(5), Ok(1u32)),
             // Second: succeeds shortly after it is staggered in.
             (Duration::from_millis(50), Ok(2u32)),
         ];
-        let mut legs = legs.into_iter();
+        let mut outcomes = outcomes.into_iter();
 
         let start = Instant::now();
         let outcome = race_candidates(0..2, RETRIEVAL_STAGGER, |_| {
-            let (after, result) = legs.next().expect("a leg per candidate");
-            TrackedLeg::new(after, result, completed.clone(), dropped.clone())
+            let (after, result) = outcomes.next().expect("an attempt per candidate");
+            TrackedAttempt::new(after, result, completed.clone(), dropped.clone())
         })
         .await;
         let elapsed = start.elapsed();
 
         assert_eq!(outcome.ok(), Some(2), "the staggered second wins");
         // Resolved well under the head's 5s withhold: stagger (~500ms) plus the
-        // second leg (~50ms).
+        // second attempt (~50ms).
         assert!(
             elapsed < Duration::from_secs(2),
             "race resolved in {elapsed:?}, expected ~stagger not the head delay"
@@ -367,16 +368,16 @@ mod tests {
         let completed = Arc::new(AtomicUsize::new(0));
         let dropped = Arc::new(AtomicUsize::new(0));
 
-        let legs = vec![
+        let outcomes = vec![
             (Duration::from_millis(10), Err("head failed")),
             (Duration::from_millis(10), Ok(2u32)),
         ];
-        let mut legs = legs.into_iter();
+        let mut outcomes = outcomes.into_iter();
 
         let start = Instant::now();
         let outcome = race_candidates(0..2, RETRIEVAL_STAGGER, |_| {
-            let (after, result) = legs.next().expect("a leg per candidate");
-            TrackedLeg::new(after, result, completed.clone(), dropped.clone())
+            let (after, result) = outcomes.next().expect("an attempt per candidate");
+            TrackedAttempt::new(after, result, completed.clone(), dropped.clone())
         })
         .await;
         let elapsed = start.elapsed();
@@ -393,16 +394,16 @@ mod tests {
         let completed = Arc::new(AtomicUsize::new(0));
         let dropped = Arc::new(AtomicUsize::new(0));
 
-        let legs = vec![
+        let outcomes = vec![
             (Duration::from_millis(5), Err("first")),
             (Duration::from_millis(5), Err("second")),
             (Duration::from_millis(5), Err("last")),
         ];
-        let mut legs = legs.into_iter();
+        let mut outcomes = outcomes.into_iter();
 
         let outcome = race_candidates(0..3, RETRIEVAL_STAGGER, |_| {
-            let (after, result) = legs.next().expect("a leg per candidate");
-            TrackedLeg::new(after, result, completed.clone(), dropped.clone())
+            let (after, result) = outcomes.next().expect("an attempt per candidate");
+            TrackedAttempt::new(after, result, completed.clone(), dropped.clone())
         })
         .await;
 
@@ -412,16 +413,16 @@ mod tests {
         }
     }
 
-    /// The walk reaches a chunk whose closest few entry points miss: the legs
-    /// before the holder fail, and the walk refills to the next-closest until the
+    /// The race reaches a chunk whose closest few entry points miss: the attempts
+    /// before the holder fail, and the race refills to the next-closest until the
     /// holder serves it, well within the budget.
     #[tokio::test]
-    async fn walk_reaches_a_holder_past_missing_close_peers() {
+    async fn race_reaches_a_holder_past_missing_close_peers() {
         // Candidates 0..10 in proximity order; the first four miss, the fifth
         // serves. A bound of 3 would have failed here.
         let attempts = Arc::new(AtomicUsize::new(0));
         let counted = attempts.clone();
-        let outcome = race_walk(
+        let outcome = race_with_refill(
             0..10u32,
             8,
             3,
@@ -442,18 +443,18 @@ mod tests {
         assert_eq!(
             attempts.load(Ordering::SeqCst),
             5,
-            "exactly the five legs up to and including the holder were dispatched"
+            "exactly the five attempts up to and including the holder were dispatched"
         );
     }
 
-    /// An all-miss walk gives up after exactly `budget` legs, never the whole
+    /// An all-miss race gives up after exactly `budget` attempts, never the whole
     /// pool: the bound caps paid coverage attempts even when far more candidates
     /// are available.
     #[tokio::test]
-    async fn walk_spends_exactly_the_budget_then_fails() {
+    async fn race_spends_exactly_the_budget_then_fails() {
         let attempts = Arc::new(AtomicUsize::new(0));
         let counted = attempts.clone();
-        let outcome = race_walk(
+        let outcome = race_with_refill(
             0..100u32,
             6,
             3,
@@ -470,20 +471,20 @@ mod tests {
         assert_eq!(
             attempts.load(Ordering::SeqCst),
             6,
-            "the budget caps dispatched legs at 6 of the 100 available"
+            "the budget caps dispatched attempts at 6 of the 100 available"
         );
     }
 
     /// A candidate the closure declines (returns `None`, a peer busy at dispatch)
     /// is skipped for the next without spending a budget unit, so the budget is
-    /// spent only on dispatched legs.
+    /// spent only on dispatched attempts.
     #[tokio::test]
-    async fn walk_skips_declined_candidates_without_spending_budget() {
+    async fn race_skips_declined_candidates_without_spending_budget() {
         // Budget 2. The first three candidates decline; the budget must survive
         // them so the fourth (a miss) and fifth (a hit) are still reached.
         let dispatched = Arc::new(AtomicUsize::new(0));
         let counted = dispatched.clone();
-        let outcome = race_walk(
+        let outcome = race_with_refill(
             0..10u32,
             2,
             3,
@@ -503,21 +504,21 @@ mod tests {
         assert_eq!(
             dispatched.load(Ordering::SeqCst),
             2,
-            "budget spent only on the two dispatched legs, not the three declines"
+            "budget spent only on the two dispatched attempts, not the three declines"
         );
     }
 
-    /// Under a withhold-storm (legs stall, never error) a stagger grows the
+    /// Under a withhold-storm (attempts stall, never error) a stagger grows the
     /// in-flight set only up to the width, never the budget: the metered
     /// over-fetch is bounded by `max_in_flight` even when the budget and the
-    /// deadline would admit more legs.
+    /// deadline would admit more attempts.
     #[tokio::test]
-    async fn walk_caps_concurrent_legs_at_the_width() {
+    async fn race_caps_concurrent_attempts_at_the_width() {
         let constructed = Arc::new(AtomicUsize::new(0));
         let counted = constructed.clone();
         // Budget 8 over a 300ms deadline at a 20ms stagger would dispatch eight
-        // legs without a width cap; max_in_flight = 3 holds it to three.
-        let outcome = race_walk(
+        // attempts without a width cap; max_in_flight = 3 holds it to three.
+        let outcome = race_with_refill(
             0..100u32,
             8,
             3,
@@ -537,17 +538,17 @@ mod tests {
         assert_eq!(
             constructed.load(Ordering::SeqCst),
             3,
-            "the width caps concurrent legs at 3, not the budget of 8"
+            "the width caps concurrent attempts at 3, not the budget of 8"
         );
     }
 
-    /// A walk whose legs all merely withhold (never an explicit failure) is
+    /// A race whose attempts all merely withhold (never an explicit failure) is
     /// bounded by the wall clock, surfacing TimedOut rather than hanging.
     #[tokio::test]
-    async fn walk_deadline_bounds_withholding_legs() {
+    async fn race_deadline_bounds_withholding_attempts() {
         let start = Instant::now();
-        // Every leg withholds for far longer than the deadline; none ever errors.
-        let outcome = race_walk(
+        // Every attempt withholds for far longer than the deadline; none ever errors.
+        let outcome = race_with_refill(
             0..8u32,
             8,
             3,
@@ -565,18 +566,18 @@ mod tests {
 
         assert!(
             matches!(outcome, Err(RaceFailure::TimedOut)),
-            "withholding legs surface TimedOut"
+            "withholding attempts surface TimedOut"
         );
         assert!(
             elapsed < Duration::from_secs(2),
-            "the deadline bounded the walk ({elapsed:?})"
+            "the deadline bounded the race ({elapsed:?})"
         );
     }
 
     /// An empty pool and a zero budget both attempt nothing.
     #[tokio::test]
-    async fn walk_with_nothing_to_try_yields_no_candidates() {
-        let empty = race_walk(
+    async fn race_with_nothing_to_try_yields_no_candidates() {
+        let empty = race_with_refill(
             Vec::<u32>::new(),
             8,
             3,
@@ -587,7 +588,7 @@ mod tests {
         .await;
         assert!(matches!(empty, Err(RaceFailure::NoCandidates)));
 
-        let zero_budget = race_walk(
+        let zero_budget = race_with_refill(
             0..4u32,
             0,
             3,

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -92,13 +92,15 @@ fn parse_stamped_chunk(req: &UploadChunkRequest) -> Result<StampedChunk, Status>
     })
 }
 
-/// Absence becomes `not_found`, all else `internal`.
+/// Exhausted retrieval becomes `unavailable` (absence is not provable, so the
+/// caller may retry), no-storer `not_found`, all else `internal`.
 #[allow(clippy::result_large_err)]
 fn retrieval_status(error: &SwarmError) -> Status {
     match error {
-        SwarmError::ChunkNotFound { .. } | SwarmError::NoStorer { .. } => {
-            Status::not_found(format!("chunk not found: {error}"))
+        SwarmError::RetrievalExhausted { .. } => {
+            Status::unavailable(format!("retrieval exhausted: {error}"))
         }
+        SwarmError::NoStorer { .. } => Status::not_found(format!("chunk not found: {error}")),
         other => Status::internal(format!("chunk retrieval failed: {other}")),
     }
 }

--- a/crates/swarm/stream/src/lib.rs
+++ b/crates/swarm/stream/src/lib.rs
@@ -670,7 +670,7 @@ mod tests {
                         served_by: OverlayAddress::from([1u8; 32]),
                     })
                 }
-                None => Err(SwarmError::ChunkNotFound { address: *address }),
+                None => Err(SwarmError::RetrievalExhausted { address: *address }),
             }
         }
 
@@ -839,7 +839,7 @@ mod tests {
         // Unordered: locate each outcome by its item address.
         for (address, result) in results {
             if address == missing {
-                assert!(matches!(result, Err(SwarmError::ChunkNotFound { .. })));
+                assert!(matches!(result, Err(SwarmError::RetrievalExhausted { .. })));
             } else {
                 assert!(result.is_ok());
             }
@@ -1217,7 +1217,7 @@ mod tests {
         assert_eq!(results.len(), addresses.len());
         for (address, result) in results {
             if address == missing {
-                assert!(matches!(result, Err(SwarmError::ChunkNotFound { .. })));
+                assert!(matches!(result, Err(SwarmError::RetrievalExhausted { .. })));
             } else {
                 assert!(result.is_ok());
             }
@@ -1338,7 +1338,7 @@ mod tests {
         let client = ClientMock::new(vec![chunk_for(11)]);
         let missing = ChunkAddress::new([0xfe; 32]);
         let err = client.get(missing).await.expect_err("missing chunk errors");
-        assert!(matches!(err, SwarmError::ChunkNotFound { .. }));
+        assert!(matches!(err, SwarmError::RetrievalExhausted { .. }));
     }
 
     #[tokio::test]

--- a/docs/design/retrieval-per-peer-substream-cap.md
+++ b/docs/design/retrieval-per-peer-substream-cap.md
@@ -25,7 +25,7 @@ The overrun bug was having only the first and not the second.
 
 ## The fix: per-peer cap + skip-busy spread
 
-Bound concurrent outbound retrieval substreams per peer with a non-blocking permit. When a peer is at its cap the scheduler SKIPS it and dispatches the chunk to the next-closest live peer that has a free slot, rather than blocking on the head peer (which would be head-of-line blocking and defeat the staggered race). The permit rides the request future and releases on drop, including a cancelled race leg. Candidate selection widens from the closest few to the closest connected peers in proximity order, filtered to those with a free slot, then fed to the existing staggered race. If every close candidate is at its cap, the dispatch falls through to the staggered race against whatever peers exist rather than erroring (degraded service beats failure).
+Bound concurrent outbound retrieval substreams per peer with a non-blocking permit. When a peer is at its cap the scheduler SKIPS it and dispatches the chunk to the next-closest live peer that has a free slot, rather than blocking on the head peer (which would be head-of-line blocking and defeat the staggered race). The permit rides the request future and releases on drop, including a cancelled race attempt. Candidate selection widens from the closest few to the closest connected peers in proximity order, filtered to those with a free slot, then fed to the existing staggered race. If every close candidate is at its cap, the dispatch falls through to the staggered race against whatever peers exist rather than erroring (degraded service beats failure).
 
 The cap is a non-economic concern, composed after economic selection. The explicit dispatch ordering is: selector decides who is eligible (proximity, not warned, affordable), skip-busy decides who has a slot, the origin credit gate bands the chosen request. The substream cap must never be merged with the affordability or debt signals.
 
@@ -58,7 +58,7 @@ nectar 0.3.0 adds wasm-ready out-of-order joiner primitives: a `ChunkGet` getter
 ## Risks
 
 - Thin peer set (browser): caps must be per-peer, never global; below a live-set threshold, fall back to the staggered race rather than refuse. Keep the browser pipeline depth small so the cap is rarely binding.
-- All close peers busy: fall through to the staggered race; a failed slot acquisition advances the candidate walk rather than erroring.
+- All close peers busy: fall through to the staggered race; a failed slot acquisition advances the candidate race rather than erroring.
 - Thundering herd on slot release: avoided by construction; a non-blocking try-acquire never parks a herd of awaiters.
 - Wide-race interaction: the last-resort race must consult the same cap or run under its own tighter cap.
 - wasm cone: the limiter stays in the node layer (not the wasm-facing stream crate); verify it builds for `wasm32-unknown-unknown`.


### PR DESCRIPTION
## What

Extract the origin retrieval dispatch policy into one `RetrievalEngine<I, O, G, L>` (`crates/swarm/node/src/retrieval_engine.rs`) that both the native `NetworkChunkProvider` and the browser `BrowserChunkProvider` drive behind the unchanged object-safe `SwarmChunkProvider` dyn edge. Bin-route primary, the staggered refilling race, the in-flight cap, adaptive stagger, headroom spill, and the over-fetch metrics now live in one place. The browser drops its bespoke widening-wave loop (292 to 109 lines) and inherits all of it.

### Capability-trait lattice
Capabilities are a small trait lattice, not runtime `Option`s: `CandidateOrdering`, `InflightLimit` (with an associated `Permit` type), and `LatencyHint`, each `auto_impl(&, Arc)`. The native client supplies `PeerSelector` / `PeerInflightLimiter` / `RetrievalLatency`; the browser supplies the zero-sized null objects `ProximityOnly` / `NoInflightLimit` / `NoLatencyHint`. No blanket impls (which would collide with the existing `auto_impl` and the `VerifyingChunkProvider` decorator); the native caps are fixed at construction (verified that `node/core.rs` always wires all three), so there is no boxing.

### One honest terminal
Forwarding retrieval has no authoritative negative, so `SwarmError::RetrievalExhausted` replaces `ChunkNotFound` on the retrieval path for both consumers, the `TerminalPolicy` seam is removed, and `is_not_found()` goes with it. Behavioural consequences, all deliberate:
- gRPC: the single-chunk retrieval status maps `RetrievalExhausted` to `UNAVAILABLE` (was `NOT_FOUND`); `NoStorer` still maps to `NOT_FOUND`. A client that treated `NOT_FOUND` as "definitely absent, stop" now sees `UNAVAILABLE` (retry hint) for retrieval exhaustion.
- browser usage snapshot: a retrieval miss is treated as a best-effort absent (`Ok(None)`). The adapter genuinely cannot distinguish "never published" from "transiently unreachable" (that is the no-authoritative-negative property), so it favours the new-batch path; a connectivity blip during a snapshot read is therefore indistinguishable from a genuinely fresh batch. Accepted for the best-effort demo snapshot.
- `is_retryable()` is left untouched here; retiring that stringly-typed predicate is the follow-up #620.

### Renames
The staggered-race vocabulary now reads as intent, not mechanism: `race_walk` to `race_with_refill`, `walk_legs` to `race_attempts`, the `RETRIEVE_WALK_*`/`RETRIEVE_LEG_BUDGET` constants lose the walk/leg tokens, and the three metrics lose the tokens and gain the `swarm.client.` namespace: `swarm.client.retrieval_attempts`, `swarm.client.retrieval_total`, `swarm.client.retrieval_overfetch_total`. Pre-v1, no stable dashboard contract.

## Why

Part of #606 (Phase 3). The same operation was implemented twice and diverged: the native origin had the bin-route + difficult-chunk race, the browser ran an older wave race with neither, so the live browser client over-fetched and spuriously failed sparse chunks the native client rescues. One engine means both consumers inherit every dispatch improvement, and one honest terminal stops the browser pretending it can prove absence.

## Review

Built by an Opus agent against an architecture spec, then gated by a four-agent Sonnet red-team (native byte-parity, lattice/object-safety/wasm-Send, the RetrievalExhausted blast radius, idiomacy/rename-completeness). Findings fixed in this commit: the engine `order` field renamed to `ordering` (it collided with the `order()` method), a sweep of leftover "race leg"/"walk" comments the extraction left in the sibling files, the metric namespace, and the `RetrievalExhausted` rustdoc reworded so it no longer implies the `is_retryable()` predicate. Red-team confirmed: native dispatch byte-identical apart from the intended terminal + metric changes; `auto_impl` forwards the associated `Permit` with no boxing; null objects are genuine no-ops; no consumer branches on `is_retryable()` for retrieval control flow.

## Testing

`cargo fmt --all --check`; `cargo clippy --all-targets --all-features -p vertex-swarm-{node,api,rpc,stream} -- -D warnings` (clean); `cargo nextest run --all-features -p vertex-swarm-{node,api,rpc,stream}` (218 pass); `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`; and the demo `cargo build --target wasm32-unknown-unknown`. No wire change.

## AI Assistance

AI Assistance: Claude Code (Opus 4.8 for architecture, spec, and implementation; Sonnet agents for the four-agent red-team) used for the engine reshape, the error-model change, the renames, and verification.

Closes #608. Part of #606.
