### PR TITLE
docs: point the README and package metadata at vtx.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 rust-version = "1.92"
 authors = ["Nexum Contributors"]
 license = "AGPL-3.0-or-later"
-homepage = "https://nxm-rs.github.io/vertex"
+homepage = "https://vtx.rs"
 repository = "https://github.com/nxm-rs/vertex"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
   <img src=".github/banner.svg" alt="Nexum · vertex — Ethereum Swarm node in Rust" width="100%" />
 </p>
 
-A new **Ethereum Swarm** node implementation in Rust — modular, high-performance, Bee-compatible. Vertex aims to be the fastest Swarm client while being easy to run on consumer hardware, and to contribute meaningful client diversity to the network.
+A new **Ethereum Swarm** node implementation in Rust - modular, high-performance, wire-compatible with the live network. Vertex aims to be the fastest Swarm client while being easy to run on consumer hardware, and to contribute meaningful client diversity to the network.
 
 Nexum builds on Swarm for content-addressed storage of firewall rulesets, snapshots, and shared state. Vertex is how we run our own node infrastructure for that.
 
 > **Pre-release** and under active development. Testnets and lab environments only.
+
+**Website: [vtx.rs](https://vtx.rs)** - the [devlog](https://vtx.rs/devlog/) tracks what actually shipped, and the [milestones](https://github.com/nxm-rs/vertex/milestones) are the roadmap's source of truth. Pre-release means stars steer: if Vertex should exist, say so with a star.
 
 Looking for the org overview? See **[github.com/nxm-rs](https://github.com/nxm-rs)**.
 


### PR DESCRIPTION
## What

Links the newly live project site from the README intro: vtx.rs, the devlog, and the GitHub milestones as the roadmap's source of truth, with a star nudge in the site's voice. Sets the workspace `homepage` in Cargo.toml to https://vtx.rs (it pointed at an unused GitHub Pages URL). The touched intro line also drops an em-dash and names wire compatibility per house style.

## Why

Closes #652.

## Testing

Docs and metadata only; no code paths touched. Links verified live (vtx.rs, vtx.rs/devlog/, the milestones page).

AI Assistance: Claude Code used for the README and metadata edits.