### PR TITLE
refactor(node): fold the run-task callbacks into one assembly context

### DIFF
--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -16,8 +16,8 @@ use vertex_swarm_identity::Identity;
 use vertex_swarm_localstore::LocalStoreConfig;
 use vertex_swarm_node::args::NetworkConfig;
 use vertex_swarm_node::{
-    BootNode, ClientNode, ClientNodeParts, ClientTailParams, NativeChunkProvider, NodeRunParts,
-    RunTaskFn, build_client_core_tail, single_task,
+    AssemblyContext, BootNode, ClientCoreTail, ClientNode, ClientNodeParts, ClientTailParams,
+    NativeChunkProvider, NodeRunParts, RunTaskFn, SettlementEventSenders, single_task,
 };
 use vertex_swarm_peer_manager::{
     DEFAULT_TICK_INTERVAL, DbPeerSnapshotStore, PeerSnapshot, spawn_peer_manager_task,
@@ -209,11 +209,7 @@ pub(crate) struct AssemblyInputs<'a> {
     pub(crate) identity: &'a Arc<Identity>,
     pub(crate) network: &'a NetworkConfig<KademliaConfig>,
     pub(crate) peer_store: Option<PeerStore>,
-    pub(crate) pseudosettle_event_sender:
-        tokio::sync::mpsc::UnboundedSender<vertex_swarm_node::PseudosettleEvent>,
-    #[cfg(feature = "swap")]
-    pub(crate) swap_event_sender:
-        Option<tokio::sync::mpsc::UnboundedSender<vertex_swarm_node::SwapEvent>>,
+    pub(crate) senders: SettlementEventSenders,
 }
 
 /// The node-type-specific launch seam. The client assembly ([`ClientAssembly`])
@@ -270,9 +266,7 @@ impl NodeAssembly for ClientAssembly {
             inputs.network,
             node_store,
             inputs.peer_store,
-            inputs.pseudosettle_event_sender,
-            #[cfg(feature = "swap")]
-            inputs.swap_event_sender,
+            inputs.senders,
         )
         .await?;
         Ok((parts, ()))
