### PR TITLE
refactor(swarm-accounting): finish the accounting noun at the operator surface

### DIFF
--- a/bin/vertex/src/cli.rs
+++ b/bin/vertex/src/cli.rs
@@ -136,13 +136,20 @@ pub async fn run() -> Result<()> {
         // shell: build the validated config, then `with_protocol().launch()`.
         match node_type {
             SwarmNodeType::Client => {
-                let bandwidth = config.protocol.bandwidth_config();
+                let accounting = config.protocol.accounting_config();
                 let local_store = config.protocol.local_store_config();
                 let chain = config.protocol.chain_config();
                 let swap = config.protocol.swap_config();
 
-                let node_config =
-                    ClientConfig::new(spec, identity, network, bandwidth, local_store, chain, swap);
+                let node_config = ClientConfig::new(
+                    spec,
+                    identity,
+                    network,
+                    accounting,
+                    local_store,
+                    chain,
+                    swap,
+                );
 
                 let handle = builder.with_protocol(node_config).launch().await?;
                 if config.infra.api.grpc {
@@ -163,7 +170,7 @@ pub async fn run() -> Result<()> {
             }
             #[cfg(feature = "storer")]
             SwarmNodeType::Storer => {
-                let bandwidth = config.protocol.bandwidth_config();
+                let accounting = config.protocol.accounting_config();
                 let local_store = config.protocol.local_store_config();
                 let storage = config.protocol.storage_config();
                 let chain = config.protocol.chain_config();
@@ -173,7 +180,7 @@ pub async fn run() -> Result<()> {
                     spec,
                     identity,
                     network,
-                    bandwidth,
+                    accounting,
                     local_store,
                     storage,
                     chain,

--- a/bin/vertex/tests/config_load.rs
+++ b/bin/vertex/tests/config_load.rs
@@ -24,3 +24,12 @@ fn quoted_u128_config_file_parses() {
     let config = FullNodeConfig::<ProtocolConfig>::load(Some(file.path())).unwrap();
     assert_eq!(config.protocol.swap.bounce_limit, 200_000_000u128);
 }
+
+#[test]
+fn accounting_section_deserializes() {
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(file, "[accounting]\npayment_threshold = 42").unwrap();
+
+    let config = FullNodeConfig::<ProtocolConfig>::load(Some(file.path())).unwrap();
+    assert_eq!(config.protocol.accounting.payment_threshold, 42);
+}

--- a/crates/swarm/accounting/core/src/args.rs
+++ b/crates/swarm/accounting/core/src/args.rs
@@ -12,27 +12,27 @@ use crate::constants::*;
 /// This struct is for CLI parsing and serialization only.
 /// Convert to `AccountingConfig` for runtime use.
 #[derive(Debug, Args, Clone, Serialize, Deserialize)]
-#[command(next_help_heading = "Bandwidth Accounting")]
+#[command(next_help_heading = "Accounting")]
 #[serde(default)]
 pub struct AccountingArgs {
     /// Payment threshold (triggers settlement when exceeded).
-    #[arg(long = "bandwidth.threshold", default_value_t = DEFAULT_PAYMENT_THRESHOLD)]
+    #[arg(long = "accounting.threshold", default_value_t = DEFAULT_PAYMENT_THRESHOLD)]
     pub payment_threshold: u64,
 
     /// Payment tolerance percent for disconnect threshold.
-    #[arg(long = "bandwidth.tolerance-percent", default_value_t = DEFAULT_PAYMENT_TOLERANCE_PERCENT)]
+    #[arg(long = "accounting.tolerance-percent", default_value_t = DEFAULT_PAYMENT_TOLERANCE_PERCENT)]
     pub payment_tolerance_percent: u64,
 
     /// Pseudosettle refresh rate per second.
-    #[arg(long = "bandwidth.refresh-rate", default_value_t = DEFAULT_REFRESH_RATE)]
+    #[arg(long = "accounting.refresh-rate", default_value_t = DEFAULT_REFRESH_RATE)]
     pub refresh_rate: u64,
 
     /// Early payment trigger percent (for SWAP).
-    #[arg(long = "bandwidth.early-percent", default_value_t = DEFAULT_EARLY_PAYMENT_PERCENT)]
+    #[arg(long = "accounting.early-percent", default_value_t = DEFAULT_EARLY_PAYMENT_PERCENT)]
     pub early_payment_percent: u64,
 
     /// Scaling factor for client-only nodes (divides thresholds).
-    #[arg(long = "bandwidth.client-only-factor", default_value_t = DEFAULT_CLIENT_ONLY_FACTOR)]
+    #[arg(long = "accounting.client-only-factor", default_value_t = DEFAULT_CLIENT_ONLY_FACTOR)]
     pub client_only_factor: u64,
 
     /// Chunk pricing configuration.
@@ -51,5 +51,39 @@ impl Default for AccountingArgs {
             client_only_factor: DEFAULT_CLIENT_ONLY_FACTOR,
             pricing: FixedPricingArgs::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: AccountingArgs,
+    }
+
+    /// The renamed `--accounting.*` flags parse into the matching fields, pricing
+    /// included via the flattened `--accounting.base-price`.
+    #[test]
+    fn accounting_flags_parse() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "--accounting.threshold",
+            "42",
+            "--accounting.tolerance-percent",
+            "7",
+            "--accounting.refresh-rate",
+            "11",
+            "--accounting.base-price",
+            "9",
+        ])
+        .expect("accounting flags parse");
+        assert_eq!(cli.args.payment_threshold, 42);
+        assert_eq!(cli.args.payment_tolerance_percent, 7);
+        assert_eq!(cli.args.refresh_rate, 11);
+        assert_eq!(cli.args.pricing.base_price, 9);
     }
 }

--- a/crates/swarm/accounting/core/src/builder.rs
+++ b/crates/swarm/accounting/core/src/builder.rs
@@ -18,7 +18,7 @@ use crate::{Accounting, ClientAccounting};
 /// # Example
 ///
 /// ```ignore
-/// let accounting = AccountingBuilder::new(bandwidth_config)
+/// let accounting = AccountingBuilder::new(accounting_config)
 ///     .with_pricer_from_config(spec.clone())
 ///     .with_settlement(PseudosettleProvider::new(&config))
 ///     .build(&identity);

--- a/crates/swarm/accounting/core/src/client_accounting.rs
+++ b/crates/swarm/accounting/core/src/client_accounting.rs
@@ -5,14 +5,17 @@ use vertex_swarm_api::{SwarmAccounting, SwarmClientAccounting, SwarmPricing};
 /// Combined pricing and bandwidth accounting for client operations.
 #[derive(Clone)]
 pub struct ClientAccounting<B, P> {
-    bandwidth: B,
+    accounting: B,
     pricing: P,
 }
 
 impl<B, P> ClientAccounting<B, P> {
     /// Create a new client accounting instance.
-    pub fn new(bandwidth: B, pricing: P) -> Self {
-        Self { bandwidth, pricing }
+    pub fn new(accounting: B, pricing: P) -> Self {
+        Self {
+            accounting,
+            pricing,
+        }
     }
 }
 
@@ -25,7 +28,7 @@ where
     type Pricing = P;
 
     fn accounting(&self) -> &B {
-        &self.bandwidth
+        &self.accounting
     }
 
     fn pricing(&self) -> &P {

--- a/crates/swarm/accounting/pricing/src/args.rs
+++ b/crates/swarm/accounting/pricing/src/args.rs
@@ -7,11 +7,11 @@ use crate::constants::DEFAULT_BASE_PRICE;
 
 /// Fixed-rate chunk pricing CLI arguments.
 #[derive(Debug, Args, Clone, Serialize, Deserialize)]
-#[command(next_help_heading = "Bandwidth Pricing")]
+#[command(next_help_heading = "Accounting Pricing")]
 #[serde(default)]
 pub struct FixedPricingArgs {
     /// Base price per chunk (scaled by proximity for peer pricing).
-    #[arg(long = "bandwidth.base-price", default_value_t = DEFAULT_BASE_PRICE)]
+    #[arg(long = "accounting.base-price", default_value_t = DEFAULT_BASE_PRICE)]
     pub base_price: u64,
 }
 

--- a/crates/swarm/builder/src/config.rs
+++ b/crates/swarm/builder/src/config.rs
@@ -84,12 +84,12 @@ impl BootnodeConfig {
 impl_common_config_getters!(BootnodeConfig);
 impl_builds_protocol!(BootnodeConfig, "Swarm Bootnode");
 
-/// Validated configuration for a Client node with bandwidth accounting.
+/// Validated configuration for a Client node with accounting.
 pub struct ClientConfig {
     spec: Arc<Spec>,
     identity: Arc<Identity>,
     network: NetworkConfig<KademliaConfig>,
-    bandwidth: DefaultAccountingConfig,
+    accounting: DefaultAccountingConfig,
     local_store: LocalStoreConfig,
     chain: ChainConfig,
     swap: SwapConfig,
@@ -101,7 +101,7 @@ impl ClientConfig {
         spec: Arc<Spec>,
         identity: Arc<Identity>,
         network: NetworkConfig<KademliaConfig>,
-        bandwidth: DefaultAccountingConfig,
+        accounting: DefaultAccountingConfig,
         local_store: LocalStoreConfig,
         chain: ChainConfig,
         swap: SwapConfig,
@@ -110,7 +110,7 @@ impl ClientConfig {
             spec,
             identity,
             network,
-            bandwidth,
+            accounting,
             local_store,
             chain,
             swap,
@@ -149,8 +149,8 @@ impl ClientConfig {
         self.cache.take()
     }
 
-    pub fn bandwidth(&self) -> &DefaultAccountingConfig {
-        &self.bandwidth
+    pub fn accounting(&self) -> &DefaultAccountingConfig {
+        &self.accounting
     }
 
     /// Cache sizing for the client's in-memory local store.

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -195,7 +195,7 @@ pub(crate) struct ClientNodeParams<'a> {
     pub(crate) spec: &'a Arc<Spec>,
     pub(crate) identity: &'a Arc<Identity>,
     pub(crate) network: &'a NetworkConfig<KademliaConfig>,
-    pub(crate) bandwidth: &'a DefaultAccountingConfig,
+    pub(crate) accounting: &'a DefaultAccountingConfig,
     #[cfg(feature = "swap")]
     pub(crate) chain: &'a ChainConfig,
     #[cfg(feature = "swap")]
@@ -291,12 +291,12 @@ pub(crate) async fn build_client_backed_node<F: NodeAssembly>(
 
     // A client paces against the scaled line a storer enforces on it; a storer
     // keeps the unscaled figures.
-    let scaled_bandwidth;
-    let bandwidth = if node_type.requires_storage() {
-        params.bandwidth
+    let scaled_accounting;
+    let accounting = if node_type.requires_storage() {
+        params.accounting
     } else {
-        scaled_bandwidth = params.bandwidth.clone().for_client();
-        &scaled_bandwidth
+        scaled_accounting = params.accounting.clone().for_client();
+        &scaled_accounting
     };
 
     // SWAP defaults on for storers (maximum support) and off for clients; an
@@ -334,7 +334,7 @@ pub(crate) async fn build_client_backed_node<F: NodeAssembly>(
         node_type,
         spec: params.spec,
         identity: params.identity,
-        bandwidth,
+        accounting,
         #[cfg(feature = "swap")]
         swap: params.swap,
     };
@@ -477,7 +477,7 @@ async fn build_client(
             spec: config.spec(),
             identity: config.identity(),
             network: config.network(),
-            bandwidth: config.bandwidth(),
+            accounting: config.accounting(),
             #[cfg(feature = "swap")]
             chain: config.chain(),
             #[cfg(feature = "swap")]

--- a/crates/swarm/builder/src/storer.rs
+++ b/crates/swarm/builder/src/storer.rs
@@ -67,7 +67,7 @@ pub struct StorerConfig {
     spec: Arc<Spec>,
     identity: Arc<Identity>,
     network: NetworkConfig<KademliaConfig>,
-    bandwidth: DefaultAccountingConfig,
+    accounting: DefaultAccountingConfig,
     local_store: LocalStoreConfig,
     storage: StorageConfig,
     chain: ChainConfig,
@@ -85,7 +85,7 @@ impl StorerConfig {
         spec: Arc<Spec>,
         identity: Arc<Identity>,
         network: NetworkConfig<KademliaConfig>,
-        bandwidth: DefaultAccountingConfig,
+        accounting: DefaultAccountingConfig,
         local_store: LocalStoreConfig,
         storage: StorageConfig,
         chain: ChainConfig,
@@ -95,7 +95,7 @@ impl StorerConfig {
             spec,
             identity,
             network,
-            bandwidth,
+            accounting,
             local_store,
             storage,
             chain,
@@ -169,8 +169,8 @@ impl StorerConfig {
         &self.network
     }
 
-    pub fn bandwidth(&self) -> &DefaultAccountingConfig {
-        &self.bandwidth
+    pub fn accounting(&self) -> &DefaultAccountingConfig {
+        &self.accounting
     }
 
     pub fn local_store(&self) -> &LocalStoreConfig {
@@ -247,7 +247,7 @@ pub(crate) async fn build_storer(
             spec: config.spec(),
             identity: config.identity(),
             network: config.network(),
-            bandwidth: config.bandwidth(),
+            accounting: config.accounting(),
             #[cfg(feature = "swap")]
             chain: config.chain(),
             #[cfg(feature = "swap")]

--- a/crates/swarm/node/src/args/swarm.rs
+++ b/crates/swarm/node/src/args/swarm.rs
@@ -63,7 +63,7 @@ impl From<SwarmNodeType> for NodeTypeArg {
 ///
 /// This struct is for CLI parsing and serialization only.
 /// Convert to `ProtocolConfig` for runtime use.
-/// Pricing is nested under `bandwidth` (accessible via `--bandwidth.base-price`).
+/// Pricing is nested under `accounting` (accessible via `--accounting.base-price`).
 #[derive(Args, Clone)]
 pub struct ProtocolArgs {
     /// Swarm network specification and node mode.
@@ -76,9 +76,9 @@ pub struct ProtocolArgs {
     #[command(flatten)]
     pub network: NetworkArgs,
 
-    /// Bandwidth accounting (includes pricing via `--bandwidth.base-price`).
+    /// Accounting (includes pricing via `--accounting.base-price`).
     #[command(flatten)]
-    pub bandwidth: AccountingArgs,
+    pub accounting: AccountingArgs,
 
     #[command(flatten)]
     pub localstore: LocalStoreArgs,

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -24,14 +24,14 @@ use crate::args::{
 ///
 /// Contains all Swarm-specific settings for config file serialization.
 /// Used as the type parameter for `vertex_node_core::config::FullNodeConfig`.
-/// Pricing is nested under `bandwidth`.
+/// Pricing is nested under `accounting`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ProtocolConfig {
     pub node_type: SwarmNodeType,
     pub identity: IdentityArgs,
     pub network: NetworkArgs,
-    pub bandwidth: AccountingArgs,
+    pub accounting: AccountingArgs,
     pub localstore: LocalStoreArgs,
     #[cfg(feature = "storer")]
     pub redistribution: RedistributionArgs,
@@ -50,9 +50,9 @@ impl ProtocolConfig {
         self.identity.identity(spec, network_dir, self.node_type)
     }
 
-    /// Build the bandwidth accounting configuration.
-    pub fn bandwidth_config(&self) -> DefaultAccountingConfig {
-        DefaultAccountingConfig::from(&self.bandwidth)
+    /// Build the accounting configuration.
+    pub fn accounting_config(&self) -> DefaultAccountingConfig {
+        DefaultAccountingConfig::from(&self.accounting)
     }
 
     /// Create local store configuration.
@@ -91,7 +91,7 @@ impl NodeProtocolConfig for ProtocolConfig {
     fn apply_args(&mut self, args: &Self::Args) {
         self.identity = args.identity.clone();
         self.network = args.network.clone();
-        self.bandwidth = args.bandwidth.clone();
+        self.accounting = args.accounting.clone();
         self.localstore = args.localstore.clone();
         #[cfg(feature = "storer")]
         {

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -112,8 +112,8 @@ pub struct ClientCoreCtx {
     pub spec: Arc<Spec>,
     /// Node identity the accounting and overlay are pinned to.
     pub identity: Arc<Identity>,
-    /// Bandwidth config the accounting builder consumes.
-    pub bandwidth: DefaultAccountingConfig,
+    /// Accounting config the accounting builder consumes.
+    pub accounting: DefaultAccountingConfig,
     /// The node's topology handle.
     pub topology: TopologyHandle<Arc<Identity>>,
     /// The client service to attach the reporter and in-flight limiter to.
@@ -139,7 +139,7 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     let ClientCoreCtx {
         spec,
         identity,
-        bandwidth,
+        accounting: accounting_config,
         topology,
         client_service,
         client_handle,
@@ -150,7 +150,7 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
 
     // Pseudosettle is registered first so soft accounting forgives total debt
     // before swap settles originated debt; the order matches `settle_all`.
-    let accounting = AccountingBuilder::new(bandwidth)
+    let accounting = AccountingBuilder::new(accounting_config)
         .with_pricer_from_config(spec)
         .with_settlement(pseudosettle_provider)
         .with_settlements(extra_settlement)
@@ -637,8 +637,8 @@ pub struct ClientTailParams<'a> {
     pub spec: &'a Arc<Spec>,
     /// Node identity the accounting, overlay, and SWAP signer are pinned to.
     pub identity: &'a Arc<Identity>,
-    /// Bandwidth config driving accounting, pricing, and the self-throttle.
-    pub bandwidth: &'a DefaultAccountingConfig,
+    /// Accounting config driving the ledger, pricing, and the self-throttle.
+    pub accounting: &'a DefaultAccountingConfig,
     /// SWAP settlement configuration.
     #[cfg(feature = "swap")]
     pub swap: &'a SwapConfig,
@@ -657,7 +657,7 @@ pub struct ClientTailParams<'a> {
 pub struct ClientCoreTail {
     spec: Arc<Spec>,
     identity: Arc<Identity>,
-    bandwidth: DefaultAccountingConfig,
+    accounting: DefaultAccountingConfig,
     pseudosettle_provider: PseudosettleProvider<DefaultAccountingConfig>,
     pseudosettle_wiring: PseudosettleWiring,
     #[cfg(feature = "swap")]
@@ -680,7 +680,7 @@ impl ClientCoreTail {
         // Pseudosettle: prepare the provider so it embeds in the accounting, and
         // the event sink so wire events route at the node build.
         let (pseudosettle_provider, pseudosettle_wiring) =
-            PseudosettleWiring::prepare(params.bandwidth);
+            PseudosettleWiring::prepare(params.accounting);
         let pseudosettle_event_sender = pseudosettle_wiring.event_sender();
 
         // SWAP: the provider embeds in the accounting and the swap event sink
@@ -694,7 +694,7 @@ impl ClientCoreTail {
             SwapWiring::prepare(
                 params.spec,
                 params.identity,
-                params.bandwidth,
+                params.accounting,
                 params.swap,
                 swap_enabled,
             )
@@ -711,7 +711,7 @@ impl ClientCoreTail {
         let tail = Self {
             spec: Arc::clone(params.spec),
             identity: params.identity.clone(),
-            bandwidth: params.bandwidth.clone(),
+            accounting: params.accounting.clone(),
             pseudosettle_provider,
             pseudosettle_wiring,
             #[cfg(feature = "swap")]
@@ -776,7 +776,7 @@ impl ClientCoreTail {
         let core = assemble_client_core(ClientCoreCtx {
             spec: Arc::clone(&self.spec),
             identity: self.identity.clone(),
-            bandwidth: self.bandwidth.clone(),
+            accounting: self.accounting.clone(),
             topology: topology.clone(),
             client_service,
             client_handle: client_handle.clone(),
@@ -1012,7 +1012,7 @@ mod tests {
     fn prepare_leaves_swap_unwired_without_chequebook() {
         let identity = test_identity_arc();
         let spec = identity.spec().clone();
-        let bandwidth = DefaultAccountingConfig::default();
+        let accounting = DefaultAccountingConfig::default();
 
         // A default client leaves SWAP off (swap_default is off for clients).
         let swap_off = SwapConfig::default();
@@ -1021,7 +1021,7 @@ mod tests {
                 node_type: SwarmNodeType::Client,
                 spec: &spec,
                 identity: &identity,
-                bandwidth: &bandwidth,
+                accounting: &accounting,
                 swap: &swap_off,
             },
             None,
@@ -1042,7 +1042,7 @@ mod tests {
                 node_type: SwarmNodeType::Client,
                 spec: &spec,
                 identity: &identity,
-                bandwidth: &bandwidth,
+                accounting: &accounting,
                 swap: &swap_no_chequebook,
             },
             None,

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -68,7 +68,7 @@ use crate::inflight::PeerInflightLimiter;
 pub struct ClientLauncher {
     identity: Arc<Identity>,
     network: NetworkConfig<KademliaConfig>,
-    bandwidth: DefaultAccountingConfig,
+    accounting: DefaultAccountingConfig,
     local_store: LocalStoreConfig,
     /// Caller-supplied client cache. `None` builds the default in-memory cache.
     store: Option<Arc<dyn SwarmLocalStore>>,
@@ -91,7 +91,7 @@ impl ClientLauncher {
         Self {
             identity: identity.into(),
             network: NetworkConfig::dial_only(),
-            bandwidth: DefaultAccountingConfig::default(),
+            accounting: DefaultAccountingConfig::default(),
             local_store: LocalStoreConfig::default(),
             store: None,
             peer_store: None,
@@ -136,13 +136,13 @@ impl ClientLauncher {
         self
     }
 
-    /// Set the bandwidth accounting configuration.
+    /// Set the accounting configuration.
     ///
     /// Drives the pseudosettle allowance, the per-chunk price, and the admission
     /// band thresholds. Defaults to [`DefaultAccountingConfig::default`].
     #[must_use]
-    pub fn with_bandwidth(mut self, bandwidth: DefaultAccountingConfig) -> Self {
-        self.bandwidth = bandwidth;
+    pub fn with_accounting(mut self, accounting: DefaultAccountingConfig) -> Self {
+        self.accounting = accounting;
         self
     }
 
@@ -269,13 +269,13 @@ impl ClientLauncher {
         };
 
         // The launcher always builds a client, which paces against the scaled line.
-        let bandwidth = self.bandwidth.for_client();
+        let accounting = self.accounting.for_client();
 
         let tail_params = ClientTailParams {
             node_type: SwarmNodeType::Client,
             spec: &spec,
             identity: &self.identity,
-            bandwidth: &bandwidth,
+            accounting: &accounting,
             #[cfg(feature = "swap")]
             swap: &self.swap,
         };

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -89,15 +89,15 @@ pub trait SettlementTrigger: Send + Sync {
 /// the set is both the dedup and the per-peer rate limit (the next settle cannot
 /// start until the prior one clears on completion).
 pub struct AccountingSettlement<B> {
-    bandwidth: B,
+    accounting: B,
     in_flight: Arc<Mutex<InFlightSet>>,
 }
 
 impl<B> AccountingSettlement<B> {
-    /// Trigger settlement through `bandwidth`.
-    pub fn new(bandwidth: B) -> Self {
+    /// Trigger settlement through `accounting`.
+    pub fn new(accounting: B) -> Self {
         Self {
-            bandwidth,
+            accounting,
             in_flight: Arc::new(Mutex::new(InFlightSet::default())),
         }
     }
@@ -135,7 +135,7 @@ where
                 return;
             }
         }
-        let handle = self.bandwidth.for_peer(peer);
+        let handle = self.accounting.for_peer(peer);
         let guard = InFlightGuard {
             in_flight: Arc::clone(&self.in_flight),
             peer,

--- a/docs/architecture/config.md
+++ b/docs/architecture/config.md
@@ -43,7 +43,7 @@ This separation is intentional. Moving the validated configs into `vertex_node_c
 
 ## NodeBuildsProtocol Delegation
 
-The `NodeBuildsProtocol` trait (in `vertex_node_api`) provides a uniform interface for node-type-specific configuration. Each validated config struct implements `NodeBuildsProtocol`, which the swarm builder uses to select the correct protocol stack. The builder delegates to the config's getters (`spec()`, `identity()`, `network()`, `bandwidth()`, etc.) when constructing protocol components.
+The `NodeBuildsProtocol` trait (in `vertex_node_api`) provides a uniform interface for node-type-specific configuration. Each validated config struct implements `NodeBuildsProtocol`, which the swarm builder uses to select the correct protocol stack. The builder delegates to the config's getters (`spec()`, `identity()`, `network()`, `accounting()`, etc.) when constructing protocol components.
 
 Methods like `identity()` on validated config structs return runtime objects (`Arc<Identity>`), not configuration structs; they are not renamed to `*_config()` because they are not config builders.
 

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -17,13 +17,13 @@ vertex node --help
 
 ## Configuration Architecture
 
-CLI arguments are organised into logical groups that correspond to node subsystems: network, bandwidth, storage, identity, and network selection.
+CLI arguments are organised into logical groups that correspond to node subsystems: network, accounting, storage, identity, and network selection.
 
 ```mermaid
 flowchart LR
     A[CLI Args] --> C[Merge]
     B["SwarmSpec\n(mainnet/testnet)"] --> C
-    C --> D["NodeConfig\n- mode\n- network\n- bandwidth\n- storage\n- identity"]
+    C --> D["NodeConfig\n- mode\n- network\n- accounting\n- storage\n- identity"]
 ```
 
 The `SwarmSpec` provides network-level constants (network ID, bootnodes, contract addresses, default pricing parameters). CLI arguments provide node-level configuration (ports, capacity, node type, settlement selection) and can override network defaults where appropriate.
@@ -34,7 +34,7 @@ The `SwarmSpec` provides network-level constants (network ID, bootnodes, contrac
 |-------|--------|------------|---------|
 | **Mode** | `--mode` | All | Node type selection (bootnode, client, storer) |
 | **Network** | `--network.*` | All | P2P listen address/port, bootnodes, max peers, NAT |
-| **Bandwidth** | `--bandwidth.*` | Client, Storer | Accounting mode, pricing, thresholds |
+| **Accounting** | `--accounting.*` | Client, Storer | Accounting mode, pricing, thresholds |
 | **Storage** | `--storage.*` | Storer | Reserve capacity, cache size, redistribution |
 | **Identity** | `--password`, `--nonce`, etc. | All | Keystore, overlay nonce, ephemeral mode |
 | **Database** | `--db.*` | All | Database persistence (per-node-type default) and cache size |
@@ -72,7 +72,7 @@ When both `--db.path` and `--db.persist` are given, the explicit path wins.
 
 What persistence covers: peer snapshots (the identity-only records described in [Peer Management](../networking/peer-management.md)), written periodically and on shutdown so a restarted node warm-starts its peer set. Peer scores, bans, and dial backoff are runtime-only and are never persisted in either mode. If the configured database cannot be opened, the node logs a warning and continues fully in-memory rather than aborting.
 
-## Bandwidth accounting
+## Accounting
 
 Soft accounting (pseudosettle) is always on for client and storer nodes; it needs no flag. Monetary settlement (SWAP) is opt-in via `--swap` and selected purely by that flag plus the node type.
 


### PR DESCRIPTION
## What

Rename the operator-facing accounting surface from "bandwidth" to "accounting".

The accounting subsystem was renamed from "bandwidth" internally, but the operator surface still said "bandwidth": the CLI flags were `--bandwidth.*`, the config-file section key was `bandwidth`, and the clap help headings read "Bandwidth". This renames the flag family to `--accounting.*`, the config key to `accounting`, both help headings to "Accounting" and "Accounting Pricing", and the internal builder, launcher, and config fields and accessors to match (`bandwidth` to `accounting`, `bandwidth_config` to `accounting_config`, `with_bandwidth` to `with_accounting`).

This is a clean break with no backward-compatibility aliases. Vertex is pre-v1, so the old `--bandwidth.*` flags and `[bandwidth]` config sections simply stop working; nothing on the wire changes.

## Why

Closes #665. The operator vocabulary now matches the internal type vocabulary that the earlier accounting reshape already adopted, so an operator reading `--help`, a config file, and the source sees one consistent noun. Keeping aliases for a deprecation window was considered and dropped: pre-v1 there is no compatibility promise for the operator surface, and an aliased config key ran into a serialize-then-alias duplicate-field conflict in the config loader anyway, so the clean rename is both simpler and more correct.

No behaviour change: every flag keeps its default and effect, the accounting config is built identically, and the amount arithmetic, pricing, and thresholds are untouched. The optional `Direction` enum rename to credit/debit is deferred to a separate change, since it is internal, not operator-facing, and would pull the settlement services into an otherwise mechanical rename.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace; a missed reference would fail to compile, so a green build is the rename-completeness proof)
- `cargo nextest run` across the accounting, pricing, node, builder, and binary crates, all features (231/231), including a new flag round-trip test and a new config-section deserialization test
- `just check-cone` and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`

## Notes

Fifth unit of epic #439.

AI Assistance: Claude Code (Opus 4.8 for implementation, Fable 5 for design and QA) used for the change and this description.

