### PR TITLE
refactor(swarm-api,swarm-node): merge the origin gate onto one accounting facade and state the commit-point rule

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -399,7 +399,7 @@ mod tests {
     fn test_refund_received_credits_back_a_committed_receive() {
         // The inverse of the dispatch commit: commit a receive debit, then refund
         // it and watch the balance return to zero. Reserved stays cleared.
-        use vertex_swarm_api::BandwidthDebit;
+        use vertex_swarm_api::OriginAccounting;
 
         let accounting = test_accounting();
 

--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -16,6 +16,20 @@
 //! [`Accounting`] also implements the `Ledger` and `AdmissionControl` surfaces
 //! (from `vertex-swarm-api`), so peer selection and pacing can consume accounting
 //! state without depending on this crate's internals.
+//!
+//! # Commit points
+//!
+//! One [`Reservation`] contract, two commit points, coupled to the dispatch
+//! discipline. An origin leg books at dispatch (the `OriginAccounting` gate:
+//! reserve and apply in one step, refund only a confirmed no-charge) because
+//! origin dispatch may race and a losing raced leg is cancelled by drop: a
+//! dropped reservation releases, so a commit deferred to delivery could
+//! un-book debt for bytes the wire may still deliver. A relay leg defers its
+//! commit to the verified answer (reserve, apply on verify, release on drop),
+//! which is safe because relay walks are sequential and never cancel
+//! mid-flight, and strictly fairer to the peer. Never unify the two: the
+//! dropped-race-loser-keeps-commit guarantee is the reason the origin books
+//! at dispatch.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -15,7 +15,7 @@ use std::vec::Vec;
 use nectar_primitives::ChunkAddress;
 use vertex_swarm_primitives::OverlayAddress;
 
-use crate::{Au, SwarmIdentity, SwarmPricing, SwarmResult};
+use crate::{Admission, AdmissionControl, Au, SwarmIdentity, SwarmPricing, SwarmResult};
 
 /// Direction of data transfer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -184,14 +184,22 @@ pub trait SwarmBandwidthAccounting: Send + Sync {
     fn prepare_provide(&self, peer: OverlayAddress, price: Au) -> SwarmResult<Self::ProvideAction>;
 }
 
-/// Object-safe receive debit for callers that hold accounting behind a trait
-/// object (the client service, which cannot name the `ReceiveAction` type).
+/// The object-safe origin dispatch gate over one accounting instance: the
+/// admission band and the dispatch-committed debit read the same ledger
+/// through one handle (the client service cannot name the `ReceiveAction`
+/// type).
 ///
-/// Commits in one step: the chunk is in hand when an origin request completes,
-/// so there is nothing to hold and release. An `Err` carries the
-/// disconnect-threshold breach the accounting already reported through its peer
-/// reporter.
-pub trait BandwidthDebit: Send + Sync {
+/// The origin commit point is at dispatch: an origin leg may be raced, and a
+/// losing raced leg is cancelled by drop, so a commit deferred to delivery
+/// could un-book debt for bytes the wire may still deliver. `debit_received`
+/// therefore commits in one step and `refund_received` reverses it only when
+/// the request provably reached no charge. An `Err` carries the
+/// disconnect-threshold breach the accounting already reported through its
+/// peer reporter.
+pub trait OriginAccounting: Send + Sync {
+    /// Band `price` against the peer's projected debt.
+    fn admit(&self, peer: &OverlayAddress, price: Au) -> Admission;
+
     /// Debit `peer` by `price` for a received chunk, committing immediately.
     fn debit_received(&self, peer: OverlayAddress, price: Au, originated: bool) -> SwarmResult<()>;
 
@@ -201,7 +209,11 @@ pub trait BandwidthDebit: Send + Sync {
     fn refund_received(&self, peer: OverlayAddress, price: Au);
 }
 
-impl<B: SwarmBandwidthAccounting> BandwidthDebit for B {
+impl<B: SwarmBandwidthAccounting + AdmissionControl> OriginAccounting for B {
+    fn admit(&self, peer: &OverlayAddress, price: Au) -> Admission {
+        AdmissionControl::admit(self, peer, price)
+    }
+
     fn debit_received(&self, peer: OverlayAddress, price: Au, originated: bool) -> SwarmResult<()> {
         self.prepare_receive(peer, price, originated)
             .map(Commit::apply)

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -9,7 +9,7 @@ mod reserve;
 mod topology;
 
 pub use self::bandwidth::{
-    BandwidthDebit, Commit, CommitOnWrite, Direction, SwarmAccountingConfig,
+    Commit, CommitOnWrite, Direction, OriginAccounting, SwarmAccountingConfig,
     SwarmBandwidthAccounting, SwarmClientAccounting, SwarmPeerBandwidth, SwarmPeerState,
     SwarmSettlementProvider,
 };

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -38,12 +38,12 @@ mod types;
 
 pub use self::accounting::{Admission, Au, AuConversionError, Debt};
 pub use self::components::{
-    BandwidthDebit, BinCursorStore, BinScanItem, BootnodeComponents, ClientComponents, Commit,
-    CommitOnWrite, Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology,
-    IntervalStore, PullChunkVerifier, PullStorage, ReserveStore, SettableRadius, StorerComponents,
-    SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting, SwarmLocalStore,
-    SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState, SwarmPricing,
-    SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
+    BinCursorStore, BinScanItem, BootnodeComponents, ClientComponents, Commit, CommitOnWrite,
+    Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology, IntervalStore,
+    OriginAccounting, PullChunkVerifier, PullStorage, ReserveStore, SettableRadius,
+    StorerComponents, SwarmAccountingConfig, SwarmBandwidthAccounting, SwarmClientAccounting,
+    SwarmLocalStore, SwarmLocalStoreConfig, SwarmPeerBandwidth, SwarmPeerResolver, SwarmPeerState,
+    SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig, SwarmSettlementProvider, SwarmTopology,
     SwarmTopologyBins, SwarmTopologyCommands, SwarmTopologyPeers, SwarmTopologyReporting,
     SwarmTopologyRouting, SwarmTopologyState, SwarmTopologyStats, VerifyError, construct,
 };

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -735,8 +735,7 @@ mod tests {
         use nectar_primitives::{AnyChunk, ChunkAddress, ContentChunk};
         use tokio::sync::mpsc;
         use vertex_swarm_api::{
-            AdmissionControl, BandwidthDebit, SwarmBandwidthAccounting, SwarmPeerBandwidth,
-            SwarmPricing,
+            OriginAccounting, SwarmBandwidthAccounting, SwarmPeerBandwidth, SwarmPricing,
         };
         use vertex_swarm_node::{
             AccountingSettlement, ClientCommand, ClientHandle, RetrievalResult, SettlementTrigger,
@@ -764,8 +763,7 @@ mod tests {
             Arc::new(AccountingSettlement::new(accounting.bandwidth().clone()));
         let handle = ClientHandle::new(tx).with_origin_gate(
             Arc::new(accounting.pricing().clone()),
-            accounting.bandwidth().clone() as Arc<dyn BandwidthDebit>,
-            accounting.bandwidth().clone() as Arc<dyn AdmissionControl>,
+            accounting.bandwidth().clone() as Arc<dyn OriginAccounting>,
             settlement,
         );
 

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -8,8 +8,8 @@ use nectar_primitives::ChunkAddress;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use vertex_swarm_api::{
-    Admission, AdmissionControl, Au, BandwidthDebit, PeerReporter, ReportSource, SwarmLocalStore,
-    SwarmPricing, SwarmScoringEvent,
+    Admission, Au, OriginAccounting, PeerReporter, ReportSource, SwarmLocalStore, SwarmPricing,
+    SwarmScoringEvent,
 };
 use vertex_swarm_client_protocol::PseudosettleAck;
 pub use vertex_swarm_client_protocol::{ChunkTransferError, RetrievalResult};
@@ -46,7 +46,7 @@ pub struct ClientHandle {
 
 /// Book-at-send and the admission band for origin requests.
 ///
-/// All four read the one shared accounting the selector uses, so the dispatch
+/// All three read the one shared accounting the selector uses, so the dispatch
 /// gate, the candidate selector, and the committed debit agree on one ledger.
 /// The settlement trigger is the selector's, so settles dedup across both
 /// paths. The band is the synchronous pacing brake: an over-threshold projected
@@ -54,8 +54,9 @@ pub struct ClientHandle {
 #[derive(Clone)]
 struct OriginGate {
     pricing: Arc<dyn SwarmPricing>,
-    debit: Arc<dyn BandwidthDebit>,
-    admission: Arc<dyn AdmissionControl>,
+    /// The admission band and the dispatch-committed debit behind one handle,
+    /// so both read the same ledger by construction.
+    accounting: Arc<dyn OriginAccounting>,
     settlement: Arc<dyn SettlementTrigger>,
 }
 
@@ -71,22 +72,20 @@ impl ClientHandle {
     /// Attach the origin credit gate so an own-request dispatch bands the
     /// request and books its price at the moment it dispatches.
     ///
-    /// `pricing`, `debit`, and `admission` must read the one shared accounting
-    /// the selector uses, and `settlement` must be the selector's so the
-    /// in-flight settle dedup is shared. Relay legs (`originated == false`) are
+    /// `pricing` and `accounting` must read the one shared accounting the
+    /// selector uses, and `settlement` must be the selector's so the in-flight
+    /// settle dedup is shared. Relay legs (`originated == false`) are
     /// accounted by the forwarder and bypass this gate.
     #[must_use]
     pub fn with_origin_gate(
         mut self,
         pricing: Arc<dyn SwarmPricing>,
-        debit: Arc<dyn BandwidthDebit>,
-        admission: Arc<dyn AdmissionControl>,
+        accounting: Arc<dyn OriginAccounting>,
         settlement: Arc<dyn SettlementTrigger>,
     ) -> Self {
         self.origin = Some(OriginGate {
             pricing,
-            debit,
-            admission,
+            accounting,
             settlement,
         });
         self
@@ -122,7 +121,7 @@ impl ClientHandle {
         }
 
         let price = gate.pricing.peer_price(&peer, address);
-        match gate.admission.admit(&peer, price) {
+        match gate.accounting.admit(&peer, price) {
             Admission::Refuse => {
                 gate.settlement.trigger_settlement(peer);
                 return Err(ChunkTransferError::Refused);
@@ -138,7 +137,7 @@ impl ClientHandle {
         // line too; a concurrent burst that crossed it between the band check and
         // here surfaces as a refusal, handled identically. The commit lands
         // immediately at dispatch.
-        match gate.debit.debit_received(peer, price, true) {
+        match gate.accounting.debit_received(peer, price, true) {
             Ok(()) => Ok(Some(price)),
             Err(_) => {
                 gate.settlement.trigger_settlement(peer);
@@ -151,7 +150,7 @@ impl ClientHandle {
     /// no origin gate is attached. Pure ledger op, never peer scoring.
     fn refund_origin(&self, peer: OverlayAddress, committed: Option<Au>) {
         if let (Some(gate), Some(price)) = (&self.origin, committed) {
-            gate.debit.refund_received(peer, price);
+            gate.accounting.refund_received(peer, price);
         }
     }
 
@@ -886,8 +885,7 @@ mod tests {
         let (tx, rx) = mpsc::channel::<ClientCommand>(16);
         let handle = ClientHandle::new(tx).with_origin_gate(
             Arc::new(FixedPeerPricer(price)) as Arc<dyn SwarmPricing>,
-            accounting.clone() as Arc<dyn BandwidthDebit>,
-            accounting.clone() as Arc<dyn AdmissionControl>,
+            accounting.clone() as Arc<dyn OriginAccounting>,
             settlement.clone() as Arc<dyn SettlementTrigger>,
         );
         (handle, accounting, settlement, rx)

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -184,7 +184,6 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     let origin_handle = client_handle.clone().with_origin_gate(
         Arc::new(accounting.pricing().clone()),
         accounting.bandwidth().clone(),
-        admission.clone(),
         settlement_trigger.clone(),
     );
 


### PR DESCRIPTION
## What

Two residues from the epic's commit-point finding. First, `OriginGate` held two `dyn` handles into the same accounting instance (the admission band and the dispatch-committed debit), leaving the shared-ledger requirement to the wiring; `BandwidthDebit` is replaced by `OriginAccounting`, the object-safe origin dispatch gate carrying `admit`, `debit_received` and `refund_received` behind one handle, blanket-implemented for any `SwarmBandwidthAccounting` that is also an `AdmissionControl`, so the band check and the commit read the same ledger by construction (and the gate costs one pointer chase, not two). Second, the commit-point rule is now stated at the accounting core crate root: one reservation contract, two commit points coupled to the dispatch discipline; the origin books at dispatch because raced legs cancel by drop and a dropped reservation releases, relays defer to verify because sequential walks never cancel mid-flight; the two are never to be unified.

## Why

Closes #604 (part of #639). The survey behind the epic resolved the issue's original question (there are not two debit models, there is one reservation contract with two commit points) and left exactly this residue: document the rule where the reservations live, and delete the second laundering handle.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-api -p vertex-swarm-accounting -p vertex-swarm-node -p vertex-swarm-builder --all-targets --all-features -- -D warnings`; `cargo nextest run` for the same four crates with `--all-features` (230/230; the origin-gate reservation tests exercise the merged facade unchanged); `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the implementation and this PR body.
