### PR TITLE
docs(swarm): pin the deliberate hive gossip divergences

### DIFF
--- a/crates/swarm/topology/src/gossip/mod.rs
+++ b/crates/swarm/topology/src/gossip/mod.rs
@@ -26,6 +26,11 @@
 //! - Exchange cadence: `refresh_interval` paces neighborhood broadcasts and
 //!   `health_check_delay` defers exchanges on fresh gossip dials until the
 //!   connection proves stable.
+//!
+//! The deliberate policy divergences from the reference (recipient-targeted
+//! composition, client recipients, the periodic and depth-decrease broadcasts,
+//! the inbound-before-crypto rate charge, and the removed outbound bucket) are
+//! wire-compatible and catalogued in `docs/swarm/differences-from-bee.md`.
 
 mod config;
 mod engine;

--- a/docs/swarm/differences-from-bee.md
+++ b/docs/swarm/differences-from-bee.md
@@ -86,6 +86,22 @@ Bee does not penalize a peer for disconnecting: its kademlia `Disconnected` hand
 
 The signal is deliberately narrow. Every locally-initiated close records its reason at the close site (`vertex_swarm_api::DisconnectReason`), so a close the node chose (bin trim, ban, low-score disconnect, bootnode rotation, shutdown) or an idle keep-alive teardown is never attributed to the peer. The penalty is reserved for a fast remote or transport close of a peer that did no useful work; a peer that served or accepted a chunk during the connection is exempt regardless of how it closed. This keeps honest serving peers, including mobile and browser clients whose transports reset under load, out of the penalty path while still scoring down a peer that handshakes and vanishes.
 
+## Hive Gossip
+
+Vertex speaks the hive wire protocol (`vertex-swarm-net-hive`, protocol id `/swarm/hive/2.0.0/peers`, thirty-record batches) byte-for-byte with the reference. Every divergence below is in gossip policy, who is told about which peers and when, and none of them changes a wire byte, so none needs a fork gate. The gossip engine lives in `vertex-swarm-topology`; the operator-facing behaviour and the tuning knobs are described in the hive gossip guide.
+
+**Recipient-targeted bootstrap composition.** Gossiping its view to a distant peer, the reference sends a sample drawn at random per kademlia bin. Vertex composes the list for the specific recipient instead: the closest storers to that recipient, then one storer per bin for diversity, filling to sixteen. A joining node's first list therefore already points toward its own neighbourhood rather than a uniform cross-section. Wire-compatible: identical record type and batch framing, only the selection differs.
+
+**Clients are gossip recipients but never subjects or sources.** Like the reference, vertex serves connecting light and browser clients discovery help: a client receives the recipient-targeted list on connect and is notified about each newly connected storer. This is parity of intent with the reference's light-node announce; only the composition is vertex's, as above. Client records are never placed in a payload and a client is never counted as a gossip source, so the population a client learns is always storers. Wire-compatible.
+
+**Periodic neighbourhood refresh.** The reference re-gossips only in reaction to connection events. Vertex adds a periodic refresh (roughly ten minutes, `GossipConfig::refresh_interval`) that re-broadcasts the local neighbourhood view, so a quiet network keeps supply flowing without waiting for churn. It is bounded by the same per-recipient broadcast stamp that damps the event-driven path. Wire-compatible.
+
+**Depth-decrease promotion.** When the locally observed neighbourhood depth decreases, meaning the neighbourhood widened, vertex gossips the newly promoted neighbours at once rather than waiting for the next connection event to surface them. The reference has no equivalent. This is a promptness gain over the same records. Wire-compatible.
+
+**No outbound rate bucket.** The reference caps outbound gossip per peer. Vertex removed the outbound per-peer bucket: the broadcast cadence is already paced by the dial and refresh intervals, each payload is capped at the batch size, and an outbound bucket measurably starved legitimate gossip cycles after a few neighbourhood refreshes. Inbound throttling is unaffected. Wire-compatible.
+
+**Inbound rate charged before signature recovery.** The reference rate-limits inbound gossip after the records are processed. Vertex charges its per-source rate bucket against the raw wire record count before any ECDSA recovery runs, so a flood of invalid signatures cannot bypass the throttle by being filtered out afterwards. This strengthens the reference posture rather than relaxing it. Wire-compatible.
+
 ## Bandwidth Accounting and Pseudosettle
 
 Vertex prices chunks and tracks per-peer balances with the same arithmetic as Bee: the proximity price is `(max_po - proximity + 1) * base_price` with `base_price` 10000 and `max_po` 31, balances are signed (positive means the peer owes us), and the pseudosettle allowance is `min(requested, owed, refresh_rate * elapsed)`. Two behaviours on the pseudosettle path are deliberately not identical to Bee.
