### PR TITLE
fix(topology): guard inbound registration against clobbering an active peer index

### DIFF
--- a/crates/net/peer/registry/src/registry.rs
+++ b/crates/net/peer/registry/src/registry.rs
@@ -256,28 +256,38 @@ impl<Id: Clone + Eq + Hash + Debug, R: Clone + Default + Send + Sync + 'static>
         state
     }
 
-    /// Register inbound connection in Connected state (awaiting identity).
+    /// Register an inbound connection in Connected state, or None if the peer is already tracked.
     pub fn connected_inbound(
         &self,
         peer_id: PeerId,
         connection_id: ConnectionId,
-    ) -> ConnectionState<Id, R> {
-        let key = RegistryKey::Pending(peer_id);
-        let started_at = Instant::now();
+    ) -> Option<ConnectionState<Id, R>> {
+        let state = self.with_maps(|maps| {
+            if maps.peer_to_key.contains_key(&peer_id) {
+                return None;
+            }
 
-        let state = ConnectionState::Connected {
-            peer_id,
-            connection_id,
-            id: None,
-            direction: ConnectionDirection::Inbound,
-            started_at,
-            reason: R::default(),
-        };
+            let key = RegistryKey::Pending(peer_id);
+            let started_at = Instant::now();
 
-        let returned = state.clone();
-        self.with_maps(|maps| maps.insert(key, state));
-        self.num_pending.fetch_add(1, Ordering::Relaxed);
-        returned
+            let state = ConnectionState::Connected {
+                peer_id,
+                connection_id,
+                id: None,
+                direction: ConnectionDirection::Inbound,
+                started_at,
+                reason: R::default(),
+            };
+
+            let returned = state.clone();
+            maps.insert(key, state);
+            Some(returned)
+        });
+
+        if state.is_some() {
+            self.num_pending.fetch_add(1, Ordering::Relaxed);
+        }
+        state
     }
 
     /// Activate a connection: transition to Active with confirmed application-level ID.
