### PR TITLE
chore(audit): ignore the quick-xml advisories unreachable via inferno

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -36,4 +36,13 @@ ignore = [
     # resolution (single-name A/AAAA queries). An attacker would need to control the
     # query content to force the O(n^2) path, which is not exposed to peers.
     "RUSTSEC-2026-0119",
+
+    # quick-xml 0.26 DoS advisories (quadratic duplicate-attribute check and
+    # unbounded namespace-declaration allocation), both requiring the parser to
+    # be fed untrusted XML. Pinned via pprof 0.15 -> inferno 0.11, the flamegraph
+    # renderer behind the profiling feature: inferno parses only locally produced
+    # profiling artefacts, never network input, so neither path is reachable.
+    # Drop these once pprof/inferno release on quick-xml >= 0.41.
+    "RUSTSEC-2026-0194", # quick-xml quadratic attribute check - via pprof -> inferno
+    "RUSTSEC-2026-0195", # quick-xml unbounded namespace allocation - via pprof -> inferno
 ]


### PR DESCRIPTION
## What

Adds justified ignores for RUSTSEC-2026-0194 and RUSTSEC-2026-0195 to `.cargo/audit.toml`, following the file's existing reachability-argument pattern, with a note to drop them once pprof or inferno release on `quick-xml >= 0.41`.

## Why

The audit CI job fails repo-wide since these advisories were published on 2026-06-29 (first surfaced on #659, but any branch fails today). Both flag denial-of-service paths in `quick-xml 0.26` that require the parser to be fed untrusted XML. The pin comes via `pprof -> inferno`, the flamegraph renderer behind the profiling feature, which parses only locally produced profiling artefacts; neither path is reachable from network input. No newer pprof/inferno release moves off quick-xml 0.26 yet.

## Testing

`cargo audit` locally is not part of the standard gate; the CI audit job on this PR is the verification.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the reachability analysis and this PR.
