### PR TITLE
fix(topology): scope handshake-failed registry removal to the failing connection

### DIFF
--- a/crates/net/peer/registry/src/registry.rs
+++ b/crates/net/peer/registry/src/registry.rs
@@ -520,6 +520,31 @@ impl<Id: Clone + Eq + Hash + Debug, R: Clone + Default + Send + Sync + 'static>
         state
     }
 
+    /// Remove the entry recorded for this connection; entries owned by other
+    /// connections of the same peer are left untouched.
+    pub fn disconnected_connection(
+        &self,
+        connection_id: ConnectionId,
+    ) -> Option<ConnectionState<Id, R>> {
+        let state = self.with_maps(|maps| {
+            let key = maps.conn_to_key.get(&connection_id).cloned()?;
+            maps.remove_by_key(&key)
+        });
+
+        if let Some(ref s) = state {
+            match s {
+                ConnectionState::Active { .. } => {
+                    self.num_active.fetch_sub(1, Ordering::Relaxed);
+                }
+                ConnectionState::Connected { .. } => {
+                    self.num_pending.fetch_sub(1, Ordering::Relaxed);
+                }
+            }
+        }
+
+        state
+    }
+
     /// Run a write transaction on the inner maps.
     fn with_maps<T>(&self, f: impl FnOnce(&mut Maps<Id, R>) -> T) -> T {
         let mut maps = self.maps.write();
@@ -869,5 +894,60 @@ mod tests {
         assert!(r.get(&TestId(1)).is_none());
         assert!(!r.contains_peer(&peer(2)));
         assert_counts(&r, 0, 1);
+    }
+
+    #[test]
+    fn test_disconnected_connection_removes_pending() {
+        let r = registry();
+        let p = peer(1);
+
+        r.connected_inbound(p, conn(1));
+        assert_counts(&r, 1, 0);
+
+        let state = r.disconnected_connection(conn(1)).unwrap();
+        assert!(!state.is_active());
+        assert!(!r.contains_peer(&p));
+        assert_counts(&r, 0, 0);
+    }
+
+    #[test]
+    fn test_disconnected_connection_removes_active() {
+        let r = registry();
+        let p = peer(1);
+        let id = TestId(1);
+
+        r.connected_outbound(p, conn(1), Some(id.clone()), Instant::now(), ());
+        r.activate(p, conn(1), id.clone());
+        assert_counts(&r, 0, 1);
+
+        let state = r.disconnected_connection(conn(1)).unwrap();
+        assert!(state.is_active());
+        assert!(r.get(&id).is_none());
+        assert_counts(&r, 0, 0);
+    }
+
+    #[test]
+    fn test_disconnected_connection_leaves_other_connections_entry() {
+        let r = registry();
+        let p = peer(1);
+        let id = TestId(1);
+
+        // Active entry owned by conn(1).
+        r.connected_outbound(p, conn(1), Some(id.clone()), Instant::now(), ());
+        r.activate(p, conn(1), id.clone());
+        assert_counts(&r, 0, 1);
+
+        // A different, unregistered connection reports failure: nothing removed.
+        assert!(r.disconnected_connection(conn(2)).is_none());
+        assert!(r.get(&id).unwrap().is_active());
+        assert_eq!(ActivePeers::active_peer_id(&r, &id), Some(p));
+        assert_counts(&r, 0, 1);
+    }
+
+    #[test]
+    fn test_disconnected_connection_unknown_returns_none() {
+        let r = registry();
+        assert!(r.disconnected_connection(conn(1)).is_none());
+        assert_counts(&r, 0, 0);
     }
 }

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -1304,9 +1304,13 @@ mod tests {
         use super::*;
 
         use libp2p::swarm::ConnectionId;
+        use vertex_net_peer_registry::{ActivePeers, ConnectionDirection};
         use vertex_swarm_api::BanCause;
+        use vertex_swarm_net_handshake::{HandshakeError, HandshakeEvent};
         use vertex_swarm_peer_manager::LIFECYCLE_CHANNEL_CAPACITY;
         use vertex_swarm_test_utils::test_overlay;
+
+        use crate::composed::ProtocolEvent;
 
         /// Register an active (handshake-complete) connection in the registry.
         fn activate_connection(
@@ -1424,6 +1428,85 @@ mod tests {
                 } => assert_eq!(closed, peer_id),
                 _ => panic!("expected CloseConnection for the disconnect request"),
             }
+        }
+
+        /// Build a handshake-failed protocol event for a given connection.
+        fn failed_event(peer_id: PeerId, connection_id: ConnectionId) -> ProtocolEvent {
+            ProtocolEvent::Handshake(HandshakeEvent::Failed {
+                peer_id,
+                connection_id,
+                direction: ConnectionDirection::Inbound,
+                // Timeout is not the peer's fault, so no reachability or score hit.
+                error: HandshakeError::Timeout,
+            })
+        }
+
+        /// A failed handshake on a duplicate connection must not remove the
+        /// healthy connection's Active entry: the peer stays routable.
+        #[tokio::test]
+        async fn handshake_failure_on_duplicate_leaves_healthy_active_entry() {
+            let mut behaviour = test_behaviour();
+            let overlay = test_overlay(1);
+            let peer_id = activate_connection(&behaviour, overlay);
+            assert_eq!(behaviour.connection_registry.active_count(), 1);
+
+            // A second, unregistered connection to the same peer fails.
+            let c2 = ConnectionId::new_unchecked(2);
+            behaviour.process_protocol_event(peer_id, c2, failed_event(peer_id, c2));
+
+            assert!(
+                behaviour
+                    .connection_registry
+                    .get(&overlay)
+                    .expect("active entry survives")
+                    .is_active()
+            );
+            assert_eq!(
+                ActivePeers::active_peer_id(&*behaviour.connection_registry, &overlay),
+                Some(peer_id)
+            );
+            assert_eq!(behaviour.connection_registry.active_count(), 1);
+        }
+
+        /// A failed handshake removes only the failing connection's own pending
+        /// entry, leaving the peer's Active connection in place.
+        #[tokio::test]
+        async fn handshake_failure_removes_only_the_failing_pending_entry() {
+            let mut behaviour = test_behaviour();
+            let overlay = test_overlay(1);
+            let peer_id = activate_connection(&behaviour, overlay);
+
+            let c2 = ConnectionId::new_unchecked(2);
+            behaviour.connection_registry.connected_inbound(peer_id, c2);
+            assert_eq!(behaviour.connection_registry.pending_count(), 1);
+
+            behaviour.process_protocol_event(peer_id, c2, failed_event(peer_id, c2));
+
+            assert!(
+                behaviour
+                    .connection_registry
+                    .get(&overlay)
+                    .expect("active entry survives")
+                    .is_active()
+            );
+            assert_eq!(behaviour.connection_registry.active_count(), 1);
+            assert_eq!(behaviour.connection_registry.pending_count(), 0);
+        }
+
+        /// A failed handshake on the peer's sole connection still removes its
+        /// registry entry exactly as before.
+        #[tokio::test]
+        async fn handshake_failure_removes_the_sole_connection_entry() {
+            let mut behaviour = test_behaviour();
+            let peer_id = PeerId::random();
+            let c1 = ConnectionId::new_unchecked(1);
+            behaviour.connection_registry.connected_inbound(peer_id, c1);
+            assert_eq!(behaviour.connection_registry.pending_count(), 1);
+
+            behaviour.process_protocol_event(peer_id, c1, failed_event(peer_id, c1));
+
+            assert!(!behaviour.connection_registry.contains_peer(&peer_id));
+            assert_eq!(behaviour.connection_registry.pending_count(), 0);
         }
     }
 

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -36,7 +36,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 self.on_handshake_completed(peer_id, connection_id, *info);
             }
             ProtocolEvent::Handshake(HandshakeEvent::Failed { error, .. }) => {
-                self.on_handshake_failed(peer_id, error);
+                self.on_handshake_failed(peer_id, connection_id, error);
             }
             ProtocolEvent::Hive(HiveEvent::PeersReceived { peers, .. }) => {
                 self.on_hive_peers_received(peer_id, peers);
@@ -312,6 +312,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     fn on_handshake_failed(
         &mut self,
         peer_id: PeerId,
+        connection_id: ConnectionId,
         error: vertex_swarm_net_handshake::HandshakeError,
     ) {
         warn!(%peer_id, %error, "Handshake failed");
@@ -327,9 +328,13 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 .update_from_handshake(peer_id, false);
         }
 
-        // Handshake failed means the peer was already registered in connection_registry.
-        // Remove it and release routing capacity.
-        let state = self.connection_registry.disconnected(&peer_id);
+        // Remove only the entry recorded for the failing connection and release
+        // its routing capacity. Scoping to the connection keeps a healthy
+        // connection's Active entry when a duplicate connection to the same peer
+        // fails, so the peer stays routable.
+        let state = self
+            .connection_registry
+            .disconnected_connection(connection_id);
         if let Some(ref s) = state {
             if s.is_active() {
                 gauge!("peer_registry_active_connections").decrement(1.0);


### PR DESCRIPTION
## What

Scope the topology connection registry's handshake-failure removal to the connection that actually failed.

`on_handshake_failed` previously removed the peer's registry entry keyed by peer id alone. A new `PeerRegistry::disconnected_connection(connection_id)` removes only the entry recorded for the failing connection, resolved through the connection-to-key index, and the topology handler now threads the failing connection id into it. A connection that holds no registry entry (a superseded duplicate) removes nothing; a sole connection is removed exactly as before.

## Why

Closes #718. `MAX_ESTABLISHED_PER_PEER` is 2, so a simultaneous dial race can leave a peer with two connections. When the duplicate connection's handshake failed, the peer-keyed removal deleted the healthy connection's Active entry. Since the connection registry became the single writer of the overlay-to-PeerId map, the client behaviour reads it directly, so this made a healthy, connected peer client-unroutable (a `RetrieveChunk` to its overlay refused `NotConnected`) and silenced its eventual real disconnect. Scoping the removal to the failing connection keeps the healthy connection routable.

This is a behaviour change confined to the failed-handshake path, non-wire, no fork gate. A new registry method is the only public-surface addition; downstream gauge, backoff, and scoring were already gated on the returned state, so on the duplicate path they now correctly skip.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-net-peer-registry -p vertex-swarm-topology` (272 topology tests plus four new registry tests and three new lifecycle tests). The named test was mutation-checked: reverting to the peer-keyed removal makes it fail on the healthy Active entry.
- `just check-cone` and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-topology -p vertex-swarm-node`

## Notes

This fixes the removal path. A related registration-side defect, where `connected_inbound` clobbers the peer index for an already-tracked peer, still breaks the specific inbound-duplicate ordering and is tracked separately in #729; a pending-gauge drift is tracked in #730.


AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the fix and this description.