@@ -283,9 +277,10 @@ impl NodeAssembly for ClientAssembly {
 ///
 /// Resolves the chain precondition, opens the database, and builds the peer
 /// store, then delegates the wasm-clean wiring (accounting, settlement, the
-/// chunk provider, service spawning) to [`build_client_core_tail`]. The
+/// chunk provider, service spawning) to [`ClientCoreTail`]. The
 /// node-type-specific local store and node assembly are injected through
-/// `assembly`, invoked by the tail over the prepared settlement event sinks.
+/// `assembly`, invoked between the tail's prepare and finish phases over the
+/// prepared settlement event sinks.
 pub(crate) async fn build_client_backed_node<F: NodeAssembly>(
     ctx: &dyn InfrastructureContext,
     params: ClientNodeParams<'_>,
@@ -344,29 +339,28 @@ pub(crate) async fn build_client_backed_node<F: NodeAssembly>(
         swap: params.swap,
     };
 
-    let parts = build_client_core_tail(
-        ctx.executor(),
+    // SWAP carries the chain provider, so the tail accepts the resolved handle
+    // whenever swap is built.
+    let (tail, senders) = ClientCoreTail::prepare(
         tail_params,
-        // SWAP carries the chain provider, so the tail accepts the resolved
-        // handle whenever swap is built.
         #[cfg(feature = "swap")]
         chain_provider,
-        |events| {
-            assembly.assemble(
-                ctx,
-                AssemblyInputs {
-                    db,
-                    identity: params.identity,
-                    network: params.network,
-                    peer_store,
-                    pseudosettle_event_sender: events.pseudosettle,
-                    #[cfg(feature = "swap")]
-                    swap_event_sender: events.swap,
-                },
-            )
-        },
-    )
-    .await?;
+    );
+
+    let (parts, store) = assembly
+        .assemble(
+            ctx,
+            AssemblyInputs {
+                db,
+                identity: params.identity,
+                network: params.network,
+                peer_store,
+                senders,
+            },
+        )
+        .await?;
+
+    let parts = tail.finish(ctx.executor(), parts, store);
 
     info!(%node_type, "Node built successfully");
     Ok(parts)
@@ -378,18 +372,13 @@ async fn assemble_client_node(
     network: &NetworkConfig<KademliaConfig>,
     node_store: Arc<dyn vertex_swarm_api::SwarmLocalStore>,
     peer_store: Option<PeerStore>,
-    pseudosettle_event_sender: tokio::sync::mpsc::UnboundedSender<
-        vertex_swarm_node::PseudosettleEvent,
-    >,
-    #[cfg(feature = "swap")] swap_event_sender: Option<
-        tokio::sync::mpsc::UnboundedSender<vertex_swarm_node::SwapEvent>,
-    >,
+    senders: SettlementEventSenders,
 ) -> Result<NodeRunParts, SwarmNodeError> {
     let node_builder = ClientNode::builder(identity.clone())
         .with_store(node_store)
-        .with_pseudosettle_events(pseudosettle_event_sender);
+        .with_pseudosettle_events(senders.pseudosettle);
     #[cfg(feature = "swap")]
-    let node_builder = match swap_event_sender {
+    let node_builder = match senders.swap {
         Some(tx) => node_builder.with_swap_events(tx),
         None => node_builder,
     };
@@ -399,7 +388,8 @@ async fn assemble_client_node(
         .map_err(|e| SwarmNodeError::Build(e.into()))?;
     let topology = node.topology_handle().clone();
 
-    let run: RunTaskFn = Box::new(move |accounting, engine| {
+    let run: RunTaskFn = Box::new(move |ctx: AssemblyContext| {
+        let AssemblyContext { accounting, engine } = ctx;
         node.enable_forwarding(engine, Arc::clone(&accounting));
         single_task(move |shutdown| async move {
             let _accounting = accounting;

--- a/crates/swarm/builder/src/storer.rs
+++ b/crates/swarm/builder/src/storer.rs
@@ -41,7 +41,10 @@ use crate::launch::{
     build_client_backed_node, resolve_cache,
 };
 use crate::protocol::SwarmProtocol;
-use vertex_swarm_node::{NativeChunkProvider, NodeRunParts, RunTaskFn, single_task};
+use vertex_swarm_node::{
+    AssemblyContext, NativeChunkProvider, NodeRunParts, RunTaskFn, SettlementEventSenders,
+    single_task,
+};
 
 /// A reserve override supplied through the config setters. With no seam the storer launch
 /// path builds the default admission-gated [`DbReserve`] over the shared database.
@@ -331,9 +334,7 @@ impl NodeAssembly for StorerAssembly {
             serve.reserve,
             serve.pullsync,
             serve.batches,
-            inputs.pseudosettle_event_sender,
-            #[cfg(feature = "swap")]
-            inputs.swap_event_sender,
+            inputs.senders,
         )
         .await?;
         Ok((capable, provider_store))
@@ -398,12 +399,7 @@ async fn assemble_storer_node(
     reserve: Arc<dyn BinCursorStore>,
     pullsync: Option<Arc<dyn PullStorage>>,
     batches: Option<DbBatchStore<RedbDatabase>>,
-    pseudosettle_event_sender: tokio::sync::mpsc::UnboundedSender<
-        vertex_swarm_node::PseudosettleEvent,
-    >,
-    #[cfg(feature = "swap")] swap_event_sender: Option<
-        tokio::sync::mpsc::UnboundedSender<vertex_swarm_node::SwapEvent>,
-    >,
+    senders: SettlementEventSenders,
 ) -> Result<NodeRunParts, SwarmNodeError> {
     // A storer without a `PullStorage`-shaped reserve cannot serve pullsync; this
     // only happens with a reserve seam that is not the default `DbReserve`.
@@ -413,9 +409,9 @@ async fn assemble_storer_node(
     let node_builder = StorerNode::builder(identity.clone())
         .with_store(node_store)
         .with_pullsync_storage(pullsync_storage)
-        .with_pseudosettle_events(pseudosettle_event_sender);
+        .with_pseudosettle_events(senders.pseudosettle);
     #[cfg(feature = "swap")]
-    let node_builder = match swap_event_sender {
+    let node_builder = match senders.swap {
         Some(tx) => node_builder.with_swap_events(tx),
         None => node_builder,
     };
@@ -441,7 +437,8 @@ async fn assemble_storer_node(
     );
     node.set_puller(puller_handle);
 
-    let run: RunTaskFn = Box::new(move |accounting, engine| {
+    let run: RunTaskFn = Box::new(move |ctx: AssemblyContext| {
+        let AssemblyContext { accounting, engine } = ctx;
         node.enable_forwarding(engine, Arc::clone(&accounting));
         node.enable_storage(reserve as Arc<dyn ReserveStore>);
         single_task(move |shutdown| async move {

--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -25,11 +25,11 @@ mod selection;
 mod staggered_race;
 
 pub use node::{
-    BaseNode, BuiltInfrastructure, ClientCore, ClientCoreCtx, ClientLauncher, ClientNode,
-    ClientNodeBuilder, ClientNodeParts, ClientTailParams, LaunchedClient, NativeChunkProvider,
-    NativeDispatchEngine, NodeBuildError, NodeRunParts, NodeRunTaskFn, PseudosettleWiring,
-    RunTaskFn, SettlementEventSenders, SharedAccounting, assemble_client_core,
-    build_client_core_tail, single_task, spawn_client_command_bridge,
+    AssemblyContext, BaseNode, BuiltInfrastructure, ClientCore, ClientCoreCtx, ClientCoreTail,
+    ClientLauncher, ClientNode, ClientNodeBuilder, ClientNodeParts, ClientTailParams,
+    LaunchedClient, NativeChunkProvider, NativeDispatchEngine, NodeBuildError, NodeRunParts,
+    NodeRunTaskFn, PseudosettleWiring, RunTaskFn, SettlementEventSenders, SharedAccounting,
+    assemble_client_core, single_task, spawn_client_command_bridge,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder};

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -555,11 +555,20 @@ where
     Box::new(move |shutdown| Box::pin(f(shutdown)))
 }
 
+/// Tail-built shared components a node assembly applies to its concrete node
+/// (forwarding, and for a storer ingest) before returning the run-loop task.
+pub struct AssemblyContext {
+    /// The one shared accounting instance; the run task keeps it alive.
+    pub accounting: SharedAccounting,
+    /// The fully-wired dispatch engine, applied as the node's relay role.
+    pub engine: NativeDispatchEngine,
+}
+
 /// A run-task factory: applies multi-hop forwarding (and, for a storer, ingest)
 /// over the shared accounting and the engine's relay role, then returns the
 /// node's run-loop task. Keeps the concrete node type out of the shared launch
 /// tail.
-pub type RunTaskFn = Box<dyn FnOnce(SharedAccounting, NativeDispatchEngine) -> NodeRunTaskFn>;
+pub type RunTaskFn = Box<dyn FnOnce(AssemblyContext) -> NodeRunTaskFn>;
 
 /// The native client's fully-capable dispatch engine instantiation, shared by
 /// the chunk provider (origin dispatch) and the forwarder (relay role).
@@ -586,7 +595,7 @@ pub struct NodeRunParts {
 pub type NativeChunkProvider =
     NetworkChunkProvider<Arc<PeerSelector>, Arc<PeerInflightLimiter>, Arc<RetrievalLatency>>;
 
-/// Outputs of [`build_client_core_tail`]: the run-loop task, the topology handle,
+/// Outputs of [`ClientCoreTail::finish`]: the run-loop task, the topology handle,
 /// the chunk provider, the shared accounting and throttled client handle
 /// (for an embedder that observes them), and the node-type-specific provider store
 /// (`()` for a client, the serve view plus reserve for a storer).
@@ -620,7 +629,7 @@ pub struct SettlementEventSenders {
     pub swap: Option<mpsc::UnboundedSender<SwapEvent>>,
 }
 
-/// Borrowed, wasm-clean inputs to [`build_client_core_tail`].
+/// Borrowed, wasm-clean inputs to [`ClientCoreTail::prepare`].
 pub struct ClientTailParams<'a> {
     /// The runtime node type, which selects the SWAP default and chain need.
     pub node_type: SwarmNodeType,
@@ -637,177 +646,214 @@ pub struct ClientTailParams<'a> {
 
 /// Shared client launch tail for the client- and storer-backed node types.
 ///
-/// Wires accounting (violations to the peer manager, SWAP settlement when
-/// enabled) and the selection-aware chunk provider, then spawns the
-/// client and settlement services and the peer-manager tick. `build_node` builds
-/// the concrete node over the settlement event sinks and returns its run parts
-/// plus the node-type provider store; the tail is agnostic to whether that node
-/// is a bare client or a storer. SWAP defaults on for storers and off for
-/// clients, overridable through `params.swap.enable`.
-///
-/// The returned run task is left for the caller to spawn: the native builder
-/// hands it to the binary, the embedded launcher spawns it on its executor.
-pub async fn build_client_core_tail<P, E, FBuild, Fut>(
-    executor: &TaskExecutor,
-    params: ClientTailParams<'_>,
-    #[cfg(feature = "swap")] chain_provider: Option<SharedChainProvider>,
-    build_node: FBuild,
-) -> Result<ClientNodeParts<P>, E>
-where
-    FBuild: FnOnce(SettlementEventSenders) -> Fut,
-    Fut: std::future::Future<Output = Result<(NodeRunParts, P), E>>,
-{
-    // Pseudosettle (soft accounting) is always on: prepare the provider so it
-    // embeds in the accounting, and the event sink so wire events route at the
-    // node build below.
-    let (pseudosettle_provider, pseudosettle_wiring) =
-        PseudosettleWiring::prepare(params.bandwidth);
-    let pseudosettle_event_sender = pseudosettle_wiring.event_sender();
-
-    // SWAP settlement is prepared next: the provider embeds in the accounting and
-    // the swap event sink routes at node build time. The enable decision lives
-    // here, once, for both entry points.
+/// Splits assembly into two infallible synchronous phases around the concrete
+/// node build. [`ClientCoreTail::prepare`] wires the settlement providers into
+/// the accounting and yields the event sinks the node build routes wire events
+/// into; [`ClientCoreTail::finish`] takes the built node's run parts, wires the
+/// selection-aware chunk provider and the shared accounting, spawns the client
+/// and settlement services and the peer-manager tick, and returns the run parts
+/// for the caller to spawn. SWAP defaults on for storers and off for clients,
+/// overridable through `params.swap.enable`.
+pub struct ClientCoreTail {
+    spec: Arc<Spec>,
+    identity: Arc<Identity>,
+    bandwidth: DefaultAccountingConfig,
+    pseudosettle_provider: PseudosettleProvider<DefaultAccountingConfig>,
+    pseudosettle_wiring: PseudosettleWiring,
     #[cfg(feature = "swap")]
-    let (swap_provider, swap_wiring) = {
-        let swap_enabled = params
-            .swap
-            .enable
-            .unwrap_or(params.node_type.swap_default());
-        SwapWiring::prepare(
-            params.spec,
-            params.identity,
-            params.bandwidth,
-            params.swap,
-            swap_enabled,
-        )
-        .unzip()
-    };
+    swap: Option<(SwapProvider<DefaultAccountingConfig>, SwapWiring)>,
     #[cfg(feature = "swap")]
-    let swap_event_sender = swap_wiring.as_ref().map(|w| w.swap_event_sender());
+    chain_provider: Option<SharedChainProvider>,
+}
 
-    // The concrete node is built over the settlement event sinks: a bare client,
-    // or (for a storer) the pullsync-capable node plus its puller. Accounting,
-    // selection, and settlement wiring below is identical for both.
-    let (
-        NodeRunParts {
+impl ClientCoreTail {
+    /// Prepare the settlement wiring and return the event sinks the node build
+    /// routes wire events into.
+    ///
+    /// Pseudosettle (soft accounting) is always wired; SWAP is wired when enabled
+    /// (defaulting on for storers, off for clients). The enable decision lives
+    /// here, once, for both entry points.
+    pub fn prepare(
+        params: ClientTailParams<'_>,
+        #[cfg(feature = "swap")] chain_provider: Option<SharedChainProvider>,
+    ) -> (Self, SettlementEventSenders) {
+        // Pseudosettle: prepare the provider so it embeds in the accounting, and
+        // the event sink so wire events route at the node build.
+        let (pseudosettle_provider, pseudosettle_wiring) =
+            PseudosettleWiring::prepare(params.bandwidth);
+        let pseudosettle_event_sender = pseudosettle_wiring.event_sender();
+
+        // SWAP: the provider embeds in the accounting and the swap event sink
+        // routes at node build time.
+        #[cfg(feature = "swap")]
+        let swap = {
+            let swap_enabled = params
+                .swap
+                .enable
+                .unwrap_or(params.node_type.swap_default());
+            SwapWiring::prepare(
+                params.spec,
+                params.identity,
+                params.bandwidth,
+                params.swap,
+                swap_enabled,
+            )
+        };
+        #[cfg(feature = "swap")]
+        let swap_event_sender = swap.as_ref().map(|(_, wiring)| wiring.swap_event_sender());
+
+        let senders = SettlementEventSenders {
+            pseudosettle: pseudosettle_event_sender,
+            #[cfg(feature = "swap")]
+            swap: swap_event_sender,
+        };
+
+        let tail = Self {
+            spec: Arc::clone(params.spec),
+            identity: params.identity.clone(),
+            bandwidth: params.bandwidth.clone(),
+            pseudosettle_provider,
+            pseudosettle_wiring,
+            #[cfg(feature = "swap")]
+            swap,
+            #[cfg(feature = "swap")]
+            chain_provider,
+        };
+
+        (tail, senders)
+    }
+
+    /// Finish assembly over the built node's run parts: wire the shared accounting
+    /// and the selection-aware chunk provider, spawn the client and settlement
+    /// services and the peer-manager tick, and return the run parts for the caller
+    /// to spawn.
+    pub fn finish<P>(
+        self,
+        executor: &TaskExecutor,
+        parts: NodeRunParts,
+        provider_store: P,
+    ) -> ClientNodeParts<P> {
+        let NodeRunParts {
             topology,
             client_service,
             client_handle,
             run,
-        },
-        provider_store,
-    ) = build_node(SettlementEventSenders {
-        pseudosettle: pseudosettle_event_sender,
+        } = parts;
+
+        // The provider reads the node's own cache before racing the swarm; it is
+        // the same store the service caches deliveries into and the handler serves
+        // from. Read before the service moves into the core.
+        let provider_cache = client_service.store();
+
+        spawn_peer_manager_task(
+            Arc::clone(topology.peer_manager()),
+            DEFAULT_TICK_INTERVAL,
+            executor,
+        );
+
+        // The peer manager is the reporting authority: accounting and the
+        // settlement services report violations through it so misbehaving peers
+        // are scored down.
+        let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
+
         #[cfg(feature = "swap")]
-        swap: swap_event_sender,
-    })
-    .await?;
+        let (swap_provider, swap_wiring) = self.swap.unzip();
 
-    // The provider reads the node's own cache before racing the swarm; it is the
-    // same store the service caches deliveries into and the handler serves from.
-    let provider_cache = client_service.store();
+        // SWAP is the only extra provider; pseudosettle is registered first inside
+        // the core so soft accounting forgives total debt before SWAP settles.
+        let extra_settlement: Vec<Box<dyn SwarmSettlementProvider>> = {
+            #[cfg(feature = "swap")]
+            {
+                swap_provider
+                    .map(|provider| Box::new(provider) as Box<dyn SwarmSettlementProvider>)
+                    .into_iter()
+                    .collect()
+            }
+            #[cfg(not(feature = "swap"))]
+            Vec::new()
+        };
 
-    spawn_peer_manager_task(
-        Arc::clone(topology.peer_manager()),
-        DEFAULT_TICK_INTERVAL,
-        executor,
-    );
+        let core = assemble_client_core(ClientCoreCtx {
+            spec: Arc::clone(&self.spec),
+            identity: self.identity.clone(),
+            bandwidth: self.bandwidth.clone(),
+            topology: topology.clone(),
+            client_service,
+            client_handle: client_handle.clone(),
+            pseudosettle_provider: self.pseudosettle_provider,
+            extra_settlement,
+            reporter: Arc::clone(&reporter),
+        });
 
-    // The peer manager is the reporting authority: accounting and the settlement
-    // services report violations through it so misbehaving peers are scored down.
-    let reporter: Arc<dyn PeerReporter> = topology.peer_manager().clone();
+        // One dispatch engine for every origin and relay path. The routing table's
+        // max bin is a spec constant; read it once here and hand it to the engine as
+        // a field rather than a per-request topology query. Origin dispatch runs
+        // over the gated origin handle; relay legs debit through the forwarder's
+        // two-leg accounting instead (`originated = false`), so the shared handle is
+        // the origin-gated one and the gate simply never fires for relays.
+        let max_bin = topology.max_bin();
+        let engine = DispatchEngine::new(
+            core.origin_handle.clone(),
+            Arc::new(topology.clone()) as Arc<dyn RetrievalTopology>,
+            max_bin,
+            Arc::clone(&core.selector),
+            Arc::clone(&core.inflight),
+            Arc::clone(&core.retrieval_latency),
+            Arc::clone(&core.settlement_trigger),
+        );
 
-    // SWAP is the only extra provider; pseudosettle is registered first inside
-    // the core so soft accounting forgives total debt before SWAP settles.
-    let extra_settlement: Vec<Box<dyn SwarmSettlementProvider>> = {
-        #[cfg(feature = "swap")]
-        {
-            swap_provider
-                .map(|provider| Box::new(provider) as Box<dyn SwarmSettlementProvider>)
-                .into_iter()
-                .collect()
-        }
-        #[cfg(not(feature = "swap"))]
-        Vec::new()
-    };
+        // Multi-hop forwarding plus storer ingest must precede the event loop. The
+        // run closure applies both to its concrete node over the shared accounting
+        // and the engine's relay role, then returns the run task.
+        let task = (run)(AssemblyContext {
+            accounting: Arc::clone(&core.accounting),
+            engine: engine.clone(),
+        });
 
-    let core = assemble_client_core(ClientCoreCtx {
-        spec: Arc::clone(params.spec),
-        identity: params.identity.clone(),
-        bandwidth: params.bandwidth.clone(),
-        topology: topology.clone(),
-        client_service,
-        client_handle: client_handle.clone(),
-        pseudosettle_provider,
-        extra_settlement,
-        reporter: Arc::clone(&reporter),
-    });
+        let chunks = NetworkChunkProvider::new(engine, provider_cache);
 
-    // One dispatch engine for every origin and relay path. The routing table's
-    // max bin is a spec constant; read it once here and hand it to the engine as
-    // a field rather than a per-request topology query. Origin dispatch runs
-    // over the gated origin handle; relay legs debit through the forwarder's
-    // two-leg accounting instead (`originated = false`), so the shared handle is
-    // the origin-gated one and the gate simply never fires for relays.
-    let max_bin = topology.max_bin();
-    let engine = DispatchEngine::new(
-        core.origin_handle.clone(),
-        Arc::new(topology.clone()) as Arc<dyn RetrievalTopology>,
-        max_bin,
-        Arc::clone(&core.selector),
-        Arc::clone(&core.inflight),
-        Arc::clone(&core.retrieval_latency),
-        Arc::clone(&core.settlement_trigger),
-    );
+        executor.spawn_service("swarm.client_service", core.client_service);
 
-    // Multi-hop forwarding plus storer ingest must precede the event loop. The
-    // run closure applies both to its concrete node over the shared accounting
-    // and the engine's relay role, then returns the run task.
-    let task = (run)(Arc::clone(&core.accounting), engine.clone());
-
-    let chunks = NetworkChunkProvider::new(engine, provider_cache);
-
-    executor.spawn_service("swarm.client_service", core.client_service);
-
-    // Pseudosettle settlement service over the shared accounting: applies
-    // time-based refresh and forwards our outbound settlement to the node.
-    pseudosettle_wiring.spawn(
-        executor,
-        core.accounting.accounting().clone(),
-        client_handle.clone(),
-        Arc::clone(&reporter),
-    );
-
-    // SWAP settlement service over the shared accounting: forwards cheque
-    // commands to the node and, with a connected chain provider, cashes received
-    // cheques on chain.
-    #[cfg(feature = "swap")]
-    if let Some(wiring) = swap_wiring {
-        wiring.spawn(
+        // Pseudosettle settlement service over the shared accounting: applies
+        // time-based refresh and forwards our outbound settlement to the node.
+        self.pseudosettle_wiring.spawn(
             executor,
             core.accounting.accounting().clone(),
-            client_handle,
+            client_handle.clone(),
             Arc::clone(&reporter),
-            #[cfg(feature = "swap-chequebook")]
-            chain_provider.as_ref(),
-            #[cfg(feature = "swap-chequebook")]
-            params.spec,
         );
+
+        // SWAP settlement service over the shared accounting: forwards cheque
+        // commands to the node and, with a connected chain provider, cashes
+        // received cheques on chain.
+        #[cfg(feature = "swap")]
+        if let Some(wiring) = swap_wiring {
+            wiring.spawn(
+                executor,
+                core.accounting.accounting().clone(),
+                client_handle,
+                Arc::clone(&reporter),
+                #[cfg(feature = "swap-chequebook")]
+                self.chain_provider.as_ref(),
+                #[cfg(feature = "swap-chequebook")]
+                &self.spec,
+            );
+        }
+
+        // The chain provider is kept alive for the node's lifetime by the run task.
+        #[cfg(feature = "swap")]
+        let task = wrap_with_chain(task, self.chain_provider);
+
+        ClientNodeParts {
+            task,
+            topology,
+            chunks,
+            inflight: core.inflight,
+            accounting: core.accounting,
+            client: core.origin_handle,
+            provider_store,
+        }
     }
-
-    // The chain provider is kept alive for the node's lifetime by the run task.
-    #[cfg(feature = "swap")]
-    let task = wrap_with_chain(task, chain_provider);
-
-    Ok(ClientNodeParts {
-        task,
-        topology,
-        chunks,
-        inflight: core.inflight,
-        accounting: core.accounting,
-        client: core.origin_handle,
-        provider_store,
-    })
 }
 
 /// Resolve and validate the shared chain provider for a client- or storer-backed
@@ -955,6 +1001,55 @@ mod tests {
             accounting.accounting().provider_names(),
             vec!["pseudosettle", "swap"],
             "a swap-enabled client reports pseudosettle then swap"
+        );
+    }
+
+    /// The tail's prepare phase leaves SWAP unwired for a default client (swap
+    /// defaults off) and for an enable-forced client with no chequebook (warn and
+    /// degrade), so the returned event sinks carry no swap sender.
+    #[cfg(feature = "swap")]
+    #[test]
+    fn prepare_leaves_swap_unwired_without_chequebook() {
+        let identity = test_identity_arc();
+        let spec = identity.spec().clone();
+        let bandwidth = DefaultAccountingConfig::default();
+
+        // A default client leaves SWAP off (swap_default is off for clients).
+        let swap_off = SwapConfig::default();
+        let (_tail, senders) = ClientCoreTail::prepare(
+            ClientTailParams {
+                node_type: SwarmNodeType::Client,
+                spec: &spec,
+                identity: &identity,
+                bandwidth: &bandwidth,
+                swap: &swap_off,
+            },
+            None,
+        );
+        assert!(
+            senders.swap.is_none(),
+            "a default client leaves swap unwired"
+        );
+
+        // Enable forced on, but no chequebook: the swap wiring warns and degrades,
+        // so still no swap sender.
+        let swap_no_chequebook = SwapConfig {
+            enable: Some(true),
+            ..Default::default()
+        };
+        let (_tail, senders) = ClientCoreTail::prepare(
+            ClientTailParams {
+                node_type: SwarmNodeType::Client,
+                spec: &spec,
+                identity: &identity,
+                bandwidth: &bandwidth,
+                swap: &swap_no_chequebook,
+            },
+            None,
+        );
+        assert!(
+            senders.swap.is_none(),
+            "an enable-forced client with no chequebook degrades swap-free"
         );
     }
 

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -5,7 +5,7 @@
 //! domain configs ([`NetworkConfig`], [`LocalStoreConfig`], and the plain-data
 //! [`SwapConfig`]) in a dial-only shape and delegates the shared client wiring
 //! (accounting, settlement, the chunk provider, service spawning) to
-//! [`build_client_core_tail`], the same tail the native builder uses, then spawns
+//! [`ClientCoreTail`], the same tail the native builder uses, then spawns
 //! the returned run task. It hands back a [`LaunchedClient`] with the handles a
 //! caller needs to observe the topology and issue chunk reads and writes.
 //! Settlement is pseudosettle (the chain-free path) by default; SWAP is
@@ -35,8 +35,8 @@ use super::client::ClientNode;
 #[cfg(feature = "swap")]
 use super::core::node_chain_provider;
 use super::core::{
-    ClientNodeParts, ClientTailParams, NativeChunkProvider, NodeRunParts, NodeRunTaskFn, RunTaskFn,
-    SharedAccounting, build_client_core_tail, single_task,
+    AssemblyContext, ClientCoreTail, ClientNodeParts, ClientTailParams, NativeChunkProvider,
+    NodeRunParts, NodeRunTaskFn, RunTaskFn, SharedAccounting, single_task,
 };
 use crate::ClientHandle;
 use crate::inflight::PeerInflightLimiter;
@@ -267,61 +267,57 @@ impl ClientLauncher {
 
         let executor = TaskExecutor::current();
 
-        // The dial-only client node is built inside the tail over the prepared
-        // settlement event sinks; the launcher carries no provider store, so it
-        // returns its overlay and peer id for the handles below.
-        let identity = Arc::clone(&self.identity);
-        let store_for_node = store.clone();
-
-        let parts: ClientNodeParts<(SwarmAddress, PeerId)> = build_client_core_tail(
-            &executor,
+        let (tail, senders) = ClientCoreTail::prepare(
             tail_params,
             #[cfg(feature = "swap")]
             chain_provider,
-            move |events| async move {
-                let node_builder = ClientNode::builder(identity)
-                    .with_kademlia_config(kademlia)
-                    .with_store(store_for_node)
-                    .with_pseudosettle_events(events.pseudosettle);
-                #[cfg(feature = "swap")]
-                let node_builder = match events.swap {
-                    Some(tx) => node_builder.with_swap_events(tx),
-                    None => node_builder,
-                };
-                let (mut node, client_service, client_handle) = node_builder
-                    .build(&config, None)
-                    .await
-                    .map_err(|e| eyre::eyre!("failed to build client node: {e}"))?;
+        );
 
-                let topology = node.topology_handle().clone();
-                let overlay = node.overlay_address();
-                let peer_id = *node.local_peer_id();
+        // The dial-only client node is built between the tail's two phases over the
+        // prepared settlement event sinks; the launcher carries no provider store,
+        // so it returns its overlay and peer id for the handles below.
+        let node_builder = ClientNode::builder(Arc::clone(&self.identity))
+            .with_kademlia_config(kademlia)
+            .with_store(store.clone())
+            .with_pseudosettle_events(senders.pseudosettle);
+        #[cfg(feature = "swap")]
+        let node_builder = match senders.swap {
+            Some(tx) => node_builder.with_swap_events(tx),
+            None => node_builder,
+        };
+        let (mut node, client_service, client_handle) = node_builder
+            .build(&config, None)
+            .await
+            .map_err(|e| eyre::eyre!("failed to build client node: {e}"))?;
 
-                // Forwarding is enabled inside the run task over the shared
-                // accounting the tail builds and the engine's relay role; the
-                // node then moves into the run loop.
-                let run: RunTaskFn = Box::new(move |accounting, engine| {
-                    node.enable_forwarding(engine, Arc::clone(&accounting));
-                    single_task(move |shutdown| async move {
-                        let _accounting = accounting;
-                        if let Err(e) = node.start_and_run(shutdown).await {
-                            tracing::error!(error = %e, "client node exited with error");
-                        }
-                    })
-                });
+        let topology = node.topology_handle().clone();
+        let overlay = node.overlay_address();
+        let peer_id = *node.local_peer_id();
 
-                Ok::<_, eyre::Report>((
-                    NodeRunParts {
-                        topology,
-                        client_service,
-                        client_handle,
-                        run,
-                    },
-                    (overlay, peer_id),
-                ))
+        // Forwarding is enabled inside the run task over the shared accounting the
+        // tail builds and the engine's relay role; the node then moves into the
+        // run loop.
+        let run: RunTaskFn = Box::new(move |ctx: AssemblyContext| {
+            let AssemblyContext { accounting, engine } = ctx;
+            node.enable_forwarding(engine, Arc::clone(&accounting));
+            single_task(move |shutdown| async move {
+                let _accounting = accounting;
+                if let Err(e) = node.start_and_run(shutdown).await {
+                    tracing::error!(error = %e, "client node exited with error");
+                }
+            })
+        });
+
+        let parts: ClientNodeParts<(SwarmAddress, PeerId)> = tail.finish(
+            &executor,
+            NodeRunParts {
+                topology,
+                client_service,
+                client_handle,
+                run,
             },
-        )
-        .await?;
+            (overlay, peer_id),
+        );
 
         let ClientNodeParts {
             task,

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -36,10 +36,10 @@ pub use bootnode::{BootNode, BootNodeBuilder};
 pub use builder::BuiltInfrastructure;
 pub use client::{ClientNode, ClientNodeBuilder};
 pub use core::{
-    ClientCore, ClientCoreCtx, ClientNodeParts, ClientTailParams, NativeChunkProvider,
-    NativeDispatchEngine, NodeRunParts, NodeRunTaskFn, PseudosettleWiring, RunTaskFn,
-    SettlementEventSenders, SharedAccounting, assemble_client_core, build_client_core_tail,
-    single_task, spawn_client_command_bridge,
+    AssemblyContext, ClientCore, ClientCoreCtx, ClientCoreTail, ClientNodeParts, ClientTailParams,
+    NativeChunkProvider, NativeDispatchEngine, NodeRunParts, NodeRunTaskFn, PseudosettleWiring,
+    RunTaskFn, SettlementEventSenders, SharedAccounting, assemble_client_core, single_task,
+    spawn_client_command_bridge,
 };
 #[cfg(feature = "swap")]
 pub use core::{NodeChainError, SwapWiring, node_chain_provider};


### PR DESCRIPTION
## What

Fold the three nested callback layers that finishing node assembly spanned into one typed run context and a two-phase synchronous tail.

`RunTaskFn` changes from a positional `Box<dyn FnOnce(SharedAccounting, NativeDispatchEngine) -> ...>` to `Box<dyn FnOnce(AssemblyContext) -> ...>`, where `AssemblyContext { accounting, engine }` names what the run factory receives. `build_client_core_tail`, a generic closure-taking async function, is replaced by `ClientCoreTail::prepare` (builds the settlement providers and returns the event senders) and `ClientCoreTail::finish` (applies the built node parts and returns the run task). Both are infallible and synchronous, so the `E`, `FBuild`, and `Fut` generics disappear. The two intermediate adaptor closures in the native builder and the embedded launcher become straight-line code, and the two per-field settlement-sender parameters fold into one `SettlementEventSenders`.

## Why

Closes #680 (the final unit of epic #674). A single capability reshape previously had to re-plumb three signatures across four files. One typed context and a two-phase tail let the intermediate closures die and turn `RunTaskFn`'s parameter list into a single named struct.

One deliberate deviation from the issue sketch: the issue drew one context carrying senders, engine, accounting, and reporter. The engine and accounting depend on outputs of the node build (the topology, the client service, the client handle), so a single struct handed to one method is not possible. The context splits at its natural seam instead: the settlement senders flow down before the node build (embedded once rather than re-flattened at each hop), and the new `AssemblyContext` flows up into the run factory. The reporter stays tail-internal because no run closure consumes it.

Strictly behaviour-preserving: the `finish` ordered span (peer-manager spawn, reporter capture, core assembly, dispatch-engine construction, run-task application before the service spawns, and the chain wrap last) is transplanted verbatim, and every Arc keep-alive binding is retained. No wire bytes, no config semantics, no spawn ordering, and no default change. The only observable delta is the deleted internal `build_client_core_tail` symbol, replaced by `AssemblyContext` and `ClientCoreTail`.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-swarm-node -p vertex-swarm-builder --all-features` (179/179; new prepare-leaves-swap-unwired seam test included; provider-name-ordering and chain-required matrices unchanged)
- `cargo check -p vertex-swarm-node --features swap` and `--features swap-chequebook`
- `just check-cone`
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (proves no Send bound leaked into the run context on the non-Send wasm path)

## Notes


AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the refactor and this description.

