### PR TITLE
refactor(swarm-client-behaviour): unify the inbound serve terminals over one serve-or-delegate driver

### DIFF
--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -38,10 +38,11 @@ use vertex_swarm_net_pseudosettle::PaymentAck;
 use vertex_swarm_net_pushsync::Receipt;
 #[cfg(feature = "swap")]
 use vertex_swarm_net_swap::SignedCheque;
-use vertex_swarm_primitives::{CachedChunk, OverlayAddress, Stamp, StampedChunk, SwarmNodeType};
+use vertex_swarm_primitives::{OverlayAddress, Stamp, StampedChunk, SwarmNodeType};
 
 use super::events::{PushResponseTx, RetrievalResponseTx};
 use super::forward::Forwarder;
+use super::serve::{self, PushServe, RetrieveServe};
 use super::storer::StorerCapability;
 use super::upgrade::{
     ClientInboundOutput, ClientInboundUpgrade, ClientOutboundInfo, ClientOutboundOutput,
@@ -473,80 +474,13 @@ impl ClientHandler {
         let address = request.address;
         debug!(%overlay, %address, "Received retrieval request");
 
-        let store = Arc::clone(&self.store);
-        let forward = Arc::clone(&self.forward);
-        self.inbound.push(Box::pin(async move {
-            // Cache hit: the store applies the single-owner TTL on `get`. Serve
-            // whichever stamp the cache held. A terminal serve is billed like a
-            // relay: reserve the upstream credit before responding, commit only
-            // after the wire write. A refusal means the requester is past its
-            // settle line, so the serve is refused too.
-            if let Ok(Some(cached)) = store.get(&address)
-                && *cached.address() == address
-            {
-                let provide = match forward.prepare_serve(overlay, &address) {
-                    Ok(provide) => provide,
-                    Err(_) => {
-                        responder.send_error();
-                        return InboundOutcome::Missed { overlay, address };
-                    }
-                };
-                let (chunk, stamp) = cached.into_parts();
-                match responder.send_chunk(chunk, stamp).await {
-                    Ok(()) => {
-                        provide.apply_boxed();
-                        return InboundOutcome::Served { overlay };
-                    }
-                    Err(e) => {
-                        // The peer refused delivery of an answer in hand:
-                        // release with a ghost trace so repeat refusers starve.
-                        debug!(%overlay, %address, error = %e, "Cache serve send failed");
-                        provide.forfeit_boxed();
-                        return InboundOutcome::Missed { overlay, address };
-                    }
-                }
-            }
-
-            // Miss: forward to a closer peer, excluding the requester. Only
-            // content chunks are cached (immutable, address-keyed); a retrieved
-            // SOC has no version signal so it is relayed but never stored.
-            match forward.retrieve(address, overlay).await {
-                Ok(forwarded) => {
-                    if *forwarded.chunk.address() != address {
-                        // Wrong address means a relay bug, not the requester's
-                        // fault; reset and drop the credit unapplied.
-                        drop(forwarded.provide);
-                        responder.send_error();
-                        return InboundOutcome::Missed { overlay, address };
-                    }
-                    if forwarded.chunk.is_content() {
-                        let _ = store.put(CachedChunk::new(
-                            forwarded.chunk.clone(),
-                            forwarded.stamp.clone(),
-                        ));
-                    }
-                    match responder.send_chunk(forwarded.chunk, forwarded.stamp).await {
-                        Ok(()) => {
-                            // Delivered: commit the upstream credit.
-                            forwarded.provide.apply_boxed();
-                            InboundOutcome::Forwarded { overlay }
-                        }
-                        Err(e) => {
-                            // The peer refused delivery after the relay paid the
-                            // downstream leg: release with a ghost trace so we
-                            // never bill for it but repeat refusers starve.
-                            debug!(%overlay, %address, error = %e, "Forward serve send failed");
-                            forwarded.provide.forfeit_boxed();
-                            InboundOutcome::Missed { overlay, address }
-                        }
-                    }
-                }
-                Err(_) => {
-                    responder.send_error();
-                    InboundOutcome::Missed { overlay, address }
-                }
-            }
-        }));
+        let op = RetrieveServe {
+            store: Arc::clone(&self.store),
+            forward: Arc::clone(&self.forward),
+            overlay,
+            address,
+        };
+        self.inbound.push(Box::pin(serve::drive(op, responder)));
     }
 
     /// Handle an inbound pushsync delivery.
@@ -571,113 +505,13 @@ impl ClientHandler {
         let address = *chunk.address();
         debug!(%overlay, %address, "Received pushsync delivery");
 
-        // Storer ingest: if responsible for the chunk, take custody locally
-        // instead of relaying. Absent on a client.
-        if let Some(storer) = &self.storer
-            && storer.reserve.is_responsible_for(&address)
-        {
-            let storer = storer.clone();
-            let forward = Arc::clone(&self.forward);
-            self.inbound.push(Box::pin(async move {
-                Self::store_and_sign(forward, storer, chunk, address, overlay, responder).await
-            }));
-            return;
-        }
-
-        let forward = Arc::clone(&self.forward);
-        self.inbound.push(Box::pin(async move {
-            match forward.push(chunk, overlay).await {
-                Ok(forwarded) => {
-                    // Relay the storer's receipt verbatim: we never sign. The
-                    // signer was verified at decode, so the wire bytes reproduce
-                    // the storer's signature, nonce, and radius unchanged.
-                    let relay = forwarded.receipt.to_wire();
-                    match responder.send_receipt(relay).await {
-                        Ok(()) => {
-                            forwarded.provide.apply_boxed();
-                            InboundOutcome::Relayed { overlay }
-                        }
-                        Err(e) => {
-                            // The pusher refused its receipt after the relay paid
-                            // the downstream leg: release with a ghost trace.
-                            debug!(%overlay, %address, error = %e, "Receipt relay send failed");
-                            forwarded.provide.forfeit_boxed();
-                            InboundOutcome::PushFailed { overlay, address }
-                        }
-                    }
-                }
-                Err(_) => {
-                    responder.send_error();
-                    InboundOutcome::PushFailed { overlay, address }
-                }
-            }
-        }));
-    }
-
-    /// Take custody of a delivery: store it into the reserve and acknowledge with
-    /// a freshly signed custody receipt. Reached only when the node holds a
-    /// [`StorerCapability`] and is responsible for `address`. A reserve put or
-    /// sign failure resets the substream rather than acknowledging a chunk we did
-    /// not durably take.
-    async fn store_and_sign(
-        forward: Arc<dyn Forwarder>,
-        storer: StorerCapability,
-        chunk: StampedChunk,
-        address: ChunkAddress,
-        overlay: OverlayAddress,
-        responder: vertex_swarm_net_pushsync::PushsyncResponder,
-    ) -> InboundOutcome {
-        // Custody is billed like any serve: reserve the upstream credit before
-        // the storage work, commit only after the receipt write. A refusal
-        // means the pusher is past its settle line, so custody is refused too.
-        let provide = match forward.prepare_serve(overlay, &address) {
-            Ok(provide) => provide,
-            Err(_) => {
-                responder.send_error();
-                return InboundOutcome::PushFailed { overlay, address };
-            }
+        let op = PushServe {
+            storer: self.storer.clone(),
+            forward: Arc::clone(&self.forward),
+            overlay,
+            chunk,
         };
-
-        // Persist before acknowledging: a receipt must never claim custody of a
-        // chunk that is not durably in the reserve.
-        if let Err(e) = storer.reserve.put(CachedChunk::from(chunk)) {
-            debug!(%overlay, %address, error = %e, "Reserve put failed; not acknowledging");
-            responder.send_error();
-            return InboundOutcome::PushFailed { overlay, address };
-        }
-
-        // Sign our own custody receipt over the address, declaring our current
-        // storage radius. The capability supplies the signing key and
-        // overlay-derivation inputs; an upstream forwarder recovers our overlay
-        // from the signature.
-        let storage_radius = storer.reserve.storage_radius();
-        let receipt = match Receipt::sign(&storer.signer, address, storage_radius) {
-            Ok(receipt) => receipt,
-            Err(e) => {
-                // Stored, but cannot prove custody. Reset rather than send an
-                // unsigned ack; the pusher retries.
-                debug!(%overlay, %address, error = %e, "Receipt sign failed; not acknowledging");
-                responder.send_error();
-                return InboundOutcome::PushFailed { overlay, address };
-            }
-        };
-
-        match responder.send_receipt(receipt.to_wire()).await {
-            Ok(()) => {
-                provide.apply_boxed();
-                InboundOutcome::Stored { overlay }
-            }
-            Err(e) => {
-                // Stored; only the ack failed to reach the pusher. The pusher
-                // retries, which is idempotent (the reserve put is
-                // content-addressed, so a re-delivery is a no-op). Release the
-                // unapplied credit with a ghost trace: never bill for an ack
-                // that did not land, but a repeat refuser starves.
-                debug!(%overlay, %address, error = %e, "Receipt send failed after store");
-                provide.forfeit_boxed();
-                InboundOutcome::PushFailed { overlay, address }
-            }
-        }
+        self.inbound.push(Box::pin(serve::drive(op, responder)));
     }
 
     /// Turn a resolved inbound outcome into a scoring/metrics event.

--- a/crates/swarm/client-behaviour/src/lib.rs
+++ b/crates/swarm/client-behaviour/src/lib.rs
@@ -19,6 +19,7 @@ mod behaviour;
 mod events;
 mod forward;
 mod handler;
+mod serve;
 mod storer;
 pub mod upgrade;
 

--- a/crates/swarm/client-behaviour/src/serve.rs
+++ b/crates/swarm/client-behaviour/src/serve.rs
@@ -1,0 +1,561 @@
+//! The serve-or-delegate driver for inbound retrieval and pushsync.
+//!
+//! Both inbound protocols share one shape: fulfil locally (a cache hit, or
+//! taking custody), else delegate to the [`Forwarder`]; either way the answer's
+//! un-applied provide commits only after the wire write and is forfeited when
+//! the peer refuses delivery, while every failure on our side releases without
+//! a trace. [`drive`] owns that shape once; a [`ServeOp`] carries the
+//! operation-specific fulfilment, delegation, payload and outcome vocabulary.
+
+use std::fmt::Display;
+use std::future::Future;
+use std::sync::Arc;
+
+use nectar_primitives::{AnyChunk, ChunkAddress};
+use tracing::debug;
+use vertex_swarm_api::{CommitOnWrite, SwarmLocalStore};
+use vertex_swarm_net_pushsync::{PushsyncError, PushsyncResponder, Receipt, WireReceipt};
+use vertex_swarm_net_retrieval::{RetrievalError, RetrievalResponder};
+use vertex_swarm_primitives::{CachedChunk, OverlayAddress, Stamp, StampedChunk};
+
+use super::forward::{ForwardError, Forwarder};
+use super::handler::InboundOutcome;
+use super::storer::StorerCapability;
+
+/// An answer in hand together with its un-applied upstream credit.
+pub(crate) struct Fulfilment<P> {
+    pub payload: P,
+    pub provide: Box<dyn CommitOnWrite>,
+}
+
+/// The local-fulfilment verdict.
+pub(crate) enum Local<P> {
+    /// Answer in hand, billed; respond and commit.
+    Fulfilled(Fulfilment<P>),
+    /// Not ours to answer; delegate to the forwarder.
+    Delegate,
+    /// Cannot answer (gate refusal, custody failure); reset without delegating.
+    Refuse,
+}
+
+/// One inbound serve operation: local fulfilment, delegation, the wire write
+/// and the outcome vocabulary. [`drive`] sequences them.
+pub(crate) trait ServeOp: Send + Sync + Sized + 'static {
+    /// The payload written back to the peer.
+    type Payload: Send;
+    /// The consumed wire responder.
+    type Responder: Send;
+    /// The wire write error, logged on a refused delivery.
+    type SendError: Display;
+
+    /// Try to fulfil from what this node already holds. A `Fulfilled` answer
+    /// carries its billed provide; `Refuse` means the request must reset
+    /// without delegating.
+    fn local(&self) -> impl Future<Output = Local<Self::Payload>> + Send;
+
+    /// Delegate to the forwarder. A provide released for a failure on our
+    /// side must be dropped (not forfeited) before returning the error.
+    fn delegate(
+        &self,
+    ) -> impl Future<Output = Result<Fulfilment<Self::Payload>, ForwardError>> + Send;
+
+    /// Write the payload back to the peer, consuming the responder.
+    fn respond(
+        responder: Self::Responder,
+        payload: Self::Payload,
+    ) -> impl Future<Output = Result<(), Self::SendError>> + Send;
+
+    /// Reset the substream without a payload.
+    fn refuse(responder: Self::Responder);
+
+    /// The requesting peer, for the driver's delivery-refused log.
+    fn peer(&self) -> OverlayAddress;
+
+    /// The chunk address, for the driver's delivery-refused log.
+    fn address(&self) -> ChunkAddress;
+
+    /// Outcome when the locally fulfilled answer was delivered.
+    fn fulfilled(&self) -> InboundOutcome;
+
+    /// Outcome when the delegated answer was delivered.
+    fn delegated(&self) -> InboundOutcome;
+
+    /// Outcome when nothing was delivered; the substream was reset.
+    fn failed(&self) -> InboundOutcome;
+}
+
+/// Serve one inbound request: local fulfilment or delegation, then the shared
+/// respond-and-commit tail.
+pub(crate) async fn drive<Op: ServeOp>(op: Op, responder: Op::Responder) -> InboundOutcome {
+    match op.local().await {
+        Local::Fulfilled(fulfilment) => {
+            let success = op.fulfilled();
+            respond_and_commit(&op, responder, fulfilment, success).await
+        }
+        Local::Refuse => {
+            Op::refuse(responder);
+            op.failed()
+        }
+        Local::Delegate => match op.delegate().await {
+            Ok(fulfilment) => {
+                let success = op.delegated();
+                respond_and_commit(&op, responder, fulfilment, success).await
+            }
+            Err(_) => {
+                Op::refuse(responder);
+                op.failed()
+            }
+        },
+    }
+}
+
+/// Write the answer back and settle its provide: commit on a landed write,
+/// forfeit when the peer refused delivery of an answer in hand (the ghost
+/// trace that starves repeat refusers).
+async fn respond_and_commit<Op: ServeOp>(
+    op: &Op,
+    responder: Op::Responder,
+    fulfilment: Fulfilment<Op::Payload>,
+    success: InboundOutcome,
+) -> InboundOutcome {
+    match Op::respond(responder, fulfilment.payload).await {
+        Ok(()) => {
+            fulfilment.provide.apply_boxed();
+            success
+        }
+        Err(e) => {
+            debug!(
+                peer = %op.peer(),
+                address = %op.address(),
+                error = %e,
+                "serve delivery refused by the peer"
+            );
+            fulfilment.provide.forfeit_boxed();
+            op.failed()
+        }
+    }
+}
+
+/// Inbound retrieval: cache hit (content indefinitely, single-owner while
+/// fresh), else forward to a closer peer.
+pub(crate) struct RetrieveServe {
+    pub store: Arc<dyn SwarmLocalStore>,
+    pub forward: Arc<dyn Forwarder>,
+    pub overlay: OverlayAddress,
+    pub address: ChunkAddress,
+}
+
+impl ServeOp for RetrieveServe {
+    type Payload = (AnyChunk, Option<Stamp>);
+    type Responder = RetrievalResponder;
+    type SendError = RetrievalError;
+
+    async fn local(&self) -> Local<Self::Payload> {
+        // Cache hit: the store applies the single-owner TTL on `get`. Serve
+        // whichever stamp the cache held. A terminal serve is billed like a
+        // relay: reserve the upstream credit before responding; a refusal
+        // means the requester is past its settle line, so the serve is
+        // refused too.
+        let Ok(Some(cached)) = self.store.get(&self.address) else {
+            return Local::Delegate;
+        };
+        if *cached.address() != self.address {
+            return Local::Delegate;
+        }
+        match self.forward.prepare_serve(self.overlay, &self.address) {
+            Ok(provide) => {
+                let (chunk, stamp) = cached.into_parts();
+                Local::Fulfilled(Fulfilment {
+                    payload: (chunk, stamp),
+                    provide,
+                })
+            }
+            Err(_) => Local::Refuse,
+        }
+    }
+
+    async fn delegate(&self) -> Result<Fulfilment<Self::Payload>, ForwardError> {
+        let forwarded = self.forward.retrieve(self.address, self.overlay).await?;
+        if *forwarded.chunk.address() != self.address {
+            // Wrong address means a relay bug, not the requester's fault;
+            // release the credit without a trace and reset.
+            drop(forwarded.provide);
+            return Err(ForwardError::UnverifiedRelay);
+        }
+        // Only content chunks are cached (immutable, address-keyed); a
+        // retrieved SOC has no version signal so it is relayed but never
+        // stored.
+        if forwarded.chunk.is_content() {
+            let _ = self.store.put(CachedChunk::new(
+                forwarded.chunk.clone(),
+                forwarded.stamp.clone(),
+            ));
+        }
+        Ok(Fulfilment {
+            payload: (forwarded.chunk, forwarded.stamp),
+            provide: forwarded.provide,
+        })
+    }
+
+    async fn respond(
+        responder: RetrievalResponder,
+        (chunk, stamp): Self::Payload,
+    ) -> Result<(), RetrievalError> {
+        responder.send_chunk(chunk, stamp).await
+    }
+
+    fn refuse(responder: RetrievalResponder) {
+        responder.send_error();
+    }
+
+    fn peer(&self) -> OverlayAddress {
+        self.overlay
+    }
+
+    fn address(&self) -> ChunkAddress {
+        self.address
+    }
+
+    fn fulfilled(&self) -> InboundOutcome {
+        InboundOutcome::Served {
+            overlay: self.overlay,
+        }
+    }
+
+    fn delegated(&self) -> InboundOutcome {
+        InboundOutcome::Forwarded {
+            overlay: self.overlay,
+        }
+    }
+
+    fn failed(&self) -> InboundOutcome {
+        InboundOutcome::Missed {
+            overlay: self.overlay,
+            address: self.address,
+        }
+    }
+}
+
+/// Inbound pushsync: take custody when responsible (store, sign, acknowledge),
+/// else forward to a closer peer and relay the storer's receipt verbatim.
+pub(crate) struct PushServe {
+    pub storer: Option<StorerCapability>,
+    pub forward: Arc<dyn Forwarder>,
+    pub overlay: OverlayAddress,
+    pub chunk: StampedChunk,
+}
+
+impl ServeOp for PushServe {
+    type Payload = WireReceipt;
+    type Responder = PushsyncResponder;
+    type SendError = PushsyncError;
+
+    async fn local(&self) -> Local<WireReceipt> {
+        let address = *self.chunk.address();
+        // Storer ingest: only when responsible for the chunk. Absent on a
+        // client.
+        let Some(storer) = self
+            .storer
+            .as_ref()
+            .filter(|storer| storer.reserve.is_responsible_for(&address))
+        else {
+            return Local::Delegate;
+        };
+
+        // Custody is billed like any serve: reserve the upstream credit
+        // before the storage work; a gate refusal refuses custody.
+        let provide = match self.forward.prepare_serve(self.overlay, &address) {
+            Ok(provide) => provide,
+            Err(_) => return Local::Refuse,
+        };
+
+        // Persist before acknowledging: a receipt must never claim custody of
+        // a chunk that is not durably in the reserve. Both failure arms below
+        // drop `provide`, releasing without a trace: they are our failures,
+        // not the pusher's.
+        if let Err(e) = storer.reserve.put(CachedChunk::from(self.chunk.clone())) {
+            debug!(peer = %self.overlay, %address, error = %e, "Reserve put failed; not acknowledging");
+            return Local::Refuse;
+        }
+
+        // Sign our own custody receipt over the address, declaring our
+        // current storage radius; an upstream forwarder recovers our overlay
+        // from the signature.
+        let storage_radius = storer.reserve.storage_radius();
+        match Receipt::sign(&storer.signer, address, storage_radius) {
+            Ok(receipt) => Local::Fulfilled(Fulfilment {
+                payload: receipt.to_wire(),
+                provide,
+            }),
+            Err(e) => {
+                // Stored, but cannot prove custody. Reset rather than send an
+                // unsigned ack; the pusher retries (the reserve put is
+                // content-addressed, so a re-delivery is a no-op).
+                debug!(peer = %self.overlay, %address, error = %e, "Receipt sign failed; not acknowledging");
+                Local::Refuse
+            }
+        }
+    }
+
+    async fn delegate(&self) -> Result<Fulfilment<WireReceipt>, ForwardError> {
+        let forwarded = self.forward.push(self.chunk.clone(), self.overlay).await?;
+        // Relay the storer's receipt verbatim: we never sign. The signer was
+        // verified at decode, so the wire bytes reproduce the storer's
+        // signature, nonce, and radius unchanged.
+        Ok(Fulfilment {
+            payload: forwarded.receipt.to_wire(),
+            provide: forwarded.provide,
+        })
+    }
+
+    async fn respond(
+        responder: PushsyncResponder,
+        receipt: WireReceipt,
+    ) -> Result<(), PushsyncError> {
+        responder.send_receipt(receipt).await
+    }
+
+    fn refuse(responder: PushsyncResponder) {
+        responder.send_error();
+    }
+
+    fn peer(&self) -> OverlayAddress {
+        self.overlay
+    }
+
+    fn address(&self) -> ChunkAddress {
+        *self.chunk.address()
+    }
+
+    fn fulfilled(&self) -> InboundOutcome {
+        InboundOutcome::Stored {
+            overlay: self.overlay,
+        }
+    }
+
+    fn delegated(&self) -> InboundOutcome {
+        InboundOutcome::Relayed {
+            overlay: self.overlay,
+        }
+    }
+
+    fn failed(&self) -> InboundOutcome {
+        InboundOutcome::PushFailed {
+            overlay: self.overlay,
+            address: *self.chunk.address(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    /// Records whether the provide was committed or forfeited.
+    #[derive(Default)]
+    struct RecordingCommit {
+        applied: Arc<AtomicBool>,
+        forfeited: Arc<AtomicBool>,
+    }
+
+    impl CommitOnWrite for RecordingCommit {
+        fn apply_boxed(self: Box<Self>) {
+            self.applied.store(true, Ordering::SeqCst);
+        }
+
+        fn forfeit_boxed(self: Box<Self>) {
+            self.forfeited.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// Records refusal and scripts the send result; the payload write lands in
+    /// `sent`.
+    #[derive(Default)]
+    struct TestResponder {
+        refused: Arc<AtomicBool>,
+        send_ok: bool,
+        sent: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl TestResponder {
+        fn sending(send_ok: bool) -> Self {
+            Self {
+                send_ok,
+                ..Self::default()
+            }
+        }
+    }
+
+    /// A scriptable op: local verdict and delegation result.
+    struct TestOp {
+        local: Mutex<Option<Local<&'static str>>>,
+        delegate: Mutex<Option<Result<Fulfilment<&'static str>, ForwardError>>>,
+    }
+
+    impl TestOp {
+        fn new(
+            local: Local<&'static str>,
+            delegate: Result<Fulfilment<&'static str>, ForwardError>,
+        ) -> Self {
+            Self {
+                local: Mutex::new(Some(local)),
+                delegate: Mutex::new(Some(delegate)),
+            }
+        }
+    }
+
+    impl ServeOp for TestOp {
+        type Payload = &'static str;
+        type Responder = TestResponder;
+        type SendError = &'static str;
+
+        async fn local(&self) -> Local<&'static str> {
+            self.local
+                .lock()
+                .unwrap()
+                .take()
+                .expect("local called once")
+        }
+
+        async fn delegate(&self) -> Result<Fulfilment<&'static str>, ForwardError> {
+            self.delegate
+                .lock()
+                .unwrap()
+                .take()
+                .expect("delegate called once")
+        }
+
+        async fn respond(
+            responder: TestResponder,
+            payload: &'static str,
+        ) -> Result<(), &'static str> {
+            if responder.send_ok {
+                responder.sent.lock().unwrap().push(payload);
+                Ok(())
+            } else {
+                Err("peer reset the substream")
+            }
+        }
+
+        fn refuse(responder: TestResponder) {
+            responder.refused.store(true, Ordering::SeqCst);
+        }
+
+        fn peer(&self) -> OverlayAddress {
+            OverlayAddress::from([0xaa; 32])
+        }
+
+        fn address(&self) -> ChunkAddress {
+            ChunkAddress::from([0xbb; 32])
+        }
+
+        fn fulfilled(&self) -> InboundOutcome {
+            InboundOutcome::Served {
+                overlay: self.peer(),
+            }
+        }
+
+        fn delegated(&self) -> InboundOutcome {
+            InboundOutcome::Forwarded {
+                overlay: self.peer(),
+            }
+        }
+
+        fn failed(&self) -> InboundOutcome {
+            InboundOutcome::Missed {
+                overlay: self.peer(),
+                address: self.address(),
+            }
+        }
+    }
+
+    fn fulfilment(
+        payload: &'static str,
+    ) -> (Fulfilment<&'static str>, Arc<AtomicBool>, Arc<AtomicBool>) {
+        let commit = RecordingCommit::default();
+        let applied = Arc::clone(&commit.applied);
+        let forfeited = Arc::clone(&commit.forfeited);
+        (
+            Fulfilment {
+                payload,
+                provide: Box::new(commit),
+            },
+            applied,
+            forfeited,
+        )
+    }
+
+    #[tokio::test]
+    async fn local_fulfilment_commits_on_a_landed_write() {
+        let (fulfilment, applied, forfeited) = fulfilment("cached");
+        let op = TestOp::new(
+            Local::Fulfilled(fulfilment),
+            Err(ForwardError::NoCloserPeer),
+        );
+        let responder = TestResponder::sending(true);
+        let sent = Arc::clone(&responder.sent);
+
+        let outcome = drive(op, responder).await;
+
+        assert!(matches!(outcome, InboundOutcome::Served { .. }));
+        assert_eq!(*sent.lock().unwrap(), vec!["cached"]);
+        assert!(applied.load(Ordering::SeqCst));
+        assert!(!forfeited.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn refused_delivery_forfeits_the_provide() {
+        let (fulfilment, applied, forfeited) = fulfilment("cached");
+        let op = TestOp::new(
+            Local::Fulfilled(fulfilment),
+            Err(ForwardError::NoCloserPeer),
+        );
+
+        let outcome = drive(op, TestResponder::sending(false)).await;
+
+        assert!(matches!(outcome, InboundOutcome::Missed { .. }));
+        assert!(!applied.load(Ordering::SeqCst));
+        assert!(forfeited.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn local_refusal_resets_without_delegating() {
+        let op = TestOp::new(Local::Refuse, Err(ForwardError::NoCloserPeer));
+        let responder = TestResponder::sending(true);
+        let refused = Arc::clone(&responder.refused);
+
+        let outcome = drive(op, responder).await;
+
+        assert!(matches!(outcome, InboundOutcome::Missed { .. }));
+        assert!(refused.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn delegation_commits_on_a_landed_write() {
+        let (fulfilment, applied, _) = fulfilment("relayed");
+        let op = TestOp::new(Local::Delegate, Ok(fulfilment));
+        let responder = TestResponder::sending(true);
+        let sent = Arc::clone(&responder.sent);
+
+        let outcome = drive(op, responder).await;
+
+        assert!(matches!(outcome, InboundOutcome::Forwarded { .. }));
+        assert_eq!(*sent.lock().unwrap(), vec!["relayed"]);
+        assert!(applied.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn failed_delegation_resets() {
+        let op = TestOp::new(Local::Delegate, Err(ForwardError::AllPeersFailed));
+        let responder = TestResponder::sending(true);
+        let refused = Arc::clone(&responder.refused);
+
+        let outcome = drive(op, responder).await;
+
+        assert!(matches!(outcome, InboundOutcome::Missed { .. }));
+        assert!(refused.load(Ordering::SeqCst));
+    }
+}


### PR DESCRIPTION
## What

Unifies the handler's two inbound serve futures over one serve-or-delegate driver. The new `serve` module carries a `ServeOp` trait (operation-specific local fulfilment, delegation, wire write and outcome vocabulary) and one `drive` function owning the shared shape: fulfil locally else delegate to the forwarder, then the single respond-and-commit tail (commit the provide on a landed write, forfeit it on a refused delivery, reset on a gate refusal or failed delegation). `RetrieveServe` (cache hit else forward) and `PushServe` (custody store-and-sign else relay verbatim) are the two ops; `on_retrieval_request` and `on_pushsync_delivery` shrink to op construction, and `store_and_sign` folds into `PushServe::local`.

Behaviour preserved: the `InboundOutcome` variants and scoring/metric mapping, every billing point, the forfeit-versus-drop split (a relay-bug wrong address and custody put/sign failures still release without a ghost trace), the cache-only-content rule, and the `MAX_INBOUND_SERVING` back-pressure are all unchanged. The driver is monomorphized (no `dyn` op); the handler still boxes one future per inbound request exactly as before. Two minor non-wire deltas: the delivery-refused debug logs collapse to one message with peer/address/error fields, and pushsync's responsibility check now runs inside the spawned future instead of before the spawn.

## Why

Closes #641 (part of #639). The respond-then-commit tail and the outcome mapping were duplicated across the two futures, so every fix to the commit-on-write discipline had to land twice (as the #645/#646 red-team fixes just demonstrated, touching four arms instead of one). The driver is also the seam the relay fold (#609) changes behind: delegation internals move onto the engine without the handler noticing.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-client-behaviour -p vertex-swarm-node --all-targets --all-features -- -D warnings`; `cargo nextest run` for both crates with `--all-features` (176/176, including five new driver tests covering commit-on-landed-write, forfeit-on-refused-delivery, reset-without-delegating, delegation commit and failed delegation); `cargo build --target wasm32-unknown-unknown` for both crates.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the implementation and this PR body.