@@ -103,6 +119,7 @@ Vertex prices chunks and tracks per-peer balances with the same arithmetic as Be
 | Postage Verification | Cached pubkeys, parallel, structural separation | Per-stamp recovery |
 | Modularity | Composable traits, pluggable backends | Monolithic implementation |
 | no_std Support | Core types work without std | Requires std |
+| Hive Gossip | Recipient-targeted composition, client recipients, periodic and depth-decrease broadcasts, inbound rate charged before crypto, no outbound bucket | Random per-bin sample, event-driven only, post-hoc inbound limit, outbound bucket |
 | Disconnect Scoring | Activity-gated early-disconnect penalty, intent-attributed closes | No disconnect penalty |
 | Pseudosettle First Contact | Allowance ramps from first-contact clock | Full debt accepted immediately |
 | Payment Threshold | Local threshold only (peer-advertised not yet applied) | Honours peer-advertised threshold |
@@ -110,4 +127,5 @@ Vertex prices chunks and tracks per-peer balances with the same arithmetic as Be
 ## See Also
 
 - [Architecture Overview](../architecture/overview.md) - High-level design
+- [Hive Gossip](hive-gossip.md) - Gossip rules, recipient composition, and client policy
 - [Swarm API](api.md) - Protocol trait definitions


### PR DESCRIPTION
## What

Pins vertex's deliberate hive-gossip policy divergences from the reference in a conformance ledger, so a future conformance sweep can tell a deliberate choice from an accidental one.

Adds a `## Hive Gossip` section to the differences page with six entries, each carrying a one-line rationale and an explicit wire-compatibility statement, plus a summary-table row and a link to the hive gossip guide; and a terse rustdoc pointer from the gossip module to the ledger. The existing `### Hive` section (the `Hive` SwarmSpec, a different concern) is untouched.

The six divergences, all verified against current code and all byte-for-byte wire-compatible (none needs a fork gate): recipient-targeted bootstrap composition (closest-to-recipient, then one per bin, fill to sixteen) versus the reference's random per-bin sample; clients are gossip recipients but never subjects or sources, parity of intent with the reference's light-node announce differing only in composition; a periodic neighbourhood refresh the reference lacks; depth-decrease promotion gossip the reference lacks; the removed outbound rate bucket; and inbound rate charged per raw record before signature recovery, a strengthening over the reference's post-hoc limit.

## Why

Closes #693, the final open issue of the hive epic #688. The divergences were introduced across the epic (the client recipients in the client-bootstrap change, the others pre-existing) and were only partly recorded, so nothing let a reviewer distinguish intent from drift.

## Testing

Docs-only, so scoped per the repo rule: `cargo fmt --all`; `cargo clippy -p vertex-swarm-topology --all-features -- -D warnings` (catches missing_docs and broken intra-doc links, clean); `cargo doc -p vertex-swarm-topology --no-deps --all-features` renders. No test suite or benches (no code changed). The one `cargo doc` link warning (`TopologyHandle` in the behaviour rustdoc) is pre-existing and outside this diff.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the reference comparison, the ledger and this PR body.
