### PR TITLE
fix(swarm-node): drive a settle on a fully-gated retrieval set to restore bulk throughput

### DIFF
--- a/bin/swarm-demo/src/client/mod.rs
+++ b/bin/swarm-demo/src/client/mod.rs
@@ -13,8 +13,11 @@ use std::sync::Arc;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage::Batch;
 use nectar_primitives::ChunkAddress;
-use vertex_swarm_api::{SwarmChunkProvider, SwarmChunkSender};
-use vertex_swarm_node::{LaunchedClient, NetworkChunkProvider, NoLatencyHint, ProximityOnly};
+use vertex_swarm_api::{SwarmChunkProvider, SwarmChunkSender, SwarmClientAccounting};
+use vertex_swarm_node::{
+    AccountingSettlement, LaunchedClient, NetworkChunkProvider, NoLatencyHint, ProximityOnly,
+    SettlementTrigger,
+};
 use wasm_bindgen::prelude::*;
 
 use cache::MemoryCache;
@@ -44,12 +47,19 @@ impl SwarmClient {
         // stagger, but the real per-peer in-flight cap the launched service
         // maintains; it shares the native custody-verdict push.
         let client = launched.client().clone();
+        // The engine drives this to drain a fully-gated peer set: the browser gates
+        // fast on its small neighbourhood, and pseudosettle is debtor-initiated, so
+        // without a settle drive a gated set would never reopen.
+        let settlement: Arc<dyn SettlementTrigger> = Arc::new(AccountingSettlement::new(
+            launched.accounting().bandwidth().clone(),
+        ));
         let routing = NetworkChunkProvider::new(
             client,
             launched.topology().clone(),
             ProximityOnly,
             launched.inflight().clone(),
             NoLatencyHint,
+            settlement,
             Some(launched.store().clone()),
         );
         let provider: Arc<dyn SwarmChunkProvider> = Arc::new(routing.clone());

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -15,6 +15,7 @@ use vertex_swarm_topology::TopologyHandle;
 
 use crate::ClientHandle;
 use crate::retrieval_engine::{CandidateOrdering, InflightLimit, LatencyHint, RetrievalEngine};
+use crate::selection::SettlementTrigger;
 
 /// Report source for shallow/malformed receipts caught on the origin upload
 /// path.
@@ -69,10 +70,18 @@ where
         ordering: O,
         inflight: G,
         latency: L,
+        settlement: Arc<dyn SettlementTrigger>,
         store: Option<Arc<dyn SwarmLocalStore>>,
     ) -> Self {
         Self {
-            engine: RetrievalEngine::new(client_handle, topology, ordering, inflight, latency),
+            engine: RetrievalEngine::new(
+                client_handle,
+                topology,
+                ordering,
+                inflight,
+                latency,
+                settlement,
+            ),
             store,
         }
     }

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -703,10 +703,12 @@ mod tests {
 
         #[tokio::test]
         async fn enforce_cap_declines_a_peer_that_filled_since_the_snapshot() {
-            // A peer free at the availability snapshot but saturated before its
-            // attempt dispatches is declined under enforce_cap: no command reaches
-            // it and it spends no attempt, so the cap holds on live state, not the stale
-            // snapshot. The next free peer serves instead.
+            // Under enforce_cap, a peer free at the availability snapshot but
+            // saturated before its attempt dispatches is declined: no command
+            // reaches it and it spends no attempt, so the cap holds on live state,
+            // not the stale snapshot. The next free peer serves instead. Retrieval
+            // no longer enforces the cap (a busy holder is a best-effort tail), so
+            // this exercises the race helper's decline path directly.
             let (tx, mut rx) = mpsc::channel::<ClientCommand>(16);
             let handle = ClientHandle::new(tx);
             let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
@@ -714,10 +716,8 @@ mod tests {
             let filled = overlay(1);
             let free = overlay(2);
 
-            // Availability sees both peers free, so the race enforces the cap.
-            let (candidates, enforce_cap) = limiter.available(vec![filled, free]);
-            assert_eq!(candidates, vec![filled, free]);
-            assert!(enforce_cap, "free-slot peers found, so the cap is enforced");
+            let candidates = vec![filled, free];
+            let enforce_cap = true;
 
             // Between the snapshot and dispatch the first peer's slot is taken.
             let _held = limiter

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -51,7 +51,7 @@ use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use crate::retrieval_latency::RetrievalLatency;
 use crate::{
     AccountingSettlement, ClientCommand, ClientHandle, ClientService, DEFAULT_PEER_INFLIGHT_CAP,
-    PeerInflightLimiter, PeerSelector,
+    PeerInflightLimiter, PeerSelector, SettlementTrigger,
 };
 
 /// The concrete shared accounting both client-backed node types build: the
@@ -88,6 +88,10 @@ pub struct ClientCore {
     /// The origin-gated client handle the provider dispatches through; its
     /// admission band paces each own request before it sends.
     pub origin_handle: ClientHandle,
+    /// The settle trigger the origin gate and the retrieval engine share; the
+    /// engine drives it to drain a fully-gated peer set. One instance so both
+    /// settle paths share the trigger's in-flight dedup.
+    pub settlement_trigger: Arc<dyn SettlementTrigger>,
     /// The node's topology handle, threaded through unchanged.
     pub topology: TopologyHandle<Arc<Identity>>,
     /// The client service with accounting and reporter attached.
@@ -158,7 +162,8 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     // never runs the selector, and both paths share the trigger's in-flight dedup
     // set.
     let admission = accounting.bandwidth().clone();
-    let settlement_trigger = Arc::new(AccountingSettlement::new(accounting.bandwidth().clone()));
+    let settlement_trigger: Arc<dyn SettlementTrigger> =
+        Arc::new(AccountingSettlement::new(accounting.bandwidth().clone()));
 
     // Ranking only: the selector triggers no settlement. The origin credit gate
     // settles the peer a request actually dispatches to (`settlement_trigger`),
@@ -209,6 +214,7 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
         inflight,
         retrieval_latency,
         origin_handle,
+        settlement_trigger,
         topology,
         client_service,
         client_handle,
@@ -772,6 +778,7 @@ where
         Arc::clone(&core.selector),
         Arc::clone(&core.inflight),
         Arc::clone(&core.retrieval_latency),
+        Arc::clone(&core.settlement_trigger),
         provider_cache,
     );
 

--- a/crates/swarm/node/src/retrieval_engine.rs
+++ b/crates/swarm/node/src/retrieval_engine.rs
@@ -10,6 +10,7 @@
 //! [`NoLatencyHint`] but the same real [`PeerInflightLimiter`].
 
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use metrics::{counter, histogram};
@@ -23,6 +24,7 @@ use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::time::Duration;
 
 use crate::retrieval_latency::{RetrievalLatency, adaptive_stagger};
+use crate::selection::SettlementTrigger;
 use crate::{
     ChunkTransferError, ClientHandle, PeerInflightLimiter, PeerSelector, RaceFailure,
     RetrievalResult, race_with_refill,
@@ -80,6 +82,29 @@ const RETRIEVE_SPILL_BUDGET: usize = RETRIEVE_ATTEMPT_BUDGET;
 /// Wall-clock bound on the farther-ring spill race, separate from the close
 /// race's deadline so the spill phase cannot itself stall the pipeline slot.
 const RETRIEVE_SPILL_DEADLINE: Duration = Duration::from_secs(15);
+
+/// Closest peers a fully-gated retrieval drives a settle on before re-selecting.
+///
+/// When every close and spill peer is past its disconnect line the band yields no
+/// candidate. The dispatch path settles only a peer it contacts, so a fully-gated
+/// set never drains on its own: nothing dispatches, nothing settles, the debt
+/// stays pinned at the line. Driving a settle on the closest gated peers reopens
+/// the band. Matches the spill ring rather than the close set: a debt-saturated
+/// bulk download reopens more headroom the more peers forgive in parallel, and
+/// the trigger's in-flight dedup (shared with the origin gate) collapses
+/// concurrent gated retrievals to one settle per peer, so a wider drive unlocks
+/// more aggregate forgiveness without multiplying the settle traffic.
+const RETRIEVE_SETTLE_DRIVE_WIDTH: usize = RETRIEVE_SPILL_WIDTH;
+
+/// Backoff between settle drives, giving a spawned pseudosettle a round trip to
+/// land and reopen the band before the fallback re-selects.
+const RETRIEVE_SETTLE_DRIVE_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Settle drives a fully-gated retrieval attempts before giving up and letting
+/// the consumer re-stream. Bounds the added latency (`WIDTH * BACKOFF`) so a
+/// genuinely peerless node still terminates rather than parking the pipeline slot
+/// for the whole retrieval deadline.
+const RETRIEVE_SETTLE_DRIVES: usize = 10;
 
 /// Attempts the bin-bucket primary route dispatches before handing off to the
 /// staggered fallback.
@@ -255,6 +280,11 @@ pub struct RetrievalEngine<I: SwarmIdentity, O: CandidateOrdering, G: InflightLi
     ordering: O,
     inflight: G,
     latency: L,
+    /// Drains a fully-gated close/spill set: the fallback drives a settle on the
+    /// closest refused peers to reopen the band. Shares the origin gate's
+    /// in-flight dedup, so concurrent gated retrievals collapse to one settle per
+    /// peer.
+    settlement: Arc<dyn SettlementTrigger>,
 }
 
 impl<I, O, G, L> RetrievalEngine<I, O, G, L>
@@ -264,13 +294,14 @@ where
     G: InflightLimit,
     L: LatencyHint,
 {
-    /// Build an engine over its three capabilities.
+    /// Build an engine over its capabilities.
     pub fn new(
         client_handle: ClientHandle,
         topology: TopologyHandle<I>,
         ordering: O,
         inflight: G,
         latency: L,
+        settlement: Arc<dyn SettlementTrigger>,
     ) -> Self {
         Self {
             client_handle,
@@ -278,6 +309,7 @@ where
             ordering,
             inflight,
             latency,
+            settlement,
         }
     }
 
@@ -447,86 +479,120 @@ where
         // bounds the paid fan-out; each attempt reserves the per-peer in-flight
         // permit that rides its future, released on drop including a cancelled
         // losing attempt.
-        let closest_peers = self.topology.closest_to(&chunk_address, RETRIEVE_WIDTH);
-        // Spill to a wider in-headroom slice when every close peer is gated, so a
-        // fully gated close set routes around its spent peers rather than
-        // blocking; if even the wide slice is gated the empty result falls through
-        // to the no-connected-peers path below, the same RetrievalExhausted a
-        // no-peers failure yields, and the consumer re-streams.
-        let closest_peers = self.order_with_spill(closest_peers, address);
-        let (close_candidates, _enforce_cap) = self.inflight.available(closest_peers);
+        // A fully-gated set (every close and spill peer past its disconnect line)
+        // yields no candidate to race. The dispatch path settles only a peer it
+        // contacts, so a gated set never drains on its own: nothing dispatches,
+        // nothing settles, the debt stays pinned at the line. Before giving up,
+        // drive a settle on the closest gated peers and re-select, bounded so a
+        // genuinely peerless node still terminates. The trigger's in-flight dedup
+        // collapses the concurrent gated retrievals of a bulk download to one
+        // settle per peer, so this drives the download at the peers' forgiveness
+        // rate rather than spamming settles.
+        let mut settle_drives = 0usize;
+        let outcome = loop {
+            let closest_peers = self.topology.closest_to(&chunk_address, RETRIEVE_WIDTH);
+            // Spill to a wider in-headroom slice when every close peer is gated, so
+            // a fully gated close set routes around its spent peers rather than
+            // blocking.
+            let closest_peers = self.order_with_spill(closest_peers, address);
+            let (close_candidates, _enforce_cap) = self.inflight.available(closest_peers);
 
-        // Farther-ring spill: when the whole close set fails on the wire (not
-        // merely gated), widen to the admissible peers of a larger slice, minus
-        // the close peers already raced, so the second race reaches holders beyond
-        // the close set rather than re-racing the same failing peers. A gated
-        // close set already spilled to this slice above, so its already-raced set
-        // covers the slice and the difference is empty.
-        let raced: HashSet<OverlayAddress> = close_candidates.iter().copied().collect();
-        let wide = self
-            .topology
-            .closest_to(&chunk_address, RETRIEVE_SPILL_WIDTH);
-        let wide = self.ordering.order_closest_admissible(wide, address);
-        let spill_ring: Vec<OverlayAddress> = wide
-            .into_iter()
-            .filter(|peer| !raced.contains(peer))
-            .collect();
-        let (spill_candidates, _spill_enforce_cap) = self.inflight.available(spill_ring);
+            // Farther-ring spill: when the whole close set fails on the wire (not
+            // merely gated), widen to the admissible peers of a larger slice, minus
+            // the close peers already raced, so the second race reaches holders
+            // beyond the close set rather than re-racing the same failing peers. A
+            // gated close set already spilled to this slice above, so its
+            // already-raced set covers the slice and the difference is empty.
+            let raced: HashSet<OverlayAddress> = close_candidates.iter().copied().collect();
+            let wide = self
+                .topology
+                .closest_to(&chunk_address, RETRIEVE_SPILL_WIDTH);
+            let wide = self.ordering.order_closest_admissible(wide, address);
+            let spill_ring: Vec<OverlayAddress> = wide
+                .into_iter()
+                .filter(|peer| !raced.contains(peer))
+                .collect();
+            let (spill_candidates, _spill_enforce_cap) = self.inflight.available(spill_ring);
 
-        // Pace each phase's staggered fan-out to the live round trip rather than a
-        // fixed constant. Each candidate's expected latency is read from the
-        // per-PO estimate at its proximity to the chunk (the forwarding distance
-        // that dominates retrieval latency). Cold buckets fall back to the
-        // constant, so this is never slower, only faster on low-RTT distances.
-        let close_stagger = adaptive_stagger(
-            close_candidates
-                .iter()
-                .map(|peer| self.latency.estimate(chunk_address.proximity(peer).get())),
-        );
-        let spill_stagger = adaptive_stagger(
-            spill_candidates
-                .iter()
-                .map(|peer| self.latency.estimate(chunk_address.proximity(peer).get())),
-        );
+            if close_candidates.is_empty() && spill_candidates.is_empty() {
+                // Either fully gated or genuinely peerless. Settle the closest raw
+                // peers so their debt drains below the disconnect line, back off for
+                // the settles to land, and re-select. A peerless node (no closest
+                // peers) or an exhausted drive budget falls through to the terminal
+                // no-candidates failure the consumer re-streams on.
+                let gated = self
+                    .topology
+                    .closest_to(&chunk_address, RETRIEVE_SETTLE_DRIVE_WIDTH);
+                if gated.is_empty() || settle_drives >= RETRIEVE_SETTLE_DRIVES {
+                    break Err(RaceFailure::NoCandidates);
+                }
+                for peer in gated {
+                    self.settlement.trigger_settlement(peer);
+                }
+                settle_drives += 1;
+                counter!("swarm.client.retrieval_settle_drive").increment(1);
+                // `futures_timer::Delay`, not `vertex_tasks::time::sleep`: the
+                // latter is `!Send` on wasm and this future carries the async-trait
+                // `Send` bound. `Delay` is the Send-safe timer the race staggers use.
+                futures_timer::Delay::new(RETRIEVE_SETTLE_DRIVE_BACKOFF).await;
+                continue;
+            }
 
-        // One dispatch closure feeds both phases. The in-flight cap is not
-        // enforced here (see `available`): a busy-but-good holder is dispatched
-        // best-effort, but only after the free leaders are exhausted, so the easy
-        // chunk still serves from a free peer with no extra over-fetch. The permit
-        // still rides each request future and releases on drop, including a
-        // cancelled losing attempt.
-        let dispatch = |peer_overlay: OverlayAddress| {
-            let permit = self.inflight.try_acquire(&peer_overlay);
-            attempts.fetch_add(1, Ordering::Relaxed);
-            // `originated = true`: our own retrieval, so the client service debits
-            // the serving peer on delivery.
-            let request = self
-                .client_handle
-                .retrieve_chunk(peer_overlay, chunk_address, true);
-            Some(async move {
-                let _permit = permit;
-                request.await
-            })
+            // Pace each phase's staggered fan-out to the live round trip rather than
+            // a fixed constant. Each candidate's expected latency is read from the
+            // per-PO estimate at its proximity to the chunk (the forwarding distance
+            // that dominates retrieval latency). Cold buckets fall back to the
+            // constant, so this is never slower, only faster on low-RTT distances.
+            let close_stagger = adaptive_stagger(
+                close_candidates
+                    .iter()
+                    .map(|peer| self.latency.estimate(chunk_address.proximity(peer).get())),
+            );
+            let spill_stagger = adaptive_stagger(
+                spill_candidates
+                    .iter()
+                    .map(|peer| self.latency.estimate(chunk_address.proximity(peer).get())),
+            );
+
+            // One dispatch closure feeds both phases. The in-flight cap is not
+            // enforced here (see `available`): a busy-but-good holder is dispatched
+            // best-effort, but only after the free leaders are exhausted, so the
+            // easy chunk still serves from a free peer with no extra over-fetch. The
+            // permit still rides each request future and releases on drop, including
+            // a cancelled losing attempt.
+            let dispatch = |peer_overlay: OverlayAddress| {
+                let permit = self.inflight.try_acquire(&peer_overlay);
+                attempts.fetch_add(1, Ordering::Relaxed);
+                // `originated = true`: our own retrieval, so the client service
+                // debits the serving peer on delivery.
+                let request = self
+                    .client_handle
+                    .retrieve_chunk(peer_overlay, chunk_address, true);
+                Some(async move {
+                    let _permit = permit;
+                    request.await
+                })
+            };
+
+            break race_close_then_spill(
+                close_candidates,
+                spill_candidates,
+                RaceBounds {
+                    budget: RETRIEVE_ATTEMPT_BUDGET,
+                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                    deadline: RETRIEVE_DEADLINE,
+                    stagger: close_stagger,
+                },
+                RaceBounds {
+                    budget: RETRIEVE_SPILL_BUDGET,
+                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                    deadline: RETRIEVE_SPILL_DEADLINE,
+                    stagger: spill_stagger,
+                },
+                dispatch,
+            )
+            .await;
         };
-
-        let outcome = race_close_then_spill(
-            close_candidates,
-            spill_candidates,
-            RaceBounds {
-                budget: RETRIEVE_ATTEMPT_BUDGET,
-                max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
-                deadline: RETRIEVE_DEADLINE,
-                stagger: close_stagger,
-            },
-            RaceBounds {
-                budget: RETRIEVE_SPILL_BUDGET,
-                max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
-                deadline: RETRIEVE_SPILL_DEADLINE,
-                stagger: spill_stagger,
-            },
-            dispatch,
-        )
-        .await;
 
         let dispatched = attempts.load(Ordering::Relaxed);
         histogram!("swarm.client.retrieval_attempts").record(dispatched as f64);

--- a/crates/swarm/node/src/retrieval_engine.rs
+++ b/crates/swarm/node/src/retrieval_engine.rs
@@ -9,6 +9,7 @@
 //! browser supplies the zero-sized null objects [`ProximityOnly`] and
 //! [`NoLatencyHint`] but the same real [`PeerInflightLimiter`].
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use metrics::{counter, histogram};
@@ -66,6 +67,19 @@ pub(crate) const RETRIEVE_DEADLINE: Duration = Duration::from_secs(30);
 /// larger set of slightly-farther peers still holds forgiveness headroom and
 /// forwards the chunk just the same.
 const RETRIEVE_SPILL_WIDTH: usize = 128;
+
+/// Attempt budget for the farther-ring spill phase: the second race a difficult
+/// chunk falls to when its whole close set fails on the wire.
+///
+/// Bounded on its own so the two phases' combined metered fan-out stays a small
+/// multiple, never a runaway. The alternative to spending it is failing the
+/// chunk outright and having the consumer re-stream, which costs more attempts
+/// still.
+const RETRIEVE_SPILL_BUDGET: usize = RETRIEVE_ATTEMPT_BUDGET;
+
+/// Wall-clock bound on the farther-ring spill race, separate from the close
+/// race's deadline so the spill phase cannot itself stall the pipeline slot.
+const RETRIEVE_SPILL_DEADLINE: Duration = Duration::from_secs(15);
 
 /// Attempts the bin-bucket primary route dispatches before handing off to the
 /// staggered fallback.
@@ -135,9 +149,10 @@ pub trait InflightLimit: Send + Sync {
     /// cancelled losing attempt.
     type Permit: vertex_tasks::MaybeSend + 'static;
 
-    /// Filter proximity-ordered `candidates` to those with a free slot,
-    /// returning the survivors and whether the race should enforce the cap. When
-    /// every candidate is at its cap the full list is returned with the cap not
+    /// Order proximity-ordered `candidates` free-slot peers first, busy peers as
+    /// a tail, and report whether the race should enforce the cap. No candidate
+    /// is dropped: a busy-but-good holder stays reachable as a last resort. The
+    /// tail is only ever contacted after the free leaders fail, so the cap is not
     /// enforced (degraded service beats failing the request).
     fn available(&self, candidates: Vec<OverlayAddress>) -> (Vec<OverlayAddress>, bool);
 
@@ -149,19 +164,18 @@ impl InflightLimit for PeerInflightLimiter {
     type Permit = OwnedSemaphorePermit;
 
     fn available(&self, candidates: Vec<OverlayAddress>) -> (Vec<OverlayAddress>, bool) {
-        let survivors: Vec<OverlayAddress> = candidates
-            .iter()
-            .copied()
-            .filter(|peer| self.has_free_slot(peer))
-            .collect();
-        // The cap is enforced only when free-slot peers were found: the all-busy
-        // fall-through returns the full list so the race still attempts,
-        // best-effort.
-        if survivors.is_empty() {
-            (candidates, false)
-        } else {
-            (survivors, true)
-        }
+        // Free-slot peers lead; busy peers are appended as a tail rather than
+        // dropped. The staggered race dispatches the free leaders first and
+        // resolves on the first success, so an easy chunk with a free holder never
+        // reaches the tail (no extra over-fetch); only a difficult chunk whose
+        // leaders all fail reaches the busy-but-good holders best-effort,
+        // dispatching over their cap as the bounded last resort that actually
+        // reaches the holder. Free-first ordering is what keeps the tail a last
+        // resort, so the cap is never enforced.
+        let (free, busy): (Vec<OverlayAddress>, Vec<OverlayAddress>) = candidates
+            .into_iter()
+            .partition(|peer| self.has_free_slot(peer));
+        (free.into_iter().chain(busy).collect(), false)
     }
 
     fn try_acquire(&self, peer: &OverlayAddress) -> Option<Self::Permit> {
@@ -440,33 +454,79 @@ where
         // to the no-connected-peers path below, the same RetrievalExhausted a
         // no-peers failure yields, and the consumer re-streams.
         let closest_peers = self.order_with_spill(closest_peers, address);
-        let (candidates, enforce_cap) = self.inflight.available(closest_peers);
+        let (close_candidates, _enforce_cap) = self.inflight.available(closest_peers);
 
-        // Pace the staggered fan-out to the live round trip rather than a fixed
-        // constant. Each candidate's expected latency is read from the per-PO
-        // estimate at its proximity to the chunk (the forwarding distance that
-        // dominates retrieval latency). Cold buckets fall back to the constant, so
-        // this is never slower, only faster on low-RTT distances.
-        let stagger = adaptive_stagger(
-            candidates
+        // Farther-ring spill: when the whole close set fails on the wire (not
+        // merely gated), widen to the admissible peers of a larger slice, minus
+        // the close peers already raced, so the second race reaches holders beyond
+        // the close set rather than re-racing the same failing peers. A gated
+        // close set already spilled to this slice above, so its already-raced set
+        // covers the slice and the difference is empty.
+        let raced: HashSet<OverlayAddress> = close_candidates.iter().copied().collect();
+        let wide = self
+            .topology
+            .closest_to(&chunk_address, RETRIEVE_SPILL_WIDTH);
+        let wide = self.ordering.order_closest_admissible(wide, address);
+        let spill_ring: Vec<OverlayAddress> = wide
+            .into_iter()
+            .filter(|peer| !raced.contains(peer))
+            .collect();
+        let (spill_candidates, _spill_enforce_cap) = self.inflight.available(spill_ring);
+
+        // Pace each phase's staggered fan-out to the live round trip rather than a
+        // fixed constant. Each candidate's expected latency is read from the
+        // per-PO estimate at its proximity to the chunk (the forwarding distance
+        // that dominates retrieval latency). Cold buckets fall back to the
+        // constant, so this is never slower, only faster on low-RTT distances.
+        let close_stagger = adaptive_stagger(
+            close_candidates
+                .iter()
+                .map(|peer| self.latency.estimate(chunk_address.proximity(peer).get())),
+        );
+        let spill_stagger = adaptive_stagger(
+            spill_candidates
                 .iter()
                 .map(|peer| self.latency.estimate(chunk_address.proximity(peer).get())),
         );
 
-        let outcome = self
-            .race_attempts(
-                candidates,
-                chunk_address,
-                RaceBounds {
-                    budget: RETRIEVE_ATTEMPT_BUDGET,
-                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
-                    deadline: RETRIEVE_DEADLINE,
-                    stagger,
-                },
-                enforce_cap,
-                &attempts,
-            )
-            .await;
+        // One dispatch closure feeds both phases. The in-flight cap is not
+        // enforced here (see `available`): a busy-but-good holder is dispatched
+        // best-effort, but only after the free leaders are exhausted, so the easy
+        // chunk still serves from a free peer with no extra over-fetch. The permit
+        // still rides each request future and releases on drop, including a
+        // cancelled losing attempt.
+        let dispatch = |peer_overlay: OverlayAddress| {
+            let permit = self.inflight.try_acquire(&peer_overlay);
+            attempts.fetch_add(1, Ordering::Relaxed);
+            // `originated = true`: our own retrieval, so the client service debits
+            // the serving peer on delivery.
+            let request = self
+                .client_handle
+                .retrieve_chunk(peer_overlay, chunk_address, true);
+            Some(async move {
+                let _permit = permit;
+                request.await
+            })
+        };
+
+        let outcome = race_close_then_spill(
+            close_candidates,
+            spill_candidates,
+            RaceBounds {
+                budget: RETRIEVE_ATTEMPT_BUDGET,
+                max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                deadline: RETRIEVE_DEADLINE,
+                stagger: close_stagger,
+            },
+            RaceBounds {
+                budget: RETRIEVE_SPILL_BUDGET,
+                max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                deadline: RETRIEVE_SPILL_DEADLINE,
+                stagger: spill_stagger,
+            },
+            dispatch,
+        )
+        .await;
 
         let dispatched = attempts.load(Ordering::Relaxed);
         histogram!("swarm.client.retrieval_attempts").record(dispatched as f64);
@@ -495,6 +555,53 @@ where
             // exhausted without serving the chunk. The which-attempt and
             // last-error detail lives in the metrics and debug log above.
             Err(_) => Err(SwarmError::RetrievalExhausted { address: *address }),
+        }
+    }
+}
+
+/// Race the `close` set for the chunk, and on race-exhaustion widen to the
+/// farther `spill` ring, reusing one dispatch closure and its shared attempt
+/// counter.
+///
+/// A close-race deadline is terminal: the wall clock is spent, so widening would
+/// only overrun it. Only an all-failed or no-candidates close race spills, which
+/// is the difficult-chunk case where a present close set could not serve the
+/// chunk but a farther holder still might. Each phase carries its own
+/// [`RaceBounds`], so the spill's metered fan-out is bounded independently of the
+/// close race rather than double-counting a shared budget.
+async fn race_close_then_spill<C, T, E, F, Fut>(
+    close: impl IntoIterator<Item = C>,
+    spill: impl IntoIterator<Item = C>,
+    close_bounds: RaceBounds,
+    spill_bounds: RaceBounds,
+    mut attempt: F,
+) -> Result<T, RaceFailure<E>>
+where
+    F: FnMut(C) -> Option<Fut>,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let close_outcome = race_with_refill(
+        close,
+        close_bounds.budget,
+        close_bounds.max_in_flight,
+        close_bounds.deadline,
+        close_bounds.stagger,
+        &mut attempt,
+    )
+    .await;
+    match close_outcome {
+        Ok(value) => Ok(value),
+        Err(RaceFailure::TimedOut) => Err(RaceFailure::TimedOut),
+        Err(RaceFailure::AllFailed(_) | RaceFailure::NoCandidates) => {
+            race_with_refill(
+                spill,
+                spill_bounds.budget,
+                spill_bounds.max_in_flight,
+                spill_bounds.deadline,
+                spill_bounds.stagger,
+                &mut attempt,
+            )
+            .await
         }
     }
 }
@@ -721,11 +828,16 @@ mod tests {
 
     mod inflight_available {
         use std::num::NonZeroUsize;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
         use nectar_primitives::SwarmAddress;
 
-        use super::super::InflightLimit;
-        use crate::PeerInflightLimiter;
+        use super::super::{
+            InflightLimit, RETRIEVE_ATTEMPT_BUDGET, RETRIEVE_DEADLINE, RETRIEVE_MAX_IN_FLIGHT,
+            RETRIEVE_SPILL_BUDGET, RETRIEVE_SPILL_DEADLINE, RaceBounds, race_close_then_spill,
+        };
+        use crate::{PeerInflightLimiter, RETRIEVAL_STAGGER, RaceFailure};
 
         const CAP_ONE: NonZeroUsize = match NonZeroUsize::new(1) {
             Some(cap) => cap,
@@ -737,35 +849,151 @@ mod tests {
         }
 
         #[test]
-        fn available_drops_a_capped_head() {
+        fn available_surfaces_a_busy_peer_as_a_tail() {
             let limiter = PeerInflightLimiter::new(CAP_ONE);
             let busy = overlay(1);
             let _held = limiter.try_acquire(&busy).expect("first slot");
 
-            let (survivors, enforce_cap) = limiter.available(vec![busy, overlay(2), overlay(3)]);
+            let (ordered, enforce_cap) = limiter.available(vec![busy, overlay(2), overlay(3)]);
             assert_eq!(
-                survivors,
-                vec![overlay(2), overlay(3)],
-                "the capped head is skipped, the next-closest free peers remain"
+                ordered,
+                vec![overlay(2), overlay(3), busy],
+                "the free peers lead, the busy peer is appended as a tail, never dropped"
             );
-            assert!(enforce_cap, "free-slot peers found, so the cap is enforced");
+            assert!(
+                !enforce_cap,
+                "free-first ordering keeps the tail a last resort, so the cap is not enforced"
+            );
         }
 
         #[test]
-        fn available_falls_through_when_every_candidate_is_capped() {
+        fn available_returns_the_full_list_when_every_candidate_is_capped() {
             let limiter = PeerInflightLimiter::new(CAP_ONE);
             let candidates = vec![overlay(1), overlay(2)];
             let _h1 = limiter.try_acquire(&overlay(1)).expect("slot a");
             let _h2 = limiter.try_acquire(&overlay(2)).expect("slot b");
 
-            let (survivors, enforce_cap) = limiter.available(candidates.clone());
+            let (ordered, enforce_cap) = limiter.available(candidates.clone());
             assert_eq!(
-                survivors, candidates,
-                "all-busy falls through to the full list rather than failing"
+                ordered, candidates,
+                "an all-busy set keeps every peer rather than failing"
             );
             assert!(
                 !enforce_cap,
-                "the all-busy fall-through is best-effort, not cap-enforced"
+                "the all-busy list is best-effort, not cap-enforced"
+            );
+        }
+
+        /// A present-but-failing close set spills to a farther holder that is busy
+        /// at its in-flight cap: `available` surfaces the busy holder as a tail
+        /// (Part A) and the spill race reaches it best-effort after the close race
+        /// exhausts (Part B), so the difficult chunk is served rather than failing.
+        #[tokio::test]
+        async fn failing_close_set_spills_to_a_busy_farther_holder() {
+            let limiter = PeerInflightLimiter::new(CAP_ONE);
+            let failing_close = overlay(1);
+            let holder = overlay(2);
+            // The farther holder is at its cap when the race begins.
+            let _held = limiter.try_acquire(&holder).expect("saturate the holder");
+
+            // The busy holder is surfaced (never dropped), as a tail, cap off.
+            let (spill, enforce_cap) = limiter.available(vec![holder]);
+            assert_eq!(
+                spill,
+                vec![holder],
+                "the busy holder is surfaced, not dropped"
+            );
+            assert!(!enforce_cap, "the busy tail is best-effort, the cap is off");
+
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let counted = Arc::clone(&attempts);
+            let limiter_ref = &limiter;
+            let outcome = race_close_then_spill(
+                vec![failing_close],
+                spill,
+                RaceBounds {
+                    budget: RETRIEVE_ATTEMPT_BUDGET,
+                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                    deadline: RETRIEVE_DEADLINE,
+                    stagger: RETRIEVAL_STAGGER,
+                },
+                RaceBounds {
+                    budget: RETRIEVE_SPILL_BUDGET,
+                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                    deadline: RETRIEVE_SPILL_DEADLINE,
+                    stagger: RETRIEVAL_STAGGER,
+                },
+                |peer: SwarmAddress| {
+                    counted.fetch_add(1, Ordering::SeqCst);
+                    // Best-effort dispatch: the busy holder has no free permit, but
+                    // the enforce-off race still contacts it.
+                    let _permit = limiter_ref.try_acquire(&peer);
+                    Some(async move {
+                        if peer == holder {
+                            Ok(holder)
+                        } else {
+                            Err("close entry point could not serve it")
+                        }
+                    })
+                },
+            )
+            .await;
+
+            assert_eq!(
+                outcome.ok(),
+                Some(holder),
+                "the spill reaches the busy farther holder the close set never held"
+            );
+        }
+
+        /// A close race that only times out does not spill: the wall clock is
+        /// spent, so widening would overrun it.
+        #[tokio::test]
+        async fn a_close_deadline_is_terminal_and_does_not_spill() {
+            use futures_timer::Delay;
+            use std::time::Duration;
+
+            let spill_dispatched = Arc::new(AtomicUsize::new(0));
+            let counted = Arc::clone(&spill_dispatched);
+            let outcome: Result<u32, RaceFailure<&str>> = race_close_then_spill(
+                vec![0u32],
+                vec![1u32],
+                RaceBounds {
+                    budget: 4,
+                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                    deadline: Duration::from_millis(100),
+                    stagger: Duration::from_secs(3600),
+                },
+                RaceBounds {
+                    budget: 4,
+                    max_in_flight: RETRIEVE_MAX_IN_FLIGHT,
+                    deadline: Duration::from_secs(1),
+                    stagger: RETRIEVAL_STAGGER,
+                },
+                |candidate: u32| {
+                    if candidate == 1 {
+                        counted.fetch_add(1, Ordering::SeqCst);
+                    }
+                    Some(async move {
+                        // The close candidate withholds past its deadline; the spill
+                        // candidate would serve if ever reached.
+                        if candidate == 0 {
+                            Delay::new(Duration::from_secs(30)).await;
+                        }
+                        Ok::<u32, &str>(candidate)
+                    })
+                },
+            )
+            .await;
+
+            assert!(
+                matches!(outcome, Err(RaceFailure::TimedOut)),
+                "a timed-out close race is terminal"
+            );
+            assert_eq!(
+                spill_dispatched.load(Ordering::SeqCst),
+                0,
+                "the spill phase never ran after a close deadline"
             );
         }
     }


### PR DESCRIPTION
## What

Restore a bounded re-settle driver for a fully-gated retrieval fallback, so a sustained bulk download no longer wedges once every close and spill peer crosses its per-peer disconnect line.

When the fallback finds no admissible close or spill candidate, it now drives a settle on the closest gated peers, backs off for the settles to land, and re-selects, bounded by an attempt budget so a genuinely peerless node still terminates. The settle trigger's in-flight dedup is shared with the origin credit gate, so the concurrent gated retrievals of a bulk download collapse to one settle per peer: the drive paces the download at the peers' forgiveness rate rather than multiplying settle traffic. The drive spans the 128-peer spill ring rather than the 32-peer close set, since a debt-saturated download reopens more headroom the more peers forgive in parallel.

This PR also carries a complementary earlier commit that lets the difficult-chunk race reach busy and farther holders (a free-slot-first ordering with a busy tail, plus a close-then-spill widening) instead of exhausting on the failing close peer. That improves the wire-level fan-out; the settle drive is the fix for the settlement-level deadlock below.

## Why

Closes #617.

Settlement is only ever triggered by the origin credit gate, for a peer a request actually dispatches to. A peer refused by the admission band (our committed debt to it past its disconnect line) is hard-skipped by candidate selection, so a request never dispatches to it, so its debt never settles and the band never reopens. Once every peer crosses the line, nothing drains any of them: a fully-gated set is a permanent deadlock, not the rare transient #616 assumed when it removed the in-request settle-and-wait gate (`order_or_wait`). Both escape hatches that removal relied on are absent for a client: a refused peer is never dispatched to, and pseudosettle is debtor-initiated so there is no passive creditor forgiveness.

Empirically the fully-gated state is not the rare hot-close-peer race #617 anticipated but the steady state of a high-concurrency download: with the band refusing all 128+ connected peers, the download stalls to zero within seconds and every retrieval exhausts having contacted no peer, even for chunks provably present on the network (confirmed independently via the public gateway).

## Testing

Live single-node mainnet download (gRPC node driven by a client at N=256), throughput measured from the node's `retrieval_total{outcome="hit"}` counter delta (mmap output defeats file-size measurement):

- Before: stalls to 0 KiB/s within ~15s; every retrieval returns `no_peers`.
- After (settle drive over the close set, width 32): ~600 KiB/s sustained.
- After (settle drive over the spill ring, width 128): ~950 KiB/s sustained over 60s, restoring the prior single-node throughput. The new `retrieval_settle_drive` counter climbs steadily, confirming the drive is the mechanism keeping the band open.

Verification: `cargo nextest run -p vertex-swarm-node` (144 passed), `cargo clippy -p vertex-swarm-node --all-features --all-targets` clean, `cargo fmt --all`, wasm32 build of `vertex-swarm-node` and of the `swarm-demo` browser client (the backoff uses `futures_timer::Delay` so the retrieval future stays Send for the async-trait provider on wasm).

## AI Assistance

Claude Code (Opus 4.8) used for diagnosis, implementation, and live benchmarking.