### PR TITLE
docs(swarm-accounting): state the two-phase construction contract at the crate root

### DIFF
--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -16,6 +16,16 @@
 //! (from `vertex-swarm-api`), so peer selection and pacing can consume accounting
 //! state without depending on this crate's internals.
 //!
+//! # Construction
+//!
+//! Construction is two-phase: [`AccountingBuilder::build`] produces a
+//! [`ClientAccounting`] with the ledger, pricer, and settlement providers
+//! embedded; node assembly (`assemble_client_core` in the node crate) then
+//! wires the selector, origin gate, settlement trigger, and settlement
+//! services around it. The invariant is a single shared instance: every
+//! consumer must read the same per-peer balances, so assembly shares one
+//! `Arc` of the one build rather than building twice.
+//!
 //! # Commit points
 //!
 //! One [`Reservation`] contract, two commit points, coupled to the dispatch

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -107,6 +107,10 @@ pub struct ClientCore {
 /// Carries the prepared pseudosettle provider plus any native-only providers
 /// (swap) in `extra_settlement`; pseudosettle is registered first so soft
 /// accounting forgives total debt before swap settles originated debt.
+///
+/// Second phase of the two-phase construction stated at the
+/// [`vertex_swarm_accounting`] crate root: the one accounting built from these
+/// inputs is shared across the selector, gate, forwarder, and services.
 pub struct ClientCoreCtx {
     /// Network spec for the config pricer.
     pub spec: Arc<Spec>,


### PR DESCRIPTION
## What

Two terse rustdoc insertions naming the two-phase accounting construction contract (builder-build then node-assembly around one shared instance) at the accounting crate root, cross-referenced from the `ClientCoreCtx` rustdoc.

## Why

Closes #666. Last streamline unit of epic #439; the single-shared-instance invariant was documented only on a struct field.

## Testing

`cargo doc --no-deps -p vertex-swarm-accounting -p vertex-swarm-node`: the two new intra-doc links resolve clean (the pre-existing `builder.rs` `with_settlement` warning is unrelated and tracked separately, as are the pre-existing node `StorerNode`/`PUSH_CANDIDATE_COUNT` warnings). `cargo clippy` (missing_docs) clean. Docs-only, no test suite per scope.

## Stacking


AI Assistance: Claude Code (Fable 5 design, Opus 4.8 implementation) used for the rustdoc paragraphs and PR prep.

