### PR TITLE
fix(topology): re-bootstrap when the table drains to isolation

### DIFF
--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -244,6 +244,12 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
     // Pending dnsaddr resolution for bootnodes (resolved_bootnodes, resolved_trusted)
     pub(crate) pending_bootnode_resolution: Option<BootnodeResolutionFuture>,
 
+    /// Isolation probe state: `(next_probe_at, current_delay)` while the
+    /// table is drained (nothing connected or pending, no candidate queued),
+    /// `None` otherwise. Backs off exponentially so a dead network is probed
+    /// at a decaying rate instead of every tick.
+    pub(crate) isolation_probe: Option<(vertex_tasks::time::Instant, Duration)>,
+
     /// Static NAT addresses to emit as external addresses on first poll.
     /// Cleared after emitting to avoid re-emission.
     pub(crate) pending_nat_external_addrs: Vec<Multiaddr>,
@@ -898,6 +904,10 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
             // expired; connection events are the other publication path.
             self.refresh_published_depth();
             self.evaluator_handle.trigger_evaluation();
+            // An all-backoff empty table is otherwise a fixed point: the
+            // evaluator keeps producing empty candidate sets and no dial
+            // ever fires again.
+            self.reconnect_if_isolated();
         }
 
         // Poll composed protocols and process their events
@@ -1536,6 +1546,32 @@ mod tests {
             match next_action(&mut behaviour).await {
                 ToSwarm::Dial { .. } => {}
                 other => panic!("expected deferred Dial after replenish, got {other:?}"),
+            }
+        }
+    }
+
+    mod isolation {
+        use super::*;
+
+        /// A drained table (nothing connected or pending, no candidates)
+        /// re-dials the bootnodes on the evaluation tick without an external
+        /// command: the all-backoff empty table must not be a fixed point.
+        #[tokio::test]
+        async fn isolation_redials_bootnodes_without_a_command() {
+            let mut behaviour = test_behaviour_with(
+                TopologyConfig::default().with_dial_interval(Duration::from_millis(25)),
+            );
+            let bootnode_peer = PeerId::random();
+            let bootnode: Multiaddr = format!("/ip4/203.0.113.9/tcp/1634/p2p/{bootnode_peer}")
+                .parse()
+                .expect("valid bootnode multiaddr");
+            behaviour.bootnodes = vec![bootnode];
+
+            match next_action(&mut behaviour).await {
+                ToSwarm::Dial { opts } => {
+                    assert_eq!(opts.get_peer_id(), Some(bootnode_peer));
+                }
+                other => panic!("expected the isolation probe to dial the bootnode, got {other:?}"),
             }
         }
     }

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -243,6 +243,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             dial_rate: RateLimiter::new(dial_quota),
             dial_rate_timer: None,
             pending_bootnode_resolution: None,
