### PR TITLE
refactor(swarm-node): collapse the two staggered race drivers onto one loop

### DIFF
--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -35,7 +35,11 @@
 
 use std::time::Duration;
 
-use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
+use futures::{
+    FutureExt, StreamExt,
+    future::{self, Either},
+    stream::FuturesUnordered,
+};
 use futures_timer::Delay;
 
 /// Default stagger between retrieval candidates joining a [`race_candidates`]
@@ -98,39 +102,19 @@ where
     F: FnMut(C) -> Fut,
     Fut: std::future::Future<Output = Result<T, E>>,
 {
-    let mut candidates = candidates.into_iter();
-
-    let mut in_flight = FuturesUnordered::new();
-    match candidates.next() {
-        Some(candidate) => in_flight.push(attempt(candidate)),
-        None => return Err(RaceFailure::NoCandidates),
-    }
-
-    let mut stagger_tick = Delay::new(stagger).fuse();
-
-    loop {
-        futures::select! {
-            result = in_flight.select_next_some() => match result {
-                Ok(value) => return Ok(value),
-                Err(error) => {
-                    // A failed attempt frees its slot: start the next candidate
-                    // immediately. Once no candidates and no attempts remain,
-                    // the race ends with the last attempt's error.
-                    if let Some(candidate) = candidates.next() {
-                        in_flight.push(attempt(candidate));
-                    } else if in_flight.is_empty() {
-                        return Err(RaceFailure::AllFailed(error));
-                    }
-                }
-            },
-            _ = stagger_tick => {
-                if let Some(candidate) = candidates.next() {
-                    in_flight.push(attempt(candidate));
-                    stagger_tick = Delay::new(stagger).fuse();
-                }
-            }
-        }
-    }
+    // Unbounded: no attempt budget, no in-flight width cap, and no wall-clock
+    // deadline, so the race never times out. The closure cannot decline a
+    // candidate, so the race ends only on a success, an all-failed drain, or an
+    // empty candidate list.
+    race(
+        candidates,
+        usize::MAX,
+        usize::MAX,
+        None,
+        stagger,
+        move |candidate| Some(attempt(candidate)),
+    )
+    .await
 }
 
 /// Like [`race_candidates`], but bounded to at most `budget` dispatched attempts
@@ -161,6 +145,38 @@ pub async fn race_with_refill<C, T, E, I, F, Fut>(
     budget: usize,
     max_in_flight: usize,
     deadline: Duration,
+    stagger: Duration,
+    attempt: F,
+) -> Result<T, RaceFailure<E>>
+where
+    I: IntoIterator<Item = C>,
+    F: FnMut(C) -> Option<Fut>,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    race(
+        candidates,
+        budget,
+        max_in_flight,
+        Some(deadline),
+        stagger,
+        attempt,
+    )
+    .await
+}
+
+/// The staggered any-candidate race behind [`race_candidates`] and
+/// [`race_with_refill`]: one `FuturesUnordered` driver with the attempt `budget`,
+/// the in-flight `max_in_flight` width cap, and an optional wall-clock `deadline`
+/// parameterised. Keeping the drop-on-resolve and refill-on-failure invariants in
+/// one loop is the point; the two public entry points fix these parameters. An
+/// unbounded budget, unbounded width, and absent deadline reproduce
+/// [`race_candidates`]; a `Some` deadline surfaces [`RaceFailure::TimedOut`] when
+/// the clock runs out with no failure to report.
+async fn race<C, T, E, I, F, Fut>(
+    candidates: I,
+    budget: usize,
+    max_in_flight: usize,
+    deadline: Option<Duration>,
     stagger: Duration,
     mut attempt: F,
 ) -> Result<T, RaceFailure<E>>
@@ -198,7 +214,13 @@ where
     }
 
     let mut stagger_tick = Delay::new(stagger).fuse();
