### PR TITLE
perf(swarm-demo): raise browser download throughput and manifest listing speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4891,7 +4891,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 [[package]]
 name = "nectar-contracts"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
+source = "git+https://github.com/nxm-rs/nectar?rev=aface29e9f01e836a654642db78d01974b9209ed#aface29e9f01e836a654642db78d01974b9209ed"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4901,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "nectar-postage"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
+source = "git+https://github.com/nxm-rs/nectar?rev=aface29e9f01e836a654642db78d01974b9209ed#aface29e9f01e836a654642db78d01974b9209ed"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4916,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "nectar-primitives"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
+source = "git+https://github.com/nxm-rs/nectar?rev=aface29e9f01e836a654642db78d01974b9209ed#aface29e9f01e836a654642db78d01974b9209ed"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4944,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "nectar-swarms"
 version = "0.3.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=304b548284f2f4d8b122ff98fea087743665948d#304b548284f2f4d8b122ff98fea087743665948d"
+source = "git+https://github.com/nxm-rs/nectar?rev=aface29e9f01e836a654642db78d01974b9209ed#aface29e9f01e836a654642db78d01974b9209ed"
 dependencies = [
  "alloy-chains",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,13 +146,13 @@ indexing_slicing = "warn"
 # BatchStore/StoreValidator/SnapshotStore conversion plus nectar-mantaray and
 # nectar-postage-usage's `client`/`issuer`/`seal` features that the browser
 # upload/download path (bin/swarm-demo) depends on.
-nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
-nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
+nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
 
 digest = "0.10"
 

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -58,18 +58,18 @@ async-trait = "0.1"
 # `parallel`/`wasm-threads`, keeping the single-threaded wasm profile (the demo
 # never calls `initThreadPool`, so there is no rayon worker pool and no shared
 # memory).
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
 # `local-signer` brings the alloy-signer-local re-export for the in-browser key.
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
 # `issuer` + `seal` give signed content stamps (SnapshotIssuer) and the
 # usage-persistence seal path; default `std` is implied.
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d", features = [
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed", features = [
     "issuer",
     "seal",
     "client",
 ] }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "304b548284f2f4d8b122ff98fea087743665948d" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "aface29e9f01e836a654642db78d01974b9209ed" }
 
 # Chequebook address parsing for the optional SWAP config input and chain
 # types/signing for the browser. alloy-sol-types decodes the BatchCreated log
