### PR TITLE
refactor(swarm-builder): flow whole domain configs through the launch path

### DIFF
--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -13,6 +13,7 @@ use vertex_swarm_api::{
     BootnodeComponents, ClientComponents, SwarmLaunchConfig, SwarmNodeType, construct,
 };
 use vertex_swarm_identity::Identity;
+use vertex_swarm_localstore::LocalStoreConfig;
 use vertex_swarm_node::args::NetworkConfig;
 use vertex_swarm_node::{
     BootNode, ClientNode, ClientNodeParts, ClientTailParams, NativeChunkProvider, NodeRunParts,
@@ -33,7 +34,7 @@ use vertex_swarm_node::args::ChainConfig;
 #[cfg(feature = "swap")]
 use vertex_swarm_node::args::SwapConfig;
 #[cfg(feature = "swap")]
-use vertex_swarm_node::{ClientSwapParams, NodeChainError, node_chain_provider};
+use vertex_swarm_node::{NodeChainError, node_chain_provider};
 
 pub(crate) type PeerStore = Arc<dyn PeerSnapshotStore<PeerSnapshot>>;
 
@@ -178,11 +179,10 @@ pub(crate) type CacheFactory = Box<
 pub(crate) fn resolve_cache(
     cache: Option<CacheSeam>,
     db: Option<Arc<RedbDatabase>>,
-    cache_budget_bytes: u64,
-    soc_cache_ttl: u64,
+    local_store: &LocalStoreConfig,
 ) -> Result<Arc<dyn vertex_swarm_api::SwarmLocalStore>, SwarmNodeError> {
     match cache {
-        None => Ok(default_cache(cache_budget_bytes, soc_cache_ttl)),
+        None => Ok(default_cache(local_store)),
         Some(CacheSeam::Ready(cache)) => Ok(cache),
         Some(CacheSeam::Factory(factory)) => factory(db),
     }
@@ -244,21 +244,12 @@ pub(crate) trait NodeAssembly: Send {
 /// The default client assembly: a bare [`ClientNode`] over an in-memory cache.
 pub(crate) struct ClientAssembly {
     cache: Option<CacheSeam>,
-    cache_budget_bytes: u64,
-    soc_cache_ttl: u64,
+    local_store: LocalStoreConfig,
 }
 
 impl ClientAssembly {
-    pub(crate) fn new(
-        cache: Option<CacheSeam>,
-        cache_budget_bytes: u64,
-        soc_cache_ttl: u64,
-    ) -> Self {
-        Self {
-            cache,
-            cache_budget_bytes,
-            soc_cache_ttl,
-        }
+    pub(crate) fn new(cache: Option<CacheSeam>, local_store: LocalStoreConfig) -> Self {
+        Self { cache, local_store }
     }
 }
 
@@ -273,12 +264,7 @@ impl NodeAssembly for ClientAssembly {
         _ctx: &dyn InfrastructureContext,
         inputs: AssemblyInputs<'_>,
     ) -> Result<(NodeRunParts, Self::ProviderStore), SwarmNodeError> {
-        let node_store = resolve_cache(
-            self.cache,
-            inputs.db,
-            self.cache_budget_bytes,
-            self.soc_cache_ttl,
-        )?;
+        let node_store = resolve_cache(self.cache, inputs.db, &self.local_store)?;
         let parts = assemble_client_node(
             inputs.identity,
             inputs.network,
@@ -355,13 +341,7 @@ pub(crate) async fn build_client_backed_node<F: NodeAssembly>(
         identity: params.identity,
         bandwidth,
         #[cfg(feature = "swap")]
-        swap: ClientSwapParams {
-            enable: params.swap.enable,
-            chequebook: params.swap.chequebook,
-            beneficiary: params.swap.beneficiary,
-            deploy: params.swap.deploy,
-            bounce_limit: params.swap.bounce_limit,
-        },
+        swap: params.swap,
     };
 
     let parts = build_client_core_tail(
@@ -501,8 +481,6 @@ async fn build_client(
     SwarmNodeError,
 > {
     let cache = config.take_cache();
-    let cache_budget = config.local_store().cache_budget_bytes();
-    let soc_ttl = config.local_store().soc_cache_ttl();
     let parts = build_client_backed_node(
         ctx,
         ClientNodeParams {
@@ -515,7 +493,7 @@ async fn build_client(
             #[cfg(feature = "swap")]
             swap: config.swap(),
         },
-        ClientAssembly::new(cache, cache_budget, soc_ttl),
+        ClientAssembly::new(cache, config.local_store().clone()),
     )
     .await?;
 
@@ -531,13 +509,10 @@ async fn build_client(
 }
 
 /// The default client cache: a byte-bounded in-memory LRU sized from the config.
-fn default_cache(
-    cache_budget_bytes: u64,
-    soc_cache_ttl: u64,
-) -> Arc<dyn vertex_swarm_api::SwarmLocalStore> {
+fn default_cache(local_store: &LocalStoreConfig) -> Arc<dyn vertex_swarm_api::SwarmLocalStore> {
     Arc::new(vertex_swarm_localstore::ChunkStore::with_budget(
-        cache_budget_bytes as usize,
-        soc_cache_ttl,
+        local_store.cache_budget_bytes() as usize,
+        local_store.soc_cache_ttl(),
     ))
 }
 
@@ -799,8 +774,12 @@ mod tests {
         use nectar_primitives::{AnyChunk, ContentChunk};
         use vertex_swarm_primitives::CachedChunk;
 
-        let store = resolve_cache(None, None, 1 << 20, DEFAULT_SOC_CACHE_TTL_NS_TEST)
-            .expect("default cache builds");
+        let store = resolve_cache(
+            None,
+            None,
+            &LocalStoreConfig::new(1 << 20, DEFAULT_SOC_CACHE_TTL_NS_TEST),
+        )
+        .expect("default cache builds");
 
         let chunk: AnyChunk = ContentChunk::new(b"cached content".to_vec())
             .expect("valid content chunk")
@@ -820,8 +799,12 @@ mod tests {
         let cache: Arc<dyn vertex_swarm_api::SwarmLocalStore> = Arc::new(
             vertex_swarm_localstore::ChunkStore::with_budget(4096, DEFAULT_SOC_CACHE_TTL_NS_TEST),
         );
-        let store = resolve_cache(Some(CacheSeam::Ready(Arc::clone(&cache))), None, 0, 0)
-            .expect("seam cache is used");
+        let store = resolve_cache(
+            Some(CacheSeam::Ready(Arc::clone(&cache))),
+            None,
+            &LocalStoreConfig::new(0, 0),
+        )
+        .expect("seam cache is used");
         assert!(
             Arc::ptr_eq(&cache, &store),
             "the supplied cache must reach the node store unchanged"
@@ -853,7 +836,8 @@ mod tests {
             vertex_swarm_localstore::ChunkStore::with_budget(4096, DEFAULT_SOC_CACHE_TTL_NS_TEST),
         );
         let mut config = test_client_config().with_cache(Arc::clone(&cache));
-        let store = resolve_cache(config.take_cache(), None, 0, 0).expect("seam cache is used");
+        let store = resolve_cache(config.take_cache(), None, &LocalStoreConfig::new(0, 0))
+            .expect("seam cache is used");
         assert!(
             Arc::ptr_eq(&cache, &store),
             "the config cache seam must reach the node store unchanged"
@@ -869,7 +853,8 @@ mod tests {
         );
         let handed = Arc::clone(&built);
         let mut config = test_client_config().with_cache_factory(move |_db| Ok(handed));
-        let store = resolve_cache(config.take_cache(), None, 0, 0).expect("factory cache is used");
+        let store = resolve_cache(config.take_cache(), None, &LocalStoreConfig::new(0, 0))
+            .expect("factory cache is used");
         assert!(
             Arc::ptr_eq(&built, &store),
             "the factory-built cache must reach the node store"

--- a/crates/swarm/builder/src/storer.rs
+++ b/crates/swarm/builder/src/storer.rs
@@ -237,8 +237,6 @@ pub(crate) async fn build_storer(
     let _redistribution_enabled = config.storage().redistribution_enabled();
     let capacity = config.spec().reserve_capacity;
     let identity = config.identity().clone();
-    let cache_budget = config.local_store().cache_budget_bytes();
-    let soc_ttl = config.local_store().soc_cache_ttl();
 
     let parts = build_client_backed_node(
         ctx,
@@ -252,7 +250,13 @@ pub(crate) async fn build_storer(
             #[cfg(feature = "swap")]
             swap: config.swap(),
         },
-        StorerAssembly::new(cache, reserve, identity, capacity, cache_budget, soc_ttl),
+        StorerAssembly::new(
+            cache,
+            reserve,
+            identity,
+            capacity,
+            config.local_store().clone(),
+        ),
     )
     .await?;
 
@@ -276,8 +280,7 @@ struct StorerAssembly {
     reserve_seam: Option<ReserveSeam>,
     identity: Arc<Identity>,
     capacity: u64,
-    cache_budget_bytes: u64,
-    soc_cache_ttl: u64,
+    local_store: LocalStoreConfig,
 }
 
 impl StorerAssembly {
@@ -286,16 +289,14 @@ impl StorerAssembly {
         reserve_seam: Option<ReserveSeam>,
         identity: Arc<Identity>,
         capacity: u64,
-        cache_budget_bytes: u64,
-        soc_cache_ttl: u64,
+        local_store: LocalStoreConfig,
     ) -> Self {
         Self {
             cache,
             reserve_seam,
             identity,
             capacity,
-            cache_budget_bytes,
-            soc_cache_ttl,
+            local_store,
         }
     }
 }
@@ -317,8 +318,7 @@ impl NodeAssembly for StorerAssembly {
             inputs.db.clone(),
             &self.identity,
             self.capacity,
-            self.cache_budget_bytes,
-            self.soc_cache_ttl,
+            &self.local_store,
         )?;
         let provider_store = (Arc::clone(&serve.local), Arc::clone(&serve.reserve));
         let capable = assemble_storer_node(
@@ -361,8 +361,7 @@ fn build_serve_store(
     db: Option<Arc<RedbDatabase>>,
     identity: &Arc<Identity>,
     capacity: u64,
-    cache_budget_bytes: u64,
-    soc_cache_ttl: u64,
+    local_store: &LocalStoreConfig,
 ) -> Result<StorerServeStore, SwarmNodeError> {
     let (reserve, pullsync, batches) = match reserve_seam {
         None => {
@@ -372,7 +371,7 @@ fn build_serve_store(
         Some(ReserveSeam::Ready(reserve)) => (reserve, None, None),
         Some(ReserveSeam::Factory(factory)) => (factory(db.clone())?, None, None),
     };
-    let cache = resolve_cache(cache, db, cache_budget_bytes, soc_cache_ttl)?;
+    let cache = resolve_cache(cache, db, local_store)?;
     // The reserve upcasts to the local-store read side; writes land in the cache.
     let local: Arc<dyn SwarmLocalStore> = Arc::new(composite::CacheThenReserve::new(
         cache,
@@ -680,8 +679,7 @@ mod tests {
             None,
             &identity,
             1 << 12,
-            1 << 20,
-            DEFAULT_SOC_CACHE_TTL_NS_TEST,
+            &LocalStoreConfig::new(1 << 20, DEFAULT_SOC_CACHE_TTL_NS_TEST),
         )
         .expect("seam reserve is used");
         assert!(
@@ -708,8 +706,7 @@ mod tests {
             None,
             &identity,
             1 << 12,
-            1 << 20,
-            DEFAULT_SOC_CACHE_TTL_NS_TEST,
+            &LocalStoreConfig::new(1 << 20, DEFAULT_SOC_CACHE_TTL_NS_TEST),
         )
         .expect("seam reserve is used");
         assert!(
@@ -750,8 +747,7 @@ mod tests {
             None,
             &identity,
             1 << 12,
-            1 << 20,
-            DEFAULT_SOC_CACHE_TTL_NS_TEST,
+            &LocalStoreConfig::new(1 << 20, DEFAULT_SOC_CACHE_TTL_NS_TEST),
         )
         .expect("default storer store builds");
 

--- a/crates/swarm/node/src/args/mod.rs
+++ b/crates/swarm/node/src/args/mod.rs
@@ -1,16 +1,32 @@
 //! CLI argument structs and validated configurations for Swarm.
+//!
+//! The argument structs need the `cli` feature; the validated [`SwapConfig`]
+//! compiles in every build so the client core can carry it whole.
 
+#[cfg(feature = "cli")]
 mod chain;
+#[cfg(feature = "cli")]
 mod network;
+#[cfg(feature = "cli")]
 mod peer;
+#[cfg(feature = "cli")]
 mod spec;
 mod swap;
+#[cfg(feature = "cli")]
 mod swarm;
 
+#[cfg(feature = "cli")]
 pub use chain::{ChainArgs, ChainConfig};
+#[cfg(feature = "cli")]
 pub use network::{NetworkArgs, NetworkConfig};
+#[cfg(feature = "cli")]
 pub use peer::{PeerArgs, PeerConfig};
+#[cfg(feature = "cli")]
 pub use spec::SwarmSpecArgs;
-pub use swap::{SwapArgs, SwapConfig};
+#[cfg(feature = "cli")]
+pub use swap::SwapArgs;
+pub use swap::SwapConfig;
+#[cfg(feature = "cli")]
 pub use swarm::{NodeTypeArg, ProtocolArgs};
+#[cfg(feature = "cli")]
 pub use vertex_swarm_topology::RoutingArgs;

--- a/crates/swarm/node/src/args/swap.rs
+++ b/crates/swarm/node/src/args/swap.rs
@@ -9,10 +9,13 @@
 //! network spec; the RPC endpoint is the shared `--chain.rpc-url`.
 
 use alloy_primitives::Address;
+#[cfg(feature = "cli")]
 use clap::Args;
+#[cfg(feature = "cli")]
 use serde::{Deserialize, Serialize};
 
 /// SWAP settlement CLI arguments.
+#[cfg(feature = "cli")]
 #[derive(Debug, Args, Clone, Serialize, Deserialize)]
 #[command(next_help_heading = "Swap")]
 #[serde(default)]
@@ -49,6 +52,7 @@ pub struct SwapArgs {
 
 /// Serialize a `u128` as a decimal string so figment's i64/u64 value model can
 /// round-trip it. In a TOML file the value is written quoted.
+#[cfg(feature = "cli")]
 mod u128_string {
     use serde::{Deserialize, Deserializer, Serializer, de::Error};
 
@@ -69,10 +73,12 @@ mod u128_string {
 /// threshold of `13_500_000` units).
 const DEFAULT_BOUNCE_LIMIT: u128 = 135_000_000;
 
+#[cfg(feature = "cli")]
 fn default_bounce_limit() -> u128 {
     DEFAULT_BOUNCE_LIMIT
 }
 
+#[cfg(feature = "cli")]
 impl Default for SwapArgs {
     fn default() -> Self {
         Self {
@@ -85,6 +91,7 @@ impl Default for SwapArgs {
     }
 }
 
+#[cfg(feature = "cli")]
 impl SwapArgs {
     /// Build the validated SWAP configuration.
     pub fn swap_config(&self) -> SwapConfig {
@@ -125,11 +132,17 @@ pub struct SwapConfig {
 
 impl Default for SwapConfig {
     fn default() -> Self {
-        SwapArgs::default().swap_config()
+        Self {
+            enable: None,
+            chequebook: None,
+            beneficiary: None,
+            deploy: false,
+            bounce_limit: DEFAULT_BOUNCE_LIMIT,
+        }
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cli"))]
 mod tests {
     use super::*;
 
@@ -141,6 +154,7 @@ mod tests {
         assert_eq!(cfg.beneficiary, None);
         assert!(!cfg.deploy);
         assert_eq!(cfg.bounce_limit, DEFAULT_BOUNCE_LIMIT);
+        assert_eq!(cfg, SwapConfig::default());
     }
 
     #[test]

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "cli")]
 pub mod args;
 #[cfg(feature = "cli")]
 mod config;
@@ -34,9 +33,7 @@ pub use node::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder};
 #[cfg(feature = "swap")]
-pub use node::{
-    ClientSwapParams, LauncherSwapConfig, NodeChainError, SwapWiring, node_chain_provider,
-};
+pub use node::{LauncherSwapConfig, NodeChainError, SwapWiring, node_chain_provider};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storer"))]
 pub use node::{StorerNode, StorerNodeBuilder, StorerPullsyncControl};
 /// The shared chain provider handle, re-exported so client entry points and the

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -32,6 +32,8 @@ use vertex_tasks::TaskExecutor;
 use crate::chunks::NetworkChunkProvider;
 
 #[cfg(feature = "swap")]
+use crate::args::SwapConfig;
+#[cfg(feature = "swap")]
 use alloy_chains::NamedChain;
 #[cfg(feature = "swap")]
 use alloy_primitives::Address;
@@ -329,15 +331,11 @@ impl SwapWiring {
     /// Ethereum address when `None`: the only payout address a cheque sent to us
     /// may name. The returned provider is registered with the accounting builder;
     /// the returned wiring is later handed to [`SwapWiring::spawn`].
-    #[allow(clippy::too_many_arguments)]
     pub fn prepare<C>(
         spec: &Arc<Spec>,
         identity: &Arc<Identity>,
         config: &C,
-        chequebook: Option<Address>,
-        beneficiary: Option<Address>,
-        deploy: bool,
-        bounce_limit: u128,
+        swap: &SwapConfig,
         swap_enabled: bool,
     ) -> Option<(SwapProvider<C>, Self)>
     where
@@ -347,13 +345,13 @@ impl SwapWiring {
             return None;
         }
 
-        let Some(chequebook) = chequebook else {
+        let Some(chequebook) = swap.chequebook else {
             warn!(
                 "SWAP enabled but no chequebook configured; settlement not wired (chequebook deploy not yet supported)"
             );
             return None;
         };
-        if deploy {
+        if swap.deploy {
             warn!(
                 "chequebook deploy is not yet supported; using the configured chequebook address"
             );
@@ -368,7 +366,9 @@ impl SwapWiring {
 
         // The beneficiary defaults to the node Ethereum address: the only payout
         // address a cheque sent to us may name.
-        let beneficiary = beneficiary.unwrap_or_else(|| identity.ethereum_address());
+        let beneficiary = swap
+            .beneficiary
+            .unwrap_or_else(|| identity.ethereum_address());
 
         let (swap_event_tx, swap_event_rx) = mpsc::unbounded_channel();
         // The handle backs the provider; its command channel is drained by the
@@ -388,7 +388,7 @@ impl SwapWiring {
             chequebook,
             beneficiary,
             chain,
-            bounce_limit,
+            bounce_limit: swap.bounce_limit,
         };
 
         Some((provider, wiring))
@@ -620,22 +620,6 @@ pub struct SettlementEventSenders {
     pub swap: Option<mpsc::UnboundedSender<SwapEvent>>,
 }
 
-/// Resolved SWAP parameters shared by both client entry points.
-#[cfg(feature = "swap")]
-#[derive(Clone)]
-pub struct ClientSwapParams {
-    /// `--swap` override; `None` defers to the node type's default.
-    pub enable: Option<bool>,
-    /// Our chequebook contract address, named in the cheques we issue.
-    pub chequebook: Option<Address>,
-    /// Payout address received cheques may name; defaults to the identity address.
-    pub beneficiary: Option<Address>,
-    /// Deploy a new chequebook on startup instead of using an existing one.
-    pub deploy: bool,
-    /// Per-peer cap on uncashed cheque exposure.
-    pub bounce_limit: u128,
-}
-
 /// Borrowed, wasm-clean inputs to [`build_client_core_tail`].
 pub struct ClientTailParams<'a> {
     /// The runtime node type, which selects the SWAP default and chain need.
@@ -646,9 +630,9 @@ pub struct ClientTailParams<'a> {
     pub identity: &'a Arc<Identity>,
     /// Bandwidth config driving accounting, pricing, and the self-throttle.
     pub bandwidth: &'a DefaultAccountingConfig,
-    /// SWAP settlement parameters.
+    /// SWAP settlement configuration.
     #[cfg(feature = "swap")]
-    pub swap: ClientSwapParams,
+    pub swap: &'a SwapConfig,
 }
 
 /// Shared client launch tail for the client- and storer-backed node types.
@@ -693,10 +677,7 @@ where
             params.spec,
             params.identity,
             params.bandwidth,
-            params.swap.chequebook,
-            params.swap.beneficiary,
-            params.swap.deploy,
-            params.swap.bounce_limit,
+            params.swap,
             swap_enabled,
         )
         .unzip()
@@ -950,17 +931,15 @@ mod tests {
         let spec = identity.spec().clone();
 
         let (pseudosettle_provider, _) = PseudosettleWiring::prepare(&config);
-        let (swap_provider, _) = SwapWiring::prepare(
-            &spec,
-            &identity,
-            &config,
-            Some(Address::repeat_byte(0xab)),
-            None,
-            false,
-            0,
-            true,
-        )
-        .expect("swap wiring is prepared for a chequebook on a named chain");
+        let swap_config = SwapConfig {
+            enable: Some(true),
+            chequebook: Some(Address::repeat_byte(0xab)),
+            beneficiary: None,
+            deploy: false,
+            bounce_limit: 0,
+        };
+        let (swap_provider, _) = SwapWiring::prepare(&spec, &identity, &config, &swap_config, true)
+            .expect("swap wiring is prepared for a chequebook on a named chain");
 
         // Compose the accounting exactly as the launch tail does: pseudosettle
         // registered first, swap pushed in through the same extra-settlement seam.

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -30,15 +30,17 @@ use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
 use vertex_tasks::TaskExecutor;
 
 #[cfg(feature = "swap")]
+use crate::args::SwapConfig;
+#[cfg(feature = "swap")]
 use alloy_primitives::Address;
 
 use super::client::ClientNode;
+#[cfg(feature = "swap")]
+use super::core::node_chain_provider;
 use super::core::{
     ClientNodeParts, ClientTailParams, NativeChunkProvider, NodeRunParts, NodeRunTaskFn, RunTaskFn,
     SharedAccounting, build_client_core_tail, single_task,
 };
-#[cfg(feature = "swap")]
-use super::core::{ClientSwapParams, node_chain_provider};
 use crate::ClientHandle;
 use crate::inflight::PeerInflightLimiter;
 
@@ -360,21 +362,25 @@ impl ClientLauncher {
         // The launcher always builds a client, which paces against the scaled line.
         let bandwidth = self.bandwidth.for_client();
 
+        // Bound before `tail_params` so the borrowed config outlives the build call.
+        #[cfg(feature = "swap")]
+        let swap_config = SwapConfig {
+            // An embedded client defaults SWAP off; `with_swap` turns it on.
+            enable: self.swap.as_ref().map(|_| true),
+            chequebook: self.swap.as_ref().map(|cfg| cfg.chequebook),
+            beneficiary: self.swap.as_ref().and_then(|cfg| cfg.beneficiary),
+            // The browser cannot deploy a chequebook.
+            deploy: false,
+            bounce_limit: self.swap.as_ref().map_or(0, |cfg| cfg.bounce_limit),
+        };
+
         let tail_params = ClientTailParams {
             node_type: SwarmNodeType::Client,
             spec: &spec,
             identity: &self.identity,
             bandwidth: &bandwidth,
             #[cfg(feature = "swap")]
-            swap: ClientSwapParams {
-                // An embedded client defaults SWAP off; `with_swap` turns it on.
-                enable: self.swap.as_ref().map(|_| true),
-                chequebook: self.swap.as_ref().map(|cfg| cfg.chequebook),
-                beneficiary: self.swap.as_ref().and_then(|cfg| cfg.beneficiary),
-                // The browser cannot deploy a chequebook.
-                deploy: false,
-                bounce_limit: self.swap.as_ref().map_or(0, |cfg| cfg.bounce_limit),
-            },
+            swap: &swap_config,
         };
 
         let executor = TaskExecutor::current();

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -42,7 +42,7 @@ pub use core::{
     single_task, spawn_client_command_bridge,
 };
 #[cfg(feature = "swap")]
-pub use core::{ClientSwapParams, NodeChainError, SwapWiring, node_chain_provider};
+pub use core::{NodeChainError, SwapWiring, node_chain_provider};
 pub use error::NodeBuildError;
 #[cfg(feature = "swap")]
 pub use launch::LauncherSwapConfig;

--- a/crates/swarm/node/tests/wasm_client_core.rs
+++ b/crates/swarm/node/tests/wasm_client_core.rs
@@ -128,23 +128,22 @@ fn client_core_accounting_wires_pseudosettle_and_swap_on_wasm() {
     use alloy_primitives::Address;
     use vertex_swarm_api::SwarmSettlementProvider;
     use vertex_swarm_node::SwapWiring;
+    use vertex_swarm_node::args::SwapConfig;
 
     let identity = test_identity_arc();
     let bandwidth = DefaultAccountingConfig::default();
     let spec = identity.spec().clone();
 
     let (pseudosettle_provider, _) = PseudosettleWiring::prepare(&bandwidth);
-    let (swap_provider, _) = SwapWiring::prepare(
-        &spec,
-        &identity,
-        &bandwidth,
-        Some(Address::repeat_byte(0xab)),
-        None,
-        false,
-        0,
-        true,
-    )
-    .expect("swap wiring is prepared for a chequebook on a named chain");
+    let swap_config = SwapConfig {
+        enable: Some(true),
+        chequebook: Some(Address::repeat_byte(0xab)),
+        beneficiary: None,
+        deploy: false,
+        bounce_limit: 0,
+    };
+    let (swap_provider, _) = SwapWiring::prepare(&spec, &identity, &bandwidth, &swap_config, true)
+        .expect("swap wiring is prepared for a chequebook on a named chain");
 
     let accounting = AccountingBuilder::new(bandwidth)
         .with_pricer_from_config(spec)


### PR DESCRIPTION
## What

Flow the validated domain configs whole through the launch path instead of hand-copying their fields across intermediate structs.

`ClientSwapParams`, a field-by-field copy of `SwapConfig`, is deleted. `ClientTailParams.swap` now carries `&SwapConfig` (gated on the `swap` feature) and `SwapWiring::prepare` takes the config by reference, dropping its four positional swap parameters and the `too_many_arguments` allow. The loose `cache_budget_bytes`/`soc_cache_ttl` pair rides an owned `LocalStoreConfig` through `resolve_cache`, `default_cache`, `ClientAssembly`, `StorerAssembly` and `build_serve_store`.

To let the client core carry `SwapConfig` in a build without the CLI, `pub mod args` is now unconditional; the argument structs and their clap/serde machinery stay gated on `cli` per module, so a cli-off build gains only the plain-data `SwapConfig`. The default client remains free of the swap and chain cone (cone guard confirms).

## Why

Closes #676 (part of epic #674). A single knob such as a swap setting crossed several hand-written structs between the CLI and the wiring that consumes it, each a manual field copy adding no validation. Flowing the whole validated config removes the relay structs and the drift risk they carry.

Behaviour-preserving: no wire bytes, no CLI surface, no default, and no public config-constructor change. `SwapConfig::default()` is now hand-rolled to the same values the CLI path produced, guarded by an equality assertion in the cli-on test.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-swarm-node -p vertex-swarm-builder --all-features` (171/171)
- `cargo check -p vertex-swarm-node --no-default-features --features swap,std` (swap-on, cli-off)
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node --no-default-features --features swap,std`
- `just check-cone` (default vertex free of the swap and chain cone)

## Notes

AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the refactor, the cli-gating fix, and this description.
