### PR TITLE
feat(swarm-accounting,swarm-client-behaviour): accrue ghost debt when a peer refuses delivery

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -128,10 +128,14 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
         let state = self.get_or_create_peer(peer);
 
         let payment_threshold = state.payment_threshold();
-        // Projected debt the peer would owe us once this provide commits.
+        // Projected debt the peer would owe us once this provide commits. The
+        // ghost balance counts too: refused deliveries were served in full and
+        // consume the same headroom, so a repeat refuser starves instead of
+        // draining relays for free.
         let projected = state
             .balance()
             .saturating_add(state.shadow_reserved_balance())
+            .saturating_add(state.ghost_balance())
             .saturating_add(price);
         if projected > payment_threshold {
             return Err(AccountingError::PaymentThreshold {

--- a/crates/swarm/accounting/core/src/accounting/peer.rs
+++ b/crates/swarm/accounting/core/src/accounting/peer.rs
@@ -46,6 +46,7 @@ pub struct PeerState {
     balance: AtomicI64,
     reserved_balance: AtomicU64,
     shadow_reserved_balance: AtomicU64,
+    ghost_balance: AtomicU64,
     payment_threshold: Au,
     disconnect_threshold: Au,
 }
@@ -57,6 +58,7 @@ impl PeerState {
             balance: AtomicI64::new(0),
             reserved_balance: AtomicU64::new(0),
             shadow_reserved_balance: AtomicU64::new(0),
+            ghost_balance: AtomicU64::new(0),
             payment_threshold,
             disconnect_threshold,
         }
@@ -103,6 +105,19 @@ impl PeerState {
     /// Subtract from shadow reserved balance, saturating at zero.
     pub fn sub_shadow_reserved(&self, amount: Au) {
         saturating_fetch_sub(&self.shadow_reserved_balance, amount.as_amount());
+    }
+
+    /// Get the ghost balance in AU: the accrued prices of provides whose
+    /// delivery the peer refused. Never committed and never settled; it only
+    /// consumes serve headroom in the provide projection.
+    pub fn ghost_balance(&self) -> Au {
+        Au::from_amount(self.ghost_balance.load(Ordering::Relaxed))
+    }
+
+    /// Add to the ghost balance.
+    pub fn add_ghost(&self, amount: Au) {
+        self.ghost_balance
+            .fetch_add(amount.as_amount(), Ordering::Relaxed);
     }
 
     /// Get the payment threshold in AU.

--- a/crates/swarm/accounting/core/src/accounting/reservation.rs
+++ b/crates/swarm/accounting/core/src/accounting/reservation.rs
@@ -89,6 +89,18 @@ impl<L: Leg> Reservation<L> {
     }
 }
 
+impl Reservation<Provide> {
+    /// Release the reservation but accrue its price as ghost debt: the answer
+    /// was in hand and the peer refused to take delivery. The ghost is never
+    /// committed or settled; it consumes serve headroom in the provide
+    /// projection so a repeat refuser starves. Our-fault failures drop
+    /// instead, releasing without a trace.
+    pub fn forfeit(self) {
+        self.state.add_ghost(self.price);
+        // Drop releases the shadow reservation.
+    }
+}
+
 impl<L: Leg> Drop for Reservation<L> {
     fn drop(&mut self) {
         if !self.applied {
@@ -106,6 +118,10 @@ impl vertex_swarm_api::Commit for Reservation<Receive> {
 impl vertex_swarm_api::CommitOnWrite for Reservation<Provide> {
     fn apply_boxed(self: Box<Self>) {
         Reservation::apply(*self);
+    }
+
+    fn forfeit_boxed(self: Box<Self>) {
+        Reservation::forfeit(*self);
     }
 }
 
@@ -159,5 +175,18 @@ mod tests {
 
         assert_eq!(state.balance(), Au::ZERO);
         assert_eq!(state.shadow_reserved_balance(), Au::ZERO);
+        assert_eq!(state.ghost_balance(), Au::ZERO);
+    }
+
+    #[test]
+    fn provide_forfeit_releases_shadow_reserve_and_accrues_ghost() {
+        let state = Arc::new(PeerState::new(au(1000), au(10000)));
+        state.add_shadow_reserved(au(100));
+
+        Reservation::<Provide>::new(Arc::clone(&state), au(100)).forfeit();
+
+        assert_eq!(state.balance(), Au::ZERO, "never committed");
+        assert_eq!(state.shadow_reserved_balance(), Au::ZERO, "released");
+        assert_eq!(state.ghost_balance(), au(100), "the refusal leaves a trace");
     }
 }

--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -113,6 +113,13 @@ pub trait Commit: Send {
 pub trait CommitOnWrite: Send {
     /// Commit the reserved balance change through a boxed reservation.
     fn apply_boxed(self: Box<Self>);
+
+    /// Release without committing, recording that the peer refused the
+    /// delivery: the answer was in hand and the write back to the peer
+    /// failed. An accounting impl accrues this as ghost debt against the
+    /// peer's serve headroom; the default releases like a plain drop. Never
+    /// call it for a failure on our side of the relay.
+    fn forfeit_boxed(self: Box<Self>) {}
 }
 
 /// Per-peer bandwidth accounting handle.

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -498,9 +498,10 @@ impl ClientHandler {
                         return InboundOutcome::Served { overlay };
                     }
                     Err(e) => {
-                        // Not delivered: drop the unapplied credit.
+                        // The peer refused delivery of an answer in hand:
+                        // release with a ghost trace so repeat refusers starve.
                         debug!(%overlay, %address, error = %e, "Cache serve send failed");
-                        drop(provide);
+                        provide.forfeit_boxed();
                         return InboundOutcome::Missed { overlay, address };
                     }
                 }
@@ -531,10 +532,11 @@ impl ClientHandler {
                             InboundOutcome::Forwarded { overlay }
                         }
                         Err(e) => {
-                            // Not delivered: drop the unapplied credit so we never
-                            // bill for a delivery that did not land.
+                            // The peer refused delivery after the relay paid the
+                            // downstream leg: release with a ghost trace so we
+                            // never bill for it but repeat refusers starve.
                             debug!(%overlay, %address, error = %e, "Forward serve send failed");
-                            drop(forwarded.provide);
+                            forwarded.provide.forfeit_boxed();
                             InboundOutcome::Missed { overlay, address }
                         }
                     }
@@ -596,9 +598,10 @@ impl ClientHandler {
                             InboundOutcome::Relayed { overlay }
                         }
                         Err(e) => {
-                            // Receipt not delivered: drop the unapplied credit.
+                            // The pusher refused its receipt after the relay paid
+                            // the downstream leg: release with a ghost trace.
                             debug!(%overlay, %address, error = %e, "Receipt relay send failed");
-                            drop(forwarded.provide);
+                            forwarded.provide.forfeit_boxed();
                             InboundOutcome::PushFailed { overlay, address }
                         }
                     }
@@ -667,10 +670,11 @@ impl ClientHandler {
             Err(e) => {
                 // Stored; only the ack failed to reach the pusher. The pusher
                 // retries, which is idempotent (the reserve put is
-                // content-addressed, so a re-delivery is a no-op). Drop the
-                // unapplied credit: never bill for an ack that did not land.
+                // content-addressed, so a re-delivery is a no-op). Release the
+                // unapplied credit with a ghost trace: never bill for an ack
+                // that did not land, but a repeat refuser starves.
                 debug!(%overlay, %address, error = %e, "Receipt send failed after store");
-                drop(provide);
+                provide.forfeit_boxed();
                 InboundOutcome::PushFailed { overlay, address }
             }
         }

--- a/crates/swarm/node/src/protocol/forward.rs
+++ b/crates/swarm/node/src/protocol/forward.rs
@@ -1157,4 +1157,46 @@ mod tests {
         held.clear();
         assert!(forwarder.prepare_serve(requester, &address).is_ok());
     }
+
+    #[tokio::test]
+    async fn refused_deliveries_accrue_ghost_debt_and_starve_the_serve_gate() {
+        // A peer that requests answers and never takes delivery: every
+        // forfeited serve leaves a ghost trace, so the gate refuses long
+        // before any balance commits, and unlike a released in-flight serve
+        // the ghost persists.
+        let chunk = stamped();
+        let address = *chunk.address();
+        let requester = overlay_at_proximity(&address, 2);
+        let local = OverlayAddress::from([0xee; 32]);
+
+        let acct = accounting();
+        let topo = Arc::new(MockTopology::default());
+        let (tx, _rx) = mpsc::channel::<ClientCommand>(4);
+        let forwarder = NetworkForwarder::new(
+            local,
+            topo,
+            Arc::clone(&acct),
+            ClientHandle::new(tx),
+            Arc::new(RecordingReporter::default()) as Arc<dyn PeerReporter>,
+        );
+
+        let mut refusals = 0usize;
+        let refused = loop {
+            match forwarder.prepare_serve(requester, &address) {
+                Ok(provide) => provide.forfeit_boxed(),
+                Err(err) => break err,
+            }
+            refusals += 1;
+            assert!(refusals <= 20_000, "the serve gate never engaged");
+        };
+        assert!(matches!(refused, ForwardError::AccountingRefused));
+        assert_eq!(
+            acct.bandwidth().for_peer(requester).balance(),
+            Au::ZERO,
+            "forfeits never commit"
+        );
+
+        // The ghost persists: the peer stays starved.
+        assert!(forwarder.prepare_serve(requester, &address).is_err());
+    }
 }

--- a/docs/design/accounting-seam.md
+++ b/docs/design/accounting-seam.md
@@ -75,7 +75,9 @@ wasm imposes no constraint on settlement: `vertex_tasks` and `web-time` are wasm
 
 ## Peer state
 
-`PeerState` carries `balance`, `reserved_balance`, `shadow_reserved_balance`, and the two thresholds. The dead fields (`last_refresh`/`set_last_refresh`, `surplus_balance`/`add_surplus`, `set_balance`, and the `snapshot`/`from_snapshot`/`PeerStateSnapshot` path) were removed in the prior deletions sweep. The `SwarmPeerState` trait is `balance()`-only (the only method read through it), which the settlement provider uses for its recheck.
+`PeerState` carries `balance`, `reserved_balance`, `shadow_reserved_balance`, `ghost_balance`, and the two thresholds. The dead fields (`last_refresh`/`set_last_refresh`, `surplus_balance`/`add_surplus`, `set_balance`, and the `snapshot`/`from_snapshot`/`PeerStateSnapshot` path) were removed in the prior deletions sweep. The `SwarmPeerState` trait is `balance()`-only (the only method read through it), which the settlement provider uses for its recheck.
+
+Ghost debt is the trace of refused deliveries. A provide reservation released because the peer refused to take the answer off the wire (`CommitOnWrite::forfeit_boxed`, only ever called by the handler arms where the answer was in hand and the write back failed) accrues its price into `ghost_balance` instead of vanishing. The ghost is never committed and never settled; it participates only in the `prepare_provide` projection (`balance + shadow_reserved + ghost + price` against the payment threshold), so a peer that repeatedly requests answers and refuses delivery starves out of service instead of draining relay legs for free. Failures on our side of a relay drop the reservation as before, releasing without a trace.
 
 ## Removed dead code
 


### PR DESCRIPTION
## What

Adds ghost debt: a `ghost_balance` on `PeerState`, accrued through the provide reservation's new forfeit path (`CommitOnWrite::forfeit_boxed`, defaulting to a plain release for no-op impls). The handler forfeits in exactly the four arms where the answer was in hand and the write back to the peer failed (cache serve, forwarded chunk, relayed receipt, custody receipt); every failure on our side of a relay keeps releasing without a trace. The ghost is never committed and never settled; it participates only in the `prepare_provide` projection (`balance + shadow_reserved + ghost + price` against the payment threshold), so a peer that repeatedly requests answers and refuses delivery starves out of service instead of draining committed downstream relay legs for free. The design note in `docs/design/accounting-seam.md` records the rule.

## Why

Closes #646 (part of #639, from the serve-side accounting red-team). A requester that never took delivery cost this node the already-committed downstream leg and left no trace, repeatable indefinitely; the reference covers the same pattern with its ghost balance and a blocklist trigger. The scoring/disconnect trigger is left out here deliberately: accounting core holds no reporter by design, and the projection starvation already removes the economic incentive; a node-layer trigger can follow if wanted.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-api -p vertex-swarm-accounting -p vertex-swarm-node -p vertex-swarm-client-behaviour --all-targets --all-features -- -D warnings`; `cargo nextest run` for the same four crates with `--all-features` (234/234, including new tests: forfeit releases the shadow reserve and accrues ghost while plain drop leaves none, and an end-to-end request-and-refuse loop that starves at the serve gate with the ghost persisting where released in-flight serves restore). `cargo build --target wasm32-unknown-unknown` for the accounting, client-behaviour and node crates.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the red-team comparison against the reference implementation, the implementation and this PR body.
