### PR TITLE
fix(topology): drive the connection phase gauges from registry counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9615,6 +9615,7 @@ dependencies = [
  "if-watch",
  "libp2p",
  "metrics",
+ "metrics-util",
  "nectar-primitives",
  "parking_lot",
  "rand 0.9.4",

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -99,6 +99,7 @@ vertex-swarm-spec.workspace = true
 tracing-subscriber.workspace = true
 vertex-swarm-peer = { workspace = true, features = ["test-utils"] }
 vertex-swarm-test-utils = { workspace = true }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 criterion.workspace = true
 
 [[bench]]

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -1525,6 +1525,281 @@ mod tests {
         }
     }
 
+    /// The connection phase gauges are set from the registry's authoritative
+    /// counts after every mutation, so no hand-counted delta can drift them.
+    mod phase_gauges {
+        use super::*;
+
+        use std::time::Instant;
+
+        use libp2p::Multiaddr;
+        use libp2p::swarm::ConnectionId;
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+        use vertex_net_peer_registry::ConnectionDirection;
+        use vertex_swarm_net_handshake::{HandshakeEvent, HandshakeInfo};
+        use vertex_swarm_test_utils::{test_overlay, test_peer_id, test_swarm_peer};
+
+        use crate::DialReason;
+        use crate::composed::ProtocolEvent;
+
+        /// Read both phase gauges from a single snapshot. A snapshot resets
+        /// gauges, so both must be read together; the sync helper writes
+        /// absolute values, so a later read after a further sync is unaffected.
+        fn phase_gauges(snapshotter: &Snapshotter) -> (f64, f64) {
+            let mut pending = 0.0;
+            let mut active = 0.0;
+            for (ck, _, _, value) in snapshotter.snapshot().into_vec() {
+                if let DebugValue::Gauge(g) = value {
+                    match ck.key().name() {
+                        "peer_registry_pending_connections" => pending = g.0,
+                        "peer_registry_active_connections" => active = g.0,
+                        _ => {}
+                    }
+                }
+            }
+            (pending, active)
+        }
+
+        /// A completed-handshake protocol event carrying `swarm_peer`. The outer
+        /// peer_id/connection_id passed to `process_protocol_event` drive the
+        /// handler; the event's own copies are unused.
+        fn completed_event(swarm_peer: vertex_swarm_peer::SwarmPeer) -> ProtocolEvent {
+            ProtocolEvent::Handshake(HandshakeEvent::Completed {
+                peer_id: PeerId::random(),
+                connection_id: ConnectionId::new_unchecked(0),
+                direction: ConnectionDirection::Inbound,
+                info: Box::new(HandshakeInfo {
+                    peer_id: PeerId::random(),
+                    swarm_peer,
+                    node_type: SwarmNodeType::Client,
+                    welcome_message: String::new(),
+                    observed_multiaddr: Multiaddr::empty(),
+                }),
+            })
+        }
+
+        /// Read the gauges once (the read resets them) and assert they equal
+        /// both the registry's authoritative counts and the expected truth.
+        fn check(
+            behaviour: &TopologyBehaviour<Identity>,
+            snapshotter: &Snapshotter,
+            expected: (f64, f64),
+        ) {
+            let got = phase_gauges(snapshotter);
+            assert_eq!(
+                got.0,
+                behaviour.connection_registry.pending_count() as f64,
+                "pending gauge must equal the registry pending count"
+            );
+            assert_eq!(
+                got.1,
+                behaviour.connection_registry.active_count() as f64,
+                "active gauge must equal the registry active count"
+            );
+            assert_eq!(got, expected, "gauges must equal the expected truth");
+        }
+
+        /// Directly setting the gauges mirrors the registry counts exactly,
+        /// whatever those counts are.
+        #[test]
+        fn sync_sets_both_gauges_to_registry_counts() {
+            let behaviour = test_behaviour();
+            let overlay = test_overlay(1);
+            let peer_id = test_peer_id(1);
+            behaviour
+                .connection_registry
+                .connected_inbound(peer_id, ConnectionId::new_unchecked(1));
+            behaviour.connection_registry.activate(
+                peer_id,
+                ConnectionId::new_unchecked(1),
+                overlay,
+            );
+            behaviour
+                .connection_registry
+                .connected_inbound(test_peer_id(2), ConnectionId::new_unchecked(2));
+            assert_eq!(behaviour.connection_registry.active_count(), 1);
+            assert_eq!(behaviour.connection_registry.pending_count(), 1);
+
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.sync_connection_phase_gauges();
+            });
+
+            check(&behaviour, &snapshotter, (1.0, 1.0));
+        }
+
+        /// Drift (a): activating a peer that had both an overlay-keyed pending
+        /// placeholder and its own pending entry consumes two pending entries.
+        /// The old +1/-1 delta decremented pending only once and leaked +1; the
+        /// sync sets pending to the true count of zero.
+        #[test]
+        fn two_pending_activation_does_not_leak_pending() {
+            let mut behaviour = test_behaviour();
+            let peer = test_swarm_peer(1);
+            let overlay = OverlayAddress::from(*peer.overlay());
+            let completing_peer = test_peer_id(1);
+            let placeholder_peer = test_peer_id(9);
+            let c_out = ConnectionId::new_unchecked(1);
+            let c_in = ConnectionId::new_unchecked(2);
+
+            behaviour.connection_registry.connected_outbound(
+                placeholder_peer,
+                c_out,
+                Some(overlay),
+                Instant::now(),
+                Some(DialReason::Discovery),
+            );
+            behaviour
+                .connection_registry
+                .connected_inbound(completing_peer, c_in);
+            assert_eq!(behaviour.connection_registry.pending_count(), 2);
+
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.process_protocol_event(completing_peer, c_in, completed_event(peer));
+            });
+
+            assert_eq!(behaviour.connection_registry.pending_count(), 0);
+            check(&behaviour, &snapshotter, (0.0, 1.0));
+        }
+
+        /// Drift (b): a refused duplicate registers nothing, so activating the
+        /// existing peer over the duplicate connection consumes no pending
+        /// entry. The old delta decremented pending anyway, driving it to -1;
+        /// the sync holds it at the true zero.
+        #[test]
+        fn refused_duplicate_then_success_does_not_underflow_pending() {
+            let mut behaviour = test_behaviour();
+            let peer = test_swarm_peer(1);
+            let overlay = OverlayAddress::from(*peer.overlay());
+            let peer_id = test_peer_id(1);
+            let c1 = ConnectionId::new_unchecked(1);
+            let c2 = ConnectionId::new_unchecked(2);
+
+            behaviour.connection_registry.connected_inbound(peer_id, c1);
+            behaviour.connection_registry.activate(peer_id, c1, overlay);
+            assert!(
+                behaviour
+                    .connection_registry
+                    .connected_inbound(peer_id, c2)
+                    .is_none()
+            );
+            assert_eq!(behaviour.connection_registry.pending_count(), 0);
+            assert_eq!(behaviour.connection_registry.active_count(), 1);
+
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.process_protocol_event(peer_id, c2, completed_event(peer));
+            });
+
+            assert_eq!(behaviour.connection_registry.pending_count(), 0);
+            check(&behaviour, &snapshotter, (0.0, 1.0));
+        }
+
+        /// Drift (c): a racing dialer replaces an active peer under the same
+        /// overlay. The registry nets active unchanged (one removed, one added),
+        /// but the old code only decremented active for the superseded entry
+        /// and never incremented for the new one, drifting active to -1. The
+        /// sync keeps active at the true count.
+        #[test]
+        fn replacement_keeps_active_gauge_at_truth() {
+            let mut behaviour = test_behaviour();
+            let peer = test_swarm_peer(1);
+            let overlay = OverlayAddress::from(*peer.overlay());
+            let completing_peer = test_peer_id(1);
+            let incumbent_peer = test_peer_id(9);
+            let c1 = ConnectionId::new_unchecked(1);
+            let c2 = ConnectionId::new_unchecked(2);
+
+            // An incumbent peer holds the overlay's active slot.
+            behaviour
+                .connection_registry
+                .connected_inbound(incumbent_peer, c1);
+            behaviour
+                .connection_registry
+                .activate(incumbent_peer, c1, overlay);
+            // A racing dialer connects inbound and completes the handshake for
+            // the same overlay.
+            behaviour
+                .connection_registry
+                .connected_inbound(completing_peer, c2);
+            assert_eq!(behaviour.connection_registry.active_count(), 1);
+
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.process_protocol_event(completing_peer, c2, completed_event(peer));
+            });
+
+            assert_eq!(behaviour.connection_registry.active_count(), 1);
+            check(&behaviour, &snapshotter, (0.0, 1.0));
+        }
+
+        /// A mixed sequence of registrations, activations, and closes keeps both
+        /// gauges pinned to the registry counts after every step.
+        #[test]
+        fn mixed_sequence_tracks_registry_counts() {
+            let mut behaviour = test_behaviour();
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+
+            let peer_a = test_swarm_peer(1);
+            let id_a = test_peer_id(1);
+            let c_a = ConnectionId::new_unchecked(1);
+
+            // Step 1: an inbound pending registration.
+            behaviour.connection_registry.connected_inbound(id_a, c_a);
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.sync_connection_phase_gauges();
+            });
+            check(&behaviour, &snapshotter, (1.0, 0.0));
+
+            // Step 2: activation over that pending entry.
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.process_protocol_event(id_a, c_a, completed_event(peer_a));
+            });
+            check(&behaviour, &snapshotter, (0.0, 1.0));
+
+            // Step 3: a second inbound pending registration.
+            let id_b = test_peer_id(2);
+            let c_b = ConnectionId::new_unchecked(2);
+            behaviour.connection_registry.connected_inbound(id_b, c_b);
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.sync_connection_phase_gauges();
+            });
+            check(&behaviour, &snapshotter, (1.0, 1.0));
+
+            // Step 4: the stale pending entry is garbage-collected.
+            metrics::with_local_recorder(&recorder, || {
+                behaviour
+                    .connection_registry
+                    .disconnected(&id_b)
+                    .expect("pending entry present");
+                behaviour.sync_connection_phase_gauges();
+            });
+            check(&behaviour, &snapshotter, (0.0, 1.0));
+
+            // Step 5: the active peer disconnects through the close handler.
+            let endpoint = libp2p::core::ConnectedPoint::Listener {
+                local_addr: "/ip4/127.0.0.1/tcp/1".parse().expect("valid"),
+                send_back_addr: "/ip4/127.0.0.2/tcp/2".parse().expect("valid"),
+            };
+            metrics::with_local_recorder(&recorder, || {
+                behaviour.handle_connection_closed(libp2p::swarm::behaviour::ConnectionClosed {
+                    peer_id: id_a,
+                    connection_id: c_a,
+                    endpoint: &endpoint,
+                    cause: None,
+                    remaining_established: 0,
+                });
+            });
+            check(&behaviour, &snapshotter, (0.0, 0.0));
+        }
+    }
+
     mod early_disconnect {
         use std::io;
 

--- a/crates/swarm/topology/src/connection_handlers.rs
+++ b/crates/swarm/topology/src/connection_handlers.rs
@@ -4,7 +4,6 @@ use libp2p::swarm::ConnectionError;
 use metrics::gauge;
 use tracing::{debug, trace, warn};
 use vertex_net_local::{AddressScope, classify_multiaddr};
-use vertex_net_peer_registry::ConnectionState;
 use vertex_swarm_api::{ReportSource, SwarmIdentity, SwarmScoringEvent};
 use vertex_swarm_net_handshake::HANDSHAKE_TIMEOUT;
 use vertex_swarm_primitives::SwarmNodeType;
@@ -15,16 +14,15 @@ use crate::kademlia::{RoutingCapacity, SwarmRouting};
 
 use crate::behaviour::TopologyBehaviour;
 
-/// Decrement the appropriate connection phase gauge based on the removed state.
-fn decrement_connection_phase_gauge<Id: Clone, R>(state: &ConnectionState<Id, R>) {
-    if state.is_active() {
-        gauge!("peer_registry_active_connections").decrement(1.0);
-    } else if state.is_pending() {
-        gauge!("peer_registry_pending_connections").decrement(1.0);
-    }
-}
-
 impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
+    /// Mirror the registry's phase counts into the connection gauges.
+    pub(crate) fn sync_connection_phase_gauges(&self) {
+        gauge!("peer_registry_pending_connections")
+            .set(self.connection_registry.pending_count() as f64);
+        gauge!("peer_registry_active_connections")
+            .set(self.connection_registry.active_count() as f64);
+    }
+
     pub(crate) fn handle_connection_established(
         &mut self,
         established: libp2p::swarm::behaviour::ConnectionEstablished,
@@ -44,16 +42,14 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
             if let Some(request) = self.dial_tracker.resolve(&established.peer_id) {
                 let overlay = request.id;
                 let reason = request.data;
-                let result = self.connection_registry.connected_outbound(
+                self.connection_registry.connected_outbound(
                     established.peer_id,
                     established.connection_id,
                     overlay,
                     request.queued_at(),
                     Some(reason),
                 );
-                if result.is_some() {
-                    gauge!("peer_registry_pending_connections").increment(1.0);
-                }
+                self.sync_connection_phase_gauges();
                 if let Some(overlay) = &overlay {
                     self.routing.dial_connected(overlay);
                 }
@@ -61,12 +57,9 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 trace!(peer_id = %established.peer_id, "ConnectionEstablished for untracked outbound peer");
             }
         } else {
-            let result = self
-                .connection_registry
+            self.connection_registry
                 .connected_inbound(established.peer_id, established.connection_id);
-            if result.is_some() {
-                gauge!("peer_registry_pending_connections").increment(1.0);
-            }
+            self.sync_connection_phase_gauges();
         }
     }
 
@@ -105,9 +98,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
         // Remove from connection registry (sole source of truth for connections)
         let removed_state = self.connection_registry.disconnected(&closed.peer_id);
-        if let Some(ref s) = removed_state {
-            decrement_connection_phase_gauge(s);
-        }
+        self.sync_connection_phase_gauges();
         let connected_at = removed_state.as_ref().and_then(|s| s.connected_at());
         let overlay = removed_state.as_ref().and_then(|s| s.id());
 
@@ -284,7 +275,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
 
         for peer_id in stale_peers {
             if let Some(state) = self.connection_registry.disconnected(&peer_id) {
-                decrement_connection_phase_gauge(&state);
+                self.sync_connection_phase_gauges();
 
                 let reason = *state.reason();
                 let overlay = state.id();

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use libp2p::PeerId;
 use libp2p::ping;
 use libp2p::swarm::{ConnectionId, ToSwarm};
-use metrics::{counter, gauge};
+use metrics::counter;
 use tracing::{debug, info, trace, warn};
 use vertex_net_local::{AddressScope, classify_multiaddr};
 use vertex_net_peer_registry::ActivateResult;
@@ -158,18 +158,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         let activate_result = self
             .connection_registry
             .activate(peer_id, connection_id, overlay);
-        match &activate_result {
-            ActivateResult::Accepted => {
-                gauge!("peer_registry_pending_connections").decrement(1.0);
-                gauge!("peer_registry_active_connections").increment(1.0);
-            }
-            ActivateResult::Replaced { old_id: None, .. } => {
-                gauge!("peer_registry_pending_connections").decrement(1.0);
-            }
-            ActivateResult::Replaced {
-                old_id: Some(_), ..
-            } => {}
-        }
+        self.sync_connection_phase_gauges();
 
         // Update routing capacity tracking (transitions Handshaking->Active)
         RoutingCapacity::handshake_completed(&*self.routing, &overlay);
@@ -193,7 +182,6 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                     .node_type(old_overlay)
                     .unwrap_or(SwarmNodeType::Client);
                 self.metrics.decrement_connected(old_node_type);
-                gauge!("peer_registry_active_connections").decrement(1.0);
 
                 debug!(
                     %peer_id,
@@ -335,13 +323,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         let state = self
             .connection_registry
             .disconnected_connection(connection_id);
-        if let Some(ref s) = state {
-            if s.is_active() {
-                gauge!("peer_registry_active_connections").decrement(1.0);
-            } else if s.is_pending() {
-                gauge!("peer_registry_pending_connections").decrement(1.0);
-            }
-        }
+        self.sync_connection_phase_gauges();
         let reason = state.as_ref().and_then(|s| *s.reason());
         let overlay = state.as_ref().and_then(|s| s.id());
 


### PR DESCRIPTION
## What

Drive the two connection phase gauges from the registry's authoritative counts instead of hand-counted increments and decrements.

`peer_registry_pending_connections` and `peer_registry_active_connections` were maintained by per-transition deltas in the topology handlers, each assuming a fixed number of entries changed hands. A new `sync_connection_phase_gauges` sets both gauges to `pending_count()` and `active_count()` after every registry mutation, and every delta site is replaced by a call to it. A gauge set to the registry count cannot drift.

## Why

Closes #730. The registry's `activate` consumes zero, one, or two pending entries depending on what it finds, but the handlers decremented the pending gauge by exactly one, so the gauges drifted three ways: a dial race that leaves an outbound placeholder plus an inbound pending entry leaked the pending gauge up by one permanently; a refused duplicate whose handshake later succeeded (a case the inbound-registration guard made reachable) pushed it down by one; and every connection replacement pushed the active gauge down by one, because the replacement decremented the superseded entry while only a fresh acceptance incremented. All three were metrics-only: the registry's own counters are adjusted from the actual removed-entry counts and stayed exact, so this fix reads that truth rather than reconstructing it.

Metrics-only, non-wire, no change to routing, registry state, or peer lifecycle. The registry crate is untouched and the node-type-labelled connected-peers metric is left alone.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-net-peer-registry -p vertex-swarm-topology` (280/280), with new tests driving each of the three drifts and a mixed register/activate/close/sweep sequence end to end through the real handlers, each asserting the gauge equals both the registry count and the expected value; re-introducing either old delta fails them
- `just check-cone` (the metrics-util test recorder is a dev-dependency and does not enter the production or wasm cone) and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-topology -p vertex-swarm-node`

## Notes

The production diff is net-negative: the two handler files delete more delta code than the helper adds. This is the last of the registry-bookkeeping fixes from epic #681.

AI Assistance: Claude Code (Fable 5 for design and QA, Opus 4.8 for implementation) used for the fix and this description.

