### PR TITLE
fix(swarm-client-behaviour,swarm-client-protocol): refuse accounting-bearing commands at queue capacity

### DIFF
--- a/crates/swarm/client-behaviour/src/behaviour.rs
+++ b/crates/swarm/client-behaviour/src/behaviour.rs
@@ -154,13 +154,38 @@ impl ClientBehaviour {
         self.swap_event_tx = Some(tx);
     }
 
+    /// Queue policy split: consumer events may drop at the cap (the swarm
+    /// re-polls and their state is re-derivable), but handler commands never
+    /// drop silently, because a dropped command strands state upstream: a lost
+    /// retrieve or push cancels its responder while the dispatch-booked debit
+    /// stands, a lost pseudosettle ack pins the handler's responder until the
+    /// stale sweep, a lost activation leaves the handler dormant forever, and a
+    /// lost settle or cheque strands the settlement service's pending entry.
+    /// So the request commands (retrieve, push) refuse back to their caller at
+    /// the cap, and every other command rides past it; each of those is
+    /// connection- or trigger-rate bounded upstream, so the overrun is bounded.
     fn push_event(&mut self, event: ToSwarm<ClientEvent, HandlerCommand>) {
-        if self.pending_events.len() >= self.config.max_pending_events {
+        if self.at_capacity() {
             warn!("Behaviour event queue full, dropping event");
             metrics::counter!("swarm.client.behaviour.events_dropped").increment(1);
             return;
         }
         self.pending_events.push_back(event);
+    }
+
+    /// True once the soft cap is reached; events drop and request commands
+    /// refuse, per the policy on [`Self::push_event`].
+    fn at_capacity(&self) -> bool {
+        self.pending_events.len() >= self.config.max_pending_events
+    }
+
+    /// Enqueue a handler command regardless of the soft cap.
+    fn push_command(&mut self, peer_id: PeerId, command: HandlerCommand) {
+        self.pending_events.push_back(ToSwarm::NotifyHandler {
+            peer_id,
+            handler: libp2p::swarm::NotifyHandler::Any,
+            event: command,
+        });
     }
 
     pub fn on_command(&mut self, command: ClientCommand) {
@@ -173,20 +198,12 @@ impl ClientBehaviour {
                 debug!(%peer_id, %overlay, ?node_type, "Activating peer");
                 self.peer_overlays.insert(peer_id, overlay);
                 self.overlay_peers.insert(overlay, peer_id);
-                self.push_event(ToSwarm::NotifyHandler {
-                    peer_id,
-                    handler: libp2p::swarm::NotifyHandler::Any,
-                    event: HandlerCommand::Activate { overlay, node_type },
-                });
+                self.push_command(peer_id, HandlerCommand::Activate { overlay, node_type });
             }
             ClientCommand::AnnouncePricing { peer, threshold } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %threshold, "Announcing pricing");
-                    self.push_event(ToSwarm::NotifyHandler {
-                        peer_id,
-                        handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::AnnouncePricing { threshold },
-                    });
+                    self.push_command(peer_id, HandlerCommand::AnnouncePricing { threshold });
                 } else {
                     debug!(%peer, "Unknown peer for pricing announcement");
                 }
