### PR TITLE
fix(swarm-peer): cap the multiaddrs accepted per peer record

### DIFF
--- a/crates/swarm/peers/peer/src/error.rs
+++ b/crates/swarm/peers/peer/src/error.rs
@@ -10,6 +10,8 @@ pub enum MultiAddrError {
     VarintError(#[from] std::io::Error),
     #[error("inconsistent data: expected {expected} bytes, got {actual}")]
     InconsistentLength { expected: u64, actual: usize },
+    #[error("multiaddr count exceeds the maximum of {max} per peer")]
+    CountExceeded { max: usize },
     #[error("failed to parse multiaddr: {0}")]
     InvalidMultiaddr(#[from] libp2p::multiaddr::Error),
 }

--- a/crates/swarm/peers/peer/src/serde_multiaddr.rs
+++ b/crates/swarm/peers/peer/src/serde_multiaddr.rs
@@ -17,6 +17,13 @@ use std::io::{Cursor, Read};
 /// BEE-COMPAT(SWIP-148): see module docs.
 const MULTIADDR_LIST_PREFIX: u8 = 0x99;
 
+/// Maximum multiaddrs accepted per peer record. A gossiped or handshaked record
+/// carrying more is rejected whole, so a peer cannot inflate resident table
+/// memory or amplify dial fan-out by flooding fabricated addresses. Matches the
+/// reference wire cap, so a conformant peer (which advertises a handful) is
+/// never rejected.
+pub(crate) const MAX_MULTIADDRS_PER_PEER: usize = 20;
+
 /// Serialize multiaddrs to bytes.
 ///
 /// - Single address: raw bytes (backward compatible)
@@ -60,6 +67,14 @@ fn deserialize_list(data: &[u8]) -> Result<Vec<Multiaddr>, MultiAddrError> {
     let mut cursor = Cursor::new(data);
 
     while (cursor.position() as usize) < data.len() {
+        // Reject an over-full record before decoding the next entry, so a flood
+        // of addresses never allocates past the cap.
+        if addrs.len() >= MAX_MULTIADDRS_PER_PEER {
+            return Err(MultiAddrError::CountExceeded {
+                max: MAX_MULTIADDRS_PER_PEER,
+            });
+        }
+
         let addr_len = decode_uvarint(&mut cursor)?;
 
         let remaining = data.len() - cursor.position() as usize;
@@ -157,5 +172,32 @@ mod tests {
 
         let deserialized = deserialize_multiaddrs(&serialized).unwrap();
         assert!(deserialized.is_empty());
+    }
+
+    fn n_addrs(n: usize) -> Vec<Multiaddr> {
+        (0..n)
+            .map(|i| format!("/ip4/127.0.0.1/tcp/{}", 1000 + i).parse().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn a_record_at_the_cap_deserializes() {
+        let addrs = n_addrs(MAX_MULTIADDRS_PER_PEER);
+        let serialized = serialize_multiaddrs(&addrs);
+
+        let deserialized = deserialize_multiaddrs(&serialized).unwrap();
+        assert_eq!(deserialized.len(), MAX_MULTIADDRS_PER_PEER);
+        assert_eq!(deserialized, addrs);
+    }
+
+    #[test]
+    fn a_record_over_the_cap_is_rejected() {
+        let serialized = serialize_multiaddrs(&n_addrs(MAX_MULTIADDRS_PER_PEER + 1));
+
+        let err = deserialize_multiaddrs(&serialized).unwrap_err();
+        assert!(
+            matches!(err, MultiAddrError::CountExceeded { max } if max == MAX_MULTIADDRS_PER_PEER),
+            "over-full record must reject with CountExceeded, got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

Caps the number of multiaddrs accepted per peer record at twenty, rejecting an over-full record rather than truncating it.

The cap lands in `vertex-swarm-peer`'s shared multiaddr deserialization primitive, the single point every `SwarmPeer` reconstruction flows through, so it bounds both the hive peer exchange and the handshake in one place: a peer cannot flood fabricated addresses through either path to inflate resident peer-table memory or amplify dial fan-out. The count is enforced during accumulation, so an over-full record never allocates past the cap. Rejecting the whole record (a new `MultiAddrError::CountExceeded`) rather than truncating is deliberate: the record's signature covers its addresses, so a truncated set would be inconsistent with the signature that authenticates it.

## Why

Closes #241 (the last intake-bound child of the hive epic #688). The audit flagged the unbounded per-record multiaddr count as the one open bound in an otherwise strong intake posture. Twenty matches the reference wire cap, so a conformant peer (which advertises a handful) is never rejected, and no conformant peer sends more than twenty through any path, keeping the shared-seam placement interop-safe.

## Testing

`cargo fmt --all`; `cargo clippy -p vertex-swarm-peer -p vertex-swarm-net-hive -p vertex-swarm-topology --all-targets --all-features -- -D warnings`; `cargo nextest run` for the three crates with `--all-features` (260/260, including the two new cap tests and, critically, the peer-crate interop conformance vectors: the pinned handshake sign and parse vectors and overlay derivation all pass unchanged, confirming the shared cap does not disturb the handshake path); `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node -p vertex-swarm-topology`. No conformance vector needed updating; no legitimate vector sends more than twenty addresses. Gates run by the implementing agent and re-verified centrally before push.

## Notes

The reference also bounds a total-bytes axis (2048); that is already implicitly bounded here by the wire frame size, and a dedicated byte cap would be a separate hardening. Scope moved from the hive crate (as originally filed) to `vertex-swarm-peer` because that shared-deserialize seam is where the reference places the cap and it protects every caller, not only hive.

## AI Assistance

AI Assistance: Claude Code (Fable 5) used for the implementation and this PR body.
