### PR TITLE
feat(swarm-demo): retry transient chunk gets on the browser download path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4891,7 +4891,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 [[package]]
 name = "nectar-contracts"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
+source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "nectar-postage"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
+source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4916,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "nectar-primitives"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
+source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4944,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "nectar-swarms"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=8e8e8ae759c6f4c7f80c23442d9bb466e8a21341#8e8e8ae759c6f4c7f80c23442d9bb466e8a21341"
+source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
 dependencies = [
  "alloy-chains",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,13 +146,13 @@ indexing_slicing = "warn"
 # BatchStore/StoreValidator/SnapshotStore conversion plus nectar-mantaray and
 # nectar-postage-usage's `client`/`issuer`/`seal` features that the browser
 # upload/download path (bin/swarm-demo) depends on.
-nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
-nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
 
 digest = "0.10"
 

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -58,18 +58,18 @@ async-trait = "0.1"
 # `parallel`/`wasm-threads`, keeping the single-threaded wasm profile (the demo
 # never calls `initThreadPool`, so there is no rayon worker pool and no shared
 # memory).
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
 # `local-signer` brings the alloy-signer-local re-export for the in-browser key.
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
 # `issuer` + `seal` give signed content stamps (SnapshotIssuer) and the
 # usage-persistence seal path; default `std` is implied.
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341", features = [
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d", features = [
     "issuer",
     "seal",
     "client",
 ] }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "8e8e8ae759c6f4c7f80c23442d9bb466e8a21341" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
 
 # Chequebook address parsing for the optional SWAP config input and chain
 # types/signing for the browser. alloy-sol-types decodes the BatchCreated log

--- a/bin/swarm-demo/src/client/download.rs
+++ b/bin/swarm-demo/src/client/download.rs
@@ -12,13 +12,24 @@ use js_sys::Uint8Array;
 use nectar_mantaray::error::MantarayError;
 use nectar_mantaray::{Entry, PlainManifest};
 use nectar_primitives::file::WriteAt;
-use nectar_primitives::{ChunkAddress, DEFAULT_BODY_SIZE, Joiner};
+use nectar_primitives::{ChunkAddress, DEFAULT_BODY_SIZE, Joiner, RetryingChunkGet};
 use vertex_swarm_api::SwarmChunkProvider;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
 
 use super::cache::MemoryCache;
