### PR TITLE
refactor(node): converge the embedded launcher onto the shared domain configs

### DIFF
--- a/bin/swarm-demo/src/lib.rs
+++ b/bin/swarm-demo/src/lib.rs
@@ -19,7 +19,8 @@ use vertex_swarm_identity::Identity;
 use vertex_swarm_localstore::{
     ChunkStore, DEFAULT_CACHE_BUDGET_BYTES, DEFAULT_SOC_CACHE_TTL_NS, IndexedDbBackend, SystemClock,
 };
-use vertex_swarm_node::{ClientLauncher, LauncherSwapConfig, SwarmNodeType};
+use vertex_swarm_node::args::SwapConfig;
+use vertex_swarm_node::{ClientLauncher, SwarmNodeType};
 use vertex_swarm_primitives::OverlayAddress;
 use vertex_swarm_spec::{init_mainnet, mainnet_wss_bootnodes};
 use vertex_swarm_topology::{TopologyEvent, TopologyHandle};
@@ -312,9 +313,12 @@ pub async fn start() -> Result<SwarmDemo, JsValue> {
     // SWAP cheque settlement is enabled when a chequebook address is supplied
     // through the page config; without one the client settles by pseudosettle
     // alone. Cheque exchange is chain-free unless an RPC URL is also supplied.
-    if let Some(swap) = swap_config_from_page() {
-        info!(chequebook = %swap.chequebook, "SWAP settlement enabled");
-        launcher = launcher.with_swap(swap);
+    if let Some((cfg, rpc)) = swap_config_from_page() {
+        info!(chequebook = ?cfg.chequebook, "SWAP settlement enabled");
+        launcher = launcher.with_swap(cfg);
+        if let Some(rpc) = rpc {
+            launcher = launcher.with_swap_rpc_url(rpc);
+        }
     }
 
     let launched = launcher
@@ -375,7 +379,7 @@ async fn open_indexeddb_store() -> Result<Arc<dyn SwarmLocalStore>, JsValue> {
 /// turns on on-chain cashout of received cheques. Returns `None` when no
 /// chequebook is supplied or the address does not parse, leaving the client on
 /// pseudosettle-only settlement.
-fn swap_config_from_page() -> Option<LauncherSwapConfig> {
+fn swap_config_from_page() -> Option<(SwapConfig, Option<String>)> {
     let search = web_sys::window()?.location().search().ok()?;
     let params = web_sys::UrlSearchParams::new_with_str(&search).ok()?;
 
@@ -388,9 +392,12 @@ fn swap_config_from_page() -> Option<LauncherSwapConfig> {
         }
     };
 
-    let mut config = LauncherSwapConfig::new(chequebook);
-    config.rpc_url = params.get("rpc").filter(|url| !url.is_empty());
-    Some(config)
+    let rpc = params.get("rpc").filter(|url| !url.is_empty());
+    let config = SwapConfig {
+        chequebook: Some(chequebook),
+        ..Default::default()
+    };
+    Some((config, rpc))
 }
 
 /// Publish a running demo handle on `window.__swarmDemo` for the JS frontend.

--- a/crates/swarm/node/src/args/mod.rs
+++ b/crates/swarm/node/src/args/mod.rs
@@ -1,13 +1,12 @@
 //! CLI argument structs and validated configurations for Swarm.
 //!
-//! The argument structs need the `cli` feature; the validated [`SwapConfig`]
-//! compiles in every build so the client core can carry it whole.
+//! The argument structs need the `cli` feature; the validated configs
+//! ([`NetworkConfig`], [`PeerConfig`], [`SwapConfig`]) compile in every build so
+//! the client core can carry them whole.
 
 #[cfg(feature = "cli")]
 mod chain;
-#[cfg(feature = "cli")]
 mod network;
-#[cfg(feature = "cli")]
 mod peer;
 #[cfg(feature = "cli")]
 mod spec;
@@ -18,9 +17,11 @@ mod swarm;
 #[cfg(feature = "cli")]
 pub use chain::{ChainArgs, ChainConfig};
 #[cfg(feature = "cli")]
-pub use network::{NetworkArgs, NetworkConfig};
+pub use network::NetworkArgs;
+pub use network::NetworkConfig;
 #[cfg(feature = "cli")]
-pub use peer::{PeerArgs, PeerConfig};
+pub use peer::PeerArgs;
+pub use peer::PeerConfig;
 #[cfg(feature = "cli")]
 pub use spec::SwarmSpecArgs;
 #[cfg(feature = "cli")]

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -2,15 +2,22 @@
 
 use std::time::Duration;
 
+#[cfg(feature = "cli")]
 use clap::Args;
+#[cfg(feature = "cli")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "cli")]
+use vertex_swarm_api::{ConfigAddressKind, ConfigError};
 use vertex_swarm_api::{
-    ConfigAddressKind, ConfigError, ConnectionProfile, Multiaddr, SwarmNetworkConfig,
-    SwarmPeerConfig, SwarmRoutingConfig,
+    ConnectionProfile, Multiaddr, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
 };
-use vertex_swarm_topology::{KademliaConfig, RoutingArgs};
+use vertex_swarm_topology::KademliaConfig;
+#[cfg(feature = "cli")]
+use vertex_swarm_topology::RoutingArgs;
 
-use super::peer::{PeerArgs, PeerConfig};
+#[cfg(feature = "cli")]
+use super::peer::PeerArgs;
+use super::peer::PeerConfig;
 
 /// Default P2P listen port.
 const DEFAULT_P2P_PORT: u16 = 1634;
@@ -34,21 +41,25 @@ const DEFAULT_MAX_PEERS: usize = 400;
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 60;
 
 /// Default for nat_auto (enabled by default for peer discovery).
+#[cfg(feature = "cli")]
 fn default_nat_auto() -> bool {
     true
 }
 
 /// Default for autonat (AutoNAT v2 enabled by default for all node types).
+#[cfg(feature = "cli")]
 fn default_autonat() -> bool {
     true
 }
 
 /// Default for mdns (local LAN peer discovery enabled by default).
+#[cfg(feature = "cli")]
 fn default_mdns() -> bool {
     true
 }
 
 /// P2P network CLI arguments.
+#[cfg(feature = "cli")]
 #[derive(Debug, Args, Clone, Serialize, Deserialize)]
 #[command(next_help_heading = "Networking")]
 #[serde(default)]
@@ -172,6 +183,7 @@ pub struct NetworkArgs {
     pub routing: RoutingArgs,
 }
 
+#[cfg(feature = "cli")]
 impl Default for NetworkArgs {
     fn default() -> Self {
         Self {
@@ -195,6 +207,7 @@ impl Default for NetworkArgs {
     }
 }
 
+#[cfg(feature = "cli")]
 impl NetworkArgs {
     /// Create validated NetworkConfig from these CLI arguments.
     ///
@@ -265,6 +278,18 @@ impl<R> NetworkConfig<R> {
         self
     }
 
+    /// Set the transport-layer cap on established connections.
+    pub fn with_max_peers(mut self, max: usize) -> Self {
+        self.max_peers = max;
+        self
+    }
+
+    /// Set the connection idle timeout.
+    pub fn with_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.idle_timeout = timeout;
+        self
+    }
+
     /// Get the routing configuration.
     pub fn routing(&self) -> &R {
         &self.routing
@@ -300,6 +325,31 @@ impl<R> NetworkConfig<R> {
     }
 }
 
+impl NetworkConfig<KademliaConfig> {
+    /// Dial-only shape for embedded clients: no listeners, no NAT traversal, no
+    /// LAN discovery.
+    pub fn dial_only() -> NetworkConfig<KademliaConfig> {
+        NetworkConfig {
+            listen_addrs: Vec::new(),
+            bootnodes: Vec::new(),
+            trusted_peers: Vec::new(),
+            nat_addrs: Vec::new(),
+            nat_auto: false,
+            autonat: false,
+            upnp: false,
+            mdns: false,
+            discovery_enabled: true,
+            trust_local_peers: true,
+            connection_profile: None,
+            max_peers: DEFAULT_MAX_PEERS,
+            idle_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
+            peer: PeerConfig::default(),
+            routing: KademliaConfig::default(),
+            agent_version: None,
+        }
+    }
+}
+
 impl Default for NetworkConfig<KademliaConfig> {
     #[allow(clippy::expect_used)]
     fn default() -> Self {
@@ -328,6 +378,7 @@ impl Default for NetworkConfig<KademliaConfig> {
     }
 }
 
+#[cfg(feature = "cli")]
 impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
     type Error = ConfigError;
 
@@ -481,7 +532,63 @@ impl<R: Default> SwarmRoutingConfig for NetworkConfig<R> {
     }
 }
 
+/// Field-equivalence checks for the dial-only constructor. Kept outside the
+/// cli-gated module so a default build still exercises the launcher shape.
 #[cfg(test)]
+mod dial_only_tests {
+    use super::*;
+    use vertex_swarm_api::PeerConfigValues;
+
+    #[test]
+    fn dial_only_reproduces_the_launcher_shape() {
+        let config = NetworkConfig::dial_only();
+
+        assert!(config.listen_addrs().is_empty());
+        assert!(config.trusted_peers().is_empty());
+        assert!(config.nat_addrs().is_empty());
+        assert!(config.bootnodes().is_empty());
+        assert!(config.discovery_enabled());
+        assert!(!config.nat_auto_enabled());
+        assert!(!config.autonat_enabled());
+        assert!(!config.upnp_enabled());
+        assert!(!config.mdns_enabled());
+        assert!(config.trust_local_peers());
+        assert_eq!(config.connection_profile(), None);
+        assert_eq!(config.agent_version(), None);
+        assert_eq!(config.max_peers(), DEFAULT_MAX_PEERS);
+        assert_eq!(
+            config.idle_timeout(),
+            Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS)
+        );
+
+        let peers = config.peers();
+        let default = PeerConfig::default();
+        assert_eq!(peers.ban_threshold(), default.ban_threshold());
+        assert_eq!(peers.warn_threshold(), default.warn_threshold());
+        assert_eq!(peers.max_per_bin(), default.max_per_bin());
+    }
+
+    #[test]
+    fn with_max_peers_sets_the_cap() {
+        assert_eq!(
+            NetworkConfig::dial_only().with_max_peers(16).max_peers(),
+            16
+        );
+    }
+
+    #[test]
+    fn with_idle_timeout_sets_the_timeout() {
+        let timeout = Duration::from_secs(17);
+        assert_eq!(
+            NetworkConfig::dial_only()
+                .with_idle_timeout(timeout)
+                .idle_timeout(),
+            timeout
+        );
+    }
+}
+
+#[cfg(all(test, feature = "cli"))]
 mod tests {
     use super::*;
     use vertex_swarm_api::{DEFAULT_PEER_MAX_PER_BIN, PeerConfigValues};

--- a/crates/swarm/node/src/args/peer.rs
+++ b/crates/swarm/node/src/args/peer.rs
@@ -1,6 +1,8 @@
 //! Peer management CLI arguments and validated configuration.
 
+#[cfg(feature = "cli")]
 use clap::Args;
+#[cfg(feature = "cli")]
 use serde::{Deserialize, Serialize};
 use vertex_swarm_api::{
     DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_MAX_PER_BIN, DEFAULT_PEER_WARN_THRESHOLD,
@@ -25,6 +27,7 @@ impl Default for PeerConfig {
     }
 }
 
+#[cfg(feature = "cli")]
 impl From<&PeerArgs> for PeerConfig {
     fn from(args: &PeerArgs) -> Self {
         Self {
@@ -54,6 +57,7 @@ impl PeerConfigValues for PeerConfig {
 }
 
 /// Peer management configuration.
+#[cfg(feature = "cli")]
 #[derive(Debug, Clone, Args, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PeerArgs {
@@ -70,6 +74,7 @@ pub struct PeerArgs {
     pub max_per_bin: usize,
 }
 
+#[cfg(feature = "cli")]
 impl Default for PeerArgs {
     fn default() -> Self {
         Self {
@@ -80,6 +85,7 @@ impl Default for PeerArgs {
     }
 }
 
+#[cfg(feature = "cli")]
 impl PeerConfigValues for PeerArgs {
     fn ban_threshold(&self) -> f64 {
         self.ban_threshold

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -34,7 +34,7 @@ pub use node::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder};
 #[cfg(feature = "swap")]
-pub use node::{LauncherSwapConfig, NodeChainError, SwapWiring, node_chain_provider};
+pub use node::{NodeChainError, SwapWiring, node_chain_provider};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storer"))]
 pub use node::{StorerNode, StorerNodeBuilder, StorerPullsyncControl};
 /// The shared chain provider handle, re-exported so client entry points and the

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -1,16 +1,17 @@
 //! Fluent launcher for an embedded Swarm client node.
 //!
 //! [`ClientLauncher`] is the lightweight entry point shared by native embedders
-//! and the browser client: no database, no RPC server. It assembles a dial-only
-//! [`ClientNode`] over a handful of network knobs and delegates the shared
-//! client wiring (accounting, settlement, the chunk provider, service
-//! spawning) to [`build_client_core_tail`], the same tail the native builder
-//! uses, then spawns the returned run task. It hands back a [`LaunchedClient`]
-//! with the handles a caller needs to observe the topology and issue chunk reads
-//! and writes. Settlement is pseudosettle (the chain-free path) by default; SWAP
-//! is chequebook-based and so always resolves a chain, with on-chain cashout
-//! added behind `swap-chequebook`. The full native stack (persistent storage,
-//! RPC, the storer reserve) still goes through `vertex-swarm-builder`.
+//! and the browser client: no database, no RPC server. It carries the shared
+//! domain configs ([`NetworkConfig`], [`LocalStoreConfig`], and the plain-data
+//! [`SwapConfig`]) in a dial-only shape and delegates the shared client wiring
+//! (accounting, settlement, the chunk provider, service spawning) to
+//! [`build_client_core_tail`], the same tail the native builder uses, then spawns
+//! the returned run task. It hands back a [`LaunchedClient`] with the handles a
+//! caller needs to observe the topology and issue chunk reads and writes.
+//! Settlement is pseudosettle (the chain-free path) by default; SWAP is
+//! chequebook-based and so always resolves a chain, with on-chain cashout added
+//! behind `swap-chequebook`. The full native stack (persistent storage, RPC, the
+//! storer reserve) still goes through `vertex-swarm-builder`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,20 +20,16 @@ use eyre::Result;
 use libp2p::{Multiaddr, PeerId};
 use nectar_primitives::SwarmAddress;
 use vertex_swarm_accounting::DefaultAccountingConfig;
-use vertex_swarm_api::{
-    DefaultPeerConfig, SwarmLocalStore, SwarmNetworkConfig, SwarmNodeType, SwarmPeerConfig,
-    SwarmRoutingConfig,
-};
+use vertex_swarm_api::{SwarmLocalStore, SwarmNodeType};
 use vertex_swarm_identity::Identity;
-use vertex_swarm_localstore::{ChunkStore, DEFAULT_CACHE_BUDGET_BYTES, DEFAULT_SOC_CACHE_TTL_NS};
+use vertex_swarm_localstore::{ChunkStore, LocalStoreConfig};
 use vertex_swarm_spec::HasSpec;
 use vertex_swarm_topology::{KademliaConfig, TopologyHandle};
 use vertex_tasks::TaskExecutor;
 
+use crate::args::NetworkConfig;
 #[cfg(feature = "swap")]
 use crate::args::SwapConfig;
-#[cfg(feature = "swap")]
-use alloy_primitives::Address;
 
 use super::client::ClientNode;
 #[cfg(feature = "swap")]
@@ -43,123 +40,6 @@ use super::core::{
 };
 use crate::ClientHandle;
 use crate::inflight::PeerInflightLimiter;
-
-/// Default connection idle timeout for a launched client.
-const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Default transport-layer cap on established connections.
-///
-/// A saturated routing table sits comfortably below this; it is a resource
-/// backstop, not a topology knob.
-const DEFAULT_MAX_PEERS: usize = 400;
-
-/// Network configuration assembled from the launcher's fields.
-///
-/// A launched client is dial-only: it carries no listen addresses and leaves
-/// mDNS, UPnP, and AutoNAT off. This is the trimmed counterpart to the
-/// CLI-driven `NetworkConfig` the full native builder uses.
-struct LaunchNetworkConfig {
-    bootnodes: Vec<Multiaddr>,
-    peer: DefaultPeerConfig,
-    routing: KademliaConfig,
-    max_peers: usize,
-    idle_timeout: Duration,
-}
-
-impl SwarmNetworkConfig for LaunchNetworkConfig {
-    fn listen_addrs(&self) -> &[Multiaddr] {
-        &[]
-    }
-
-    fn bootnodes(&self) -> &[Multiaddr] {
-        &self.bootnodes
-    }
-
-    fn discovery_enabled(&self) -> bool {
-        true
-    }
-
-    fn max_peers(&self) -> usize {
-        self.max_peers
-    }
-
-    fn idle_timeout(&self) -> Duration {
-        self.idle_timeout
-    }
-
-    fn nat_auto_enabled(&self) -> bool {
-        false
-    }
-
-    fn autonat_enabled(&self) -> bool {
-        false
-    }
-
-    fn upnp_enabled(&self) -> bool {
-        false
-    }
-
-    fn mdns_enabled(&self) -> bool {
-        false
-    }
-}
-
-impl SwarmPeerConfig for LaunchNetworkConfig {
-    type Peers = DefaultPeerConfig;
-
-    fn peers(&self) -> &Self::Peers {
-        &self.peer
-    }
-}
-
-impl SwarmRoutingConfig for LaunchNetworkConfig {
-    type Routing = KademliaConfig;
-
-    fn routing(&self) -> &Self::Routing {
-        &self.routing
-    }
-}
-
-/// SWAP settlement parameters for an embedded client.
-///
-/// The signer and the settlement chain are not carried here: the swap service
-/// signs with the launcher identity and resolves the chain from the identity's
-/// spec. SWAP is chequebook-based, so enabling it requires a resolvable chain;
-/// with the `swap-chequebook` feature an `rpc_url` supplies it and turns on
-/// on-chain cashout of received cheques, paying out to `beneficiary`.
-#[cfg(feature = "swap")]
-#[derive(Clone)]
-pub struct LauncherSwapConfig {
-    /// Our chequebook contract address, named in the cheques we issue.
-    pub chequebook: Address,
-    /// The payout address received cheques may name. Defaults to the identity's
-    /// Ethereum address when `None`.
-    pub beneficiary: Option<Address>,
-    /// Cap on the cumulative cheque value we accept from a peer before refusing
-    /// further cheques.
-    pub bounce_limit: u128,
-    /// RPC endpoint for on-chain cashout. `None` keeps settlement chain-free
-    /// (cheque exchange only, no cashout).
-    #[cfg(feature = "swap-chequebook")]
-    pub rpc_url: Option<String>,
-}
-
-#[cfg(feature = "swap")]
-impl LauncherSwapConfig {
-    /// A swap config for the given chequebook, beneficiary defaulted to the
-    /// identity address. Add an `rpc_url` (under `swap-chequebook`) to supply the
-    /// chain SWAP requires and turn on on-chain cashout.
-    #[must_use]
-    pub fn new(chequebook: Address) -> Self {
-        Self {
-            chequebook,
-            beneficiary: None,
-            bounce_limit: 0,
-            #[cfg(feature = "swap-chequebook")]
-            rpc_url: None,
-        }
-    }
-}
 
 /// Fluent launcher for an embedded Swarm client node.
 ///
@@ -185,20 +65,18 @@ impl LauncherSwapConfig {
 /// ```
 pub struct ClientLauncher {
     identity: Arc<Identity>,
-    bootnodes: Vec<Multiaddr>,
-    kademlia: KademliaConfig,
+    network: NetworkConfig<KademliaConfig>,
     bandwidth: DefaultAccountingConfig,
-    max_peers: usize,
-    idle_timeout: Duration,
-    /// Byte budget for the default in-memory cache (ignored when a store is set).
-    cache_budget_bytes: u64,
-    /// TTL (ns) governing single-owner-chunk freshness in the default cache.
-    soc_cache_ttl_ns: u64,
+    local_store: LocalStoreConfig,
     /// Caller-supplied client cache. `None` builds the default in-memory cache.
     store: Option<Arc<dyn SwarmLocalStore>>,
-    /// SWAP settlement parameters. `None` keeps settlement pseudosettle-only.
+    /// SWAP settlement parameters.
     #[cfg(feature = "swap")]
-    swap: Option<LauncherSwapConfig>,
+    swap: SwapConfig,
+    /// RPC endpoint for on-chain cashout of received cheques. `None` keeps
+    /// settlement chain-free (cheque exchange only, no cashout).
+    #[cfg(feature = "swap-chequebook")]
+    rpc_url: Option<String>,
 }
 
 impl ClientLauncher {
@@ -207,24 +85,29 @@ impl ClientLauncher {
     pub fn new(identity: impl Into<Arc<Identity>>) -> Self {
         Self {
             identity: identity.into(),
-            bootnodes: Vec::new(),
-            kademlia: KademliaConfig::default(),
+            network: NetworkConfig::dial_only(),
             bandwidth: DefaultAccountingConfig::default(),
-            max_peers: DEFAULT_MAX_PEERS,
-            idle_timeout: DEFAULT_IDLE_TIMEOUT,
-            cache_budget_bytes: DEFAULT_CACHE_BUDGET_BYTES,
-            soc_cache_ttl_ns: DEFAULT_SOC_CACHE_TTL_NS,
+            local_store: LocalStoreConfig::default(),
             store: None,
             #[cfg(feature = "swap")]
-            swap: None,
+            swap: SwapConfig::default(),
+            #[cfg(feature = "swap-chequebook")]
+            rpc_url: None,
         }
     }
 
-    /// Set the byte budget for the default in-memory cache. Ignored when a store
-    /// is supplied through [`Self::with_store`].
+    /// Set the local-store configuration for the default in-memory cache.
+    /// Ignored when a store is supplied through [`Self::with_store`].
     #[must_use]
-    pub fn with_cache_budget(mut self, budget_bytes: u64) -> Self {
-        self.cache_budget_bytes = budget_bytes;
+    pub fn with_local_store(mut self, config: LocalStoreConfig) -> Self {
+        self.local_store = config;
+        self
+    }
+
+    /// Replace the whole dial-only network configuration.
+    #[must_use]
+    pub fn with_network(mut self, network: NetworkConfig<KademliaConfig>) -> Self {
+        self.network = network;
         self
     }
 
@@ -235,14 +118,15 @@ impl ClientLauncher {
     /// system resolver natively, DNS-over-HTTPS in the browser.
     #[must_use]
     pub fn with_bootnodes(mut self, bootnodes: impl IntoIterator<Item = Multiaddr>) -> Self {
-        self.bootnodes = bootnodes.into_iter().collect();
+        self.network
+            .override_bootnodes(bootnodes.into_iter().collect());
         self
     }
 
     /// Set the Kademlia routing configuration.
     #[must_use]
     pub fn with_kademlia(mut self, config: KademliaConfig) -> Self {
-        self.kademlia = config;
+        self.network = self.network.with_routing(config);
         self
     }
 
@@ -259,14 +143,14 @@ impl ClientLauncher {
     /// Set the transport-layer cap on established connections.
     #[must_use]
     pub fn with_max_peers(mut self, max: usize) -> Self {
-        self.max_peers = max;
+        self.network = self.network.with_max_peers(max);
         self
     }
 
     /// Set the connection idle timeout.
     #[must_use]
     pub fn with_idle_timeout(mut self, timeout: Duration) -> Self {
-        self.idle_timeout = timeout;
+        self.network = self.network.with_idle_timeout(timeout);
         self
     }
 
@@ -282,13 +166,23 @@ impl ClientLauncher {
 
     /// Enable SWAP cheque settlement on top of pseudosettle.
     ///
-    /// Without this the launched client settles by pseudosettle only. With the
-    /// `swap-chequebook` feature and an `rpc_url` in the config, received cheques
-    /// are also cashed on chain.
+    /// An unset `enable` in the passed config defaults on: calling this at all
+    /// means the caller wants SWAP. With the `swap-chequebook` feature and an
+    /// RPC URL set through [`Self::with_swap_rpc_url`], received cheques are also
+    /// cashed on chain.
     #[cfg(feature = "swap")]
     #[must_use]
-    pub fn with_swap(mut self, cfg: LauncherSwapConfig) -> Self {
-        self.swap = Some(cfg);
+    pub fn with_swap(mut self, mut cfg: SwapConfig) -> Self {
+        cfg.enable.get_or_insert(true);
+        self.swap = cfg;
+        self
+    }
+
+    /// Set the RPC endpoint used to cash received cheques on chain.
+    #[cfg(feature = "swap-chequebook")]
+    #[must_use]
+    pub fn with_swap_rpc_url(mut self, url: impl Into<String>) -> Self {
+        self.rpc_url = Some(url.into());
         self
     }
 
@@ -316,13 +210,10 @@ impl ClientLauncher {
     /// construction). Failures after spawn, including the run loop exiting
     /// with an error, are logged by the spawned task.
     pub async fn launch(self) -> Result<LaunchedClient> {
-        let config = LaunchNetworkConfig {
-            bootnodes: self.bootnodes,
-            peer: DefaultPeerConfig::default(),
-            routing: self.kademlia.clone(),
-            max_peers: self.max_peers,
-            idle_timeout: self.idle_timeout,
-        };
+        let config = self.network;
+        // The routing config is needed by the node builder after `config` moves
+        // into the build closure, so clone it out up front.
+        let kademlia = config.routing().clone();
 
         let spec = Arc::clone(HasSpec::spec(&self.identity));
 
@@ -332,8 +223,8 @@ impl ClientLauncher {
         // browser) replaces the default in-memory one.
         let store: Arc<dyn SwarmLocalStore> = self.store.unwrap_or_else(|| {
             Arc::new(ChunkStore::with_budget(
-                self.cache_budget_bytes as usize,
-                self.soc_cache_ttl_ns,
+                self.local_store.cache_budget_bytes() as usize,
+                self.local_store.soc_cache_ttl(),
             ))
         });
 
@@ -343,9 +234,12 @@ impl ClientLauncher {
         // settlement path.
         #[cfg(feature = "swap")]
         let chain_provider = {
-            let swap_enabled = self.swap.is_some();
+            let swap_enabled = self
+                .swap
+                .enable
+                .unwrap_or(SwarmNodeType::Client.swap_default());
             #[cfg(feature = "swap-chequebook")]
-            let rpc_url = self.swap.as_ref().and_then(|cfg| cfg.rpc_url.as_deref());
+            let rpc_url = self.rpc_url.as_deref();
             #[cfg(not(feature = "swap-chequebook"))]
             let rpc_url: Option<&str> = None;
             node_chain_provider(
@@ -362,25 +256,13 @@ impl ClientLauncher {
         // The launcher always builds a client, which paces against the scaled line.
         let bandwidth = self.bandwidth.for_client();
 
-        // Bound before `tail_params` so the borrowed config outlives the build call.
-        #[cfg(feature = "swap")]
-        let swap_config = SwapConfig {
-            // An embedded client defaults SWAP off; `with_swap` turns it on.
-            enable: self.swap.as_ref().map(|_| true),
-            chequebook: self.swap.as_ref().map(|cfg| cfg.chequebook),
-            beneficiary: self.swap.as_ref().and_then(|cfg| cfg.beneficiary),
-            // The browser cannot deploy a chequebook.
-            deploy: false,
-            bounce_limit: self.swap.as_ref().map_or(0, |cfg| cfg.bounce_limit),
-        };
-
         let tail_params = ClientTailParams {
             node_type: SwarmNodeType::Client,
             spec: &spec,
             identity: &self.identity,
             bandwidth: &bandwidth,
             #[cfg(feature = "swap")]
-            swap: &swap_config,
+            swap: &self.swap,
         };
 
         let executor = TaskExecutor::current();
@@ -389,7 +271,6 @@ impl ClientLauncher {
         // settlement event sinks; the launcher carries no provider store, so it
         // returns its overlay and peer id for the handles below.
         let identity = Arc::clone(&self.identity);
-        let kademlia = self.kademlia;
         let store_for_node = store.clone();
 
         let parts: ClientNodeParts<(SwarmAddress, PeerId)> = build_client_core_tail(
@@ -547,5 +428,32 @@ impl LaunchedClient {
     /// The node's libp2p peer id.
     pub fn local_peer_id(&self) -> PeerId {
         self.peer_id
+    }
+}
+
+#[cfg(all(test, feature = "swap"))]
+mod tests {
+    use super::*;
+
+    fn test_launcher() -> ClientLauncher {
+        let spec = vertex_swarm_spec::init_testnet();
+        let identity = Arc::new(Identity::random(spec, SwarmNodeType::Client));
+        ClientLauncher::new(identity)
+    }
+
+    #[test]
+    fn with_swap_defaults_enable_on() {
+        let launcher = test_launcher().with_swap(SwapConfig::default());
+        assert_eq!(launcher.swap.enable, Some(true));
+    }
+
+    #[test]
+    fn with_swap_honours_explicit_disable() {
+        let cfg = SwapConfig {
+            enable: Some(false),
+            ..Default::default()
+        };
+        let launcher = test_launcher().with_swap(cfg);
+        assert_eq!(launcher.swap.enable, Some(false));
     }
 }

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -44,8 +44,6 @@ pub use core::{
 #[cfg(feature = "swap")]
 pub use core::{NodeChainError, SwapWiring, node_chain_provider};
 pub use error::NodeBuildError;
-#[cfg(feature = "swap")]
-pub use launch::LauncherSwapConfig;
 pub use launch::{ClientLauncher, LaunchedClient};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storer"))]
 pub use storer::{StorerNode, StorerNodeBuilder, StorerPullsyncControl};


### PR DESCRIPTION
## What

Converge the embedded `ClientLauncher` onto the shared domain configs.

The launcher privately restated three configs the native builder already validates: `LaunchNetworkConfig` (a hand-rolled `SwarmNetworkConfig` implementation duplicating `NetworkConfig`), `LauncherSwapConfig` (duplicating `SwapConfig` plus an RPC-URL knob), and two loose cache fields duplicating `LocalStoreConfig`. All three are deleted. The launcher now holds a `NetworkConfig<KademliaConfig>` built by a new `dial_only()` constructor, a `LocalStoreConfig`, and the plain-data `SwapConfig`, and passes them to the same launch seam the native builder uses.

To make the validated configs available in a build without the CLI, `NetworkConfig` and `PeerConfig` are un-gated from the `cli` feature following the established `SwapConfig` pattern: the plain-data config compiles in every build while the clap and serde argument machinery stays behind `#[cfg(feature = "cli")]`. Divergence from the native builder now reduces to the genuinely launcher-shaped parts: no listeners, no database, no RPC server, and a bare RPC-URL string for browser cashout.

## Why

Closes #679 (part of epic #674). The private restatements each carried their own defaults, so the embedded launcher and the native builder drifted knob by knob. Flowing the shared domain configs removes the duplication and the drift.

Two deliberate behaviour changes come out of the convergence and are intended:

- The launcher's `bounce_limit` default moves from 0 to the domain default of 135,000,000. The old 0 refused every received cheque (the swap headroom is `bounce_limit - received_uncashed`), so this adopts the documented default that actually admits settlement.
- `with_swap` now honours an explicit `enable: Some(false)` while an unset enable still defaults on, an escape hatch the old required-chequebook struct could not express.

No Swarm wire change: the launcher builds the same dial-only network shape (verified field-by-field against the deleted implementation) and the same default cache budget, and a Client still defaults swap off.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo nextest run -p vertex-swarm-node --all-features` (160/160; new `dial_only` equivalence, setter, and `with_swap` enable-rule tests included and running under default features too)
- `cargo check -p vertex-swarm-node --no-default-features --features swap,std` (swap-on, cli-off)
- `just check-cone`
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (plus the swap-on/cli-off variant)
- `bin/swarm-demo` (separate workspace root) checked for wasm32

## Notes


AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the refactor and this description.

