### PR TITLE
feat(swarm-node): serve own retrievals from the local cache before racing the swarm

### DIFF
--- a/bin/swarm-demo/src/client/mod.rs
+++ b/bin/swarm-demo/src/client/mod.rs
@@ -50,6 +50,7 @@ impl SwarmClient {
             ProximityOnly,
             launched.inflight().clone(),
             NoLatencyHint,
+            Some(launched.store().clone()),
         );
         let provider: Arc<dyn SwarmChunkProvider> = Arc::new(routing.clone());
         let sender: Arc<dyn SwarmChunkSender> = Arc::new(routing);

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -1,11 +1,13 @@
 //! RPC provider implementations for Swarm nodes.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use nectar_primitives::SwarmAddress;
 use tracing::warn;
 use vertex_swarm_api::{
     ChunkAddress, ChunkRetrievalResult, PeerReporter, PushReceipt, ReportSource, StampedChunk,
-    SwarmChunkProvider, SwarmChunkSender, SwarmError, SwarmIdentity, SwarmResult,
+    SwarmChunkProvider, SwarmChunkSender, SwarmError, SwarmIdentity, SwarmLocalStore, SwarmResult,
     SwarmScoringEvent, SwarmTopologyRouting, SwarmTopologyState,
 };
 use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
@@ -45,6 +47,10 @@ where
     L: LatencyHint + 'static,
 {
     engine: RetrievalEngine<I, O, G, L>,
+    /// The node's own chunk cache, consulted before racing the swarm so a
+    /// duplicate origin retrieval of a cached content chunk serves locally.
+    /// `None` for an embedder that wires a cacheless provider.
+    store: Option<Arc<dyn SwarmLocalStore>>,
 }
 
 impl<I, O, G, L> NetworkChunkProvider<I, O, G, L>
@@ -56,16 +62,18 @@ where
 {
     /// Build the provider over the three retrieval capabilities: candidate
     /// `ordering`, the per-peer `inflight` cap, and the per-PO `latency`
-    /// estimate.
+    /// estimate. `store` is the node's own cache, read before the swarm race.
     pub fn new(
         client_handle: ClientHandle,
         topology: TopologyHandle<I>,
         ordering: O,
         inflight: G,
         latency: L,
+        store: Option<Arc<dyn SwarmLocalStore>>,
     ) -> Self {
         Self {
             engine: RetrievalEngine::new(client_handle, topology, ordering, inflight, latency),
+            store,
         }
     }
 }