@@ -116,7 +116,7 @@ web-sys = { version = "0.3", features = [
     "File",
     "FileList",
     "Blob",
-    # `fetch`-based JSON-RPC for the gnosis log query (Milestone 4).
+    # `fetch`-based JSON-RPC for the gnosis batch-discovery log query.
     "Request",
     "RequestInit",
     "Response",

--- a/bin/swarm-demo/README.md
+++ b/bin/swarm-demo/README.md
@@ -23,7 +23,7 @@ The wasm-bindgen surface in `src/lib.rs` is small: a `#[wasm_bindgen(start)]` `m
 
 ## Build
 
-The build is single-threaded against the prebuilt `wasm32-unknown-unknown` std on a stable toolchain: no wasm atomics, no shared memory, no `build-std`, no nightly. It needs the `wasm32-unknown-unknown` target, Trunk, and `wasm-bindgen-cli`. The only extra rustflag is the getrandom wasm backend (`getrandom_backend="wasm_js"`), set in this crate's own `.cargo/config.toml`, which fully replaces the workspace config because this crate is its own workspace root. Trunk passes it through, so a plain `trunk build --release` needs no extra flags.
+The build is single-threaded against the prebuilt `wasm32-unknown-unknown` std on a stable toolchain: no wasm atomics, no shared memory, no `build-std`, no nightly. It needs the `wasm32-unknown-unknown` target and Trunk; Trunk fetches the lockfile-matching `wasm-bindgen-cli` itself. The only extra rustflag is the getrandom wasm backend (`getrandom_backend="wasm_js"`), set in this crate's own `.cargo/config.toml`, which fully replaces the workspace config because this crate is its own workspace root. Trunk passes it through, so a plain `trunk build --release` needs no extra flags.
 
 On the project's Nix host, the whole toolchain is available through the project shell:
 

--- a/bin/swarm-demo/src/client/download.rs
+++ b/bin/swarm-demo/src/client/download.rs
@@ -131,18 +131,24 @@ impl WriteAt for JsWriteSink<'_> {
 /// Chunk retrievals kept in flight while the joiner walks a file's chunk tree.
 ///
 /// The browser is a light client racing only the closest connected peers, never
-/// dialling for a retrieval. The engine's per-peer in-flight cap bounds how many
-/// retrieval substreams land on any one peer, so a wide fan-out stays within a
-/// healthy neighbourhood's budget; the joiner's split of its budget between a
-/// small cap of intermediate-node fetches and the remaining data-leaf fetches is
-/// what makes the wide fan-out worthwhile, landing the first data leaf after a
-/// short descent rather than behind the whole intermediate frontier.
-const DOWNLOAD_CONCURRENCY: usize = 32;
+/// dialling for a retrieval. Per-chunk latency is forwarding-chain dominated
+/// (seconds, not bandwidth), so bulk throughput is `width / latency` and the
+/// width is the lever; the engine's per-peer in-flight cap spreads the fan-out
+/// across the connected set so no single peer is overrun, and the joiner's
+/// split between a small cap of intermediate-node fetches and the remaining
+/// data-leaf fetches keeps the first data leaf ahead of the intermediate
+/// frontier.
+const DOWNLOAD_CONCURRENCY: usize = 128;
 
 /// Leaf bodies held at once while streaming to a sequential sink: in-flight plus
 /// buffered-for-reorder. At least `2 * DOWNLOAD_CONCURRENCY` keeps the pool full
 /// even when the lowest-offset leaf is the straggler the sink is waiting on.
 const STREAM_WINDOW: usize = DOWNLOAD_CONCURRENCY * 2;
+
+/// Sibling manifest nodes loaded concurrently during a listing walk. Manifest
+/// tries are shallow and their per-level frontiers small, so this comfortably
+/// covers a whole level; per-node latency is what the width hides.
+const LIST_CONCURRENCY: usize = 32;
 
 /// Download the file at `root`, resolving it as a single-file manifest if it is one.
 pub async fn download_reference(
@@ -189,20 +195,24 @@ pub async fn stream_file(
     sink: &DownloadSink,
 ) -> Result<(), JsValue> {
     let getter = retrying(NetworkChunkGet::new(provider, cache.snapshot_map()));
-    let joiner = Joiner::<RetryGetter, DEFAULT_BODY_SIZE>::new(getter, file_root)
-        .await
-        .map_err(|e| JsValue::from_str(&format!("joiner open: {e}")))?
-        .with_concurrency(DOWNLOAD_CONCURRENCY);
-
-    // Total is known once the joiner is open; announce it before streaming so
-    // the progress bar can show a fraction rather than a bare byte count.
-    sink.set_total(joiner.size() as f64);
-
-    if joiner.size() == 0 {
-        return finish(sink).await;
-    }
 
     if sink.seekable() {
+        // A forward download wants the lazy open: seeding the walk with the
+        // root alone lets the bounded pool descend with no per-level barrier,
+        // so the first data leaf lands after a short descent instead of behind
+        // the whole eagerly-expanded intermediate frontier.
+        let joiner = Joiner::<RetryGetter, DEFAULT_BODY_SIZE>::open_streaming(getter, file_root)
+            .await
+            .map_err(|e| JsValue::from_str(&format!("joiner open: {e}")))?
+            .with_concurrency(DOWNLOAD_CONCURRENCY);
+
+        // Total is known once the joiner is open; announce it before streaming
+        // so the progress bar can show a fraction rather than a bare byte count.
+        sink.set_total(joiner.size() as f64);
+        if joiner.size() == 0 {
+            return finish(sink).await;
+        }
+
         // Out-of-order positional writes: the joiner writes each leaf at its
         // offset the moment it resolves, off the fetch thread, so a slow chunk
         // never gates the writes already in hand.
@@ -216,8 +226,19 @@ pub async fn stream_file(
 
     // Ordered fallback: a sequential disk stream (File System Access append or a
     // service-worker download body) must be fed in file order. The windowed
-    // reader fetches the tree at full width but reorders to in-order emission,
-    // bounding held leaf bodies to the window.
+    // reader wants the balanced frontier of the eager open; it fetches the tree
+    // at full width but reorders to in-order emission, bounding held leaf
+    // bodies to the window.
+    let joiner = Joiner::<RetryGetter, DEFAULT_BODY_SIZE>::new(getter, file_root)
+        .await
+        .map_err(|e| JsValue::from_str(&format!("joiner open: {e}")))?
+        .with_concurrency(DOWNLOAD_CONCURRENCY);
+
+    sink.set_total(joiner.size() as f64);
+    if joiner.size() == 0 {
+        return finish(sink).await;
+    }
+
     let mut reader = joiner.into_windowed_reader(STREAM_WINDOW);
     let stream = reader.stream();
     futures::pin_mut!(stream);
@@ -258,9 +279,8 @@ async fn probe_manifest_entries(
     cache: &MemoryCache,
 ) -> Result<Option<Vec<Entry>>, JsValue> {
     let getter = NetworkChunkGet::new(provider, cache.snapshot_map());
-    let mut manifest: PlainManifest<RetryGetter> =
-        PlainManifest::open(root, retrying(getter.clone()));
-    let result = manifest.entries().await;
+    let manifest: PlainManifest<RetryGetter> = PlainManifest::open(root, retrying(getter.clone()));
+    let result = manifest.entries_concurrent(LIST_CONCURRENCY).await;
     publish(&getter, cache);
     match result {
         Ok(entries) if !entries.is_empty() => Ok(Some(entries)),
@@ -315,7 +335,9 @@ pub async fn download_file(
     cache: &MemoryCache,
 ) -> Result<Vec<u8>, JsValue> {
     let getter = retrying(NetworkChunkGet::new(provider, cache.snapshot_map()));
-    let joiner = Joiner::<RetryGetter, DEFAULT_BODY_SIZE>::new(getter, file_root)
+    // Lazy open: the chunk-granular offset stream descends from the root seed
+    // with no per-level barrier (see `stream_file`).
+    let joiner = Joiner::<RetryGetter, DEFAULT_BODY_SIZE>::open_streaming(getter, file_root)
         .await
         .map_err(|e| JsValue::from_str(&format!("joiner open: {e}")))?
         .with_concurrency(DOWNLOAD_CONCURRENCY);
@@ -343,13 +365,14 @@ pub async fn ls_manifest(
     cache: &MemoryCache,
 ) -> Result<Vec<(String, String)>, JsValue> {
     let getter = NetworkChunkGet::new(provider, cache.snapshot_map());
-    let mut manifest: PlainManifest<RetryGetter> =
-        PlainManifest::open(root, retrying(getter.clone()));
-    let result = manifest.entries().await;
+    let manifest: PlainManifest<RetryGetter> = PlainManifest::open(root, retrying(getter.clone()));
+    let result = manifest.entries_concurrent(LIST_CONCURRENCY).await;
     publish(&getter, cache);
     let entries = result.map_err(|e| JsValue::from_str(&format!("manifest list: {e}")))?;
 
-    Ok(entries
+    // The concurrent walk yields entries in completion order; sort for a
+    // stable listing.
+    let mut listed: Vec<(String, String)> = entries
         .iter()
         .map(|e| {
             let path = e.path_str().unwrap_or("<non-utf8>").to_string();
@@ -359,7 +382,9 @@ pub async fn ls_manifest(
                 .unwrap_or_else(|| "<none>".to_string());
             (path, addr)
         })
-        .collect())
+        .collect();
+    listed.sort();
+    Ok(listed)
 }
 
 /// Walk `path` in the manifest at `root`, returning the referenced file's bytes.

--- a/bin/swarm-demo/src/client/mod.rs
+++ b/bin/swarm-demo/src/client/mod.rs
@@ -13,11 +13,8 @@ use std::sync::Arc;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage::Batch;
 use nectar_primitives::ChunkAddress;
-use vertex_swarm_api::{SwarmChunkProvider, SwarmChunkSender, SwarmClientAccounting};
-use vertex_swarm_node::{
-    AccountingSettlement, LaunchedClient, NetworkChunkProvider, NoLatencyHint, ProximityOnly,
-    RetrievalTopology, SettlementTrigger,
-};
+use vertex_swarm_api::{SwarmChunkProvider, SwarmChunkSender};
+use vertex_swarm_node::LaunchedClient;
 use wasm_bindgen::prelude::*;
 
 use cache::MemoryCache;
@@ -40,33 +37,14 @@ pub struct SwarmClient {
 impl SwarmClient {
     /// Build the client surface over an already-launched browser node.
     pub fn from_launched(launched: &LaunchedClient) -> Self {
-        // The launched client's handle already paces its own outbound retrieval
-        // and pushsync under each peer's pseudosettle allowance (the builder
-        // wires the self-throttle), so the provider reuses it as-is. The browser
-        // drives the shared provider with proximity ordering and the constant
-        // stagger, but the real per-peer in-flight cap the launched service
-        // maintains; it shares the native custody-verdict push.
-        let client = launched.client().clone();
-        // The engine drives this to drain a fully-gated peer set: the browser gates
-        // fast on its small neighbourhood, and pseudosettle is debtor-initiated, so
-        // without a settle drive a gated set would never reopen.
-        let settlement: Arc<dyn SettlementTrigger> = Arc::new(AccountingSettlement::new(
-            launched.accounting().bandwidth().clone(),
-        ));
-        let max_bin = launched.topology().max_bin();
-        let topology: Arc<dyn RetrievalTopology> = Arc::new(launched.topology().clone());
-        let routing = NetworkChunkProvider::new(
-            client,
-            topology,
-            max_bin,
-            ProximityOnly,
-            launched.inflight().clone(),
-            NoLatencyHint,
-            settlement,
-            Some(launched.store().clone()),
-        );
-        let provider: Arc<dyn SwarmChunkProvider> = Arc::new(routing.clone());
-        let sender: Arc<dyn SwarmChunkSender> = Arc::new(routing);
+        // The launched client already assembles the fully-capable chunk provider:
+        // score- and affordability-aware candidate ordering, the shared per-peer
+        // in-flight cap, the adaptive per-proximity retrieval stagger, the
+        // settle drive on a fully-gated peer set, and the session cache. Reuse
+        // it rather than assembling a second engine over the same handle.
+        let chunks = launched.chunks().clone();
+        let provider: Arc<dyn SwarmChunkProvider> = Arc::new(chunks.clone());
+        let sender: Arc<dyn SwarmChunkSender> = Arc::new(chunks);
         Self {
             provider,
             sender,
@@ -93,10 +71,10 @@ impl SwarmClient {
         let batch_id = parse_b256(&batch_id_hex)?;
         let owner = signer.address();
 
-        // Task B follow-up #5: resolve the real batch geometry from the
-        // discoverBatches path rather than assuming defaults. Only fall back to
-        // defaults when discovery is unavailable (no rpc) or the batch is not
-        // found in the queried window, and warn so the operator knows.
+        // Resolve the real batch geometry from batch discovery; fall back to
+        // the default geometry only when discovery is unavailable (no rpc) or
+        // the batch is not found in the queried window, and warn so the
+        // operator knows.
         let batch = if rpc_url.is_empty() {
             tracing::warn!(
                 "uploadFile: no rpc_url provided; using default batch geometry \

--- a/bin/swarm-demo/src/files_ui.rs
+++ b/bin/swarm-demo/src/files_ui.rs
@@ -227,6 +227,88 @@ fn wire_download(client: SwarmClient) {
     cb.forget();
 }
 
+/// Smoothed download-rate state fed by successive progress callbacks.
+struct RateTracker {
+    last_ms: f64,
+    last_written: f64,
+    bytes_per_sec: f64,
+}
+
+thread_local! {
+    /// Rate state for the in-flight download; reset when the progress widget
+    /// is shown. Wasm is single-threaded, so a thread local is a plain global.
+    static RATE: std::cell::RefCell<Option<RateTracker>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Minimum spacing between rate samples: callbacks arrive per leaf write
+/// (potentially hundreds per second), so per-callback deltas are too noisy to
+/// display raw.
+const RATE_SAMPLE_MS: f64 = 250.0;
+
+/// EWMA blend per accepted sample; heavy enough smoothing that the label does
+/// not flicker, light enough to track a stall within a couple of seconds.
+const RATE_ALPHA: f64 = 0.3;
+
+/// Fold `written` at `now_ms` into the rate estimate, returning the current
+/// bytes-per-second once at least one interval has elapsed.
+fn update_rate(now_ms: f64, written: f64) -> Option<f64> {
+    RATE.with_borrow_mut(|state| match state {
+        None => {
+            *state = Some(RateTracker {
+                last_ms: now_ms,
+                last_written: written,
+                bytes_per_sec: 0.0,
+            });
+            None
+        }
+        Some(t) => {
+            let dt_ms = now_ms - t.last_ms;
+            if dt_ms >= RATE_SAMPLE_MS {
+                let instant = ((written - t.last_written) / dt_ms * 1000.0).max(0.0);
+                t.bytes_per_sec = if t.bytes_per_sec == 0.0 {
+                    instant
+                } else {
+                    t.bytes_per_sec + RATE_ALPHA * (instant - t.bytes_per_sec)
+                };
+                t.last_ms = now_ms;
+                t.last_written = written;
+            }
+            (t.bytes_per_sec > 0.0).then_some(t.bytes_per_sec)
+        }
+    })
+}
+
+/// Clear the rate state ahead of a new download.
+fn reset_rate() {
+    RATE.with_borrow_mut(|state| *state = None);
+}
+
+/// Render a byte count as a compact human-readable size.
+fn fmt_bytes(bytes: f64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    if bytes >= GIB {
+        format!("{:.2} GiB", bytes / GIB)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{:.0} KiB", bytes / KIB)
+    } else {
+        format!("{bytes:.0} B")
+    }
+}
+
+/// Render seconds as a compact `1h02m` / `4m07s` / `12s` ETA.
+fn fmt_eta(seconds: f64) -> String {
+    let s = seconds.round() as u64;
+    match (s / 3600, (s % 3600) / 60, s % 60) {
+        (0, 0, secs) => format!("{secs}s"),
+        (0, mins, secs) => format!("{mins}m{secs:02}s"),
+        (hours, mins, _) => format!("{hours}h{mins:02}m"),
+    }
+}
+
 /// Install the `window.__swarmDownloadProgress(written, total)` hook the sink
 /// calls per write, rendering it into the progress bar. Idempotent.
 fn install_progress_hook() {
@@ -249,7 +331,8 @@ fn install_progress_hook() {
     cb.forget();
 }
 
-/// Render `written`/`total` bytes into the progress bar and label.
+/// Render `written`/`total` bytes plus the smoothed rate and ETA into the
+/// progress bar and label.
 fn render_progress(written: f64, total: f64) {
     let doc = document();
     let pct = if total.is_finite() && total > 0.0 {
@@ -262,11 +345,18 @@ fn render_progress(written: f64, total: f64) {
     {
         el.style().set_property("width", &format!("{pct:.1}%")).ok();
     }
-    let label = if total.is_finite() && total > 0.0 {
-        format!("{} / {} bytes ({pct:.0}%)", written as u64, total as u64)
+
+    let mut label = if total.is_finite() && total > 0.0 {
+        format!("{} / {} ({pct:.0}%)", fmt_bytes(written), fmt_bytes(total))
     } else {
-        format!("{} bytes", written as u64)
+        fmt_bytes(written)
     };
+    if let Some(rate) = update_rate(js_sys::Date::now(), written) {
+        label.push_str(&format!(" · {}/s", fmt_bytes(rate)));
+        if total.is_finite() && total > written {
+            label.push_str(&format!(" · ETA {}", fmt_eta((total - written) / rate)));
+        }
+    }
     set_text(DOWNLOAD_PROGRESS_TEXT_ID, &label);
 }
 
@@ -275,6 +365,7 @@ fn show_progress(visible: bool) {
     let doc = document();
     if let Some(el) = doc.get_element_by_id(DOWNLOAD_PROGRESS_ID) {
         if visible {
+            reset_rate();
             el.remove_attribute("hidden").ok();
             render_progress(0.0, f64::NAN);
         } else {

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,8 @@
             cargo-watch        # File watcher
             cargo-expand       # Macro expansion
             cargo-nextest      # Test runner
+            trunk              # wasm bundler for bin/swarm-demo (fetches the
+                               # lockfile-matching wasm-bindgen itself)
 
             # Git
             git


### PR DESCRIPTION
## What

Raises the wasm swarm-demo's browser download throughput and manifest-listing speed, and adds a live download rate and ETA to the progress label.

- The demo now reuses the launched client's fully-wired chunk provider instead of assembling its own engine with `ProximityOnly` ordering and `NoLatencyHint`. That null hint forced every staggered retrieval race onto the constant 1200ms stagger; the launched provider carries the adaptive per-proximity estimate, score-aware ordering, and the shared per-peer in-flight cap.
- Browser retrieval is forwarding-chain bound (roughly 1.8s per chunk regardless of width), so bulk throughput is width over latency: the joiner width goes from 32 to 128 and forward downloads open with nectar's lazy streaming walk so the first data leaf is not gated behind the eagerly-expanded intermediate frontier.
- Manifest walks switch from the serial depth-first `entries()` (one awaited node fetch at a time) to the concurrent listing at width 32, with sorted output.
- The progress label renders human-readable sizes plus a 250ms-sampled EWMA rate and remaining-time estimate.
- Bumps the pinned nectar rev to `aface29` (two additive commits: concurrent manifest listing #126, lazy streaming joiner open #124), workspace and demo kept on the same rev so shared nectar types resolve to one copy.

## Why

Downloads ran at roughly 100 KB/s and a manifest listing took tens of seconds of dead time, making the demo feel broken against live mainnet even with a healthy node. No linked issue; found and fixed in one pass.

## Testing

- `cargo check --workspace`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --all` on the workspace; demo crate clippy clean for `wasm32-unknown-unknown`; `trunk build --release` clean.
- Verified against live mainnet in headless Chromium (cold sessions, IndexedDB cleared): 3.5 MiB file went from 69 KiB/s to 173 KiB/s; an 834 MiB file sustains 200-460 KiB/s in bursts paced by the per-peer debt band (test bounded to 75s); a 12-entry manifest listing went from 23s to 12s cold and is instant warm. Rate and ETA label observed updating live through the OPFS sink path.
- The remaining ceiling is the bilateral accounting line times the connected peer count, not wasm CPU, so a node-in-worker split would not raise throughput; a follow-up could revisit the single-flight bin-route primary (2s deadline) for shallow clients.

AI Assistance: Claude Code used for diagnosis, implementation, and live-network verification.
