### PR TITLE
fix(swarm-accounting-pseudosettle): grant zero allowance on a missing anchor instead of seeding from now

### DIFF
--- a/crates/swarm/accounting/pseudosettle/src/service.rs
+++ b/crates/swarm/accounting/pseudosettle/src/service.rs
@@ -340,19 +340,25 @@ impl<A: SwarmAccounting + 'static> PseudosettleService<A> {
 
         // Cap at time-based allowance: refresh_rate AU accumulate per second.
         // The elapsed interval is measured from the last settlement, or, with
-        // none yet, from when we first started accounting for this peer. It is
-        // never seeded from `now`: that would treat the whole Unix epoch as
-        // elapsed and overflow the scaling into an unbounded grant, defeating
-        // the only anti-free-ride brake on first contact and after a reconnect.
+        // none yet, from when we first started accounting for this peer. The
+        // anchor must be a recorded wall-clock instant: deriving `elapsed`
+        // from an absolute epoch seed (timestamp zero) rather than a recorded
+        // anchor would scale the whole epoch into an unbounded grant,
+        // defeating the only anti-free-ride brake on first contact and after
+        // a reconnect.
         // On overflow the allowance saturates, but the request and owed caps
         // below still bound the result.
+        // A missing anchor grants zero; the allowance is never derived from the clock alone.
         let now = current_timestamp();
-        let since = self
+        let Some(since) = self
             .last_settlement
             .get(peer)
             .or_else(|| self.first_seen.get(peer))
             .copied()
-            .unwrap_or(now);
+        else {
+            debug!(%peer, "no allowance anchor recorded, granting zero");
+            return Au::ZERO;
+        };
         let elapsed = now.saturating_sub(since);
         let allowance = self
             .refresh_rate
@@ -773,6 +779,52 @@ mod tests {
         assert!(
             acceptable <= ceiling,
             "post-reconnect grant {acceptable} exceeded the elapsed-bounded ceiling {ceiling}"
+        );
+    }
+
+    #[test]
+    fn missing_anchor_yields_zero_allowance() {
+        let peer = test_peer();
+        let refresh_rate = Au::from_amount(4_500_000);
+        let svc = service_with_large_debt(peer, refresh_rate);
+
+        // Neither anchor map holds this peer, so the zero provably comes from
+        // the missing-anchor branch rather than the positive-balance guard.
+        assert!(!svc.last_settlement.contains_key(&peer));
+        assert!(!svc.first_seen.contains_key(&peer));
+
+        let handle = svc.accounting.for_peer(peer);
+        let requested = Au::from_amount(1_000_000_000_000);
+        // Pins the missing-anchor branch to a hard zero grant. A re-arming
+        // seeded from the absolute epoch, or any positive grant reaching this
+        // branch, trips the assertion; a `now` seed also yields zero elapsed,
+        // so that shape is not distinguished here.
+        assert_eq!(
+            svc.calculate_acceptable(&peer, &handle, requested),
+            Au::ZERO
+        );
+    }
+
+    #[test]
+    fn present_anchor_allowance_arithmetic_unchanged() {
+        let peer = test_peer();
+        let refresh_rate = Au::from_amount(4_500_000);
+        let mut svc = service_with_large_debt(peer, refresh_rate);
+
+        // A settlement anchored ten seconds ago: the normal path computes
+        // refresh_rate * elapsed, so the grant tracks ten times the rate.
+        let now = current_timestamp();
+        svc.last_settlement.insert(peer, now - 10);
+
+        let handle = svc.accounting.for_peer(peer);
+        let acceptable =
+            svc.calculate_acceptable(&peer, &handle, Au::from_amount(1_000_000_000_000));
+
+        let floor = refresh_rate.checked_scale(10).unwrap();
+        let ceiling = refresh_rate.checked_scale(12).unwrap();
+        assert!(
+            acceptable >= floor && acceptable <= ceiling,
+            "present-anchor grant {acceptable} left the expected [{floor}, {ceiling}] band"
         );
     }
 


### PR DESCRIPTION
## What

Replace the `unwrap_or(now)` allowance-anchor fallback in `PseudosettleService::calculate_acceptable` with a `let...else` that grants a hard zero allowance (with a debug log) on a genuinely-missing anchor, so the inbound pseudosettle allowance can never be derived from the absolute clock. Add a mutation-probe test and a normal-path regression test.

## Why

Closes #444

The fallback is the shape of the original allowance bug; it is safe and unreachable today, but a future reorder or a new caller could re-arm it into an unbounded epoch-elapsed grant. Part of epic #439.

## Note

The deliberate first-contact allowance ramp is preserved exactly (the `first_seen` anchoring is untouched); the zero-accepted ack is a wire shape already emitted by the rate gate, so there is no wire or interop change. Folding the anchor into the ledger (removing the per-service maps entirely) is a possible larger follow-up, deliberately out of scope here.

## Testing

`cargo nextest run -p vertex-swarm-accounting-pseudosettle` (including the two new tests and the unmodified first-contact ramp tests), clippy `--all-features`, and the wasm32 build.


AI Assistance: Claude Code (Fable 5 design and QA, Opus 4.8 implementation) used for the fix and tests.