@@ -197,17 +214,19 @@ impl ClientBehaviour {
                 response,
                 originated,
             } => {
-                if let Some(&peer_id) = self.overlay_peers.get(&peer) {
+                if self.at_capacity() {
+                    metrics::counter!("swarm.client.behaviour.commands_refused").increment(1);
+                    let _ = response.send(Err(ChunkTransferError::Overloaded));
+                } else if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %address, "Retrieving chunk");
-                    self.push_event(ToSwarm::NotifyHandler {
+                    self.push_command(
                         peer_id,
-                        handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::RetrieveChunk {
+                        HandlerCommand::RetrieveChunk {
                             address,
                             response,
                             originated,
                         },
-                    });
+                    );
                 } else {
                     debug!(%peer, "Unknown peer for retrieval");
                     let _ = response.send(Err(ChunkTransferError::NotConnected));
@@ -220,17 +239,19 @@ impl ClientBehaviour {
                 response,
                 originated,
             } => {
-                if let Some(&peer_id) = self.overlay_peers.get(&peer) {
+                if self.at_capacity() {
+                    metrics::counter!("swarm.client.behaviour.commands_refused").increment(1);
+                    let _ = response.send(Err(ChunkTransferError::Overloaded));
+                } else if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %address, "Pushing chunk");
-                    self.push_event(ToSwarm::NotifyHandler {
+                    self.push_command(
                         peer_id,
-                        handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::PushChunk {
+                        HandlerCommand::PushChunk {
                             chunk,
                             response,
                             originated,
                         },
-                    });
+                    );
                 } else {
                     debug!(%peer, "Unknown peer for push");
                     let _ = response.send(Err(ChunkTransferError::NotConnected));
@@ -239,11 +260,7 @@ impl ClientBehaviour {
             ClientCommand::SendPseudosettle { peer, amount } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %amount, "Sending pseudosettle");
-                    self.push_event(ToSwarm::NotifyHandler {
-                        peer_id,
-                        handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::SendPseudosettle { amount },
-                    });
+                    self.push_command(peer_id, HandlerCommand::SendPseudosettle { amount });
                 } else {
                     debug!(%peer, "Unknown peer for pseudosettle");
                 }
@@ -255,14 +272,13 @@ impl ClientBehaviour {
             } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, %request_id, "Acking pseudosettle");
-                    self.push_event(ToSwarm::NotifyHandler {
+                    self.push_command(
                         peer_id,
-                        handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::AckPseudosettle {
+                        HandlerCommand::AckPseudosettle {
                             request_id,
                             ack: wire_ack(ack),
                         },
-                    });
+                    );
                 } else {
                     debug!(%peer, "Unknown peer for pseudosettle ack");
                 }
@@ -271,11 +287,7 @@ impl ClientBehaviour {
             ClientCommand::SendCheque { peer, cheque } => {
                 if let Some(&peer_id) = self.overlay_peers.get(&peer) {
                     debug!(%peer_id, %peer, "Sending swap cheque");
-                    self.push_event(ToSwarm::NotifyHandler {
-                        peer_id,
-                        handler: libp2p::swarm::NotifyHandler::Any,
-                        event: HandlerCommand::SendCheque { cheque },
-                    });
+                    self.push_command(peer_id, HandlerCommand::SendCheque { cheque });
                 } else {
                     debug!(%peer, "Unknown peer for swap cheque");
                 }
@@ -654,6 +666,66 @@ mod tests {
             Arc::new(NoopStore),
             Arc::new(StubForwarder),
         )
+    }
+
+    /// A behaviour whose event queue is permanently at capacity.
+    fn saturated_behaviour() -> ClientBehaviour {
+        let config = Config {
+            max_pending_events: 0,
+            ..Config::default()
+        };
+        ClientBehaviour::new(config, Arc::new(NoopStore), Arc::new(StubForwarder))
+    }
+
+    #[test]
+    fn a_saturated_queue_refuses_a_retrieve_command_explicitly() {
+        let mut behaviour = saturated_behaviour();
+        let overlay = test_peer();
+        // Activation rides past the cap (a dropped activation would leave the
+        // handler dormant forever), so the peer is known when the request lands.
+        behaviour.on_command(ClientCommand::ActivatePeer {
+            peer_id: PeerId::random(),
+            overlay,
+            node_type: vertex_swarm_primitives::SwarmNodeType::Storer,
+        });
+
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        behaviour.on_command(ClientCommand::RetrieveChunk {
+            peer: overlay,
+            address: ChunkAddress::zero(),
+            response: tx,
+            originated: true,
+        });
+
+        match rx.try_recv() {
+            Ok(Err(ChunkTransferError::Overloaded)) => {}
+            other => panic!("expected an explicit Overloaded refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn commands_ride_past_the_cap_that_drops_events() {
+        let mut behaviour = saturated_behaviour();
+        let before = behaviour.pending_events.len();
+        behaviour.on_command(ClientCommand::ActivatePeer {
+            peer_id: PeerId::random(),
+            overlay: test_peer(),
+            node_type: vertex_swarm_primitives::SwarmNodeType::Storer,
+        });
+        assert_eq!(
+            behaviour.pending_events.len(),
+            before + 1,
+            "an activation command enqueues past the soft cap"
+        );
+
+        behaviour.push_event(ToSwarm::GenerateEvent(ClientEvent::PricingSent {
+            peer: test_peer(),
+        }));
+        assert_eq!(
+            behaviour.pending_events.len(),
+            before + 1,
+            "a consumer event still drops at the cap"
+        );
     }
 
     #[test]

--- a/crates/swarm/client-protocol/src/lib.rs
+++ b/crates/swarm/client-protocol/src/lib.rs
@@ -98,6 +98,12 @@ pub enum ChunkTransferError {
     /// candidate should be tried.
     #[error("Admission refused at the disconnect line")]
     Refused,
+
+    /// The local behaviour command queue was at capacity, so the request was
+    /// refused before any bytes left. Provably never dispatched, so the origin
+    /// debit refunds; retryable once pressure drops or against another peer.
+    #[error("Local command queue at capacity")]
+    Overloaded,
 }
 
 impl ChunkTransferError {
@@ -113,7 +119,8 @@ impl ChunkTransferError {
             | Self::Remote
             | Self::Protocol(_)
             | Self::NotFound(_)
-            | Self::Refused => true,
+            | Self::Refused
+            | Self::Overloaded => true,
             Self::ChannelClosed | Self::NotConnected | Self::Cancelled => false,
         }
     }
@@ -127,7 +134,7 @@ impl ChunkTransferError {
     /// so the debit stays committed to keep our debt-view at or above the server's.
     pub fn is_confirmed_absent(&self) -> bool {
         match self {
-            Self::NotFound(_) | Self::NotConnected => true,
+            Self::NotFound(_) | Self::NotConnected | Self::Overloaded => true,
             Self::ChannelClosed
             | Self::Cancelled
             | Self::TimedOut

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -974,6 +974,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn origin_dispatch_refunds_an_overloaded_refusal() {
+        // A queue-capacity refusal provably never dispatched to the wire, so the
+        // dispatch-booked debit must refund in full.
+        let (handle, accounting, settlement, mut rx) = gated_handle(100);
+        let peer = peer(7);
+
+        let task = tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                handle
+                    .retrieve_chunk(peer, ChunkAddress::zero(), true)
+                    .await
+            }
+        });
+        let response = match rx.recv().await.expect("dispatched") {
+            ClientCommand::RetrieveChunk { response, .. } => response,
+            other => panic!("unexpected command: {other:?}"),
+        };
+        assert_eq!(Ledger::balance(&*accounting, &peer), Au::new(-100));
+
+        response
+            .send(Err(ChunkTransferError::Overloaded))
+            .expect("receiver alive");
+        assert!(matches!(
+            task.await.unwrap(),
+            Err(ChunkTransferError::Overloaded)
+        ));
+        assert_eq!(
+            Ledger::balance(&*accounting, &peer),
+            Au::ZERO,
+            "the refusal refunds the dispatch commit"
+        );
+        assert_eq!(Ledger::reserved(&*accounting, &peer), Au::ZERO);
+        assert!(settlement.triggered.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn origin_dispatch_keeps_the_commit_on_cancelled() {
         // The cancel path: the response oneshot is dropped without an answer, so
         // the request returns `Cancelled`. This is a mid-flight teardown, not a


### PR DESCRIPTION
## What

Splits the behaviour's queue policy at the pending-events cap. Consumer events drop under pressure exactly as before. The responder-carrying request commands (retrieve, push) now refuse explicitly: the response resolves with the new `ChunkTransferError::Overloaded` (retryable, and confirmed-absent in the predicate's documented sense of "provably no charge occurred"), so the origin gate refunds the dispatch-booked debit for a request that never reached the wire, and the race tries another peer instead of hanging. Every other handler command (activation, pricing, pseudosettle send and ack, cheques) rides past the soft cap: each is connection- or trigger-rate bounded upstream, a drop would strand handler or settlement state (a dropped activation left the handler dormant forever; a dropped ack pinned its responder until the stale sweep), and the behaviour cannot reach the handler-side responder to fail it promptly, so delivery beats refusal there. The decision table lives as one comment at the policy split. Refusals are counted under a new metric.

## Why

Closes #669 (part of #667, from the hot-path audit). A dropped `NotifyHandler` carrying a retrieve or push cancelled its responder while the dispatch-booked origin debit stood unrefunded: the no-refund-on-Cancelled guarantee exists for raced legs, not queue drops, so queue pressure silently leaked booked debits.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-client-behaviour -p vertex-swarm-client-protocol -p vertex-swarm-node --all-targets --all-features -- -D warnings`; `cargo nextest run` for the three crates with `--all-features` (179/179, including three new tests: a saturated queue refuses a retrieve with `Overloaded` rather than hanging or cancelling, commands ride past the cap that drops events, and the origin gate refunds the dispatch commit on `Overloaded`); `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`. Gates were run by the implementing agent and re-verified centrally before push.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the implementation and this PR body.
