### PR TITLE
refactor(accounting): stop leaking clap into every consumer cone

### DIFF
--- a/crates/swarm/accounting/core/Cargo.toml
+++ b/crates/swarm/accounting/core/Cargo.toml
@@ -13,15 +13,15 @@ nectar-primitives = { workspace = true }
 vertex-swarm-primitives = { workspace = true }
 vertex-metrics = { workspace = true }
 vertex-swarm-api = { workspace = true }
-vertex-swarm-accounting-pricing = { workspace = true, features = ["cli"] }
+vertex-swarm-accounting-pricing = { workspace = true }
 vertex-swarm-spec = { workspace = true }
 async-trait = { workspace = true }
 auto_impl = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive"], optional = true }
 metrics = { workspace = true }
 parking_lot = { workspace = true }
 rustc-hash = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 
@@ -30,5 +30,4 @@ vertex-swarm-test-utils = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 [features]
-default = ["std"]
-std = []
+cli = ["dep:clap", "dep:serde", "vertex-swarm-accounting-pricing/cli"]

--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -25,7 +25,6 @@ pub use error::AccountingError;
 pub use peer::PeerState;
 pub use reservation::{Provide, Receive, Reservation};
 
-use alloc::vec::Vec;
 use parking_lot::RwLock;
 use rustc_hash::FxBuildHasher;
 use std::collections::HashMap;

--- a/crates/swarm/accounting/core/src/config.rs
+++ b/crates/swarm/accounting/core/src/config.rs
@@ -3,6 +3,7 @@
 use vertex_swarm_accounting_pricing::FixedPricingConfig;
 use vertex_swarm_api::{Au, SwarmAccountingConfig, SwarmPricingConfig};
 
+#[cfg(feature = "cli")]
 use crate::args::AccountingArgs;
 use crate::constants::*;
 
@@ -58,6 +59,7 @@ impl<P> AccountingConfig<P> {
     }
 }
 
+#[cfg(feature = "cli")]
 impl From<&AccountingArgs> for AccountingConfig<FixedPricingConfig> {
     fn from(args: &AccountingArgs) -> Self {
         Self {
@@ -124,6 +126,7 @@ where
 mod tests {
     use super::*;
 
+    #[cfg(feature = "cli")]
     #[test]
     fn from_args_carries_the_thresholds() {
         let config = AccountingConfig::from(&AccountingArgs::default());

--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -31,11 +31,8 @@
 //! dropped-race-loser-keeps-commit guarantee is the reason the origin books
 //! at dispatch.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
-extern crate alloc;
-
 mod accounting;
+#[cfg(feature = "cli")]
 pub mod args;
 mod builder;
 mod client_accounting;
@@ -47,6 +44,7 @@ mod settlement;
 pub use accounting::{
     Accounting, AccountingError, AccountingPeerHandle, PeerState, Provide, Receive, Reservation,
 };
+#[cfg(feature = "cli")]
 pub use args::AccountingArgs;
 pub use builder::{AccountingBuilder, NoAccountingBuilder};
 pub use client_accounting::ClientAccounting;

--- a/crates/swarm/accounting/core/src/noop.rs
+++ b/crates/swarm/accounting/core/src/noop.rs
@@ -1,7 +1,5 @@
 //! No-op implementations that always allow and never settle.
 
-use std::vec::Vec;
-
 use vertex_swarm_api::{
     Au, Direction, SwarmAccounting, SwarmIdentity, SwarmPeerAccounting, SwarmResult,
 };

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -190,6 +190,7 @@ cli = [
     "dep:serde",
     "dep:vertex-node-api",
     "dep:vertex-swarm-accounting-pricing",
+    "vertex-swarm-accounting/cli",
     "vertex-swarm-localstore/cli",
     "vertex-swarm-primitives/serde",
     "alloy-primitives/serde",


### PR DESCRIPTION
## What

Make `clap` and `serde` optional behind a `cli` feature in `vertex-swarm-accounting`, and delete the fake `no_std` scaffolding.

`clap` and `serde` were unconditional dependencies of the accounting core, used only by the CLI argument struct, so they were pulled into every build of the crate including the default client, the wasm client, and the FFI library. They are now optional and enabled by a new `cli` feature that also turns on the pricing crate's own `cli` feature; the `args` module and its `AccountingArgs` re-export, and the config conversion that consumes it, are gated on that feature. The composition root that needs them, the node crate's `cli` feature, now enables `vertex-swarm-accounting/cli`.

The crate also carried a `#![cfg_attr(not(feature = "std"), no_std)]` attribute and an `extern crate alloc`, but every module used `std` unconditionally, so the `no_std` configuration could never compile. That scaffolding, the now-unused `std`/`default` features, and two redundant `Vec` imports are removed.

## Why

Closes #661. This is the feature-unification footgun the cone guards exist to catch: an unconditional `clap` dependency on a shared crate drags the CLI argument parser into the bare and wasm clients that never use it. Gating it behind a capability feature keeps the argument parser in the builds that are actually the CLI, and lets the default, wasm, and FFI cones drop it.

Build-graph change only, no behaviour change: with `cli` on (the binary and the node's cli build) everything is byte-for-byte identical, including the argument spellings and the config conversion; with `cli` off the crate simply no longer compiles clap or serde. No pricing, settlement, or accounting value changes, and no wire change.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-swarm-accounting -p vertex-swarm-node --all-features` (201/201)
- `cargo build -p vertex-swarm-accounting --no-default-features` proves the crate compiles free of clap, serde, and the argument module
- `just check-cone` and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`; a `cargo tree` check confirms the accounting-to-clap edge is gone from the wasm cone

## Notes

`clap` still reaches the wasm client through `vertex-swarm-spec`'s `std` feature and through `vertex-swarm-identity`; those are separate per-crate leaks tracked for a follow-up, out of scope here.

First unit of epic #439.

AI Assistance: Claude Code (Opus 4.8 for design, implementation, and QA) used for the change and this description.