-    let mut deadline_tick = Delay::new(deadline).fuse();
+    // No deadline: a never-ready arm the select never wakes on, so the race is
+    // bounded only by the budget and the candidate source.
+    let mut deadline_tick = match deadline {
+        Some(deadline) => Either::Left(Delay::new(deadline)),
+        None => Either::Right(future::pending::<()>()),
+    }
+    .fuse();
 
     loop {
         futures::select! {

--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -167,7 +167,7 @@ where
 /// The staggered any-candidate race behind [`race_candidates`] and
 /// [`race_with_refill`]: one `FuturesUnordered` driver with the attempt `budget`,
 /// the in-flight `max_in_flight` width cap, and an optional wall-clock `deadline`
-/// parameterised. Keeping the drop-on-resolve and refill-on-failure invariants in
+/// parameterized. Keeping the drop-on-resolve and refill-on-failure invariants in
 /// one loop is the point; the two public entry points fix these parameters. An
 /// unbounded budget, unbounded width, and absent deadline reproduce
 /// [`race_candidates`]; a `Some` deadline surfaces [`RaceFailure::TimedOut`] when
@@ -240,11 +240,14 @@ where
                 // Grow the in-flight set only up to the width: a stagger adds an
                 // attempt, a withholding attempt never does. Failure-refill above
                 // still replaces a freed slot, so reach is preserved without
-                // widening.
-                if in_flight.len() < max_in_flight {
-                    dispatch_next(&mut in_flight, &mut dispatched);
+                // widening. A failed dispatch is permanent (the budget and the
+                // source are both monotone), so let the tick lapse rather than
+                // re-arm a wakeup that can never dispatch again.
+                if in_flight.len() >= max_in_flight
+                    || dispatch_next(&mut in_flight, &mut dispatched)
+                {
+                    stagger_tick = Delay::new(stagger).fuse();
                 }
-                stagger_tick = Delay::new(stagger).fuse();
             },
             _ = deadline_tick => {
                 // Out of wall-clock time. Surface the last real failure if one


### PR DESCRIPTION
## What

Collapse `race_candidates` and `race_with_refill` in `crates/swarm/node/src/staggered_race.rs` onto one private driver, parameterized by the attempt budget, the in-flight width cap, and an optional wall-clock deadline. The two public entry points stay as thin wrappers that fix these parameters:

- `race_candidates` fixes an unbounded budget, an unbounded width, and no deadline over a non-declinable attempt, so it never yields `TimedOut`.
- `race_with_refill` fixes a `Some` deadline and forwards its budget, width, and declinable attempt through unchanged.

The unified loop also lets the stagger tick lapse once a dispatch fails: the attempt budget and the candidate source are both monotone, so a failed dispatch is permanent and re-arming the tick would only buy no-op wakeups. This restores the pre-unification `race_candidates` behaviour of going quiet once the source drains and extends it to the refill race.

## Why

Closes #603.

The two drivers were the same `FuturesUnordered` plus staggered-dispatch plus refill-on-failure loop, differing only in the budget cap, the width cap, the deadline arm, and whether the failure outcome distinguished `TimedOut` from `AllFailed`. That forced the drop-on-resolve and refill-on-failure invariants to be reasoned about and kept correct in two places. One loop body removes roughly sixty lines of duplication while preserving the `NoCandidates` versus `AllFailed` versus `TimedOut` discrimination each caller relies on.

## Testing

No wire change, no behaviour change; both public signatures are untouched and the existing tests for both drivers pin the behaviour.

- `cargo fmt --all`
- `cargo clippy -p vertex-swarm-node --all-targets --all-features -- -D warnings` (clean)
- `cargo test -p vertex-swarm-node --all-features staggered_race` (13 passed: the driver suite and the provider race tests, covering `NoCandidates`, `AllFailed`, `TimedOut`, the budget cap, the width cap, the declined-candidate skip, withholding-head overtake, failed-head immediate refill, and the deadline bound)
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (green; the driver is on the retrieval dispatch path)

## AI Assistance

Claude Code (Opus 4.8 and Fable 5) used for the analysis, the refactor, the review pass, and this PR description.