@@ -709,7 +719,7 @@ mod tests {
         let r = registry();
         let p = peer(1);
 
-        let state = r.connected_inbound(p, conn(1));
+        let state = r.connected_inbound(p, conn(1)).unwrap();
         assert!(matches!(
             state,
             ConnectionState::Connected {
@@ -791,7 +801,7 @@ mod tests {
         struct TestReason(Option<String>);
 
         let r = PeerRegistry::<TestId, TestReason>::new();
-        let state = r.connected_inbound(peer(1), conn(1));
+        let state = r.connected_inbound(peer(1), conn(1)).unwrap();
         assert_eq!(state.reason(), &TestReason(None));
     }
 
@@ -862,6 +872,47 @@ mod tests {
         r.disconnected(&p);
         assert_eq!(ActivePeers::active_peer_id(&r, &id), None);
         assert_eq!(ActivePeers::active_id(&r, &p), None);
+    }
+
+    #[test]
+    fn test_connected_inbound_duplicate_does_not_clobber_active() {
+        let r = registry();
+        let p = peer(1);
+        let id = TestId(1);
+
+        r.connected_inbound(p, conn(1)).unwrap();
+        r.activate(p, conn(1), id.clone());
+
+        // An inbound duplicate for an already-tracked peer registers nothing.
+        assert!(r.connected_inbound(p, conn(2)).is_none());
+
+        // The Active mapping is untouched in both directions.
+        assert_eq!(ActivePeers::active_id(&r, &p), Some(id.clone()));
+        assert_eq!(ActivePeers::active_peer_id(&r, &id), Some(p));
+        assert_counts(&r, 0, 1);
+
+        // Closing the healthy connection still returns the Active state with its id.
+        let s = r.disconnected(&p).unwrap();
+        assert!(s.is_active());
+        assert_eq!(s.id(), Some(id));
+    }
+
+    #[test]
+    fn test_connected_inbound_duplicate_over_pending_registers_nothing() {
+        let r = registry();
+        let p = peer(1);
+
+        r.connected_inbound(p, conn(1)).unwrap();
+        assert!(r.connected_inbound(p, conn(2)).is_none());
+        assert_eq!(r.pending_count(), 1);
+
+        // conn(2) was never registered: removing it is a no-op.
+        assert!(r.disconnected_connection(conn(2)).is_none());
+        assert_eq!(r.pending_count(), 1);
+
+        // conn(1) still owns the sole pending entry.
+        assert!(r.disconnected_connection(conn(1)).is_some());
+        assert_counts(&r, 0, 0);
     }
 
     /// Regression: ByPeerId replacement must clean up Connected entries under the

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -1468,17 +1468,24 @@ mod tests {
             assert_eq!(behaviour.connection_registry.active_count(), 1);
         }
 
-        /// A failed handshake removes only the failing connection's own pending
-        /// entry, leaving the peer's Active connection in place.
+        /// An inbound duplicate to an already-active peer is refused, so a later
+        /// handshake failure on it cannot clobber the identity index: the peer
+        /// stays fully routable in both directions.
         #[tokio::test]
-        async fn handshake_failure_removes_only_the_failing_pending_entry() {
+        async fn handshake_failure_on_refused_duplicate_leaves_peer_fully_routable() {
             let mut behaviour = test_behaviour();
             let overlay = test_overlay(1);
             let peer_id = activate_connection(&behaviour, overlay);
 
+            // A duplicate inbound connection to the tracked peer registers nothing.
             let c2 = ConnectionId::new_unchecked(2);
-            behaviour.connection_registry.connected_inbound(peer_id, c2);
-            assert_eq!(behaviour.connection_registry.pending_count(), 1);
+            assert!(
+                behaviour
+                    .connection_registry
+                    .connected_inbound(peer_id, c2)
+                    .is_none()
+            );
+            assert_eq!(behaviour.connection_registry.pending_count(), 0);
 
             behaviour.process_protocol_event(peer_id, c2, failed_event(peer_id, c2));
 
@@ -1488,6 +1495,14 @@ mod tests {
                     .get(&overlay)
                     .expect("active entry survives")
                     .is_active()
+            );
+            assert_eq!(
+                ActivePeers::active_peer_id(&*behaviour.connection_registry, &overlay),
+                Some(peer_id)
+            );
+            assert_eq!(
+                ActivePeers::active_id(&*behaviour.connection_registry, &peer_id),
+                Some(overlay)
             );
             assert_eq!(behaviour.connection_registry.active_count(), 1);
             assert_eq!(behaviour.connection_registry.pending_count(), 0);

--- a/crates/swarm/topology/src/connection_handlers.rs
+++ b/crates/swarm/topology/src/connection_handlers.rs
@@ -61,9 +61,12 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 trace!(peer_id = %established.peer_id, "ConnectionEstablished for untracked outbound peer");
             }
         } else {
-            self.connection_registry
+            let result = self
+                .connection_registry
                 .connected_inbound(established.peer_id, established.connection_id);
-            gauge!("peer_registry_pending_connections").increment(1.0);
+            if result.is_some() {
+                gauge!("peer_registry_pending_connections").increment(1.0);
+            }
         }
     }
 


### PR DESCRIPTION
## What

Guard inbound connection registration against clobbering an already-tracked peer's index.

`PeerRegistry::connected_inbound` previously wrote the peer-to-key index unconditionally, even when the peer was already tracked under a different connection. A duplicate inbound connection to a peer that already held an Active entry therefore overwrote that index to point at the duplicate's pending state. It now mirrors the outbound path: if the peer is already tracked it registers nothing and returns `None`, and the pending gauge and counter are incremented only on a real registration.

## Why

Closes #729. This is the registration-side half of the reconnect-race index corruption whose removal-side half was fixed in #718. With the connection registry as the single writer of the overlay-to-PeerId map, the clobbered index made `active_id` return `None` for a healthy, connected peer, so the client could not route to it and its eventual real disconnect resolved no overlay and was silenced. The removal-side fix could not close this because the corruption happened at registration, before any removal ran.

With both halves in place the peer stays fully routable across the duplicate's lifecycle. The test #718 introduced deliberately stopped short of asserting routability on this ordering because the registration bug still broke it; that test is reworked here to assert full routability (the index resolves the overlay), and it fails against the old clobbering registration, so it pins the fix rather than merely compiling.

Behaviour change only on the inbound-duplicate registration path, non-wire.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-net-peer-registry -p vertex-swarm-topology` (275/275), including two new registry tests (duplicate over an Active entry, duplicate over a Pending entry) and the reworked full-routability lifecycle test; all fail against the old clobbering registration
- `just check-cone` and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-topology -p vertex-swarm-node`

## Notes

One pre-existing, metrics-only residual is left untouched and composes with #730: the activate replacement arm decrements the pending gauge assuming a prior pending increment, so a refused duplicate whose handshake later succeeds under-counts the gauge by one. This is already true for refused outbound duplicates today, and the registry's own active and pending counters stay exact because activation adjusts them from actual removed-entry counts.


AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the fix and this description.

