### PR TITLE
refactor(swarm-api,swarm-node): hold retrieval topology as one object-safe Arc<dyn RetrievalTopology>

### DIFF
--- a/bin/swarm-demo/src/client/mod.rs
+++ b/bin/swarm-demo/src/client/mod.rs
@@ -16,7 +16,7 @@ use nectar_primitives::ChunkAddress;
 use vertex_swarm_api::{SwarmChunkProvider, SwarmChunkSender, SwarmClientAccounting};
 use vertex_swarm_node::{
     AccountingSettlement, LaunchedClient, NetworkChunkProvider, NoLatencyHint, ProximityOnly,
-    SettlementTrigger,
+    RetrievalTopology, SettlementTrigger,
 };
 use wasm_bindgen::prelude::*;
 
@@ -53,9 +53,12 @@ impl SwarmClient {
         let settlement: Arc<dyn SettlementTrigger> = Arc::new(AccountingSettlement::new(
             launched.accounting().bandwidth().clone(),
         ));
+        let max_bin = launched.topology().max_bin();
+        let topology: Arc<dyn RetrievalTopology> = Arc::new(launched.topology().clone());
         let routing = NetworkChunkProvider::new(
             client,
-            launched.topology().clone(),
+            topology,
+            max_bin,
             ProximityOnly,
             launched.inflight().clone(),
             NoLatencyHint,

--- a/crates/swarm/api/src/components/topology.rs
+++ b/crates/swarm/api/src/components/topology.rs
@@ -4,9 +4,9 @@ use core::future::Future;
 use std::sync::Arc;
 use std::vec::Vec;
 
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, NetworkId};
 
-use crate::{PeerReporter, SwarmIdentity};
+use crate::PeerReporter;
 use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
 
 /// Bin sizes for topology routing (one per proximity order).
@@ -21,11 +21,11 @@ pub trait SwarmTopologyBins: Send + Sync {
 /// Node identity and state within the topology.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait SwarmTopologyState: Send + Sync {
-    /// The identity type for this topology.
-    type Identity: SwarmIdentity;
+    /// The node's overlay address.
+    fn overlay_address(&self) -> OverlayAddress;
 
-    /// Get the identity.
-    fn identity(&self) -> &Self::Identity;
+    /// The network id this node participates in, fixed at construction.
+    fn network_id(&self) -> NetworkId;
 
     /// Get the current neighborhood depth.
     fn depth(&self) -> NeighborhoodDepth;
@@ -40,11 +40,6 @@ pub trait SwarmTopologyState: Send + Sync {
     /// attacker-controlled bar (see the pushsync receipt depth policy). Returns
     /// true once the neighbourhood is saturated.
     fn neighbourhood_credible(&self) -> bool;
-
-    /// Get the node's overlay address.
-    fn overlay_address(&self) -> OverlayAddress {
-        self.identity().overlay_address()
-    }
 }
 
 /// Access to the peer-scoring authority behind the topology.

--- a/crates/swarm/api/src/types.rs
+++ b/crates/swarm/api/src/types.rs
@@ -26,7 +26,7 @@ pub trait SwarmPrimitives: Send + Sync + 'static {
 /// Extends primitives with topology (peer discovery service).
 pub trait SwarmNetworkTypes: SwarmPrimitives {
     /// Peer discovery and routing.
-    type Topology: SwarmTopologyState<Identity = <Self as SwarmPrimitives>::Identity>
+    type Topology: SwarmTopologyState
         + SwarmTopologyRouting
         + SwarmTopologyPeers
         + SwarmTopologyStats;

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use nectar_primitives::SwarmAddress;
 use tracing::warn;
 use vertex_swarm_api::{
-    ChunkAddress, ChunkRetrievalResult, PeerReporter, PushReceipt, ReportSource, StampedChunk,
+    Bin, ChunkAddress, ChunkRetrievalResult, PeerReporter, PushReceipt, ReportSource, StampedChunk,
     SwarmChunkProvider, SwarmChunkSender, SwarmError, SwarmLocalStore, SwarmResult,
     SwarmScoringEvent,
 };
@@ -41,23 +41,21 @@ const PUSH_CANDIDATE_COUNT: usize = 5;
 /// forwarding retrieval has no authoritative negative, so absence is never
 /// claimed.
 #[derive(Clone)]
-pub struct NetworkChunkProvider<T, O, G, L>
+pub struct NetworkChunkProvider<O, G, L>
 where
-    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,
 {
-    engine: RetrievalEngine<T, O, G, L>,
+    engine: RetrievalEngine<O, G, L>,
     /// The node's own chunk cache, consulted before racing the swarm so a
     /// duplicate origin retrieval of a cached content chunk serves locally.
     /// `None` for an embedder that wires a cacheless provider.
     store: Option<Arc<dyn SwarmLocalStore>>,
 }
 
-impl<T, O, G, L> NetworkChunkProvider<T, O, G, L>
+impl<O, G, L> NetworkChunkProvider<O, G, L>
 where
-    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,
@@ -65,9 +63,14 @@ where
     /// Build the provider over the three retrieval capabilities: candidate
     /// `ordering`, the per-peer `inflight` cap, and the per-PO `latency`
     /// estimate. `store` is the node's own cache, read before the swarm race.
+    // A wiring constructor over the node's already-built collaborators; grouping
+    // them into a params struct would only move the same fields behind one more
+    // type.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client_handle: ClientHandle,
-        topology: T,
+        topology: Arc<dyn RetrievalTopology>,
+        max_bin: Bin,
         ordering: O,
         inflight: G,
         latency: L,
@@ -78,6 +81,7 @@ where
             engine: RetrievalEngine::new(
                 client_handle,
                 topology,
+                max_bin,
                 ordering,
                 inflight,
                 latency,
@@ -89,9 +93,8 @@ where
 }
 
 #[async_trait]
-impl<T, O, G, L> SwarmChunkProvider for NetworkChunkProvider<T, O, G, L>
+impl<O, G, L> SwarmChunkProvider for NetworkChunkProvider<O, G, L>
 where
-    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     // The retrieval race holds the in-flight permit across the request await, so
@@ -126,9 +129,8 @@ where
     }
 }
 
-impl<T, O, G, L> NetworkChunkProvider<T, O, G, L>
+impl<O, G, L> NetworkChunkProvider<O, G, L>
 where
-    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,
@@ -252,9 +254,8 @@ fn push_receipt_of(receipt: Receipt) -> PushReceipt {
 }
 
 #[async_trait]
-impl<T, O, G, L> SwarmChunkSender for NetworkChunkProvider<T, O, G, L>
+impl<O, G, L> SwarmChunkSender for NetworkChunkProvider<O, G, L>
 where
-    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -7,14 +7,15 @@ use nectar_primitives::SwarmAddress;
 use tracing::warn;
 use vertex_swarm_api::{
     ChunkAddress, ChunkRetrievalResult, PeerReporter, PushReceipt, ReportSource, StampedChunk,
-    SwarmChunkProvider, SwarmChunkSender, SwarmError, SwarmIdentity, SwarmLocalStore, SwarmResult,
-    SwarmScoringEvent, SwarmTopologyRouting, SwarmTopologyState,
+    SwarmChunkProvider, SwarmChunkSender, SwarmError, SwarmLocalStore, SwarmResult,
+    SwarmScoringEvent,
 };
 use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
-use vertex_swarm_topology::TopologyHandle;
 
 use crate::ClientHandle;
-use crate::retrieval_engine::{CandidateOrdering, InflightLimit, LatencyHint, RetrievalEngine};
+use crate::retrieval_engine::{
+    CandidateOrdering, InflightLimit, LatencyHint, RetrievalEngine, RetrievalTopology,
+};
 use crate::selection::SettlementTrigger;
 
 /// Report source for shallow/malformed receipts caught on the origin upload
@@ -40,23 +41,23 @@ const PUSH_CANDIDATE_COUNT: usize = 5;
 /// forwarding retrieval has no authoritative negative, so absence is never
 /// claimed.
 #[derive(Clone)]
-pub struct NetworkChunkProvider<I, O, G, L>
+pub struct NetworkChunkProvider<T, O, G, L>
 where
-    I: SwarmIdentity + 'static,
+    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,
 {
-    engine: RetrievalEngine<I, O, G, L>,
+    engine: RetrievalEngine<T, O, G, L>,
     /// The node's own chunk cache, consulted before racing the swarm so a
     /// duplicate origin retrieval of a cached content chunk serves locally.
     /// `None` for an embedder that wires a cacheless provider.
     store: Option<Arc<dyn SwarmLocalStore>>,
 }
 
-impl<I, O, G, L> NetworkChunkProvider<I, O, G, L>
+impl<T, O, G, L> NetworkChunkProvider<T, O, G, L>
 where
-    I: SwarmIdentity + 'static,
+    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,
@@ -66,7 +67,7 @@ where
     /// estimate. `store` is the node's own cache, read before the swarm race.
     pub fn new(
         client_handle: ClientHandle,
-        topology: TopologyHandle<I>,
+        topology: T,
         ordering: O,
         inflight: G,
         latency: L,
@@ -88,9 +89,9 @@ where
 }
 
 #[async_trait]
-impl<I, O, G, L> SwarmChunkProvider for NetworkChunkProvider<I, O, G, L>
+impl<T, O, G, L> SwarmChunkProvider for NetworkChunkProvider<T, O, G, L>
 where
-    I: SwarmIdentity + 'static,
+    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     // The retrieval race holds the in-flight permit across the request await, so
@@ -125,9 +126,9 @@ where
     }
 }
 