@@ -84,6 +92,21 @@ where
     L: LatencyHint + 'static,
 {
     async fn retrieve_chunk(&self, address: &ChunkAddress) -> SwarmResult<ChunkRetrievalResult> {
+        // Serve our own duplicate retrieval from the local cache before racing
+        // the swarm. `get` applies the single-owner TTL and only content chunks
+        // are cached, so a hit is an immutable, byte-safe content chunk; the
+        // node's own overlay stands in as the serving peer to mark a local serve.
+        if let Some(store) = &self.store
+            && let Ok(Some(cached)) = store.get(address)
+            && *cached.address() == *address
+        {
+            let (chunk, stamp) = cached.into_parts();
+            return Ok(ChunkRetrievalResult {
+                chunk,
+                stamp,
+                served_by: self.engine.topology().overlay_address(),
+            });
+        }
         self.engine.retrieve(address).await
     }
 

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -372,6 +372,12 @@ impl ClientService {
         self.handle.clone()
     }
 
+    /// The attached client cache, so the chunk provider can read its own
+    /// deliveries back before racing the swarm. `None` when no store is wired.
+    pub(crate) fn store(&self) -> Option<Arc<dyn SwarmLocalStore>> {
+        self.store.clone()
+    }
+
     fn report(&self, peer: &OverlayAddress, event: SwarmScoringEvent, source: ReportSource) {
         if let Some(reporter) = &self.reporter {
             reporter.report_peer(peer, event, source);

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -716,6 +716,10 @@ where
     })
     .await?;
 
+    // The provider reads the node's own cache before racing the swarm; it is the
+    // same store the service caches deliveries into and the handler serves from.
+    let provider_cache = client_service.store();
+
     spawn_peer_manager_task(
         Arc::clone(topology.peer_manager()),
         DEFAULT_TICK_INTERVAL,
@@ -768,6 +772,7 @@ where
         Arc::clone(&core.selector),
         Arc::clone(&core.inflight),
         Arc::clone(&core.retrieval_latency),
+        provider_cache,
     );
 
     executor.spawn_service("swarm.client_service", core.client_service);

--- a/crates/swarm/node/tests/client_launcher.rs
+++ b/crates/swarm/node/tests/client_launcher.rs
@@ -12,17 +12,34 @@
 use std::sync::Arc;
 
 use eyre::Result;
-use nectar_primitives::{AnyChunk, ContentChunk};
+use nectar_primitives::{AnyChunk, ChunkAddress, ContentChunk};
 use vertex_swarm_api::{
-    SwarmClientAccounting as _, SwarmIdentity as _, SwarmLocalStore as _, SwarmNodeType,
-    SwarmTopologyStats as _,
+    OverlayAddress, SwarmChunkProvider as _, SwarmClientAccounting as _, SwarmError,
+    SwarmIdentity as _, SwarmLocalStore as _, SwarmNodeType, SwarmTopologyStats as _,
 };
 use vertex_swarm_identity::Identity;
-use vertex_swarm_node::ClientLauncher;
+use vertex_swarm_node::{ClientLauncher, LaunchedClient};
 use vertex_swarm_primitives::CachedChunk;
 use vertex_swarm_spec::SpecBuilder;
 use vertex_swarm_test_utils::TEST_NETWORK_ID;
 use vertex_tasks::{TaskExecutor, TaskManager};
+
+/// Bring up a hermetic (no-bootnode) native client, returning it and its overlay.
+async fn hermetic_client() -> Result<(LaunchedClient, OverlayAddress)> {
+    let spec = Arc::new(
+        SpecBuilder::testnet()
+            .network_id(TEST_NETWORK_ID)
+            .bootnodes(Vec::new())
+            .build(),
+    );
+    let identity = Identity::random(spec, SwarmNodeType::Client);
+    let overlay = identity.overlay_address();
+    let launched = ClientLauncher::new(identity)
+        .with_max_peers(16)
+        .launch()
+        .await?;
+    Ok((launched, overlay))
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn launcher_brings_up_client_node() -> Result<()> {
@@ -71,6 +88,64 @@ async fn launcher_brings_up_client_node() -> Result<()> {
     let address = *cached.address();
     launched.store().put(cached).expect("put");
     assert!(launched.store().contains(&address));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retrieve_serves_a_cached_content_chunk_without_racing_the_swarm() -> Result<()> {
+    let _task_manager = match TaskExecutor::try_current() {
+        Ok(_) => None,
+        Err(_) => Some(TaskManager::current()),
+    };
+    let (launched, overlay) = hermetic_client().await?;
+
+    // Seed the node's own cache with a content chunk, then retrieve it: the
+    // provider serves the cached bytes and never races the peerless swarm.
+    let chunk: AnyChunk = ContentChunk::new(&b"cache-read serves locally"[..])
+        .expect("valid content chunk")
+        .into();
+    let cached = CachedChunk::new(chunk.clone(), None);
+    let address = *cached.address();
+    launched.store().put(cached).expect("put");
+
+    let result = launched
+        .chunks()
+        .retrieve_chunk(&address)
+        .await
+        .expect("the cached chunk is served");
+    assert_eq!(
+        result.chunk, chunk,
+        "the cached bytes are returned unchanged"
+    );
+    assert!(
+        result.stamp.is_none(),
+        "a content chunk is cached stampless"
+    );
+    assert_eq!(
+        result.served_by, overlay,
+        "a cache hit is marked served by our own overlay, not a peer"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retrieve_misses_fall_through_to_the_engine() -> Result<()> {
+    let _task_manager = match TaskExecutor::try_current() {
+        Ok(_) => None,
+        Err(_) => Some(TaskManager::current()),
+    };
+    let (launched, _overlay) = hermetic_client().await?;
+
+    // An address the cache does not hold falls through to the retrieval engine,
+    // which has no connected peers to race and so exhausts at once.
+    let missing = ChunkAddress::new([0x7c; 32]);
+    let outcome = launched.chunks().retrieve_chunk(&missing).await;
+    assert!(
+        matches!(outcome, Err(SwarmError::RetrievalExhausted { .. })),
+        "a cache miss races the swarm and exhausts with no peers, got {outcome:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## What

Make the node's own `retrieve_chunk` serve a cached content chunk from its local store before racing the swarm, so a duplicate origin retrieval de-dups at the node instead of paying a full swarm round-trip.

`NetworkChunkProvider` gains the same `SwarmLocalStore` the client service already writes and the client handler already reads; `retrieve_chunk` consults `store.get(address)` first and, on a hit, returns the chunk with `served_by` set to the node's own overlay (a local-serve sentinel). On a miss it races the swarm exactly as before. Wired at the native (`core.rs`) and browser (`from_launched`) construction sites. The write path (`client_service.rs`) is untouched.

## Why

Closes #632. Part of #606.

The node already caches its retrievals (write on delivery) and reads that cache when serving inbound requests, but never on its own retrieve path, so every consumer that re-reads a chunk pays a duplicate swarm retrieval unless it carries its own front cache. That pushed the de-dup into the wrong layer: dipper (a separate gRPC process) and the browser (in-process joiner) each reimplement it. Reading the cache at the node puts the de-dup where the expensive swarm retrieval happens, so native, wasm, and ffi consumers all benefit transparently.

Freshness is safe: only content chunks are cached and `ChunkStore::get` applies the single-owner TTL (returning `None` for a stampless or expired SOC), so a hit is always an immutable, byte-safe content chunk. The serve path already relies on exactly this rule.

## Testing

- `cargo build --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo nextest run -p vertex-swarm-node --all-features`: 147 pass, including two hermetic `ClientLauncher` tests - `retrieve_serves_a_cached_content_chunk_without_racing_the_swarm` (seeds the store, asserts the bytes and `served_by == our overlay` on a peerless node) and `retrieve_misses_fall_through_to_the_engine`.
- `cargo build -p vertex-swarm-node --target wasm32-unknown-unknown` and the swarm-demo wasm build + clippy: clean.
- `just check-cone`: all four guards pass.

## Follow-ups

Once merged, close dipper #19 (its `GrpcStore` cache is redundant) and drop the browser demo's `net_get` cache read.

## AI Assistance

Claude Code (Opus 4.8) used for the investigation, implementation, and verification.
