### PR TITLE
perf(swarm-node): put the dispatch hot loop on an allocation diet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9262,6 +9262,7 @@ dependencies = [
  "auto_impl",
  "bytes",
  "clap 4.6.1",
+ "codspeed-criterion-compat",
  "eyre",
  "futures",
  "futures-bounded 0.2.4",

--- a/crates/swarm/client-behaviour/src/forward.rs
+++ b/crates/swarm/client-behaviour/src/forward.rs
@@ -246,17 +246,20 @@ pub fn closer_candidates<T: SwarmTopologyRouting + ?Sized>(
     requester: OverlayAddress,
     local: OverlayAddress,
 ) -> Vec<OverlayAddress> {
-    topology
-        .closest_to(target, MAX_FORWARD_CANDIDATES * 2)
-        .into_iter()
-        .filter(|peer| *peer != requester && *peer != local)
-        // `target.closer(peer, other)` is true iff `peer` is strictly closer to
-        // `target` than `other` by full XOR distance. The candidate must beat
-        // both the requester (loop prevention) and this node (the
-        // self-relative "closer than me" gate).
-        .filter(|peer| target.closer(peer, &requester) && target.closer(peer, &local))
-        .take(MAX_FORWARD_CANDIDATES)
-        .collect()
+    let mut candidates = topology.closest_to(target, MAX_FORWARD_CANDIDATES * 2);
+    // `target.closer(peer, other)` is true iff `peer` is strictly closer to
+    // `target` than `other` by full XOR distance. The candidate must beat
+    // both the requester (loop prevention) and this node (the
+    // self-relative "closer than me" gate). In place: the topology snapshot
+    // is the walk's only allocation.
+    candidates.retain(|peer| {
+        *peer != requester
+            && *peer != local
+            && target.closer(peer, &requester)
+            && target.closer(peer, &local)
+    });
+    candidates.truncate(MAX_FORWARD_CANDIDATES);
+    candidates
 }
 
 #[cfg(test)]

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -134,6 +134,7 @@ alloy-signer-local.workspace = true
 # native-only and would drag native-only transitive crates (mio, errno) into the
 # wasm test build, so they stay off wasm32.
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync", "test-util"] }
 vertex-swarm-test-utils = { workspace = true, features = ["cluster"] }
 vertex-swarm-topology.workspace = true
@@ -202,3 +203,7 @@ storer = [
 # any `SwarmLocalStore` through `with_store`, so the node crate needs no backend
 # code of its own.
 indexeddb = ["vertex-swarm-localstore/indexeddb"]
+
+[[bench]]
+name = "dispatch_hot_loop"
+harness = false

--- a/crates/swarm/node/benches/dispatch_hot_loop.rs
+++ b/crates/swarm/node/benches/dispatch_hot_loop.rs
@@ -1,0 +1,136 @@
+//! Allocation-diet benchmarks for the dispatch hot loop: candidate ordering
+//! and the in-flight availability partition, the per-chunk CPU work of a bulk
+//! download.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use nectar_primitives::ChunkAddress;
+use vertex_swarm_api::{Au, Ledger, SwarmPricing};
+use vertex_swarm_node::{InflightLimit, PeerInflightLimiter, PeerScores, PeerSelector};
+use vertex_swarm_primitives::OverlayAddress;
+
+fn peer(n: usize) -> OverlayAddress {
+    let mut bytes = [0u8; 32];
+    bytes[0] = (n >> 8) as u8;
+    bytes[1] = n as u8;
+    bytes[2] = 0xa5;
+    OverlayAddress::from(bytes)
+}
+
+/// True for every `nth` peer of the deterministic candidate mix.
+fn mix(overlay: &OverlayAddress, nth: u8) -> bool {
+    overlay
+        .as_bytes()
+        .get(1)
+        .is_some_and(|b| b.is_multiple_of(nth))
+}
+
+/// Every 7th peer is warned; everyone else carries a healthy score.
+struct MixScores;
+
+impl PeerScores for MixScores {
+    fn peer_score(&self, overlay: &OverlayAddress) -> Option<f64> {
+        if mix(overlay, 7) {
+            Some(-10.0)
+        } else {
+            Some(0.0)
+        }
+    }
+}
+
+/// At the unit price: every 8th peer refuses, every 5th settles-and-admits,
+/// the rest admit with headroom.
+struct MixLedger;
+
+impl Ledger for MixLedger {
+    fn balance(&self, _overlay: &OverlayAddress) -> Au {
+        Au::ZERO
+    }
+
+    fn reserved(&self, _overlay: &OverlayAddress) -> Au {
+        Au::ZERO
+    }
+
+    fn disconnect_line(&self, overlay: &OverlayAddress) -> Au {
+        if mix(overlay, 8) {
+            Au::ZERO
+        } else {
+            Au::from_amount(1000)
+        }
+    }
+
+    fn settle_trigger(&self, overlay: &OverlayAddress) -> Au {
+        if mix(overlay, 5) {
+            Au::ZERO
+        } else {
+            Au::from_amount(1000)
+        }
+    }
+}
+
+struct UnitPricer;
+
+impl SwarmPricing for UnitPricer {
+    fn price(&self, _chunk: &ChunkAddress) -> Au {
+        Au::from_amount(1)
+    }
+
+    fn peer_price(&self, _peer: &OverlayAddress, _chunk: &ChunkAddress) -> Au {
+        Au::from_amount(1)
+    }
+}
+
+fn candidates(n: usize) -> Vec<OverlayAddress> {
+    (0..n).map(peer).collect()
+}
+
+fn bench_order(c: &mut Criterion) {
+    let selector = PeerSelector::new(
+        Arc::new(MixScores),
+        Arc::new(MixLedger),
+        Arc::new(UnitPricer),
+    );
+    let chunk = ChunkAddress::new([0xcc; 32]);
+
+    for n in [32usize, 128] {
+        let input = candidates(n);
+        c.bench_function(&format!("selector_order_{n}"), |b| {
+            b.iter_batched(
+                || input.clone(),
+                |cands| selector.order(cands, &chunk),
+                BatchSize::SmallInput,
+            )
+        });
+        c.bench_function(&format!("selector_order_closest_admissible_{n}"), |b| {
+            b.iter_batched(
+                || input.clone(),
+                |cands| selector.order_closest_admissible(cands, &chunk),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+fn bench_available(c: &mut Criterion) {
+    let limiter = PeerInflightLimiter::new(NonZeroUsize::MIN);
+    let input = candidates(128);
+    // Every 4th peer is at its cap, so the partition genuinely reorders.
+    let _permits: Vec<_> = input
+        .iter()
+        .filter(|p| mix(p, 4))
+        .filter_map(|p| limiter.try_acquire(p))
+        .collect();
+
+    c.bench_function("inflight_available_128", |b| {
+        b.iter_batched(
+            || input.clone(),
+            |cands| InflightLimit::available(&limiter, cands),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, bench_order, bench_available);
+criterion_main!(benches);

--- a/crates/swarm/node/src/dispatch.rs
+++ b/crates/swarm/node/src/dispatch.rs
@@ -15,7 +15,6 @@
 //! commit-at-dispatch, only sequential dispatch may pair with an on-verify
 //! commit.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -231,10 +230,21 @@ impl InflightLimit for PeerInflightLimiter {
         // dispatching over their cap as the bounded last resort that actually
         // reaches the holder. Free-first ordering is what keeps the tail a last
         // resort, so the cap is never enforced.
-        let (free, busy): (Vec<OverlayAddress>, Vec<OverlayAddress>) = candidates
-            .into_iter()
-            .partition(|peer| self.has_free_slot(peer));
-        (free.into_iter().chain(busy).collect(), false)
+        let mut candidates = candidates;
+        // One linear pass: free peers compact in place through `retain`
+        // (keeping their relative order), the busy tail spills to a scratch
+        // that stays unallocated when nothing is busy.
+        let mut busy: Vec<OverlayAddress> = Vec::new();
+        candidates.retain(|peer| {
+            if self.has_free_slot(peer) {
+                true
+            } else {
+                busy.push(*peer);
+                false
+            }
+        });
+        candidates.append(&mut busy);
+        (candidates, false)
     }
 
     fn try_acquire(&self, peer: &OverlayAddress) -> Option<Self::Permit> {
@@ -777,15 +787,14 @@ where
             // beyond the close set rather than re-racing the same failing peers. A
             // gated close set already spilled to this slice above, so its
             // already-raced set covers the slice and the difference is empty.
-            let raced: HashSet<OverlayAddress> = close_candidates.iter().copied().collect();
             let wide = self
                 .topology
                 .closest_to(&chunk_address, RETRIEVE_SPILL_WIDTH);
-            let wide = self.ordering.order_closest_admissible(wide, address);
-            let spill_ring: Vec<OverlayAddress> = wide
-                .into_iter()
-                .filter(|peer| !raced.contains(peer))
-                .collect();
+            let mut spill_ring = self.ordering.order_closest_admissible(wide, address);
+            // A linear scan over the close set (at most RETRIEVE_WIDTH entries,
+            // contiguous) beats building a hash set for one pass, and dedups in
+            // place.
+            spill_ring.retain(|peer| !close_candidates.contains(peer));
             let (spill_candidates, _spill_enforce_cap) = self.inflight.available(spill_ring);
 
             if close_candidates.is_empty() && spill_candidates.is_empty() {

--- a/crates/swarm/node/src/retrieval_latency.rs
+++ b/crates/swarm/node/src/retrieval_latency.rs
@@ -98,13 +98,12 @@ pub(crate) fn adaptive_stagger(estimates: impl Iterator<Item = Option<Duration>>
     if known.is_empty() {
         return RETRIEVAL_STAGGER;
     }
-    known.sort_unstable();
-    match known.get(known.len() / 2) {
-        Some(median) => median
-            .saturating_mul(HEDGE_RTT_MULTIPLIER)
-            .clamp(HEDGE_STAGGER_FLOOR, RETRIEVAL_STAGGER),
-        None => RETRIEVAL_STAGGER,
-    }
+    // Selection, not a full sort: only the median needs its place.
+    let mid = known.len() / 2;
+    let (_, median, _) = known.select_nth_unstable(mid);
+    median
+        .saturating_mul(HEDGE_RTT_MULTIPLIER)
+        .clamp(HEDGE_STAGGER_FLOOR, RETRIEVAL_STAGGER)
 }
 
 #[cfg(test)]

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -226,15 +226,17 @@ impl PeerSelector {
         // nothing is settled here. A request settles only the peer it actually
         // dispatches to, at the origin credit gate, so the settle fan-out is the
         // legs contacted rather than the whole candidate window.
+        let mut candidates = candidates;
         rank_candidates(
-            &candidates,
+            &mut candidates,
             |peer| self.scores.peer_score(peer),
             |peer| {
                 self.admission
                     .admit(peer, self.pricing.peer_price(peer, chunk))
             },
             tiering,
-        )
+        );
+        candidates
     }
 }
 
@@ -265,46 +267,44 @@ enum Tiering {
 /// proximity order so a degraded request can still go out; a refused peer is
 /// never resurrected this way. `admit` is invoked exactly once per candidate.
 fn rank_candidates(
-    candidates: &[OverlayAddress],
+    candidates: &mut Vec<OverlayAddress>,
     score: impl Fn(&OverlayAddress) -> Option<f64>,
     admit: impl Fn(&OverlayAddress) -> Admission,
     tiering: Tiering,
-) -> Vec<OverlayAddress> {
-    let mut headroom = Vec::with_capacity(candidates.len());
-    let mut near_threshold = Vec::new();
-    let mut warned = Vec::new();
-
-    for peer in candidates {
+) {
+    // One linear pass: the leading tier compacts in place through `retain`
+    // (which keeps proximity order), the two rarer tiers spill to scratches
+    // that stay unallocated on the common all-headroom call.
+    let mut near_threshold: Vec<OverlayAddress> = Vec::new();
+    let mut warned: Vec<OverlayAddress> = Vec::new();
+    candidates.retain(|peer| {
         let band = admit(peer);
         if matches!(band, Admission::Refuse) {
-            continue;
+            return false;
         }
         if score(peer).is_some_and(|s| s <= DEFAULT_PEER_WARN_THRESHOLD) {
             warned.push(*peer);
-        } else if matches!(tiering, Tiering::SpreadDebt)
-            && matches!(band, Admission::SettleAndAdmit)
-        {
-            near_threshold.push(*peer);
-        } else {
-            // Under `Proximity` both admissible bands land here, preserving the
-            // input proximity order; under `SpreadDebt` only headroom peers do.
-            headroom.push(*peer);
+            return false;
         }
-    }
+        if matches!(tiering, Tiering::SpreadDebt) && matches!(band, Admission::SettleAndAdmit) {
+            near_threshold.push(*peer);
+            return false;
+        }
+        // Under `Proximity` both admissible bands land here, preserving the
+        // input proximity order; under `SpreadDebt` only headroom peers do.
+        true
+    });
 
     // Headroom (or, under `Proximity`, all admissible) first, near-threshold
     // after, each in proximity order.
-    let mut ordered = headroom;
-    ordered.append(&mut near_threshold);
+    candidates.append(&mut near_threshold);
 
-    if ordered.is_empty() {
+    if candidates.is_empty() {
         // Every admissible candidate is warned (or there are none). Fall back to
         // the warned admissible peers so a degraded request can still be
         // attempted; refused peers stay excluded.
-        ordered = warned;
+        candidates.append(&mut warned);
     }
-
-    ordered
 }
 
 #[cfg(test)]
@@ -422,8 +422,9 @@ mod tests {
         // peer(1) and peer(3) are past the settle trigger; under SpreadDebt the
         // headroom peers lead, proximity within each tier.
         let candidates = vec![peer(1), peer(2), peer(3), peer(4)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[]),
             settle_due(&[peer(1), peer(3)]),
             Tiering::SpreadDebt,
@@ -438,8 +439,9 @@ mod tests {
         // spill travels the minimum distance rather than skipping a near in-band
         // peer for a far headroom one.
         let candidates = vec![peer(1), peer(2), peer(3), peer(4)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[]),
             settle_due(&[peer(1), peer(3)]),
             Tiering::Proximity,
@@ -452,8 +454,9 @@ mod tests {
         // Proximity changes only the admissible ordering: a refused peer is still
         // hard-skipped and a warned peer still excluded.
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[peer(3)]),
             refusing(&[peer(1)]),
             Tiering::Proximity,
@@ -464,15 +467,17 @@ mod tests {
     #[test]
     fn healthy_admitted_candidates_keep_proximity_order() {
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(&candidates, warned(&[]), refusing(&[]), Tiering::SpreadDebt);
+        let mut ranked = candidates.clone();
+        rank_candidates(&mut ranked, warned(&[]), refusing(&[]), Tiering::SpreadDebt);
         assert_eq!(ranked, candidates);
     }
 
     #[test]
     fn warned_peer_is_excluded() {
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[peer(2)]),
             refusing(&[]),
             Tiering::SpreadDebt,
@@ -483,7 +488,8 @@ mod tests {
     #[test]
     fn unknown_peer_is_not_treated_as_warned() {
         let candidates = vec![peer(1), peer(2)];
-        let ranked = rank_candidates(&candidates, |_| None, refusing(&[]), Tiering::SpreadDebt);
+        let mut ranked = candidates.clone();
+        rank_candidates(&mut ranked, |_| None, refusing(&[]), Tiering::SpreadDebt);
         assert_eq!(ranked, candidates);
     }
 
@@ -492,8 +498,9 @@ mod tests {
         // A refused peer is excluded entirely, not deprioritized: sending would
         // cross its disconnect line.
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[]),
             refusing(&[peer(1)]),
             Tiering::SpreadDebt,
@@ -505,8 +512,9 @@ mod tests {
     fn all_refused_yields_no_candidates() {
         // Every candidate would cross its disconnect line, so none is sendable.
         let candidates = vec![peer(1), peer(2), peer(3)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[]),
             refusing(&[peer(1), peer(2), peer(3)]),
             Tiering::SpreadDebt,
@@ -517,8 +525,9 @@ mod tests {
     #[test]
     fn all_warned_falls_back_to_proximity_order() {
         let candidates = vec![peer(1), peer(2)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[peer(1), peer(2)]),
             refusing(&[]),
             Tiering::SpreadDebt,
@@ -531,8 +540,9 @@ mod tests {
         // peer(1) is refused and peer(2) is warned: the fallback returns the
         // warned admissible peer, never the refused one.
         let candidates = vec![peer(1), peer(2)];
-        let ranked = rank_candidates(
-            &candidates,
+        let mut ranked = candidates.clone();
+        rank_candidates(
+            &mut ranked,
             warned(&[peer(2)]),
             refusing(&[peer(1)]),
             Tiering::SpreadDebt,
@@ -542,7 +552,8 @@ mod tests {
 
     #[test]
     fn empty_candidates_stay_empty() {
-        let ranked = rank_candidates(&[], warned(&[]), refusing(&[]), Tiering::SpreadDebt);
+        let mut ranked: Vec<OverlayAddress> = Vec::new();
+        rank_candidates(&mut ranked, warned(&[]), refusing(&[]), Tiering::SpreadDebt);
         assert!(ranked.is_empty());
     }
 


### PR DESCRIPTION
## What

Puts the dispatch hot loop on an allocation diet. Each step of the per-chunk candidate pipeline becomes one linear in-place pass, so the common case allocates nothing beyond the topology snapshot: `rank_candidates` compacts the leading tier in place through `retain` with the two rarer tiers spilling to scratches that stay unallocated on the all-headroom call (previously up to three vecs per call); `PeerInflightLimiter::available` compacts free peers in place with the busy tail in one scratch (previously partition plus chain-collect, three vecs); the farther-ring spill dedups against the close set with a linear scan and in-place `retain` (previously a std-hasher `HashSet` plus a filter-collect per fallback pass); `adaptive_stagger` selects its median with `select_nth_unstable` instead of a full sort; and `closer_candidates` filters the topology snapshot in place (previously a second collect). Behaviour is unchanged throughout: same orderings (stable within tiers), same warned-fallback and refuse semantics, `admit` still invoked exactly once per candidate, same busy-tail policy.

Adds the `dispatch_hot_loop` criterion bench (candidate ordering at 32/128 over a mixed refuse/settle/warned population, and the availability partition) as the measurement harness, native-only so the wasm dev-dep cone stays clean.

## Why

Closes #643, the final phase of #639, landing last by design so the measurements cover the unified engine. At bulk-download rates the pipeline's per-chunk allocations contend on the allocator across concurrent retrievals; the #605 over-fetch metric and the existing dispatch tests are the behavioural regression guards.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-node -p vertex-swarm-client-behaviour --all-targets --all-features -- -D warnings` (the bench is linted too); `cargo nextest run` for both crates with `--all-features` (176/176, including the tier, warned-fallback, refuse, and availability semantics tests, unchanged); `cargo build --target wasm32-unknown-unknown` for both crates. Benches (single-threaded, noisy box, ±20% run-to-run): the retain shape measures at parity or better against the pre-change baseline (`selector_order_128` ~1.11µs -> ~0.84µs in the cleanest pair of runs), while a tier-key sort variant tried first benched 25-70% SLOWER than the original and was discarded; the durable claim is the structural one (zero steady-state allocations on the common path), which the single-threaded bench understates because allocator contention only appears under concurrent load.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the design, implementation, benchmarking and this PR body.
