### PR TITLE
feat(swarm-client-behaviour,swarm-node): bill terminal serves via the forwarder seam

### DIFF
--- a/crates/swarm/client-behaviour/src/forward.rs
+++ b/crates/swarm/client-behaviour/src/forward.rs
@@ -127,6 +127,26 @@ pub trait Forwarder: Send + Sync {
         chunk: StampedChunk,
         exclude: OverlayAddress,
     ) -> BoxFuture<'static, Result<ForwardedReceipt, ForwardError>>;
+
+    /// Reserve the upstream credit for a terminal serve: `peer` pays for an
+    /// answer this node already holds (a cache hit or its own custody
+    /// receipt), so no relay legs run.
+    ///
+    /// Returned un-applied under the same deferred-commit contract as the
+    /// relays: commit after the wire write, drop to release. A refusal means
+    /// the peer is past its settle line and the serve must be refused.
+    fn prepare_serve(
+        &self,
+        peer: OverlayAddress,
+        address: &ChunkAddress,
+    ) -> Result<Box<dyn CommitOnWrite>, ForwardError>;
+}
+
+/// The no-op upstream credit for nodes that do not account their serves.
+struct Unaccounted;
+
+impl CommitOnWrite for Unaccounted {
+    fn apply_boxed(self: Box<Self>) {}
 }
 
 /// A relayed chunk together with the un-applied upstream credit.
@@ -198,6 +218,14 @@ impl Forwarder for StubForwarder {
         _exclude: OverlayAddress,
     ) -> BoxFuture<'static, Result<ForwardedReceipt, ForwardError>> {
         Box::pin(async { Err(ForwardError::NoCloserPeer) })
