### PR TITLE
fix(topology): harden phase-counter release against a wrong-phase remove

### DIFF
--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -18,7 +18,7 @@ use super::{
 use crate::metrics::{phase, record_phase_transition, record_topology_phase_change};
 use nectar_primitives::{ChunkAddress, recompute_neighborhood_depth};
 use parking_lot::{Mutex, RwLock};
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 use vertex_net_peer_registry::ConnectionDirection;
 use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use vertex_swarm_peer_manager::{PeerManager, ProximityIndex};
@@ -34,7 +34,7 @@ use vertex_util_runtime::time::Instant as PhaseInstant;
 /// Connection phase for capacity tracking. `Dialing` is outbound by
 /// construction; the later phases carry the direction so the per-bin outbound
 /// counter can be maintained on every transition.
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum ConnectionPhase {
     Dialing,
     Handshaking(ConnectionDirection),
@@ -931,11 +931,18 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
 
     fn release_dial(&self, overlay: &OverlayAddress) {
         let mut phases = self.connection_phases.write();
-        if let Some(ConnectionPhase::Dialing) = phases.remove(overlay) {
-            let bin = self.bin_for(overlay);
-            atomic_dec(&self.dialing_counts, bin);
-            atomic_dec(&self.outbound_counts, bin);
-            record_phase_transition(phase::DIALING, phase::NONE);
+        match phases.get(overlay) {
+            Some(ConnectionPhase::Dialing) => {
+                phases.remove(overlay);
+                let bin = self.bin_for(overlay);
+                atomic_dec(&self.dialing_counts, bin);
+                atomic_dec(&self.outbound_counts, bin);
+                record_phase_transition(phase::DIALING, phase::NONE);
+            }
+            Some(actual) => {
+                warn!(%overlay, phase = ?actual, "release_dial called for a non-dialing phase; leaving the entry");
+            }
+            None => {}
         }
     }
 
@@ -973,13 +980,20 @@ impl<I: SwarmIdentity> RoutingCapacity for KademliaRouting<I> {
 
     fn release_handshake(&self, overlay: &OverlayAddress) {
         let mut phases = self.connection_phases.write();
-        if let Some(ConnectionPhase::Handshaking(direction)) = phases.remove(overlay) {
-            let bin = self.bin_for(overlay);
-            atomic_dec(&self.handshaking_counts, bin);
-            if direction.is_outbound() {
-                atomic_dec(&self.outbound_counts, bin);
+        match phases.get(overlay) {
+            Some(&ConnectionPhase::Handshaking(direction)) => {
+                phases.remove(overlay);
+                let bin = self.bin_for(overlay);
+                atomic_dec(&self.handshaking_counts, bin);
+                if direction.is_outbound() {
+                    atomic_dec(&self.outbound_counts, bin);
+                }
+                record_phase_transition(phase::HANDSHAKING, phase::NONE);
             }
-            record_phase_transition(phase::HANDSHAKING, phase::NONE);
+            Some(actual) => {
+                warn!(%overlay, phase = ?actual, "release_handshake called for a non-handshaking phase; leaving the entry");
+            }
+            None => {}
         }
     }
 
@@ -1830,6 +1844,73 @@ mod tests {
             peer,
             ConnectionPhase::Handshaking(ConnectionDirection::Outbound),
         );
+    }
+
+    #[test]
+    fn wrong_phase_release_leaves_counters_consistent() {
+        let base = SwarmAddress::with_first_byte(0x00);
+        let config = KademliaConfig::default().with_nominal(2);
+        let (routing, _pm) = make_routing(base, config);
+
+        let has_entry = |peer: &OverlayAddress| routing.connection_phases.read().contains_key(peer);
+
+        // Case 1: a handshaking peer wrongly released as a dial stays put; the
+        // matching release_handshake then drains it.
+        let peer_a = SwarmAddress::with_first_byte(0x80); // bin 0
+        let bin_a = routing.bin_for(&peer_a);
+        force_handshaking(&routing, peer_a);
+        routing.release_dial(&peer_a);
+        assert_eq!(routing.bin_phase_counts(bin_a), (0, 1, 0));
+        assert_eq!(routing.bin_outbound_count(bin_a), 1);
+        assert!(has_entry(&peer_a));
+        routing.release_handshake(&peer_a);
+        assert_eq!(routing.bin_phase_counts(bin_a), (0, 0, 0));
+        assert_eq!(routing.bin_outbound_count(bin_a), 0);
+        assert!(!has_entry(&peer_a));
+
+        // Case 2: an active peer is untouched by either release; only the
+        // authoritative disconnected() drains it.
+        let peer_b = SwarmAddress::with_first_byte(0x40); // bin 1
+        let bin_b = routing.bin_for(&peer_b);
+        force_active(&routing, peer_b);
+        routing.release_dial(&peer_b);
+        routing.release_handshake(&peer_b);
+        assert_eq!(routing.bin_phase_counts(bin_b), (0, 0, 1));
+        assert_eq!(routing.bin_outbound_count(bin_b), 1);
+        assert!(has_entry(&peer_b));
+        RoutingCapacity::disconnected(&*routing, &peer_b);
+        assert_eq!(routing.bin_phase_counts(bin_b), (0, 0, 0));
+        assert_eq!(routing.bin_outbound_count(bin_b), 0);
+        assert!(!has_entry(&peer_b));
+
+        // Case 3: a dialing peer wrongly released as a handshake stays put; the
+        // matching release_dial then drains it.
+        let peer_c = SwarmAddress::with_first_byte(0x20); // bin 2
+        let bin_c = routing.bin_for(&peer_c);
+        assert!(routing.try_reserve_dial(&peer_c, SwarmNodeType::Storer));
+        routing.release_handshake(&peer_c);
+        assert_eq!(routing.bin_phase_counts(bin_c), (1, 0, 0));
+        assert_eq!(routing.bin_outbound_count(bin_c), 1);
+        assert!(has_entry(&peer_c));
+        routing.release_dial(&peer_c);
+        assert_eq!(routing.bin_phase_counts(bin_c), (0, 0, 0));
+        assert_eq!(routing.bin_outbound_count(bin_c), 0);
+        assert!(!has_entry(&peer_c));
+
+        // Case 4: an inbound handshaking peer (no outbound tally) wrongly
+        // released as a dial stays put; release_handshake drains handshaking
+        // only, leaving the outbound count at zero throughout.
+        let peer_d = SwarmAddress::with_first_byte(0x10); // bin 3
+        let bin_d = routing.bin_for(&peer_d);
+        routing.reserve_inbound(&peer_d);
+        routing.release_dial(&peer_d);
+        assert_eq!(routing.bin_phase_counts(bin_d), (0, 1, 0));
+        assert_eq!(routing.bin_outbound_count(bin_d), 0);
+        assert!(has_entry(&peer_d));
+        routing.release_handshake(&peer_d);
+        assert_eq!(routing.bin_phase_counts(bin_d), (0, 0, 0));
+        assert_eq!(routing.bin_outbound_count(bin_d), 0);
+        assert!(!has_entry(&peer_d));
     }
 
     #[test]


### PR DESCRIPTION
## What

Harden the two topology phase-counter release methods against a wrong-phase remove.

`KademliaRouting::release_dial` and `release_handshake` previously removed the connection-phase entry first and matched the removed value second. If either were ever called for an overlay whose phase did not match the expected variant, the entry was dropped without decrementing its per-bin counters (dialling, handshaking, active, and the outbound counter the minimum-outbound quota reads), silently desyncing the counters from the phase map. Both now peek first, remove and decrement only on the expected variant, and on a mismatch log a warning and leave the entry in place so the authoritative teardown reconciles it.

## Why

Closes #724. The mismatch path is unreachable through today's callers, so this is defensive hardening rather than a live-bug fix. Its value grew because the minimum-outbound quota work added an outbound counter that rides these same paths, so a wrong-phase call would now corrupt a dial-admission input, not just a gauge. Leaving the entry on a mismatch is deliberately safer than decrementing by the actual variant: removing a live connection's phase entry would let a duplicate reservation slip through and no-op the later real disconnect.

The happy path is byte-for-byte unchanged: only the guard shape changed from remove-then-match to peek-then-remove, with the same decrements and phase-transition records. No behaviour change on any reachable path, non-wire.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-swarm-topology` run twice for determinism: identical 253/253, including a new test that drives all four wrong-phase cases (each on a distinct bin) and asserts the counters stay consistent through the wrong release and then drain to zero on the correct one. Each method was mutation-checked: reverting either to the old remove-before-match shape fails the test.
- `just check-cone` and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-topology -p vertex-swarm-node`

## Notes

A follow-up worth doing: the convergence sim never exercises `release_handshake` or an inbound-Active disconnect, so its per-tick counter reconciliation does not yet cover those two paths. Adding a handshake-fail script and an inbound-Active disconnect to the flood scenario would close that coverage gap.


AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the fix and this description.

