### PR TITLE
perf(swarm-node,swarm-demo): cap browser retrieval per-peer via the shared limiter

### DIFF
--- a/bin/swarm-demo/src/client/mod.rs
+++ b/bin/swarm-demo/src/client/mod.rs
@@ -43,7 +43,11 @@ impl SwarmClient {
         // and pushsync under each peer's pseudosettle allowance (the builder
         // wires the self-throttle), so the provider reuses it as-is.
         let client = launched.client().clone();
-        let routing = BrowserChunkProvider::new(client, launched.topology().clone());
+        let routing = BrowserChunkProvider::new(
+            client,
+            launched.topology().clone(),
+            launched.inflight().clone(),
+        );
         let provider: Arc<dyn SwarmChunkProvider> = Arc::new(routing.clone());
         let sender: Arc<dyn SwarmChunkSender> = Arc::new(routing);
         Self {

--- a/bin/swarm-demo/src/client/network.rs
+++ b/bin/swarm-demo/src/client/network.rs
@@ -8,7 +8,7 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_node::{
-    ClientHandle, NoInflightLimit, NoLatencyHint, ProximityOnly, RetrievalEngine,
+    ClientHandle, NoLatencyHint, PeerInflightLimiter, ProximityOnly, RetrievalEngine,
 };
 use vertex_swarm_topology::TopologyHandle;
 
@@ -17,26 +17,37 @@ const PUSH_CANDIDATE_COUNT: usize = 5;
 
 /// A proximity-routing chunk provider/sender over the browser client node.
 ///
-/// Drives the shared [`RetrievalEngine`] with the null-object capabilities
-/// ([`ProximityOnly`], [`NoInflightLimit`], [`NoLatencyHint`]): no economic
-/// ordering, no per-peer cap, and the constant stagger. Every retrieval terminal
-/// surfaces as `RetrievalExhausted`.
+/// Drives the shared [`RetrievalEngine`] with [`ProximityOnly`] ordering and the
+/// constant stagger ([`NoLatencyHint`]), but a real per-peer [`PeerInflightLimiter`]
+/// (the launched service's own instance, so a disconnect forgets the same peer the
+/// engine caps against). The per-peer cap is the browser's flood guard: it bounds
+/// how many concurrent retrieval substreams the wide download fan-out lands on any
+/// one close peer, so the fan-out stays inside the light-client debt band without
+/// relying on the joiner's walk shape. The cap is sized to leave a subtree
+/// descent's worth of concurrent structure fetches unthrottled, so it never
+/// strangles time-to-first-byte. Every retrieval terminal surfaces as
+/// `RetrievalExhausted`.
 #[derive(Clone)]
 pub struct BrowserChunkProvider {
-    engine: RetrievalEngine<Arc<Identity>, ProximityOnly, NoInflightLimit, NoLatencyHint>,
+    engine: RetrievalEngine<Arc<Identity>, ProximityOnly, Arc<PeerInflightLimiter>, NoLatencyHint>,
     client: ClientHandle,
     topology: TopologyHandle<Arc<Identity>>,
 }
 
 impl BrowserChunkProvider {
-    /// Build the provider from the launched client's handle and topology.
-    pub fn new(client: ClientHandle, topology: TopologyHandle<Arc<Identity>>) -> Self {
+    /// Build the provider from the launched client's handle, topology, and the
+    /// service-shared per-peer in-flight limiter.
+    pub fn new(
+        client: ClientHandle,
+        topology: TopologyHandle<Arc<Identity>>,
+        inflight: Arc<PeerInflightLimiter>,
+    ) -> Self {
         Self {
             engine: RetrievalEngine::new(
                 client.clone(),
                 topology.clone(),
                 ProximityOnly,
-                NoInflightLimit,
+                inflight,
                 NoLatencyHint,
             ),
             client,

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -584,6 +584,10 @@ pub struct ClientNodeParts<P> {
     pub topology: TopologyHandle<Arc<Identity>>,
     /// The selection-aware verified chunk provider.
     pub chunks: VerifiedChunkProvider,
+    /// The per-peer retrieval in-flight limiter, shared with the service that
+    /// forgets a peer on disconnect. Exposed so an embedder driving its own
+    /// engine (the browser provider) caps against the same instance.
+    pub inflight: Arc<PeerInflightLimiter>,
     /// The shared client accounting (selector, throttle, forwarder, service, and
     /// settlement all read this instance).
     pub accounting: SharedAccounting,
@@ -798,6 +802,7 @@ where
         task,
         topology,
         chunks,
+        inflight: core.inflight,
         accounting: core.accounting,
         client: core.origin_handle,
         provider_store,

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -41,6 +41,7 @@ use super::core::{
 use super::core::{ClientSwapParams, node_chain_provider};
 use crate::ChunkVerifyConfig;
 use crate::ClientHandle;
+use crate::inflight::PeerInflightLimiter;
 
 /// Default connection idle timeout for a launched client.
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -456,6 +457,7 @@ impl ClientLauncher {
             task,
             topology,
             chunks,
+            inflight,
             accounting,
             client,
             provider_store: (overlay, peer_id),
@@ -469,6 +471,7 @@ impl ClientLauncher {
         Ok(LaunchedClient {
             topology,
             client,
+            inflight,
             accounting,
             chunks,
             store,
@@ -502,6 +505,7 @@ fn spawn_node_run_loop(executor: &TaskExecutor, task: NodeRunTaskFn) {
 pub struct LaunchedClient {
     topology: TopologyHandle<Arc<Identity>>,
     client: ClientHandle,
+    inflight: Arc<PeerInflightLimiter>,
     accounting: SharedAccounting,
     chunks: VerifiedChunkProvider,
     store: Arc<dyn SwarmLocalStore>,
@@ -519,6 +523,13 @@ impl LaunchedClient {
     /// Origin-gated client handle for chunk retrieval and upload.
     pub fn client(&self) -> &ClientHandle {
         &self.client
+    }
+
+    /// The per-peer retrieval in-flight limiter the launched service forgets on
+    /// disconnect. An embedder driving its own retrieval engine caps against
+    /// this shared instance rather than a private one.
+    pub fn inflight(&self) -> &Arc<PeerInflightLimiter> {
+        &self.inflight
     }
 
     /// The selection-aware verified chunk provider: the retrieval and upload


### PR DESCRIPTION
## What

Give the browser client a real per-peer retrieval in-flight cap instead of the `NoInflightLimit` null object.

`LaunchedClient` now exposes the `PeerInflightLimiter` the shared client tail already builds (threaded out through `ClientNodeParts`), and `BrowserChunkProvider` drives the shared `RetrievalEngine` with it. Ordering stays `ProximityOnly` and the stagger stays constant (`NoLatencyHint`); only the per-peer cap changes.

## Why

Closes #621. Part of #606 (Phase 3).

The browser download fan-out runs at concurrency 32 with no per-peer bound anywhere in its stack, so it can pile many concurrent retrieval substreams onto the one or two closest connected storers, pushing per-peer debt past the light-client band and aborting the retrieval. The engine already owns the seam for this (`InflightLimit`), and the native client wires the real `PeerInflightLimiter`; the browser just declined to. The launched service already builds that limiter and forgets a peer on disconnect through it, so the engine now caps against the same instance the service maintains, with no new instance and no new disconnect wiring.

This re-homes the browser's flood-safety from the joiner's cold-start walk shape (which relieves nothing once data leaves stream) to the engine, where it holds in steady state. The default per-peer cap is sized to leave a subtree descent's worth of concurrent structure fetches unthrottled, so it bounds leaf fan-out without regressing time-to-first-byte. When every candidate is at its cap (the one or two peer case) the cap deliberately degrades to best-effort, which is strictly better than the previous unbounded behaviour.

## Testing

- `cargo build -p vertex-swarm-node`
- `cargo build --manifest-path bin/swarm-demo/Cargo.toml --target wasm32-unknown-unknown` (the browser target)
- `cargo clippy -p vertex-swarm-node --all-features -- -D warnings` and the demo wasm clippy, both clean
- `cargo nextest run -p vertex-swarm-node --all-features`: 153 passed

## AI Assistance

Claude Code (Opus 4.8) used for the domain-boundary analysis, the implementation, and the build/lint/test verification.
