### PR TITLE
perf(metrics,swarm-topology): sample the per-poll timing guard and cache the hot metric handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8377,6 +8377,7 @@ dependencies = [
 name = "vertex-metrics"
 version = "0.1.0"
 dependencies = [
+ "codspeed-criterion-compat",
  "metrics",
  "parking_lot",
  "strum 0.28.0",

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -26,3 +26,8 @@ strum = { workspace = true }
 
 [dev-dependencies]
 strum = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "timing"
+harness = false

--- a/crates/metrics/benches/timing.rs
+++ b/crates/metrics/benches/timing.rs
@@ -1,0 +1,104 @@
+//! Profiles the per-poll timing cost: uncached `histogram!` per call versus a
+//! cached handle versus a sampled guard, plus a no-recorder floor.
+//!
+//! A hand-rolled summing recorder keeps histogram storage O(1); the debugging
+//! recorder from `metrics-util` retains every recorded value unbounded.
+
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use metrics::{
+    Counter, Gauge, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+};
+use vertex_metrics::{TimingGuard, TimingSampler};
+
+/// Summing histogram handle: counts records into one atomic, no retention.
+#[derive(Default)]
+struct SummingHistogram(AtomicU64);
+
+impl HistogramFn for SummingHistogram {
+    fn record(&self, _value: f64) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Recorder returning one shared summing histogram for every registration.
+struct SummingRecorder(Arc<SummingHistogram>);
+
+impl Recorder for SummingRecorder {
+    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+    fn register_counter(&self, _: &Key, _: &Metadata<'_>) -> Counter {
+        Counter::noop()
+    }
+    fn register_gauge(&self, _: &Key, _: &Metadata<'_>) -> Gauge {
+        Gauge::noop()
+    }
+    fn register_histogram(&self, _: &Key, _: &Metadata<'_>) -> Histogram {
+        Histogram::from_arc(self.0.clone())
+    }
+}
+
+static CACHED_HIST: LazyLock<Histogram> =
+    LazyLock::new(|| metrics::histogram!("bench_poll_duration_seconds"));
+static SAMPLER_HIST: LazyLock<Histogram> =
+    LazyLock::new(|| metrics::histogram!("bench_poll_duration_seconds"));
+
+const SAMPLE_INTERVAL: NonZeroU32 = NonZeroU32::new(64).expect("nonzero");
+
+fn bench_timing(c: &mut Criterion) {
+    let recorder = SummingRecorder(Arc::new(SummingHistogram::default()));
+    let mut group = c.benchmark_group("poll_timing");
+
+    // (a) Current pattern: register the histogram every call, guard per call.
+    group.bench_function("uncached_guard", |b| {
+        metrics::with_local_recorder(&recorder, || {
+            b.iter(|| {
+                let guard = TimingGuard::new(metrics::histogram!("bench_poll_duration_seconds"));
+                black_box(&guard);
+                drop(guard);
+            });
+        });
+    });
+
+    // (b) Cached handle: register once, guard per call.
+    group.bench_function("cached_guard", |b| {
+        metrics::with_local_recorder(&recorder, || {
+            let _ = LazyLock::force(&CACHED_HIST);
+            b.iter(|| {
+                let guard = TimingGuard::new(CACHED_HIST.clone());
+                black_box(&guard);
+                drop(guard);
+            });
+        });
+    });
+
+    // (c) Sampled guard at interval 64: skip path is a decrement and branch.
+    group.bench_function("sampler_64", |b| {
+        metrics::with_local_recorder(&recorder, || {
+            let mut sampler = TimingSampler::new(&SAMPLER_HIST, SAMPLE_INTERVAL);
+            b.iter(|| {
+                let guard = sampler.start();
+                black_box(&guard);
+            });
+        });
+    });
+
+    // (d) No-recorder floor: global noop recorder, guard per call.
+    group.bench_function("no_recorder", |b| {
+        b.iter(|| {
+            let guard = TimingGuard::new(metrics::histogram!("bench_poll_duration_seconds"));
+            black_box(&guard);
+            drop(guard);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_timing);
+criterion_main!(benches);

--- a/crates/metrics/src/guards.rs
+++ b/crates/metrics/src/guards.rs
@@ -1,6 +1,8 @@
 //! Drop-based RAII guards for automatic metric updates.
 
 use core::fmt;
+use core::num::NonZeroU32;
+use std::sync::LazyLock;
 
 use metrics::{Counter, Gauge, Histogram};
 use vertex_util_runtime::time::Instant;
@@ -132,6 +134,52 @@ impl fmt::Debug for TimingGuard {
 impl Drop for TimingGuard {
     fn drop(&mut self) {
         self.histogram.record(self.start.elapsed().as_secs_f64());
+    }
+}
+
+/// Samples a [`TimingGuard`] one call in `interval`, so a hot loop pays the
+/// clock read and histogram record on a fixed fraction of iterations.
+///
+/// The skip path is a single decrement and branch: no clock read, no atomic,
+/// no deref of the lazy handle. The static [`LazyLock`] is only forced on the
+/// first sampled call, so a handle materialized before the recorder is
+/// installed is never cached.
+pub struct TimingSampler {
+    histogram: &'static LazyLock<Histogram>,
+    interval: NonZeroU32,
+    countdown: u32,
+}
+
+impl TimingSampler {
+    /// Sampler over `histogram`, recording one call in `interval`. Countdown
+    /// starts at zero so the first call samples and a quiet node reports promptly.
+    #[inline]
+    pub const fn new(histogram: &'static LazyLock<Histogram>, interval: NonZeroU32) -> Self {
+        Self {
+            histogram,
+            interval,
+            countdown: 0,
+        }
+    }
+
+    /// Start timing on a sampled call, or `None` to skip.
+    #[inline]
+    pub fn start(&mut self) -> Option<TimingGuard> {
+        if self.countdown > 0 {
+            self.countdown -= 1;
+            return None;
+        }
+        self.countdown = self.interval.get() - 1;
+        Some(TimingGuard::new(LazyLock::force(self.histogram).clone()))
+    }
+}
+
+impl fmt::Debug for TimingSampler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TimingSampler")
+            .field("interval", &self.interval)
+            .field("countdown", &self.countdown)
+            .finish()
     }
 }
 
@@ -278,5 +326,65 @@ mod tests {
         let lock = parking_lot::Mutex::new(42);
         let guard = timed_lock(&lock, metrics::histogram!("test_mutex_lock"));
         assert_eq!(*guard, 42);
+    }
+
+    #[test]
+    fn timing_sampler_cadence() {
+        static HIST: LazyLock<Histogram> =
+            LazyLock::new(|| metrics::histogram!("test_sampler_cadence"));
+        let mut sampler = TimingSampler::new(&HIST, NonZeroU32::new(4).unwrap());
+
+        // Interval 4 samples calls 1, 5, 9 over nine calls.
+        let sampled: Vec<u32> = (1u32..=9).filter(|_| sampler.start().is_some()).collect();
+        assert_eq!(sampled, vec![1, 5, 9]);
+    }
+
+    #[test]
+    fn timing_sampler_records_at_interval() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        use metrics::{
+            Counter, Gauge, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString,
+            Unit,
+        };
+
+        #[derive(Default)]
+        struct CountingHistogram(AtomicU64);
+        impl HistogramFn for CountingHistogram {
+            fn record(&self, _value: f64) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        struct CountingRecorder(Arc<CountingHistogram>);
+        impl Recorder for CountingRecorder {
+            fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+            fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+            fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+            fn register_counter(&self, _: &Key, _: &Metadata<'_>) -> Counter {
+                Counter::noop()
+            }
+            fn register_gauge(&self, _: &Key, _: &Metadata<'_>) -> Gauge {
+                Gauge::noop()
+            }
+            fn register_histogram(&self, _: &Key, _: &Metadata<'_>) -> Histogram {
+                Histogram::from_arc(self.0.clone())
+            }
+        }
+
+        static HIST: LazyLock<Histogram> =
+            LazyLock::new(|| metrics::histogram!("test_sampler_record"));
+
+        let hist = Arc::new(CountingHistogram::default());
+        let recorder = CountingRecorder(hist.clone());
+        metrics::with_local_recorder(&recorder, || {
+            let mut sampler = TimingSampler::new(&HIST, NonZeroU32::new(2).unwrap());
+            // Interval 2 across 4 calls records exactly 2 histograms.
+            for _ in 0..4 {
+                drop(sampler.start());
+            }
+        });
+        assert_eq!(hist.0.load(Ordering::Relaxed), 2);
     }
 }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -14,7 +14,8 @@ pub use buckets::{
     LOCK_CONTENTION, POLL_DURATION,
 };
 pub use guards::{
-    CounterGuard, GaugeGuard, OperationGuard, TimingGuard, timed_lock, timed_read, timed_write,
+    CounterGuard, GaugeGuard, OperationGuard, TimingGuard, TimingSampler, timed_lock, timed_read,
+    timed_write,
 };
 pub use label_value::LabelValue;
 pub use protocol::StreamGuard;

--- a/crates/observability/AGENTS.md
+++ b/crates/observability/AGENTS.md
@@ -27,6 +27,7 @@ Consumer enablement: `vertex-node-core` enables nothing (plain config structs on
 - New metric primitives (RAII guards, macros, label helpers) go in `vertex-metrics`. Heavy infra (subscriber layers, exporters, HTTP servers) goes in `vertex-observability`.
 - Derive `strum::IntoStaticStr` on every label enum. `LabelValue` is what makes labels zero-allocation.
 - Use the lazy macros (`lazy_counter!`, `lazy_gauge!`, `lazy_histogram!`) instead of `metrics::counter!` in hot paths; they handle registration ordering.
+- Per-poll timing in a behaviour hot path goes through `TimingSampler` over a cached `lazy_histogram!` handle, never a fresh `histogram!` per poll. The sampler pays the clock read and record on one poll in `interval` and skips the rest with a decrement and branch.
 - Histograms must pick a documented bucket config (`DURATION_FINE`, `DURATION_NETWORK`, `DURATION_SECONDS`, `LOCK_CONTENTION`, `POLL_DURATION`, `CONNECTION_LIFETIME`). Do not invent new buckets without updating `HistogramBucketConfig`.
 - Span boundaries follow `docs/observability/design.md`. Read it before adding a new top-level span.
 

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -21,6 +21,7 @@ use libp2p::{
     },
 };
 use tracing::{debug, info, warn};
+use vertex_metrics::TimingSampler;
 use vertex_net_local::{AddressScope, classify_multiaddr, same_subnet};
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_net_ratelimiter::{Quota, RateLimitedErr, RateLimiter};
@@ -55,7 +56,7 @@ use crate::events::TopologyEvent;
 use crate::extract_peer_id;
 use crate::gossip::{GossipConfig, GossipEngine};
 use crate::kademlia::{KademliaConfig, KademliaRouting, RoutingEvaluatorHandle, SwarmRouting};
-use crate::metrics::{TopologyMetrics, po_label};
+use crate::metrics::{POLL_EVENTS_TOTAL, TopologyMetrics, po_label};
 use crate::nat_discovery::LocalAddressManager;
 
 /// Type-erased peer snapshot store.
@@ -299,6 +300,10 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
 
     // Metrics
     pub(crate) metrics: Arc<TopologyMetrics>,
+
+    /// Samples per-poll timing so the histogram record and clock reads fire on
+    /// a fixed fraction of polls; the skip path is a decrement and branch.
+    pub(crate) poll_timer: TimingSampler,
 
     /// Background-task inputs captured by [`crate::TopologyBehaviourBuilder`]
     /// and consumed by [`TopologyBehaviour::spawn_tasks`]. `None` once the
@@ -875,9 +880,9 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
-        // Use TimingGuard for automatic poll duration recording
-        let _poll_timer =
-            vertex_metrics::TimingGuard::new(metrics::histogram!("topology_poll_duration_seconds"));
+        // Sampled poll-duration timing; the guard lives to the end of poll on
+        // sampled iterations and is None (no clock read) on skipped ones.
+        let _poll_timer = self.poll_timer.start();
 
         // Emit any pending static NAT addresses as external addresses (one-time on startup)
         if !self.pending_nat_external_addrs.is_empty() {
@@ -930,7 +935,7 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
         loop {
             match self.protocols.poll(cx) {
                 Poll::Ready(ToSwarm::GenerateEvent(event)) => {
-                    metrics::counter!("topology_poll_events_total").increment(1);
+                    POLL_EVENTS_TOTAL.increment(1);
                     let (peer_id, connection_id) = event.peer_connection();
                     self.process_protocol_event(peer_id, connection_id, event);
                 }

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -9,6 +9,7 @@ use std::{
 use libp2p::Multiaddr;
 use tokio::sync::{broadcast, mpsc};
 use tracing::info;
+use vertex_metrics::TimingSampler;
 use vertex_net_dialer::{DialTracker, DialTrackerConfig};
 use vertex_net_local::LocalCapabilities;
 use vertex_net_ratelimiter::RateLimiter;
@@ -265,6 +266,10 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             trust_local_peers: self.trust_local_peers,
             pending_nat_external_addrs,
             metrics,
+            poll_timer: TimingSampler::new(
+                &crate::metrics::POLL_DURATION_HISTOGRAM,
+                crate::metrics::POLL_SAMPLE_INTERVAL,
+            ),
             pending_tasks: Some(PendingTopologyTasks {
                 evaluation_interval,
             }),

--- a/crates/swarm/topology/src/metrics.rs
+++ b/crates/swarm/topology/src/metrics.rs
@@ -1,13 +1,15 @@
 //! Topology metrics recording for Prometheus export.
 
+use std::num::NonZeroU32;
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use metrics::{counter, gauge, histogram};
+use metrics::{Counter, Histogram, counter, gauge, histogram};
 use vertex_metrics::labels::outcome;
 use vertex_metrics::{
     CONNECTION_LIFETIME, DURATION_NETWORK, HistogramBucketConfig, LOCK_CONTENTION, LabelValue,
-    POLL_DURATION,
+    POLL_DURATION, lazy_counter, lazy_histogram,
 };
 use vertex_swarm_primitives::SwarmNodeType;
 
@@ -25,6 +27,18 @@ const PO_LABELS: [&str; 32] = [
 pub(crate) fn po_label(po: u8) -> &'static str {
     PO_LABELS.get(po as usize).copied().unwrap_or("overflow")
 }
+
+/// Cached handle for the per-poll duration histogram, sampled via
+/// [`vertex_metrics::TimingSampler`] to keep the poll hot path cheap.
+pub(crate) static POLL_DURATION_HISTOGRAM: LazyLock<Histogram> =
+    lazy_histogram!("topology_poll_duration_seconds");
+
+/// Cached handle for the per-poll processed-event counter.
+pub(crate) static POLL_EVENTS_TOTAL: LazyLock<Counter> =
+    lazy_counter!("topology_poll_events_total");
+
+/// Record one poll timing in this many polls.
+pub(crate) const POLL_SAMPLE_INTERVAL: NonZeroU32 = NonZeroU32::new(64).expect("nonzero");
 
 /// Histogram bucket configurations for topology metrics.
 pub const HISTOGRAM_BUCKETS: &[HistogramBucketConfig] = &[

--- a/docs/observability/helpers.md
+++ b/docs/observability/helpers.md
@@ -54,6 +54,7 @@ Guards ensure metrics are updated even on early returns or panics. Each guard ty
 |-------|-------------|-------------|---------|----------|
 | `GaugeGuard` | `GaugeGuard::increment(gauge)` | Gauge +1 | Gauge -1 | Tracking active/in-flight operations |
 | `TimingGuard` | `TimingGuard::new(histogram)` | Records start time | Records elapsed duration to histogram | Measuring operation duration |
+| `TimingSampler` | `TimingSampler::new(&LAZY_HISTOGRAM, interval)` | `start()` returns `Some(TimingGuard)` one call in `interval`, else `None` | Guard records on drop | Per-iteration timing in a hot loop, where the skip path (a decrement and branch, no clock read) keeps the untimed calls cheap |
 | `OperationGuard` | `OperationGuard::new(gauge, counter)` | Gauge +1 | Gauge -1, Counter +1 | Combined active tracking and completion counting |
 | `CounterGuard` | `CounterGuard::new(counter)` | Nothing | Counter +1 | Ensuring an event is counted even on panic |
 

--- a/docs/observability/profiling.md
+++ b/docs/observability/profiling.md
@@ -229,7 +229,7 @@ The dialer crate (`vertex-net-dialer`) tracks its own per-purpose state, where `
 
 | Metric | Type | Description | Target |
 |--------|------|-------------|--------|
-| `topology_poll_duration_seconds` | Histogram | Time per poll loop iteration | < 1ms p99 |
+| `topology_poll_duration_seconds` | Histogram | Time per poll loop iteration, sampled one poll in 64, so `_count` is polls/64 | < 1ms p99 |
 | `topology_poll_events_total` | Counter | Events processed per poll | - |
 | `topology_phase_transitions_total` | Counter | Connection phase transitions | - |
 


### PR DESCRIPTION
## What

Sample the topology per-poll timing histogram instead of recording every poll, and cache the hot metric handles.

`vertex-metrics` gains `TimingSampler`: it holds a reference to a lazily-registered histogram, a sampling interval, and a countdown. Its `start` returns a `TimingGuard` on one poll in every N and `None` otherwise; the skip path is a single decrement and branch, with no clock read, no atomic, and no handle deref. `TopologyBehaviour::poll` replaces its unconditional `TimingGuard::new(histogram!(...))` with `self.poll_timer.start()`, and the per-event counter moves from a `counter!` macro (a recorder lookup per event) to a cached `lazy_counter!` static.

## Why

Closes #673 (the capstone of epic #667). This issue is explicit that the change must be justified by measurement, so it is profile-first. A criterion bench on the per-call cost of the current pattern under a registered recorder:

| Case | Pattern | ns/call |
|---|---|---|
| a | `histogram!(name)` + `TimingGuard` every call | 42.9 |
| b | cached `LazyLock<Histogram>` + `TimingGuard` | 42.9 |
| c | `TimingSampler` at interval 64 | 1.0 |
| d | no-recorder baseline | 37.2 |

The floor is the two monotonic clock reads a `TimingGuard` performs (baseline 37ns), not the registry lookup (a and b are indistinguishable under this recorder, so the bench is conservative: under the real Prometheus recorder the per-call lookup this change also removes is pricier). Sampling avoids the clock reads on 63 of every 64 polls, which drops the amortized per-poll timing cost roughly forty-fold.

Behaviour-preserving: metric names, labels, and bucket configs are unchanged; the histogram simply reports one sample in 64, so its `_count` is polls divided by 64 and quantiles are unaffected. The `topology_poll_events_total` counter stays exact. The poll and wake contract is untouched, and the clock stays the wasm-safe `web-time` instant, so the topology crate still builds for wasm32.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-metrics -p vertex-swarm-topology -p vertex-swarm-node` (378/378, including new sampler cadence and recording tests and the topology poll-cycle and relay integration tests)
- `just check-cone` and `cargo build --target wasm32-unknown-unknown` for vertex-metrics, vertex-swarm-topology, vertex-swarm-node
- `cargo bench -p vertex-metrics` for the numbers above

## Notes

The `TimingSampler` helper lands in the `vertex-metrics` leaf where the other timing guards live, not in `crates/observability` as the issue's scope line suggested; the split is per the observability area guide.


AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the change and this description.