+    }
+
+    fn prepare_serve(
+        &self,
+        _peer: OverlayAddress,
+        _address: &ChunkAddress,
+    ) -> Result<Box<dyn CommitOnWrite>, ForwardError> {
+        Ok(Box::new(Unaccounted))
     }
 }
 

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -477,15 +477,30 @@ impl ClientHandler {
         let forward = Arc::clone(&self.forward);
         self.inbound.push(Box::pin(async move {
             // Cache hit: the store applies the single-owner TTL on `get`. Serve
-            // whichever stamp the cache held.
+            // whichever stamp the cache held. A terminal serve is billed like a
+            // relay: reserve the upstream credit before responding, commit only
+            // after the wire write. A refusal means the requester is past its
+            // settle line, so the serve is refused too.
             if let Ok(Some(cached)) = store.get(&address)
                 && *cached.address() == address
             {
+                let provide = match forward.prepare_serve(overlay, &address) {
+                    Ok(provide) => provide,
+                    Err(_) => {
+                        responder.send_error();
+                        return InboundOutcome::Missed { overlay, address };
+                    }
+                };
                 let (chunk, stamp) = cached.into_parts();
                 match responder.send_chunk(chunk, stamp).await {
-                    Ok(()) => return InboundOutcome::Served { overlay },
+                    Ok(()) => {
+                        provide.apply_boxed();
+                        return InboundOutcome::Served { overlay };
+                    }
                     Err(e) => {
+                        // Not delivered: drop the unapplied credit.
                         debug!(%overlay, %address, error = %e, "Cache serve send failed");
+                        drop(provide);
                         return InboundOutcome::Missed { overlay, address };
                     }
                 }
@@ -560,8 +575,9 @@ impl ClientHandler {
             && storer.reserve.is_responsible_for(&address)
         {
             let storer = storer.clone();
+            let forward = Arc::clone(&self.forward);
             self.inbound.push(Box::pin(async move {
-                Self::store_and_sign(storer, chunk, address, overlay, responder).await
+                Self::store_and_sign(forward, storer, chunk, address, overlay, responder).await
             }));
             return;
         }
@@ -601,12 +617,24 @@ impl ClientHandler {
     /// sign failure resets the substream rather than acknowledging a chunk we did
     /// not durably take.
     async fn store_and_sign(
+        forward: Arc<dyn Forwarder>,
         storer: StorerCapability,
         chunk: StampedChunk,
         address: ChunkAddress,
         overlay: OverlayAddress,
         responder: vertex_swarm_net_pushsync::PushsyncResponder,
     ) -> InboundOutcome {
+        // Custody is billed like any serve: reserve the upstream credit before
+        // the storage work, commit only after the receipt write. A refusal
+        // means the pusher is past its settle line, so custody is refused too.
+        let provide = match forward.prepare_serve(overlay, &address) {
+            Ok(provide) => provide,
+            Err(_) => {
+                responder.send_error();
+                return InboundOutcome::PushFailed { overlay, address };
+            }
+        };
+
         // Persist before acknowledging: a receipt must never claim custody of a
         // chunk that is not durably in the reserve.
         if let Err(e) = storer.reserve.put(CachedChunk::from(chunk)) {
@@ -632,12 +660,17 @@ impl ClientHandler {
         };
 
         match responder.send_receipt(receipt.to_wire()).await {
-            Ok(()) => InboundOutcome::Stored { overlay },
+            Ok(()) => {
+                provide.apply_boxed();
+                InboundOutcome::Stored { overlay }
+            }
             Err(e) => {
                 // Stored; only the ack failed to reach the pusher. The pusher
                 // retries, which is idempotent (the reserve put is
-                // content-addressed, so a re-delivery is a no-op).
+                // content-addressed, so a re-delivery is a no-op). Drop the
+                // unapplied credit: never bill for an ack that did not land.
                 debug!(%overlay, %address, error = %e, "Receipt send failed after store");
+                drop(provide);
                 InboundOutcome::PushFailed { overlay, address }
             }
         }

--- a/crates/swarm/node/src/protocol/forward.rs
+++ b/crates/swarm/node/src/protocol/forward.rs
@@ -29,8 +29,8 @@ use futures::future::BoxFuture;
 use nectar_primitives::ChunkAddress;
 use tracing::{debug, warn};
 use vertex_swarm_api::{
-    Commit, PeerReporter, ReportSource, SwarmBandwidthAccounting, SwarmClientAccounting,
-    SwarmScoringEvent, SwarmTopologyRouting, SwarmTopologyState,
+    Commit, CommitOnWrite, PeerReporter, ReportSource, SwarmBandwidthAccounting,
+    SwarmClientAccounting, SwarmScoringEvent, SwarmTopologyRouting, SwarmTopologyState,
 };
 use vertex_swarm_client_behaviour::{
     ForwardError, ForwardedChunk, ForwardedReceipt, Forwarder, closer_candidates,
@@ -360,6 +360,18 @@ where
                 provide: Box::new(provide),
             })
         })
+    }
+
+    fn prepare_serve(
+        &self,
+        peer: OverlayAddress,
+        address: &ChunkAddress,
+    ) -> Result<Box<dyn CommitOnWrite>, ForwardError> {
+        let provide = self
+            .accounting
+            .prepare_provide_chunk(peer, address)
+            .map_err(|_| ForwardError::AccountingRefused)?;
+        Ok(Box::new(provide))
     }
 }
 
@@ -1074,5 +1086,75 @@ mod tests {
         // Both reservations were released on drop: balances are untouched.
         assert_eq!(acct.bandwidth().for_peer(requester).balance(), Au::ZERO);
         assert_eq!(acct.bandwidth().for_peer(closer).balance(), Au::ZERO);
+    }
+
+    #[tokio::test]
+    async fn prepare_serve_bills_only_after_the_wire_write() {
+        let chunk = stamped();
+        let address = *chunk.address();
+        let requester = overlay_at_proximity(&address, 2);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default());
+        let (tx, _rx) = mpsc::channel::<ClientCommand>(4);
+        let forwarder = NetworkForwarder::new(
+            local,
+            topo,
+            Arc::clone(&acct),
+            ClientHandle::new(tx),
+            Arc::new(RecordingReporter::default()) as Arc<dyn PeerReporter>,
+        );
+
+        let price = acct.pricing().peer_price(&requester, &address);
+        let provide = forwarder
+            .prepare_serve(requester, &address)
+            .expect("within the settle line");
+
+        // Reserved, not billed, until the handler commits after the write.
+        assert_eq!(acct.bandwidth().for_peer(requester).balance(), Au::ZERO);
+        provide.apply_boxed();
+        assert_eq!(acct.bandwidth().for_peer(requester).balance(), price);
+    }
+
+    #[tokio::test]
+    async fn concurrent_prepared_serves_exhaust_the_settle_line_and_release_on_drop() {
+        // In-flight serves count against the settle line via the shadow
+        // reservation, so a peer holding many concurrent requests cannot run
+        // its exposure past the payment threshold; dropping them restores the
+        // headroom.
+        let chunk = stamped();
+        let address = *chunk.address();
+        let requester = overlay_at_proximity(&address, 2);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default());
+        let (tx, _rx) = mpsc::channel::<ClientCommand>(4);
+        let forwarder = NetworkForwarder::new(
+            local,
+            topo,
+            Arc::clone(&acct),
+            ClientHandle::new(tx),
+            Arc::new(RecordingReporter::default()) as Arc<dyn PeerReporter>,
+        );
+
+        let mut held = Vec::new();
+        let refused = loop {
+            match forwarder.prepare_serve(requester, &address) {
+                Ok(provide) => held.push(provide),
+                Err(err) => break err,
+            }
+            assert!(held.len() <= 20_000, "the settle line never engaged");
+        };
+        assert!(matches!(refused, ForwardError::AccountingRefused));
+        assert_eq!(
+            acct.bandwidth().for_peer(requester).balance(),
+            Au::ZERO,
+            "held serves reserve, never commit"
+        );
+
+        held.clear();
+        assert!(forwarder.prepare_serve(requester, &address).is_ok());
     }
 }


### PR DESCRIPTION
## What

Bills terminal serves. Adds `Forwarder::prepare_serve`, the terminal-serve provide reservation: `NetworkForwarder` implements it over `prepare_provide_chunk`, `StubForwarder` returns a no-op commit (a client does not account its serves, the known open-loop state). The handler reserves before responding on the cache-hit retrieval path and the storer custody path, commits after a successful wire write and drops to release otherwise, exactly the deferred-commit discipline the relay paths already follow. A gate refusal refuses the serve (`send_error`), so the reserve-time settle-line projection is authoritative for every serve, terminal or relayed.

## Why

Closes #645 (part of #639, from the serve-side accounting red-team). Terminal serves were never billed: `prepare_provide` was reachable only through the relay, so cache hits and custody receipts were free, an economic hole and a conformance divergence (the reference debits every served chunk), and honest counterparties booked and settled debt this node never recorded.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-node -p vertex-swarm-client-behaviour --all-targets --all-features -- -D warnings`; `cargo nextest run -p vertex-swarm-node -p vertex-swarm-client-behaviour --all-features` (170/170, including two new tests: the serve bills only after the wire write, and concurrent held serves exhaust the settle line via the shadow reservation then release on drop); `cargo build --target wasm32-unknown-unknown` for both crates.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the red-team comparison against the reference implementation, the implementation and this PR body.
