### PR TITLE
fix(observability): gate the unauthenticated debug routes behind a profiling build

### DIFF
--- a/crates/observability/src/metrics/server.rs
+++ b/crates/observability/src/metrics/server.rs
@@ -1,16 +1,14 @@
 //! HTTP server for prometheus metrics and profiling endpoints.
 
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc};
 
 use axum::{
-    Json, Router,
-    extract::{Query, State},
-    http::{StatusCode, header},
-    response::{Html, IntoResponse, Response},
+    Router,
+    extract::State,
+    response::{Html, IntoResponse},
     routing::get,
 };
 use metrics_exporter_prometheus::PrometheusHandle;
-use serde::Deserialize;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 use vertex_tasks::TaskExecutor;
@@ -18,7 +16,6 @@ use vertex_tasks::TaskExecutor;
 use super::Hooks;
 use super::task::spawn_server_task;
 use crate::MetricsServerConfig;
-use crate::profiling;
 
 /// Metrics server exposing a prometheus endpoint.
 #[derive(Debug)]
@@ -58,10 +55,21 @@ impl MetricsServer {
         let app = Router::new()
             .route("/", get(root))
             .route("/metrics", get(metrics_handler))
-            .route("/health", get(health_handler))
-            .route("/debug/pprof/profile", get(pprof_handler))
-            .route("/debug/memory", get(memory_handler))
-            .route("/debug/heap/dump", get(heap_dump_handler))
+            .route("/health", get(health_handler));
+
+        // The unauthenticated debug routes mount only in a build carrying a
+        // profiling capability. A default build never exposes them, so an
+        // operator scraping /metrics cannot be reached through pprof (a
+        // blocking-pool exhaustion lever) or the allocator-stats fingerprint;
+        // within a profiling build the pprof duration stays bounded and
+        // single-flight, and the default bind stays on localhost regardless.
+        #[cfg(any(feature = "profiling", feature = "jemalloc"))]
+        let app = app
+            .route("/debug/pprof/profile", get(debug_routes::pprof_handler))
+            .route("/debug/memory", get(debug_routes::memory_handler))
+            .route("/debug/heap/dump", get(debug_routes::heap_dump_handler));
+
+        let app = app
             .with_state(shared_state)
             .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()));
 
@@ -82,8 +90,11 @@ struct ServerState {
 }
 
 async fn root() -> Html<&'static str> {