+            isolation_probe: None,
             evaluator_handle,
             dial_tracker: DialTracker::new(DialTrackerConfig {
                 max_pending: 0, // not used as a queue, only for direct in-flight tracking

--- a/crates/swarm/topology/src/dialing.rs
+++ b/crates/swarm/topology/src/dialing.rs
@@ -18,6 +18,12 @@ use crate::kademlia::RoutingCapacity;
 
 use crate::behaviour::{DialTarget, TopologyBehaviour};
 
+/// First interval between isolation probes; doubles per probe.
+const ISOLATION_PROBE_INITIAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Ceiling on the isolation probe interval.
+const ISOLATION_PROBE_MAX: std::time::Duration = std::time::Duration::from_secs(600);
+
 impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     /// Dial a known SwarmPeer for discovery.
     ///
@@ -123,6 +129,43 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         }
 
         self.pending_actions.push_back(ToSwarm::Dial { opts });
+    }
+
+    /// Re-dial the bootnodes when the table has drained to isolation:
+    /// nothing connected or pending, no candidate queued, no resolution in
+    /// flight. Without this the all-backoff empty table is a fixed point.
+    /// The first probe fires immediately on detection; repeats back off
+    /// exponentially. Any connection, pending handshake or queued candidate
+    /// resets the probe. A dial still in flight may overlap one probe;
+    /// `dial` deduplicates tracked peers so the overlap is a no-op.
+    pub(crate) fn reconnect_if_isolated(&mut self) {
+        if self.connection_registry.active_count() > 0
+            || self.connection_registry.pending_count() > 0
+            || self.routing.has_queued_candidates()
+            || self.pending_bootnode_resolution.is_some()
+        {
+            self.isolation_probe = None;
+            return;
+        }
+
+        let now = vertex_tasks::time::Instant::now();
+        match &mut self.isolation_probe {
+            Some((next_probe_at, delay)) => {
+                if now < *next_probe_at {
+                    return;
+                }
+                *delay = delay.saturating_mul(2).min(ISOLATION_PROBE_MAX);
+                *next_probe_at = now + *delay;
+            }
+            None => {
+                self.isolation_probe =
+                    Some((now + ISOLATION_PROBE_INITIAL, ISOLATION_PROBE_INITIAL));
+            }
+        }
+
+        info!("table drained to isolation; re-dialing bootnodes");
+        metrics::counter!("topology_isolation_rebootstrap_total").increment(1);
+        self.connect_bootnodes();
     }
 
     pub(crate) fn connect_bootnodes(&mut self) {

--- a/crates/swarm/topology/src/kademlia/candidate_queues.rs
+++ b/crates/swarm/topology/src/kademlia/candidate_queues.rs
@@ -77,6 +77,11 @@ impl CandidateQueues {
         result
     }
 
+    /// True when no candidate is queued in any bin.
+    pub(super) fn is_empty(&self) -> bool {
+        self.pending.lock().is_empty()
+    }
+
     /// Clone the dedup set for snapshot purposes.
     pub(super) fn snapshot_queued(&self) -> HashSet<OverlayAddress> {
         self.pending.lock().clone()

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -980,6 +980,12 @@ impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
         self.candidate_queues.pop_next()
     }
 
+    /// True when any dial candidate is queued (the isolation probe treats a
+    /// non-empty queue as recovery already in motion).
+    pub(crate) fn has_queued_candidates(&self) -> bool {
+        !self.candidate_queues.is_empty()
+    }
+
     /// Return a popped candidate to its bin queue, e.g. when the dial-rate
     /// bucket ran out before it could be dialed. Re-enters the dedup set so
     /// the evaluator does not select it again while it waits.


### PR DESCRIPTION
## What

Re-bootstraps a node whose table drains to isolation. A new `reconnect_if_isolated` check runs from the dial tick after evaluation: when the node has zero active connections, zero pending dials, no queued candidates and no dnsaddr resolution in flight, it re-issues the bootnode connect, immediately on first detection and then under a dedicated exponential backoff (30s doubling to a 600s ceiling, wasm-safe timers). Any connection, pending dial or queued candidate resets the probe; overlap with in-flight dials is a no-op through the existing dial tracker dedup. Re-bootstrap attempts are counted under a new metric.

## Why

Closes #682 (part of #681, from the kademlia audit). The bootnode connect previously ran only at startup, on the dial-capability edge, and on the external command, so an all-backoff empty table was a terminal fixed point: an isolated node stayed isolated until restart. The reference re-attempts bootnode connection from its manage loop whenever the table empties; this is the vertex equivalent, kept polite on dead networks by the ceiling. The issue's optional backoff-relaxation clause was deliberately left out; it belongs with the #683 simulation where the policy can be chosen against a modelled adversary.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-topology --all-targets --all-features -- -D warnings`; `cargo nextest run -p vertex-swarm-topology --all-features` (225/225, including the new `isolation_redials_bootnodes_without_a_command`, asserting the bootnode dial fires from the tick alone); `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`. Gates run by the implementing agent and re-verified centrally before push.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the implementation and this PR body.