-use super::net_get::NetworkChunkGet;
+use super::net_get::{NetworkChunkGet, VtxSleeper};
+
+/// The joiner/manifest getter with transient-miss retry: a per-chunk retrieval
+/// error retries with backoff instead of aborting the whole walk or download.
+type RetryGetter = RetryingChunkGet<NetworkChunkGet, VtxSleeper>;
+
+/// Wrap a network getter in nectar's retrying getter over the browser sleeper.
+/// The wrapper shares the inner getter's local cache, so a cache hit skips both
+/// the network and the retry loop.
+fn retrying(getter: NetworkChunkGet) -> RetryGetter {
+    RetryingChunkGet::with_default(getter, VtxSleeper)
+}
 
 #[wasm_bindgen]
 extern "C" {
@@ -177,8 +188,8 @@ pub async fn stream_file(
     cache: &MemoryCache,
     sink: &DownloadSink,
 ) -> Result<(), JsValue> {
-    let getter = NetworkChunkGet::new(provider, cache.snapshot_map());
-    let joiner = Joiner::<NetworkChunkGet, DEFAULT_BODY_SIZE>::new(getter, file_root)
+    let getter = retrying(NetworkChunkGet::new(provider, cache.snapshot_map()));
+    let joiner = Joiner::<RetryGetter, DEFAULT_BODY_SIZE>::new(getter, file_root)
         .await
         .map_err(|e| JsValue::from_str(&format!("joiner open: {e}")))?
         .with_concurrency(DOWNLOAD_CONCURRENCY);
@@ -247,7 +258,8 @@ async fn probe_manifest_entries(
     cache: &MemoryCache,
 ) -> Result<Option<Vec<Entry>>, JsValue> {
     let getter = NetworkChunkGet::new(provider, cache.snapshot_map());
-    let mut manifest: PlainManifest<NetworkChunkGet> = PlainManifest::open(root, getter.clone());
+    let mut manifest: PlainManifest<RetryGetter> =
+        PlainManifest::open(root, retrying(getter.clone()));
     let result = manifest.entries().await;
     publish(&getter, cache);
     match result {
@@ -302,8 +314,8 @@ pub async fn download_file(
     provider: Arc<dyn SwarmChunkProvider>,
     cache: &MemoryCache,
 ) -> Result<Vec<u8>, JsValue> {
-    let getter = NetworkChunkGet::new(provider, cache.snapshot_map());
-    let joiner = Joiner::<NetworkChunkGet, DEFAULT_BODY_SIZE>::new(getter, file_root)
+    let getter = retrying(NetworkChunkGet::new(provider, cache.snapshot_map()));
+    let joiner = Joiner::<RetryGetter, DEFAULT_BODY_SIZE>::new(getter, file_root)
         .await
         .map_err(|e| JsValue::from_str(&format!("joiner open: {e}")))?
         .with_concurrency(DOWNLOAD_CONCURRENCY);
@@ -331,7 +343,8 @@ pub async fn ls_manifest(
     cache: &MemoryCache,
 ) -> Result<Vec<(String, String)>, JsValue> {
     let getter = NetworkChunkGet::new(provider, cache.snapshot_map());
-    let mut manifest: PlainManifest<NetworkChunkGet> = PlainManifest::open(root, getter.clone());
+    let mut manifest: PlainManifest<RetryGetter> =
+        PlainManifest::open(root, retrying(getter.clone()));
     let result = manifest.entries().await;
     publish(&getter, cache);
     let entries = result.map_err(|e| JsValue::from_str(&format!("manifest list: {e}")))?;
@@ -357,7 +370,8 @@ pub async fn walk(
     cache: &MemoryCache,
 ) -> Result<Vec<u8>, JsValue> {
     let getter = NetworkChunkGet::new(provider.clone(), cache.snapshot_map());
-    let mut manifest: PlainManifest<NetworkChunkGet> = PlainManifest::open(root, getter.clone());
+    let mut manifest: PlainManifest<RetryGetter> =
+        PlainManifest::open(root, retrying(getter.clone()));
     let result = manifest.lookup(path).await;
     publish(&getter, cache);
     let entry: Entry =

--- a/bin/swarm-demo/src/client/net_get.rs
+++ b/bin/swarm-demo/src/client/net_get.rs
@@ -3,9 +3,10 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use nectar_primitives::store::{ChunkGet, ChunkStoreError};
-use nectar_primitives::{AnyChunk, ChunkAddress, DEFAULT_BODY_SIZE};
+use nectar_primitives::{AnyChunk, ChunkAddress, DEFAULT_BODY_SIZE, Sleeper};
 use vertex_swarm_api::SwarmChunkProvider;
 
 /// A `Send + Sync` chunk getter: local cache first, then the network.
@@ -64,5 +65,16 @@ impl ChunkGet<DEFAULT_BODY_SIZE> for NetworkChunkGet {
             .expect("cache mutex")
             .insert(*result.chunk.address(), result.chunk.clone());
         Ok(result.chunk)
+    }
+}
+
+/// A [`Sleeper`] backing nectar's retrying getter with the browser timer, so a
+/// retry backoff waits on `setTimeout` rather than the absent tokio driver.
+#[derive(Clone, Copy)]
+pub struct VtxSleeper;
+
+impl Sleeper for VtxSleeper {
+    fn sleep(&self, dur: Duration) -> impl Future<Output = ()> {
+        vertex_tasks::time::sleep(dur)
     }
 }


### PR DESCRIPTION
## What

Retry transient per-chunk retrieval misses on the browser download path, so a single hard chunk no longer aborts the whole file download or manifest walk.

The browser drives nectar's `Joiner` over `NetworkChunkGet`. This wraps that getter in nectar's new `RetryingChunkGet` (a `ChunkGet` decorator, PR nxm-rs/nectar#130) via a wasm `VtxSleeper` that delays with `vertex_tasks::time::sleep`. All five joiner/manifest paths (`stream_file`, `download_file`, `probe_manifest_entries`, `ls_manifest`, `walk`) go through the wrapped getter, so each inherits bounded exponential-backoff retry. The per-chunk local cache is unchanged: a cache hit skips both the network and the retry loop.

- Pins nectar to the merged rev `304b548` (nxm-rs/nectar#130) in both `Cargo.toml` and `bin/swarm-demo/Cargo.toml` together.
- `DOWNLOAD_CONCURRENCY` and all node/engine code untouched.

## Why

Closes #630. Part of #606.

The browser is a light client with a small, sometimes-collapsing neighbourhood, so a per-chunk retrieval often misses transiently (few candidate storers for a moment, a candidate refusing under load). Retrieval is honest that this is retryable (it returns `RetrievalExhausted`, never a proven absence), but the browser's joiner path aborted the entire download on the first miss. Retrying at the getter turns those transient misses into eventual hits.

This is the consumer-side placement: retry lives in the in-process joiner consumer (the browser's `ChunkGet`), exactly as dipper's gRPC store retries across its boundary. The node is not made to retry on consumers' behalf. gRPC and FFI are boundaries that stream chunks to a consumer which owns retry, so they are deliberately untouched (confirmed by a red-team).

## Depends on nectar#130

Pins the workspace nectar rev to the `feat/retrying-chunk-get` branch (PR nxm-rs/nectar#130), not yet merged. Re-pin to the merged rev once #130 lands; do not merge ahead of it.

## Testing

- `cargo build --workspace` against the bumped nectar rev: clean.
- `cargo build --manifest-path bin/swarm-demo/Cargo.toml --target wasm32-unknown-unknown`: clean (proves the wrapped getter and the wasm sleeper are wasm-clean).
- `cargo clippy` on the demo wasm target: clean.
- `just check-cone`: all four cone guards pass.

## AI Assistance

Claude Code (Opus 4.8) used for the design, the getter wiring, and the build verification.