-    Html(
-        r#"<!DOCTYPE html>
+    // The debug endpoints are advertised only when they are mounted (a
+    // profiling build), so the index never leaks routes that are not served.
+    // The two pages are identical apart from the debug list block.
+    #[cfg(any(feature = "profiling", feature = "jemalloc"))]
+    let page = r#"<!DOCTYPE html>
 <html>
 <head>
     <title>Vertex Swarm Metrics</title>
@@ -105,8 +116,30 @@ async fn root() -> Html<&'static str> {
         <li><a href="/debug/heap/dump">Heap Profile Dump</a> (requires <code>heap-profiling</code> feature + <code>MALLOC_CONF=prof:true</code>)</li>
     </ul>
 </body>
-</html>"#,
-    )
+</html>"#;
+    #[cfg(not(any(feature = "profiling", feature = "jemalloc")))]
+    let page = r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>Vertex Swarm Metrics</title>
+    <style>
+        body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 2em; }
+        h1 { color: #333; }
+        a { color: #0066cc; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <h1>Vertex Swarm Metrics</h1>
+    <p>Available endpoints:</p>
+    <ul>
+        <li><a href="/metrics">Prometheus Metrics</a></li>
+        <li><a href="/health">Health Check</a></li>
+    </ul>
+</body>
+</html>"#;
+
+    Html(page)
 }
 
 async fn metrics_handler(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
@@ -118,87 +151,197 @@ async fn health_handler() -> impl IntoResponse {
     "OK"
 }
 
-/// Query parameters for CPU profile endpoint.
-#[derive(Debug, Deserialize)]
-struct ProfileParams {
-    /// Profile duration in seconds (default: 30).
-    #[serde(default = "default_profile_seconds")]
-    seconds: u64,
-}
+/// The unauthenticated profiling and allocator-inspection endpoints. Compiled
+/// only for a build that carries a profiling capability, so a default build
+/// neither mounts nor references them.
+#[cfg(any(feature = "profiling", feature = "jemalloc"))]
+mod debug_routes {
+    use std::time::Duration;
 
-fn default_profile_seconds() -> u64 {
-    30
-}
+    use axum::{
+        Json,
+        extract::Query,
+        http::{StatusCode, header},
+        response::{IntoResponse, Response},
+    };
+    use serde::Deserialize;
 
-/// CPU profile endpoint - generates flamegraph SVG.
-async fn pprof_handler(Query(params): Query<ProfileParams>) -> Response {
-    if !profiling::cpu_profiling_available() {
-        return (
-            StatusCode::NOT_IMPLEMENTED,
-            "CPU profiling requires the 'profiling' feature",
-        )
-            .into_response();
+    use crate::profiling;
+
+    /// Query parameters for CPU profile endpoint.
+    #[derive(Debug, Deserialize)]
+    pub(super) struct ProfileParams {
+        /// Profile duration in seconds (default: 30, capped at [`MAX_PROFILE_SECONDS`]).
+        #[serde(default = "default_profile_seconds")]
+        seconds: u64,
     }
 
-    let duration = Duration::from_secs(params.seconds);
-
-    // Run profiling in a blocking task to avoid blocking the async runtime
-    let result = tokio::task::spawn_blocking(move || profiling::cpu_profile(duration)).await;
-
-    match result {
-        Ok(Ok(svg)) => ([(header::CONTENT_TYPE, "image/svg+xml")], svg).into_response(),
-        Ok(Err(e)) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Profiling failed: {e}"),
-        )
-            .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Task failed: {e}"),
-        )
-            .into_response(),
+    fn default_profile_seconds() -> u64 {
+        30
     }
-}
 
-/// Memory stats endpoint - returns JSON with allocator statistics.
-async fn memory_handler() -> Response {
-    match profiling::memory_stats() {
-        Ok(stats) => Json(stats).into_response(),
-        Err(e) => (StatusCode::NOT_IMPLEMENTED, e.to_string()).into_response(),
+    /// Upper bound on a requested profile duration. A caller-controlled duration
+    /// parks a blocking-pool thread for its whole length, so an unbounded value is
+    /// a denial-of-service lever; clamp it.
+    const MAX_PROFILE_SECONDS: u64 = 60;
+
+    /// Clamp a requested profile duration into `[1, MAX_PROFILE_SECONDS]`.
+    fn clamp_profile_seconds(requested: u64) -> u64 {
+        requested.clamp(1, MAX_PROFILE_SECONDS)
     }
-}
 
-/// Heap profile dump endpoint.
-///
-/// Dumps a jemalloc heap profile to /tmp and returns the path.
-/// Requires: `--features heap-profiling` AND `MALLOC_CONF=prof:true`.
-/// Analyze with: `jeprof --svg /path/to/vertex /tmp/vertex_heap_<ts>.heap > heap.svg`
-async fn heap_dump_handler() -> Response {
-    if !profiling::heap_profiling_available() {
-        return (
-            StatusCode::NOT_IMPLEMENTED,
-            "Heap profiling requires the 'heap-profiling' feature. \
+    /// One CPU profile at a time. The profiler is process-global, so concurrent
+    /// runs would collide and each parks a blocking thread; a second request is
+    /// refused rather than queued.
+    static PROFILE_IN_FLIGHT: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    /// Releases the single-flight guard on drop so an early return or a panic in the
+    /// blocking task cannot wedge the endpoint.
+    struct ProfileGuard;
+
+    impl Drop for ProfileGuard {
+        fn drop(&mut self) {
+            PROFILE_IN_FLIGHT.store(false, std::sync::atomic::Ordering::Release);
+        }
+    }
+
+    /// CPU profile endpoint - generates flamegraph SVG.
+    pub(super) async fn pprof_handler(Query(params): Query<ProfileParams>) -> Response {
+        if !profiling::cpu_profiling_available() {
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                "CPU profiling requires the 'profiling' feature",
+            )
+                .into_response();
+        }
+
+        if PROFILE_IN_FLIGHT
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                "A CPU profile is already running; retry when it completes",
+            )
+                .into_response();
+        }
+        let _guard = ProfileGuard;
+
+        let duration = Duration::from_secs(clamp_profile_seconds(params.seconds));
+
+        // Run profiling in a blocking task to avoid blocking the async runtime
+        let result = tokio::task::spawn_blocking(move || profiling::cpu_profile(duration)).await;
+
+        match result {
+            Ok(Ok(svg)) => ([(header::CONTENT_TYPE, "image/svg+xml")], svg).into_response(),
+            Ok(Err(e)) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Profiling failed: {e}"),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Task failed: {e}"),
+            )
+                .into_response(),
+        }
+    }
+
+    /// Memory stats endpoint - returns JSON with allocator statistics.
+    pub(super) async fn memory_handler() -> Response {
+        match profiling::memory_stats() {
+            Ok(stats) => Json(stats).into_response(),
+            Err(e) => (StatusCode::NOT_IMPLEMENTED, e.to_string()).into_response(),
+        }
+    }
+
+    /// Heap profile dump endpoint.
+    ///
+    /// Dumps a jemalloc heap profile to /tmp and returns the path.
+    /// Requires: `--features heap-profiling` AND `MALLOC_CONF=prof:true`.
+    /// Analyze with: `jeprof --svg /path/to/vertex /tmp/vertex_heap_<ts>.heap > heap.svg`
+    pub(super) async fn heap_dump_handler() -> Response {
+        if !profiling::heap_profiling_available() {
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                "Heap profiling requires the 'heap-profiling' feature. \
              Build with: cargo build --release --features heap-profiling",
-        )
-            .into_response();
-    }
+            )
+                .into_response();
+        }
 
