### PR TITLE
refactor(swarm-net-handler-core,swarm-client-behaviour,swarm-storer-behaviour): extract the shared handler scaffold into building blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8888,6 +8888,7 @@ dependencies = [
  "vertex-net-peer-registry",
  "vertex-swarm-api",
  "vertex-swarm-client-protocol",
+ "vertex-swarm-net-handler-core",
  "vertex-swarm-net-headers",
  "vertex-swarm-net-pricing",
  "vertex-swarm-net-pseudosettle",
@@ -8975,7 +8976,8 @@ dependencies = [
 name = "vertex-swarm-net-handler-core"
 version = "0.1.0"
 dependencies = [
- "futures-bounded 0.2.4",
+ "futures",
+ "tokio",
  "vertex-net-ratelimiter",
 ]
 

--- a/crates/swarm/client-behaviour/Cargo.toml
+++ b/crates/swarm/client-behaviour/Cargo.toml
@@ -19,6 +19,7 @@ nectar-primitives.workspace = true
 vertex-swarm-primitives.workspace = true
 
 ## vertex - network (libp2p codecs and upgrades)
+vertex-swarm-net-handler-core.workspace = true
 vertex-swarm-net-headers.workspace = true
 vertex-swarm-net-pricing.workspace = true
 vertex-swarm-net-pseudosettle.workspace = true

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -12,7 +12,7 @@
 //! cannot be folded inline.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -21,8 +21,6 @@ use std::{
 use vertex_util_runtime::time::Instant;
 
 use alloy_primitives::U256;
-use futures::future::BoxFuture;
-use futures::stream::{FuturesUnordered, StreamExt};
 use futures_bounded::Timeout;
 use libp2p::swarm::{
     SubstreamProtocol,
@@ -34,6 +32,7 @@ use libp2p::swarm::{
 use nectar_primitives::{ChunkAddress, NetworkId};
 use tracing::{debug, warn};
 use vertex_swarm_api::{Au, SwarmLocalStore};
+use vertex_swarm_net_handler_core::{BoundedQueue, OutcomeDriver};
 use vertex_swarm_net_pseudosettle::PaymentAck;
 use vertex_swarm_net_pushsync::Receipt;
 use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
@@ -233,12 +232,12 @@ pub struct ClientHandler {
     /// when absent, every delivery takes the verbatim-relay path.
     storer: Option<StorerCapability>,
     next_request_id: u64,
-    pending_commands: VecDeque<HandlerCommand>,
-    pending_events: VecDeque<HandlerEvent>,
+    pending_commands: BoundedQueue<HandlerCommand>,
+    pending_events: BoundedQueue<HandlerEvent>,
     pricing_sent: bool,
     pricing_outbound_pending: bool,
     /// Self-contained inbound serving futures (retrieval and pushsync).
-    inbound: FuturesUnordered<BoxFuture<'static, InboundOutcome>>,
+    inbound: OutcomeDriver<InboundOutcome>,
     /// Pseudosettle responders awaiting the service's ack, keyed by request_id.
     /// Only pseudosettle uses this, because its ack is gated on a time-based
     /// allowance.
@@ -250,12 +249,10 @@ pub struct ClientHandler {
 impl ClientHandler {
     /// Push an event if the queue isn't full, otherwise drop with a metric.
     fn push_event(&mut self, event: HandlerEvent) {
-        if self.pending_events.len() >= self.config.max_pending_events {
+        if self.pending_events.push(event).is_err() {
             warn!("Handler event queue full, dropping event");
             metrics::counter!("swarm.client.handler.events_dropped").increment(1);
-            return;
         }
-        self.pending_events.push_back(event);
     }
 
     /// Create a new handler in dormant state. `storer` is `Some` only on a storer
@@ -266,6 +263,8 @@ impl ClientHandler {
         forward: Arc<dyn Forwarder>,
         storer: Option<StorerCapability>,
     ) -> Self {
+        let max_pending_commands = config.max_pending_commands;
+        let max_pending_events = config.max_pending_events;
         Self {
             config,
             state: State::Dormant,
@@ -273,11 +272,11 @@ impl ClientHandler {
             forward,
             storer,
             next_request_id: 0,
-            pending_commands: VecDeque::new(),
-            pending_events: VecDeque::new(),
+            pending_commands: BoundedQueue::new(max_pending_commands),
+            pending_events: BoundedQueue::new(max_pending_events),
             pricing_sent: false,
             pricing_outbound_pending: false,
-            inbound: FuturesUnordered::new(),
+            inbound: OutcomeDriver::new(MAX_INBOUND_SERVING),
             pending_responses: HashMap::new(),
             response_sends: futures_bounded::FuturesSet::new(
                 RESPONSE_SEND_TIMEOUT,
@@ -589,7 +588,7 @@ impl ConnectionHandler for ClientHandler {
         // dormant (empty) protocol set so the muxer stops accepting new inbound
         // substreams until we drain.
         let upgrade = match &self.state {
-            State::Active { .. } if self.inbound.len() < MAX_INBOUND_SERVING => {
+            State::Active { .. } if self.inbound.has_capacity() => {
                 let upgrade = ClientInboundUpgrade::active_for(self.config.local_role);
                 #[cfg(feature = "swap")]
                 let upgrade = upgrade.with_swap_rate(self.config.swap_exchange_rate);
@@ -606,14 +605,14 @@ impl ConnectionHandler for ClientHandler {
     ) -> Poll<
         ConnectionHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::ToBehaviour>,
     > {
-        if let Some(event) = self.pending_events.pop_front() {
+        if let Some(event) = self.pending_events.pop() {
             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
         }
 
         // Drain resolved inbound serving futures into scoring/metrics events.
-        while let Poll::Ready(Some(outcome)) = self.inbound.poll_next_unpin(cx) {
+        while let Poll::Ready(Some(outcome)) = self.inbound.poll_next(cx) {
             self.push_event(outcome.into());
-            if let Some(event) = self.pending_events.pop_front() {
+            if let Some(event) = self.pending_events.pop() {
                 return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
             }
         }
@@ -641,16 +640,16 @@ impl ConnectionHandler for ClientHandler {
                     });
                 }
             }
-            if let Some(event) = self.pending_events.pop_front() {
+            if let Some(event) = self.pending_events.pop() {
                 return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
             }
         }
 
-        while let Some(cmd) = self.pending_commands.pop_front() {
+        while let Some(cmd) = self.pending_commands.pop() {
             match cmd {
                 HandlerCommand::Activate { overlay, node_type } => {
                     self.activate(overlay, node_type);
-                    if let Some(event) = self.pending_events.pop_front() {
+                    if let Some(event) = self.pending_events.pop() {
                         return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
                     }
                 }
@@ -772,12 +771,10 @@ impl ConnectionHandler for ClientHandler {
     }
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
-        if self.pending_commands.len() >= self.config.max_pending_commands {
+        if self.pending_commands.push(event).is_err() {
             warn!("Handler command queue full, dropping command");
             metrics::counter!("swarm.client.handler.commands_dropped").increment(1);
-            return;
         }
-        self.pending_commands.push_back(event);
     }
 
     fn on_connection_event(

--- a/crates/swarm/net/AGENTS.md
+++ b/crates/swarm/net/AGENTS.md
@@ -14,7 +14,7 @@ Global rules: see root `/AGENTS.md`. Deep guides for changes here: `docs/agents/
 - `pushsync`: `/swarm/pushsync/1.3.1/pushsync`. Chunk push with receipts.
 - `retrieval`: `/swarm/retrieval/1.4.0/retrieval`. Chunk request and delivery.
 - `headers`: shared header frame for request-response protocols, with trace-context propagation. W3C-over-OpenTelemetry inject/extract is native-only (`tracing.rs`); the wasm sibling (`tracing_wasm.rs`, Pattern C) is a no-op since a browser client has no OTLP backend. The on-wire `tracing-span-context` field is unaffected.
-- `handler-core`: shared `HandlerCore<E>` for handlers (pending events, GCRA, outbound-pending flag).
+- `handler-core`: handler scaffolding. `HandlerCore<E>` (unbounded pending events, GCRA rate limiter, outbound-pending flag) plus two opt-in blocks composed a la carte: `BoundedQueue<T>` (bounded FIFO with a caller-owned reject-newest or evict-oldest policy) and `OutcomeDriver<O>` (a capped `FuturesUnordered` outcome driver). The blocks carry mechanics only; the drop policy, metrics, warn lines, and cap constants stay at the call site.
 - `identify`: vendored libp2p-identify with a targeted-push extension.
 - `proto`: consolidated protobuf modules. Re-exports `handshake`, `headers`, `hive`, `pricing`, `pseudosettle`, `pullsync`, `pushsync`, `retrieval`, `swap`.
 
@@ -23,7 +23,7 @@ Global rules: see root `/AGENTS.md`. Deep guides for changes here: `docs/agents/
 - One protocol per crate, one `PROTOCOL_NAME` constant. Reference that constant from tests and metrics labels.
 - Implement the codec in its own `codec` module, separate from the behaviour. Wire types live behind a domain wrapper so the protobuf type never escapes.
 - Compose `vertex-net-codec::FramedProto` for framing. Use its `protocol_error!` macro for the common error variants (`ConnectionClosed`, `Protobuf`, `Io`).
-- Compose `HandlerCore` for the rate-limited inbound queue and outbound flag.
+- Compose `HandlerCore` for the rate-limited inbound queue and outbound flag. Reach for `BoundedQueue` when a handler needs a bounded pending-event or pending-command queue with an explicit drop policy, and `OutcomeDriver` when it drives a capped set of inbound or outbound outcome futures. Keep the policy (reject-newest vs evict-oldest), the metric name, the warn line, and the cap constant at the call site; the blocks are pieces, not a framework.
 - Embed metrics in a `pub mod metrics` submodule and derive `strum::IntoStaticStr` on event/stage enums so labels are static strs.
 - Pull the protobuf module from `vertex-swarm-net-proto`. Never add a `build.rs` or `OUT_DIR` include path in a protocol crate.
 

--- a/crates/swarm/net/handler-core/Cargo.toml
+++ b/crates/swarm/net/handler-core/Cargo.toml
@@ -11,7 +11,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-futures-bounded = "0.2"
+futures.workspace = true
 vertex-net-ratelimiter.workspace = true
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/swarm/net/handler-core/src/driver.rs
+++ b/crates/swarm/net/handler-core/src/driver.rs
@@ -1,0 +1,87 @@
+//! Capped driver over a `FuturesUnordered` of boxed outcome futures.
+
+use std::task::{Context, Poll};
+
+use futures::future::BoxFuture;
+use futures::stream::{FuturesUnordered, StreamExt};
+
+/// Wraps a `FuturesUnordered<BoxFuture<'static, O>>` with a capacity cap. The cap
+/// is advisory: the caller decides where to enforce it via [`has_capacity`]. The
+/// wrapper adds capacity bookkeeping only and never buffers or defers a poll.
+///
+/// [`has_capacity`]: OutcomeDriver::has_capacity
+pub struct OutcomeDriver<O> {
+    inner: FuturesUnordered<BoxFuture<'static, O>>,
+    cap: usize,
+}
+
+impl<O> OutcomeDriver<O> {
+    /// Create an empty driver with the given capacity cap.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            inner: FuturesUnordered::new(),
+            cap,
+        }
+    }
+
+    /// Add a future to the set.
+    pub fn push(&mut self, fut: BoxFuture<'static, O>) {
+        self.inner.push(fut);
+    }
+
+    /// Whether the set holds fewer than `cap` futures.
+    pub fn has_capacity(&self) -> bool {
+        self.inner.len() < self.cap
+    }
+
+    /// Number of in-flight futures.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Whether the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Poll for the next completed outcome. Delegates 1:1 to the underlying
+    /// stream; it registers `cx` on every call and never buffers a resolved
+    /// outcome.
+    pub fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<O>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future;
+
+    use futures::future::poll_fn;
+    use futures::task::noop_waker_ref;
+
+    #[test]
+    fn has_capacity_flips_at_cap() {
+        let mut d: OutcomeDriver<u32> = OutcomeDriver::new(2);
+        assert!(d.has_capacity());
+        d.push(Box::pin(future::ready(1)));
+        assert!(d.has_capacity());
+        d.push(Box::pin(future::ready(2)));
+        assert!(!d.has_capacity());
+        assert_eq!(d.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn poll_next_yields_then_empties() {
+        let mut d: OutcomeDriver<u32> = OutcomeDriver::new(4);
+        d.push(Box::pin(future::ready(7)));
+
+        let first = poll_fn(|cx| d.poll_next(cx)).await;
+        assert_eq!(first, Some(7));
+
+        // Empty set resolves to Ready(None).
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(matches!(d.poll_next(&mut cx), Poll::Ready(None)));
+        assert!(d.is_empty());
+    }
+}

--- a/crates/swarm/net/handler-core/src/lib.rs
+++ b/crates/swarm/net/handler-core/src/lib.rs
@@ -1,12 +1,20 @@
-//! Shared handler core for protocol connection handlers.
+//! Shared handler core and scaffolding blocks for protocol connection handlers.
 //!
-//! Provides [`HandlerCore`] which encapsulates the common pattern of:
-//! - A bounded event queue (`VecDeque<E>`)
+//! Provides [`HandlerCore`], which encapsulates the common pattern of:
+//! - An unbounded event queue (`VecDeque<E>`)
 //! - A rate limiter for inbound stream throttling
 //! - An outbound-pending flag to serialize outbound requests
 //!
-//! Protocol handlers (e.g., hive, pushsync) compose this struct instead of
-//! duplicating the same fields and logic.
+//! and two opt-in building blocks composed a la carte by handlers with their own
+//! drop policy and cap sites: [`BoundedQueue`] (a bounded FIFO with a
+//! caller-owned reject-newest or evict-oldest policy) and [`OutcomeDriver`] (a
+//! capped `FuturesUnordered` outcome driver).
+
+mod driver;
+mod queue;
+
+pub use driver::OutcomeDriver;
+pub use queue::BoundedQueue;
 
 use std::collections::VecDeque;
 
@@ -14,7 +22,7 @@ use vertex_net_ratelimiter::{Quota, RateLimiter};
 
 /// Shared core for protocol connection handlers.
 ///
-/// Manages a bounded event queue, rate limiter, and outbound serialization flag.
+/// Manages an unbounded event queue, rate limiter, and outbound serialization flag.
 /// Protocol handlers embed this struct and delegate common operations to it.
 pub struct HandlerCore<E> {
     /// Pending events to emit to the behaviour.

--- a/crates/swarm/net/handler-core/src/queue.rs
+++ b/crates/swarm/net/handler-core/src/queue.rs
@@ -1,0 +1,119 @@
+//! Bounded FIFO queue with an explicit, caller-owned drop policy.
+
+use std::collections::VecDeque;
+
+/// Bounded FIFO backed by a `VecDeque`. Mechanics only: the drop policy lives at
+/// the call site, which warns or increments its own counter on rejection or
+/// eviction. Wakerless by design; every producer edge is followed by a handler
+/// poll.
+pub struct BoundedQueue<T> {
+    inner: VecDeque<T>,
+    cap: usize,
+}
+
+impl<T> BoundedQueue<T> {
+    /// Create an empty queue that holds at most `cap` items.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            inner: VecDeque::new(),
+            cap,
+        }
+    }
+
+    /// Enqueue, rejecting the newest item once full. Returns `Err(t)` when the
+    /// queue already holds `cap` items so the caller can warn or count the drop.
+    pub fn push(&mut self, t: T) -> Result<(), T> {
+        if self.inner.len() >= self.cap {
+            return Err(t);
+        }
+        self.inner.push_back(t);
+        Ok(())
+    }
+
+    /// Enqueue unconditionally, evicting and returning the oldest item once full.
+    pub fn push_evict_oldest(&mut self, t: T) -> Option<T> {
+        let evicted = if self.inner.len() >= self.cap {
+            self.inner.pop_front()
+        } else {
+            None
+        };
+        self.inner.push_back(t);
+        evicted
+    }
+
+    /// Enqueue unconditionally, ignoring the cap. For internal state-machine
+    /// events that must never be dropped.
+    pub fn push_back(&mut self, t: T) {
+        self.inner.push_back(t);
+    }
+
+    /// Pop the oldest item.
+    pub fn pop(&mut self) -> Option<T> {
+        self.inner.pop_front()
+    }
+
+    /// Number of queued items.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Whether the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Iterate the queued items oldest-first.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.inner.iter()
+    }
+
+    /// Remove the item at `idx` (oldest is 0), returning it if present.
+    pub fn remove(&mut self, idx: usize) -> Option<T> {
+        self.inner.remove(idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_newest_returns_item_at_cap() {
+        let mut q = BoundedQueue::new(2);
+        assert!(q.push(1).is_ok());
+        assert!(q.push(2).is_ok());
+        // At cap: reject-newest returns the item.
+        assert_eq!(q.push(3), Err(3));
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.pop(), Some(1));
+        assert_eq!(q.pop(), Some(2));
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn evict_oldest_returns_evicted_and_holds_cap() {
+        let mut q = BoundedQueue::new(2);
+        assert_eq!(q.push_evict_oldest(1), None);
+        assert_eq!(q.push_evict_oldest(2), None);
+        // At cap: evicts and returns the oldest, len stays <= cap.
+        assert_eq!(q.push_evict_oldest(3), Some(1));
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.push_evict_oldest(4), Some(2));
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.pop(), Some(3));
+        assert_eq!(q.pop(), Some(4));
+    }
+
+    #[test]
+    fn remove_mid_queue() {
+        let mut q = BoundedQueue::new(4);
+        q.push_back(10);
+        q.push_back(20);
+        q.push_back(30);
+        assert_eq!(q.remove(1), Some(20));
+        assert_eq!(q.len(), 2);
+        let rest: Vec<_> = q.iter().copied().collect();
+        assert_eq!(rest, vec![10, 30]);
+        assert_eq!(q.remove(5), None);
+    }
+}

--- a/crates/swarm/storer-behaviour/src/handler.rs
+++ b/crates/swarm/storer-behaviour/src/handler.rs
@@ -8,17 +8,12 @@
 //! whole offer and collects the deliveries.
 
 use std::{
-    collections::VecDeque,
     num::NonZeroU32,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
 
-use futures::{
-    future::BoxFuture,
-    stream::{FuturesUnordered, StreamExt},
-};
 use libp2p::{
     PeerId,
     swarm::{
@@ -32,7 +27,7 @@ use libp2p::{
 use tracing::{debug, warn};
 use vertex_net_ratelimiter::{KeyedRateLimiter, Quota};
 use vertex_swarm_api::{Bin, ChunkAddress, PullStorage, StampedChunk, SwarmResult};
-use vertex_swarm_net_handler_core::HandlerCore;
+use vertex_swarm_net_handler_core::{BoundedQueue, HandlerCore, OutcomeDriver};
 use vertex_swarm_net_pullsync::{
     Ack, BitVector, ChunkDescriptor, DEFAULT_MAX_PAGE, Delivery, Get, Offer, SyncRequester,
     SyncResponder, Want,
@@ -149,9 +144,9 @@ pub struct PullsyncHandler {
     /// Shared with the behaviour so the per-peer chunks-per-second bucket
     /// survives reconnects; freed on the final `ConnectionClosed`.
     chunk_limit: Arc<KeyedRateLimiter<PeerId>>,
-    pending_commands: VecDeque<PullsyncCommand>,
-    inbound: FuturesUnordered<BoxFuture<'static, InboundOutcome>>,
-    outbound: FuturesUnordered<BoxFuture<'static, RangeOutcome>>,
+    pending_commands: BoundedQueue<PullsyncCommand>,
+    inbound: OutcomeDriver<InboundOutcome>,
+    outbound: OutcomeDriver<RangeOutcome>,
 }
 
 impl PullsyncHandler {
@@ -165,9 +160,9 @@ impl PullsyncHandler {
             storage,
             core: HandlerCore::new(INBOUND_SUBSTREAM_QUOTA),
             chunk_limit,
-            pending_commands: VecDeque::new(),
-            inbound: FuturesUnordered::new(),
-            outbound: FuturesUnordered::new(),
+            pending_commands: BoundedQueue::new(MAX_PENDING_COMMANDS),
+            inbound: OutcomeDriver::new(MAX_INBOUND_SERVING),
+            outbound: OutcomeDriver::new(MAX_OUTBOUND_DRIVING),
         }
     }
 
@@ -226,7 +221,7 @@ impl PullsyncHandler {
     /// Index of the first queued command that may dispatch now. A `FetchCursors`
     /// always may; a `SyncRange` only while the outbound driving cap has room.
     fn next_dispatchable_command(&self) -> Option<usize> {
-        let has_range_slot = self.outbound.len() < MAX_OUTBOUND_DRIVING;
+        let has_range_slot = self.outbound.has_capacity();
         self.pending_commands.iter().position(|cmd| match cmd {
             PullsyncCommand::FetchCursors { .. } => true,
             PullsyncCommand::SyncRange { .. } => has_range_slot,
@@ -457,7 +452,7 @@ impl ConnectionHandler for PullsyncHandler {
             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(event));
         }
 
-        while let Poll::Ready(Some(outcome)) = self.inbound.poll_next_unpin(cx) {
+        while let Poll::Ready(Some(outcome)) = self.inbound.poll_next(cx) {
             match outcome {
                 InboundOutcome::Cursors => crate::metrics::inbound_cursors_served(),
                 InboundOutcome::Range { delivered } => {
@@ -467,7 +462,7 @@ impl ConnectionHandler for PullsyncHandler {
             }
         }
 
-        if let Poll::Ready(Some(outcome)) = self.outbound.poll_next_unpin(cx) {
+        if let Poll::Ready(Some(outcome)) = self.outbound.poll_next(cx) {
             let event = match outcome {
                 RangeOutcome::Delivered {
                     request_id,
@@ -527,11 +522,9 @@ impl ConnectionHandler for PullsyncHandler {
     }
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
-        if self.pending_commands.len() >= MAX_PENDING_COMMANDS {
+        if self.pending_commands.push_evict_oldest(event).is_some() {
             warn!(peer_id = %self.remote_peer_id, "Pullsync command queue full, dropping oldest");
-            self.pending_commands.pop_front();
         }
-        self.pending_commands.push_back(event);
     }
 
     fn on_connection_event(
@@ -547,7 +540,7 @@ impl ConnectionHandler for PullsyncHandler {
             ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
                 protocol, ..
             }) => {
-                if !self.core.try_accept_inbound() || self.inbound.len() >= MAX_INBOUND_SERVING {
+                if !self.core.try_accept_inbound() || !self.inbound.has_capacity() {
                     warn!(peer_id = %self.remote_peer_id, "Rate limiting inbound pullsync stream");
                     crate::metrics::inbound_rate_limited();
                     return;


### PR DESCRIPTION
## What

Extract the hand-copied connection-handler scaffolding into two small opt-in building blocks in the existing `vertex-swarm-net-handler-core` crate, and adopt them in the client and pullsync handlers.

`BoundedQueue<T>` is a bounded `VecDeque` exposing the mechanics only: reject-newest `push` (returns the item on a full queue), `push_evict_oldest` (returns the evicted item), an unconditional `push_back` for the cap-exempt lifecycle events, and the `iter`/`remove` a handler needs for out-of-order dispatch. `OutcomeDriver<O>` wraps a capped `FuturesUnordered<BoxFuture>` with a capacity check and a `poll_next` that delegates one-to-one to the inner set. Drop policy, metric names, cap constants, and the cap-exemption sets stay at the call sites, so nothing observable moves.

The client handler adopts both blocks for its pending events, pending commands, and inbound-serving futures; the pullsync handler adopts them for its commands and its inbound and outbound futures, keeping its existing `HandlerCore` for events and rate limiting. `HandlerCore` itself is unchanged, so the hive handler is unaffected.

## Why

Closes #672 (part of epic #667). The bounded-queue drop policies and the capped futures sets were hand-copied across the two handler files. Sharing the mechanics removes the duplication while leaving each handler its own policy, poll-drain shape, and back-pressure siting, which are deliberately different.

Behaviour-preserving: the client poll drain order is transplanted verbatim (proven byte-identical after normalizing the two block method names), the pullsync drain keeps its inbound-drain-all versus outbound-one-per-poll asymmetry, `OutcomeDriver::poll_next` is a direct delegation that registers the live waker on every call, and the five cap-exempt client events still bypass the cap through `push_back`. No wire change.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run` across handler-core, client-behaviour, storer-behaviour, node, and hive (176/176), including the cap-policy behaviour tests, the withholding-peer timeout, the storer round-trip and stalled-read tests, and five new block unit tests
- `just check-cone` and `cargo build --target wasm32-unknown-unknown` for `vertex-swarm-client-behaviour` and `vertex-swarm-node`

## Notes

Also drops an unused `futures-bounded` dependency from `handler-core` and corrects the crate rustdoc that described its event queue as bounded (it is unbounded, as the area guide states).


AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the refactor and this description.