-impl<I, O, G, L> NetworkChunkProvider<I, O, G, L>
+impl<T, O, G, L> NetworkChunkProvider<T, O, G, L>
 where
-    I: SwarmIdentity + 'static,
+    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,
@@ -161,7 +162,7 @@ where
         // error below).
         let local_depth = self.engine.topology().depth();
         let neighbourhood_credible = self.engine.topology().neighbourhood_credible();
-        let reporter = self.engine.topology().peer_manager();
+        let reporter = self.engine.topology().reporter();
 
         // Try each closest peer in order and return the first receipt that
         // verifies. A shallow receipt is rejected, the responding peer scored
@@ -193,7 +194,7 @@ where
                         peer,
                         local_depth,
                         neighbourhood_credible,
-                        reporter,
+                        reporter.as_ref(),
                     ) {
                         DepthVerdict::Verified => return Ok(push_receipt_of(receipt)),
                         DepthVerdict::Shallow(err) => {
@@ -251,9 +252,9 @@ fn push_receipt_of(receipt: Receipt) -> PushReceipt {
 }
 
 #[async_trait]
-impl<I, O, G, L> SwarmChunkSender for NetworkChunkProvider<I, O, G, L>
+impl<T, O, G, L> SwarmChunkSender for NetworkChunkProvider<T, O, G, L>
 where
-    I: SwarmIdentity + 'static,
+    T: RetrievalTopology + 'static,
     O: CandidateOrdering + 'static,
     G: InflightLimit + 'static,
     L: LatencyHint + 'static,

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -65,4 +65,5 @@ pub use node::stats::StatsConfig;
 pub use node::task::spawn_stats_task;
 pub use retrieval_engine::{
     CandidateOrdering, InflightLimit, LatencyHint, NoLatencyHint, ProximityOnly, RetrievalEngine,
+    RetrievalTopology,
 };

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -190,10 +190,8 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
             + 'static,
         A: vertex_swarm_api::SwarmClientAccounting + Send + Sync + 'static,
     {
-        use vertex_swarm_api::SwarmSpec;
-
         let local = self.overlay_address();
-        let network_id = topology.identity().spec().network_id();
+        let network_id = topology.network_id();
         let reporter = topology.reporter();
         // Network id recovers an inbound receipt's signer; set it before any
         // handler is created (handlers clone the config at connection setup).

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -580,7 +580,7 @@ pub struct NodeRunParts {
 /// the RPC chunk surface both client entry points expose; content integrity is
 /// enforced during retrieval decode, so no download-side wrapper sits over it.
 pub type NativeChunkProvider = NetworkChunkProvider<
-    Arc<Identity>,
+    TopologyHandle<Arc<Identity>>,
     Arc<PeerSelector>,
     Arc<PeerInflightLimiter>,
     Arc<RetrievalLatency>,

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -51,7 +51,7 @@ use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use crate::retrieval_latency::RetrievalLatency;
 use crate::{
     AccountingSettlement, ClientCommand, ClientHandle, ClientService, DEFAULT_PEER_INFLIGHT_CAP,
-    PeerInflightLimiter, PeerSelector, SettlementTrigger,
+    PeerInflightLimiter, PeerSelector, RetrievalTopology, SettlementTrigger,
 };
 
 /// The concrete shared accounting both client-backed node types build: the
@@ -579,12 +579,8 @@ pub struct NodeRunParts {
 /// ordering, the per-peer in-flight cap, and the per-PO latency estimate. This is
 /// the RPC chunk surface both client entry points expose; content integrity is
 /// enforced during retrieval decode, so no download-side wrapper sits over it.
-pub type NativeChunkProvider = NetworkChunkProvider<
-    TopologyHandle<Arc<Identity>>,
-    Arc<PeerSelector>,
-    Arc<PeerInflightLimiter>,
-    Arc<RetrievalLatency>,
->;
+pub type NativeChunkProvider =
+    NetworkChunkProvider<Arc<PeerSelector>, Arc<PeerInflightLimiter>, Arc<RetrievalLatency>>;
 
 /// Outputs of [`build_client_core_tail`]: the run-loop task, the topology handle,
 /// the chunk provider, the shared accounting and throttled client handle
@@ -772,9 +768,13 @@ where
         core.client_handle.clone(),
     );
 
+    // The routing table's max bin is a spec constant; read it once here and hand
+    // it to the engine as a field rather than a per-request topology query.
+    let max_bin = topology.max_bin();
     let chunks = NetworkChunkProvider::new(
         core.origin_handle.clone(),
-        topology.clone(),
+        Arc::new(topology.clone()) as Arc<dyn RetrievalTopology>,
+        max_bin,
         Arc::clone(&core.selector),
         Arc::clone(&core.inflight),
         Arc::clone(&core.retrieval_latency),

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -266,10 +266,8 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
             + 'static,
         A: vertex_swarm_api::SwarmClientAccounting + Send + Sync + 'static,
     {
-        use vertex_swarm_api::SwarmSpec;
-
         let local = self.overlay_address();
-        let network_id = topology.identity().spec().network_id();
+        let network_id = topology.network_id();
         let reporter = topology.reporter();
         self.base
             .swarm

--- a/crates/swarm/node/src/retrieval_engine.rs
+++ b/crates/swarm/node/src/retrieval_engine.rs
@@ -17,8 +17,9 @@ use metrics::{counter, histogram};
 use nectar_primitives::SwarmAddress;
 use tokio::sync::OwnedSemaphorePermit;
 use vertex_swarm_api::{
-    Bin, ChunkAddress, ChunkRetrievalResult, OverlayAddress, SwarmError, SwarmIdentity,
-    SwarmResult, SwarmTopologyPeers, SwarmTopologyRouting, SwarmTopologyState,
+    Bin, ChunkAddress, ChunkRetrievalResult, NeighborhoodDepth, OverlayAddress, PeerReporter,
+    SwarmError, SwarmIdentity, SwarmResult, SwarmTopologyPeers, SwarmTopologyReporting,
+    SwarmTopologyRouting, SwarmTopologyState,
 };
 use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::time::Duration;
@@ -129,6 +130,70 @@ const PRIMARY_ROUTE_DEADLINE: Duration = Duration::from_secs(2);
 /// Exactly one metered attempt is in flight at a time on the primary path. The
 /// staggered fan-out is reserved for the fallback.
 const PRIMARY_ROUTE_SINGLE_FLIGHT: Duration = Duration::from_secs(3600);
+
+/// Topology surface the retrieval engine and native push path read.
+///
+/// A bundle of the routing, state, bin, and reporting queries dispatch needs, so
+/// the engine is generic over the topology as a capability alongside its ordering,
+/// in-flight, and latency seams rather than over the identity type. Blanket-impl'd
+/// for [`TopologyHandle`], so the node wires its real handle unchanged and a test
+/// wires a mock.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait RetrievalTopology: Send + Sync {
+    /// Our own overlay address, the local end of every proximity measure.
+    fn overlay_address(&self) -> OverlayAddress;
+
+    /// The highest routable bin, the ceiling for the forwarding-bin route.
+    fn max_bin(&self) -> Bin;
+
+    /// Current neighbourhood depth, the push receipt's custody floor.
+    fn depth(&self) -> NeighborhoodDepth;
+
+    /// Whether the neighbourhood view is saturated enough to anchor that floor.
+    fn neighbourhood_credible(&self) -> bool;
+
+    /// The `count` connected peers closest to `address`, closest first.
+    fn closest_to(&self, address: &ChunkAddress, count: usize) -> Vec<OverlayAddress>;
+
+    /// Connected peers in `bin`, the forwarding-bin route's entry points.
+    fn connected_peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress>;
+
+    /// The peer-scoring reporter, for penalising a shallow push receipt.
+    fn reporter(&self) -> Arc<dyn PeerReporter>;
+}
+
+impl<I: SwarmIdentity> RetrievalTopology for TopologyHandle<I> {
+    fn overlay_address(&self) -> OverlayAddress {
+        SwarmTopologyState::overlay_address(self)
+    }
+
+    fn max_bin(&self) -> Bin {
+        // Inherent method on the handle; method-call syntax resolves to it over
+        // this trait's same-named method (inherent takes precedence), so this is
+        // a delegation, not recursion.
+        self.max_bin()
+    }
+
+    fn depth(&self) -> NeighborhoodDepth {
+        SwarmTopologyState::depth(self)
+    }
+
+    fn neighbourhood_credible(&self) -> bool {
+        SwarmTopologyState::neighbourhood_credible(self)
+    }
+
+    fn closest_to(&self, address: &ChunkAddress, count: usize) -> Vec<OverlayAddress> {
+        SwarmTopologyRouting::closest_to(self, address, count)
+    }
+
+    fn connected_peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress> {
+        SwarmTopologyPeers::connected_peers_in_bin(self, bin)
+    }
+
+    fn reporter(&self) -> Arc<dyn PeerReporter> {
+        SwarmTopologyReporting::reporter(self)
+    }
+}
 
 /// Economic ordering of retrieval and pushsync candidates.
 ///
@@ -273,10 +338,14 @@ struct RaceBounds {
 /// [`SwarmError::RetrievalExhausted`]: forwarding retrieval has no authoritative
 /// negative, so the engine never adjudicates absence.
 #[derive(Clone)]
-pub struct RetrievalEngine<I: SwarmIdentity, O: CandidateOrdering, G: InflightLimit, L: LatencyHint>
-{
+pub struct RetrievalEngine<
+    T: RetrievalTopology,
+    O: CandidateOrdering,
+    G: InflightLimit,
+    L: LatencyHint,
+> {
     client_handle: ClientHandle,
-    topology: TopologyHandle<I>,
+    topology: T,
     ordering: O,
     inflight: G,
     latency: L,
@@ -287,9 +356,9 @@ pub struct RetrievalEngine<I: SwarmIdentity, O: CandidateOrdering, G: InflightLi
     settlement: Arc<dyn SettlementTrigger>,
 }
 
-impl<I, O, G, L> RetrievalEngine<I, O, G, L>
+impl<T, O, G, L> RetrievalEngine<T, O, G, L>
 where
-    I: SwarmIdentity,
+    T: RetrievalTopology,
     O: CandidateOrdering,
     G: InflightLimit,
     L: LatencyHint,
@@ -297,7 +366,7 @@ where
     /// Build an engine over its capabilities.
     pub fn new(
         client_handle: ClientHandle,
-        topology: TopologyHandle<I>,
+        topology: T,
         ordering: O,
         inflight: G,
         latency: L,
@@ -313,9 +382,9 @@ where
         }
     }
 
-    /// The topology handle, for the native push path's closest-storer dispatch;
+    /// The topology, for the native push path's closest-storer dispatch;
     /// retrieval reaches topology through the engine's own dispatch.
-    pub(crate) fn topology(&self) -> &TopologyHandle<I> {
+    pub(crate) fn topology(&self) -> &T {
         &self.topology
     }
 
@@ -1060,6 +1129,129 @@ mod tests {
                 spill_dispatched.load(Ordering::SeqCst),
                 0,
                 "the spill phase never ran after a close deadline"
+            );
+        }
+    }
+
+    /// The fully-gated settle-drive: when the band refuses every candidate, the
+    /// fallback must drive a settle on the closest gated peers and re-select,
+    /// bounded, rather than exhaust having contacted nobody. Testable here only
+    /// because the engine is generic over [`RetrievalTopology`], so a mock stands
+    /// in for the real handle.
+    mod settle_drive {
+        use std::num::NonZeroUsize;
+        use std::sync::{Arc, Mutex};
+
+        use vertex_swarm_api::{
+            Bin, ChunkAddress, NeighborhoodDepth, OverlayAddress, PeerReporter, ReportSource,
+            SwarmError, SwarmScoringEvent,
+        };
+
+        use super::super::{
+            CandidateOrdering, NoLatencyHint, RETRIEVE_SETTLE_DRIVES, RetrievalEngine,
+            RetrievalTopology,
+        };
+        use crate::ClientHandle;
+        use crate::inflight::PeerInflightLimiter;
+        use crate::selection::SettlementTrigger;
+
+        fn overlay(byte: u8) -> OverlayAddress {
+            OverlayAddress::from([byte; 32])
+        }
+
+        /// A topology whose every routing query returns the same connected set.
+        #[derive(Clone)]
+        struct MockTopology {
+            peers: Vec<OverlayAddress>,
+        }
+
+        impl RetrievalTopology for MockTopology {
+            fn overlay_address(&self) -> OverlayAddress {
+                overlay(0xff)
+            }
+            fn max_bin(&self) -> Bin {
+                Bin::MAX
+            }
+            fn depth(&self) -> NeighborhoodDepth {
+                NeighborhoodDepth::new(Bin::MAX)
+            }
+            fn neighbourhood_credible(&self) -> bool {
+                false
+            }
+            fn closest_to(&self, _address: &ChunkAddress, count: usize) -> Vec<OverlayAddress> {
+                self.peers.iter().copied().take(count).collect()
+            }
+            fn connected_peers_in_bin(&self, _bin: Bin) -> Vec<OverlayAddress> {
+                self.peers.clone()
+            }
+            fn reporter(&self) -> Arc<dyn PeerReporter> {
+                Arc::new(NoopReporter)
+            }
+        }
+
+        struct NoopReporter;
+        impl PeerReporter for NoopReporter {
+            fn report_peer(&self, _: &OverlayAddress, _: SwarmScoringEvent, _: ReportSource) {}
+        }
+
+        /// Ordering that gates every candidate: the fully-refused band.
+        #[derive(Clone)]
+        struct GateAll;
+        impl CandidateOrdering for GateAll {
+            fn order(&self, _: Vec<OverlayAddress>, _: &ChunkAddress) -> Vec<OverlayAddress> {
+                Vec::new()
+            }
+            fn order_closest_admissible(
+                &self,
+                _: Vec<OverlayAddress>,
+                _: &ChunkAddress,
+            ) -> Vec<OverlayAddress> {
+                Vec::new()
+            }
+        }
+
+        /// Records every peer the settle-drive fires on.
+        #[derive(Clone, Default)]
+        struct RecordingSettle {
+            calls: Arc<Mutex<Vec<OverlayAddress>>>,
+        }
+        impl SettlementTrigger for RecordingSettle {
+            fn trigger_settlement(&self, peer: OverlayAddress) {
+                self.calls.lock().unwrap().push(peer);
+            }
+        }
+
+        #[tokio::test]
+        async fn a_fully_gated_fallback_drives_settles_then_exhausts() {
+            // Every candidate is banded out, so the fallback finds no admissible
+            // close or spill peer. It must drive a settle on the gated set each
+            // round, bounded by the drive budget, then surface the honest
+            // RetrievalExhausted rather than exhaust having contacted nobody.
+            let peers: Vec<OverlayAddress> = (1..=4).map(overlay).collect();
+            let settle = RecordingSettle::default();
+            let (tx, _rx) = tokio::sync::mpsc::channel(16);
+            let engine = RetrievalEngine::new(
+                ClientHandle::new(tx),
+                MockTopology {
+                    peers: peers.clone(),
+                },
+                GateAll,
+                PeerInflightLimiter::new(NonZeroUsize::new(4).unwrap()),
+                NoLatencyHint,
+                Arc::new(settle.clone()),
+            );
+
+            let result = engine.retrieve(&ChunkAddress::from([0x42; 32])).await;
+
+            assert!(
+                matches!(result, Err(SwarmError::RetrievalExhausted { .. })),
+                "a fully-gated retrieval exhausts, never claims absence"
+            );
+            let calls = settle.calls.lock().unwrap();
+            assert_eq!(
+                calls.len(),
+                RETRIEVE_SETTLE_DRIVES * peers.len(),
+                "each of the bounded drive rounds settles the full gated set"
             );
         }
     }

--- a/crates/swarm/node/src/retrieval_engine.rs
+++ b/crates/swarm/node/src/retrieval_engine.rs
@@ -17,11 +17,9 @@ use metrics::{counter, histogram};
 use nectar_primitives::SwarmAddress;
 use tokio::sync::OwnedSemaphorePermit;
 use vertex_swarm_api::{
-    Bin, ChunkAddress, ChunkRetrievalResult, NeighborhoodDepth, OverlayAddress, PeerReporter,
-    SwarmError, SwarmIdentity, SwarmResult, SwarmTopologyPeers, SwarmTopologyReporting,
-    SwarmTopologyRouting, SwarmTopologyState,
+    Bin, ChunkAddress, ChunkRetrievalResult, OverlayAddress, SwarmError, SwarmResult,
+    SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting, SwarmTopologyState,
 };
-use vertex_swarm_topology::TopologyHandle;
 use vertex_tasks::time::Duration;
 
 use crate::retrieval_latency::{RetrievalLatency, adaptive_stagger};
@@ -133,66 +131,21 @@ const PRIMARY_ROUTE_SINGLE_FLIGHT: Duration = Duration::from_secs(3600);
 
 /// Topology surface the retrieval engine and native push path read.
 ///
-/// A bundle of the routing, state, bin, and reporting queries dispatch needs, so
-/// the engine is generic over the topology as a capability alongside its ordering,
-/// in-flight, and latency seams rather than over the identity type. Blanket-impl'd
-/// for [`TopologyHandle`], so the node wires its real handle unchanged and a test
-/// wires a mock.
-#[auto_impl::auto_impl(&, Arc)]
-pub trait RetrievalTopology: Send + Sync {
-    /// Our own overlay address, the local end of every proximity measure.
-    fn overlay_address(&self) -> OverlayAddress;
-
-    /// The highest routable bin, the ceiling for the forwarding-bin route.
-    fn max_bin(&self) -> Bin;
-
-    /// Current neighbourhood depth, the push receipt's custody floor.
-    fn depth(&self) -> NeighborhoodDepth;
-
-    /// Whether the neighbourhood view is saturated enough to anchor that floor.
-    fn neighbourhood_credible(&self) -> bool;
-
-    /// The `count` connected peers closest to `address`, closest first.
-    fn closest_to(&self, address: &ChunkAddress, count: usize) -> Vec<OverlayAddress>;
-
-    /// Connected peers in `bin`, the forwarding-bin route's entry points.
-    fn connected_peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress>;
-
-    /// The peer-scoring reporter, for penalising a shallow push receipt.
-    fn reporter(&self) -> Arc<dyn PeerReporter>;
+/// A marker bundling the four topology query traits dispatch needs into one
+/// object-safe trait, so the engine holds a single `Arc<dyn RetrievalTopology>`
+/// rather than a generic per identity type. Every method it calls belongs to a
+/// sub-trait; the one non-trait value the engine needs, the routing table's max
+/// bin, is a construction constant carried as an engine field, not a query. The
+/// blanket impl means the node's real handle and a test mock both qualify with no
+/// bespoke impl.
+pub trait RetrievalTopology:
+    SwarmTopologyState + SwarmTopologyRouting + SwarmTopologyPeers + SwarmTopologyReporting
+{
 }
 
-impl<I: SwarmIdentity> RetrievalTopology for TopologyHandle<I> {
-    fn overlay_address(&self) -> OverlayAddress {
-        SwarmTopologyState::overlay_address(self)
-    }
-
-    fn max_bin(&self) -> Bin {
-        // Inherent method on the handle; method-call syntax resolves to it over
-        // this trait's same-named method (inherent takes precedence), so this is
-        // a delegation, not recursion.
-        self.max_bin()
-    }
-
-    fn depth(&self) -> NeighborhoodDepth {
-        SwarmTopologyState::depth(self)
-    }
-
-    fn neighbourhood_credible(&self) -> bool {
-        SwarmTopologyState::neighbourhood_credible(self)
-    }
-
-    fn closest_to(&self, address: &ChunkAddress, count: usize) -> Vec<OverlayAddress> {
-        SwarmTopologyRouting::closest_to(self, address, count)
-    }
-
-    fn connected_peers_in_bin(&self, bin: Bin) -> Vec<OverlayAddress> {
-        SwarmTopologyPeers::connected_peers_in_bin(self, bin)
-    }
-
-    fn reporter(&self) -> Arc<dyn PeerReporter> {
-        SwarmTopologyReporting::reporter(self)
-    }
+impl<T> RetrievalTopology for T where
+    T: SwarmTopologyState + SwarmTopologyRouting + SwarmTopologyPeers + SwarmTopologyReporting
+{
 }
 
 /// Economic ordering of retrieval and pushsync candidates.
@@ -338,14 +291,13 @@ struct RaceBounds {
 /// [`SwarmError::RetrievalExhausted`]: forwarding retrieval has no authoritative
 /// negative, so the engine never adjudicates absence.
 #[derive(Clone)]
-pub struct RetrievalEngine<
-    T: RetrievalTopology,
-    O: CandidateOrdering,
-    G: InflightLimit,
-    L: LatencyHint,
-> {
+pub struct RetrievalEngine<O: CandidateOrdering, G: InflightLimit, L: LatencyHint> {
     client_handle: ClientHandle,
-    topology: T,
+    topology: Arc<dyn RetrievalTopology>,
+    /// The routing table's highest bin, the ceiling for the forwarding-bin route.
+    /// A spec constant fixed at construction, so it is a field, not a per-request
+    /// topology query.
+    max_bin: Bin,
     ordering: O,
     inflight: G,
     latency: L,
@@ -356,9 +308,8 @@ pub struct RetrievalEngine<
     settlement: Arc<dyn SettlementTrigger>,
 }
 
-impl<T, O, G, L> RetrievalEngine<T, O, G, L>
+impl<O, G, L> RetrievalEngine<O, G, L>
 where
-    T: RetrievalTopology,
     O: CandidateOrdering,
     G: InflightLimit,
     L: LatencyHint,
@@ -366,7 +317,8 @@ where
     /// Build an engine over its capabilities.
     pub fn new(
         client_handle: ClientHandle,
-        topology: T,
+        topology: Arc<dyn RetrievalTopology>,
+        max_bin: Bin,
         ordering: O,
         inflight: G,
         latency: L,
@@ -375,6 +327,7 @@ where
         Self {
             client_handle,
             topology,
+            max_bin,
             ordering,
             inflight,
             latency,
@@ -384,7 +337,7 @@ where
 
     /// The topology, for the native push path's closest-storer dispatch;
     /// retrieval reaches topology through the engine's own dispatch.
-    pub(crate) fn topology(&self) -> &T {
+    pub(crate) fn topology(&self) -> &Arc<dyn RetrievalTopology> {
         &self.topology
     }
 
@@ -496,7 +449,7 @@ where
         // the route here; a gated route falls through to the staggered fallback,
         // which spills to a wider headroom slice.
         let local = self.topology.overlay_address();
-        let max_bin = self.topology.max_bin().get();
+        let max_bin = self.max_bin.get();
         let bin_candidates =
             bin_routed_order(&chunk_address, &local, max_bin, RETRIEVE_WIDTH, |bin| {
                 self.topology.connected_peers_in_bin(bin)
@@ -1142,10 +1095,8 @@ mod tests {
         use std::num::NonZeroUsize;
         use std::sync::{Arc, Mutex};
 
-        use vertex_swarm_api::{
-            Bin, ChunkAddress, NeighborhoodDepth, OverlayAddress, PeerReporter, ReportSource,
-            SwarmError, SwarmScoringEvent,
-        };
+        use vertex_swarm_api::{Bin, ChunkAddress, OverlayAddress, SwarmError};
+        use vertex_swarm_test_utils::MockTopology;
 
         use super::super::{
             CandidateOrdering, NoLatencyHint, RETRIEVE_SETTLE_DRIVES, RetrievalEngine,
@@ -1157,41 +1108,6 @@ mod tests {
 
         fn overlay(byte: u8) -> OverlayAddress {
             OverlayAddress::from([byte; 32])
-        }
-
-        /// A topology whose every routing query returns the same connected set.
-        #[derive(Clone)]
-        struct MockTopology {
-            peers: Vec<OverlayAddress>,
-        }
-
-        impl RetrievalTopology for MockTopology {
-            fn overlay_address(&self) -> OverlayAddress {
-                overlay(0xff)
-            }
-            fn max_bin(&self) -> Bin {
-                Bin::MAX
-            }
-            fn depth(&self) -> NeighborhoodDepth {
-                NeighborhoodDepth::new(Bin::MAX)
-            }
-            fn neighbourhood_credible(&self) -> bool {
-                false
-            }
-            fn closest_to(&self, _address: &ChunkAddress, count: usize) -> Vec<OverlayAddress> {
-                self.peers.iter().copied().take(count).collect()
-            }
-            fn connected_peers_in_bin(&self, _bin: Bin) -> Vec<OverlayAddress> {
-                self.peers.clone()
-            }
-            fn reporter(&self) -> Arc<dyn PeerReporter> {
-                Arc::new(NoopReporter)
-            }
-        }
-
-        struct NoopReporter;
-        impl PeerReporter for NoopReporter {
-            fn report_peer(&self, _: &OverlayAddress, _: SwarmScoringEvent, _: ReportSource) {}
         }
 
         /// Ordering that gates every candidate: the fully-refused band.
@@ -1228,13 +1144,17 @@ mod tests {
             // round, bounded by the drive budget, then surface the honest
             // RetrievalExhausted rather than exhaust having contacted nobody.
             let peers: Vec<OverlayAddress> = (1..=4).map(overlay).collect();
+            // The mock's `closest_to` returns this set (its `connected_peers_in_bin`
+            // is empty, so the primary bin route yields nothing and the fallback
+            // drives the settle).
+            let topology: Arc<dyn RetrievalTopology> =
+                Arc::new(MockTopology::new(4, 4, 0).with_closest(peers.clone()));
             let settle = RecordingSettle::default();
             let (tx, _rx) = tokio::sync::mpsc::channel(16);
             let engine = RetrievalEngine::new(
                 ClientHandle::new(tx),
-                MockTopology {
-                    peers: peers.clone(),
-                },
+                topology,
+                Bin::MAX,
                 GateAll,
                 PeerInflightLimiter::new(NonZeroUsize::new(4).unwrap()),
                 NoLatencyHint,

--- a/crates/swarm/test-utils/src/topology.rs
+++ b/crates/swarm/test-utils/src/topology.rs
@@ -1,9 +1,10 @@
 //! Mock topology implementations for testing.
 
-use nectar_primitives::{ChunkAddress, SwarmAddress};
+use nectar_primitives::{ChunkAddress, NetworkId, SwarmAddress};
 use std::sync::Arc;
 use vertex_swarm_api::{
-    SwarmIdentity, SwarmNodeType, SwarmTopologyBins, SwarmTopologyPeers, SwarmTopologyRouting,
+    PeerReporter, ReportSource, SwarmIdentity, SwarmNodeType, SwarmScoringEvent, SwarmSpec,
+    SwarmTopologyBins, SwarmTopologyPeers, SwarmTopologyReporting, SwarmTopologyRouting,
     SwarmTopologyState, SwarmTopologyStats,
 };
 use vertex_swarm_identity::Identity;
@@ -143,10 +144,12 @@ impl SwarmTopologyBins for MockTopology {
 }
 
 impl SwarmTopologyState for MockTopology {
-    type Identity = Identity;
+    fn overlay_address(&self) -> OverlayAddress {
+        self.identity.overlay_address()
+    }
 
-    fn identity(&self) -> &Self::Identity {
-        self.identity.as_ref()
+    fn network_id(&self) -> NetworkId {
+        self.identity.spec().network_id()
     }
 
     fn depth(&self) -> NeighborhoodDepth {
@@ -196,6 +199,26 @@ impl SwarmTopologyStats for MockTopology {
 
     fn stored_peers_count(&self) -> usize {
         self.stored
+    }
+}
+
+impl SwarmTopologyReporting for MockTopology {
+    fn reporter(&self) -> Arc<dyn PeerReporter> {
+        Arc::new(NoopReporter)
+    }
+}
+
+/// A no-op peer reporter: components under test that reach the mock's reporter do
+/// not exercise scoring.
+struct NoopReporter;
+
+impl PeerReporter for NoopReporter {
+    fn report_peer(
+        &self,
+        _overlay: &OverlayAddress,
+        _event: SwarmScoringEvent,
+        _source: ReportSource,
+    ) {
     }
 }
 

--- a/crates/swarm/topology/src/handle.rs
+++ b/crates/swarm/topology/src/handle.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use libp2p::{Multiaddr, PeerId};
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, NetworkId};
 use tokio::sync::{broadcast, mpsc};
 use vertex_swarm_api::{
     PeerReporter, SwarmIdentity, SwarmSpec, SwarmTopologyBins, SwarmTopologyCommands,
@@ -325,10 +325,12 @@ impl<I: SwarmIdentity> SwarmTopologyBins for TopologyHandle<I> {
 }
 
 impl<I: SwarmIdentity> SwarmTopologyState for TopologyHandle<I> {
-    type Identity = I;
+    fn overlay_address(&self) -> OverlayAddress {
+        self.identity.overlay_address()
+    }
 
-    fn identity(&self) -> &Self::Identity {
-        &self.identity
+    fn network_id(&self) -> NetworkId {
+        self.identity.spec().network_id()
     }
 
     fn depth(&self) -> NeighborhoodDepth {


### PR DESCRIPTION
## What

Make the retrieval engine hold its topology as a single object-safe trait object and drop its last generic, and remove the associated type that made that impossible.

Landed in two steps on this branch:

1. Introduce a `RetrievalTopology` seam so the engine is generic over the topology capability rather than the identity type.
2. Collapse that seam to its object-safe end state (this is the substance):
   - `max_bin` is a spec constant (the routing table's bin count, fixed at construction), not a live query, so it moves to a `RetrievalEngine` field read once at build time and leaves the topology surface.
   - `SwarmTopologyState` carried `type Identity: SwarmIdentity` + `identity()`, which made it non-object-safe. Its only consumers reached through it for an overlay address and a network id, so `identity()` is replaced by a required `overlay_address()` and a concrete `network_id() -> NetworkId`. The associated type is gone and the trait is object-safe. `SwarmSpec` is deliberately not exposed: it is itself non-object-safe (`type ChunkSet`, `type Token`), and only `network_id` is actually consumed.
   - `RetrievalTopology` becomes a zero-method marker supertrait of `SwarmTopologyState + SwarmTopologyRouting + SwarmTopologyPeers + SwarmTopologyReporting` with a blanket impl, so the node's real `TopologyHandle` and a mock qualify with no bespoke impl. The push path reads the scoring reporter through the object-safe `SwarmTopologyReporting::reporter()`.

End state: `RetrievalEngine<O, G, L>` holds `Arc<dyn RetrievalTopology>` and a `max_bin: Bin` field; `NetworkChunkProvider<O, G, L>` drops its topology generic. Net -60 lines.

## Why

Closes #635. Part of #606.

The engine's `I: SwarmIdentity` generic existed only to hold `TopologyHandle<I>`, and the bespoke topology trait only existed because the four existing topology query traits could not be named as one trait object (`SwarmTopologyState`'s associated type) and because `max_bin` lived on no trait. Removing both roots lets the engine compose the traits it already depends on instead of redefining them.

### Note on the core-trait change

`SwarmTopologyState` is a public `api` trait, so this is a public-trait change (per AGENTS.md). It is a pure internal-trait refactor: no wire bytes, no `SwarmSpec` change. The `<Identity = ...>` equality bound in `SwarmNetworkTypes::Topology` is dropped; it was the associated type's only binding site and nothing downstream relied on it. Blast radius: the trait def, that one bound, the two impls (`TopologyHandle`, `MockTopology`), and two setup-time call sites (`node/client.rs`, `node/storer.rs`) that now call `topology.network_id()`.

## Testing

No behaviour change: the retrieval and settle-drive logic is untouched; the diff is the trait reshape plus the generic drop. Verified:

- `cargo nextest run -p vertex-swarm-node` (145 passed), including the fully-gated settle-drive test, now driven against the shared `MockTopology` (which gained a `SwarmTopologyReporting` impl) rather than a bespoke mock.
- `cargo clippy -p vertex-swarm-node --all-features --all-targets` clean.
- `cargo build --workspace` and `cargo build -p vertex-swarm-builder --features storer` both build, exercising the `api` ripple across every crate that names `SwarmTopologyState`.
- wasm32 builds of `vertex-swarm-node` and the `swarm-demo` browser client.

## AI Assistance

Claude Code (Opus 4.8) used for a five-agent analysis (topology cartography, reth-idiomatic design, adversarial review of both the seam and the associated-type removal), the implementation, and verification.