-    let timestamp = vertex_util_runtime::time::now_unix_secs();
-    let path = std::path::PathBuf::from(format!("/tmp/vertex_heap_{timestamp}.heap"));
+        let timestamp = vertex_util_runtime::time::now_unix_secs();
+        let path = std::path::PathBuf::from(format!("/tmp/vertex_heap_{timestamp}.heap"));
 
-    match profiling::heap_dump(&path) {
-        Ok(()) => {
-            let msg = format!(
-                "Heap profile dumped to: {}\n\n\
+        match profiling::heap_dump(&path) {
+            Ok(()) => {
+                let msg = format!(
+                    "Heap profile dumped to: {}\n\n\
                  Analyze with:\n  \
                  jeprof --svg /path/to/vertex {} > heap.svg\n  \
                  jeprof --text /path/to/vertex {}\n",
-                path.display(),
-                path.display(),
-                path.display(),
-            );
-            (StatusCode::OK, msg).into_response()
+                    path.display(),
+                    path.display(),
+                    path.display(),
+                );
+                (StatusCode::OK, msg).into_response()
+            }
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
         }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn profile_duration_is_clamped_to_the_bound() {
+            assert_eq!(clamp_profile_seconds(0), 1, "a zero duration floors to one");
+            assert_eq!(
+                clamp_profile_seconds(30),
+                30,
+                "an in-range duration is kept"
+            );
+            assert_eq!(
+                clamp_profile_seconds(u64::MAX),
+                MAX_PROFILE_SECONDS,
+                "an unbounded duration is capped, so pprof cannot park a blocking thread for longer"
+            );
+        }
+    }
+} // mod debug_routes
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A default (non-profiling) build must not advertise the debug endpoints on
+    /// the index, so an operator serving /metrics leaks no unauthenticated
+    /// routes. The route registration is gated by the same cfg, so absence on
+    /// the index mirrors absence on the listener.
+    #[cfg(not(any(feature = "profiling", feature = "jemalloc")))]
+    #[tokio::test]
+    async fn default_build_index_advertises_no_debug_routes() {
+        let Html(page) = root().await;
+        assert!(!page.contains("/debug/"), "index leaks a debug route");
+        assert!(page.contains("/metrics"), "index still serves metrics");
+    }
+
+    /// A profiling build advertises the debug endpoints, confirming the gate
+    /// selects the populated page rather than always hiding them.
+    #[cfg(any(feature = "profiling", feature = "jemalloc"))]
+    #[tokio::test]
+    async fn profiling_build_index_advertises_debug_routes() {
+        let Html(page) = root().await;
+        assert!(
+            page.contains("/debug/pprof/profile"),
+            "profiling index omits pprof"
+        );
     }
 }


### PR DESCRIPTION
## What

Gates the unauthenticated metrics-server debug routes behind a profiling build and bounds the pprof endpoint.

The `/debug/pprof/profile`, `/debug/memory` and `/debug/heap/dump` routes, their handlers and the `Query`/`Deserialize`/`profiling` imports they need now live in a `debug_routes` module compiled only under `any(feature = "profiling", feature = "jemalloc")`. A default build (bare client, the plain `http-server` recorder build) mounts neither the routes nor the handlers and advertises only `/metrics` and `/health` on the index, so an operator scraping metrics exposes no debug surface and no route the listener does not serve. Within a profiling build the pprof duration is clamped to sixty seconds and served one at a time behind a drop-guarded single-flight latch (the profiler is process-global and each run parks a blocking-pool thread), so the route can no longer be driven to exhaust the pool. The default metrics bind is already localhost (`127.0.0.1`, in the node CLI args), satisfying that acceptance criterion without a change here.

## Why

Closes #282 (part of the observability audit follow-ups). The debug routes mounted unauthenticated on the same listener as `/metrics` in every build, the index advertised them, and pprof accepted a caller-controlled unbounded duration: a denial-of-service lever and an allocator-stats fingerprint on any operator that bound the listener wide.

All three acceptance criteria are met: debug routes unreachable on the default bind in a default build (structural, via the cfg gate, proved by `default_build_index_advertises_no_debug_routes`); pprof duration bounded and concurrent profiles capped (`profile_duration_is_clamped_to_the_bound` plus the single-flight latch); metrics bind defaults to localhost (pre-existing).

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-observability --features http-server --all-targets -- -D warnings` and `--all-features` (both cones clean; the gate means the non-profiling cone must compile with no debug machinery); `cargo nextest run -p vertex-observability` in both configs (5/5 non-profiling incl. the no-debug-routes index assertion, 6/6 all-features incl. the clamp and profiling-index assertions).

## Notes

The heap-dump predictable `/tmp` path (symlink and path-leak risk) is left as a residual: it is now reachable only in a heap-profiling build behind the gate, and tightening it (a process-unique directory, path not echoed) is a separable hardening better done with the launcher persistence seam. Flagged here so it is not forgotten.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the analysis, implementation and this PR body.
