### PR TITLE
feat(swarm-accounting): adopt the peer-announced payment threshold as the per-peer settle line

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -38,6 +38,10 @@ use vertex_swarm_primitives::OverlayAddress;
 
 use vertex_swarm_api::SwarmSettlementProvider;
 
+/// The lower clamp on an adopted settle line, in refresh-rate units: a peer
+/// cannot drive our settle timing tighter than twice the refresh rate.
+const MIN_ANNOUNCED_REFRESH_MULTIPLES: u64 = 2;
+
 /// Per-peer accounting with pluggable settlement providers.
 ///
 /// Manages balances and delegates settlement to configured providers.
@@ -99,7 +103,7 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
         _originated: bool,
     ) -> Result<Reservation<Receive>, AccountingError> {
         let state = self.peer_state(peer);
-        if !state_snapshot(&state, self.settle_trigger())
+        if !state_snapshot(&state, self.settle_trigger_for(&state))
             .admit(price)
             .admits()
         {
@@ -169,8 +173,13 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
                 // connect hook seeds the real node type, so an unknown peer must
                 // never be served on the full storer line. connect_peer heals it
                 // in place once the type is known.
+                // Seed the settle line with the full local payment threshold, not
+                // the client serve line: an un-announced peer must settle on
+                // exactly today's config-derived timing. A peer announcement
+                // tightens it later through adopt_payment_threshold.
                 Arc::new(PeerState::new(
                     self.config.client_payment_threshold(),
+                    self.config.payment_threshold(),
                     self.config.disconnect_threshold(),
                 ))
             })
@@ -194,6 +203,37 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
         self.config
             .early_payment_trigger()
             .max(self.config.refresh_rate())
+    }
+
+    /// The per-peer settle trigger: the peer's settle line less the early-payment
+    /// headroom, floored at one refresh-rate unit. For an un-announced peer the
+    /// settle line equals the local payment threshold, so this is identical to
+    /// [`Accounting::settle_trigger`].
+    fn settle_trigger_for(&self, state: &PeerState) -> Au {
+        let early = self.config.early_payment_percent().min(100);
+        state
+            .settle_line()
+            .scale_percent(100 - early)
+            .max(self.config.refresh_rate())
+    }
+
+    /// Adopt a peer's announced payment threshold as its settle line, clamped to
+    /// `[2 * refresh_rate, local payment threshold]`. The lower bound floors an
+    /// adversarial tiny or zero announcement; the local payment threshold caps it
+    /// so adoption only ever tightens our settle timing, never widens it past the
+    /// config default. Writes only the settle line, never the serve line.
+    fn adopt_announced(&self, peer: OverlayAddress, announced: Au) {
+        let min = self
+            .config
+            .refresh_rate()
+            .checked_scale(MIN_ANNOUNCED_REFRESH_MULTIPLES)
+            .unwrap_or(Au::new(i64::MAX));
+        let max = self.config.payment_threshold();
+        // max-then-min, not Ord::clamp: a misconfigured 2*refresh above the
+        // threshold inverts the band, and std clamp panics on that; letting the
+        // local ceiling win keeps the settle line at the config default instead.
+        self.peer_state(peer)
+            .set_settle_line(announced.max(min).min(max));
     }
 }
 
@@ -224,7 +264,6 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> SwarmAccounting for Accounting<
             state,
             providers: Arc::clone(&self.providers),
             disconnect_threshold: self.config.disconnect_threshold(),
-            payment_threshold: self.config.payment_threshold(),
         }
     }
 
@@ -259,6 +298,12 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> SwarmAccounting for Accounting<
         self.peer_state(peer)
             .set_payment_threshold(self.provide_line(node_type));
     }
+
+    fn adopt_payment_threshold(&self, peer: OverlayAddress, announced: Au) {
+        // Single-writer on the settle line, disjoint from connect_peer's serve
+        // line, so the two compose with no write-write race on shared state.
+        self.adopt_announced(peer, announced);
+    }
 }
 
 /// Per-peer ledger reads for admission.
@@ -291,28 +336,31 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Ledger for Accounting<C, I> {
         )
     }
 
-    fn settle_trigger(&self, _peer: &OverlayAddress) -> Au {
-        // The early-payment trigger floored at one refresh-rate unit, so a settle
-        // always offers at least the minimum the peer acts on. Per-peer state
-        // carries no early-payment figure, so this reads from config.
-        Accounting::settle_trigger(self)
+    fn settle_trigger(&self, peer: &OverlayAddress) -> Au {
+        // The per-peer settle trigger derived from the peer's adopted settle line,
+        // floored at one refresh-rate unit so a settle always offers at least the
+        // minimum the peer acts on. An unknown peer (no adoption yet) falls back to
+        // the config-derived trigger, matching the lazy peer_state seed, and never
+        // inserts state.
+        self.peers.read().get(peer).map_or_else(
+            || Accounting::settle_trigger(self),
+            |state| self.settle_trigger_for(state),
+        )
     }
 
     fn snapshot(&self, peer: &OverlayAddress) -> LedgerSnapshot {
-        // One read lock and one key hash for the three per-peer fields; the
-        // settle trigger is config-derived and needs no lock. The fallback for an
-        // unknown peer matches the per-field reads (fresh zero-balance peer at the
-        // configured disconnect threshold), so a band over this snapshot is
-        // identical to one over four separate reads.
-        let settle_trigger = self.settle_trigger();
+        // One read lock and one key hash for the per-peer fields. The fallback for
+        // an unknown peer matches the per-field reads (fresh zero-balance peer at
+        // the configured disconnect threshold and config-derived settle trigger),
+        // so a band over this snapshot is identical to one over the separate reads.
         self.peers.read().get(peer).map_or_else(
             || LedgerSnapshot {
                 balance: Au::ZERO,
                 reserved: Au::ZERO,
                 disconnect_line: self.config.disconnect_threshold(),
-                settle_trigger,
+                settle_trigger: self.settle_trigger(),
             },
-            |state| state_snapshot(state, settle_trigger),
+            |state| state_snapshot(state, self.settle_trigger_for(state)),
         )
     }
 }
@@ -324,18 +372,12 @@ pub struct AccountingPeerHandle {
     state: Arc<PeerState>,
     providers: Arc<[Box<dyn SwarmSettlementProvider>]>,
     disconnect_threshold: Au,
-    payment_threshold: Au,
 }
 
 impl AccountingPeerHandle {
     /// Get access to the underlying peer state.
     pub fn state(&self) -> &Arc<PeerState> {
         &self.state
-    }
-
-    /// Get the payment threshold in AU.
-    pub fn payment_threshold(&self) -> Au {
-        self.payment_threshold
     }
 
     /// Get the disconnect threshold in AU.
@@ -350,11 +392,12 @@ impl AccountingPeerHandle {
         for provider in self.providers.iter() {
             total = total.saturating_add(provider.settle(self.peer, self.state.as_ref()).await?);
 
-            // Stop once the committed debt no longer exceeds the payment
-            // threshold. Reasoning in `Debt` keeps the comparison sign-safe (both
-            // sides non-negative); each provider re-reads `balance()` internally,
-            // so the fresh committed debt drives the break.
-            if !Debt::committed(self.state.balance()).exceeds(self.payment_threshold) {
+            // Stop once the committed debt no longer exceeds the settle line.
+            // Read live: an announcement may land between handle creation and this
+            // break. Reasoning in `Debt` keeps the comparison sign-safe (both sides
+            // non-negative); each provider re-reads `balance()` internally, so the
+            // fresh committed debt drives the break.
+            if !Debt::committed(self.state.balance()).exceeds(self.state.settle_line()) {
                 break;
             }
         }
@@ -1082,5 +1125,140 @@ mod tests {
         assert_eq!(direct.settle_trigger, via_ledger.settle_trigger);
 
         drop(reservation);
+    }
+
+    // Default config: refresh 4_500_000, threshold 13_500_000, early 50%, so the
+    // adopted-settle-line band is [9_000_000, 13_500_000].
+
+    #[test]
+    fn announced_threshold_within_band_is_adopted() {
+        // An announcement inside the band sets the settle line verbatim, and the
+        // derived per-peer settle trigger is its early-payment fraction floored at
+        // one refresh unit: 9_000_000 * 50% = 4_500_000.
+        let accounting = test_accounting();
+        let peer = test_peer();
+
+        accounting.adopt_payment_threshold(peer, au(9_000_000));
+
+        assert_eq!(accounting.peer_state(peer).settle_line(), au(9_000_000));
+        assert_eq!(Ledger::settle_trigger(&accounting, &peer), au(4_500_000));
+    }
+
+    #[test]
+    fn announced_threshold_below_min_clamps_to_min() {
+        // A hostile tiny announcement floors at 2 * refresh_rate = 9_000_000,
+        // never driving our settle timing tighter than the minimum.
+        let accounting = test_accounting();
+        let peer = test_peer();
+
+        accounting.adopt_payment_threshold(peer, au(1));
+
+        assert_eq!(accounting.peer_state(peer).settle_line(), au(9_000_000));
+    }
+
+    #[test]
+    fn announced_threshold_above_local_default_clamps() {
+        // An announcement above the local payment threshold caps at it, so
+        // adoption only ever tightens our settle line, never widens it.
+        let accounting = test_accounting();
+        let peer = test_peer();
+
+        accounting.adopt_payment_threshold(peer, au(100_000_000));
+
+        assert_eq!(accounting.peer_state(peer).settle_line(), au(13_500_000));
+    }
+
+    #[test]
+    fn unannounced_peer_keeps_the_config_trigger() {
+        // A peer that never announced reads the config-derived settle trigger, so
+        // adoption changes nothing until an announcement lands. Both the map-miss
+        // fallback and the lazily seeded settle line must yield it: the seed is
+        // the full local payment threshold, not the tighter client serve line.
+        let accounting = test_accounting();
+        let peer = test_peer();
+
+        let config = AccountingConfig::default();
+        let expected = config.early_payment_trigger().max(config.refresh_rate());
+        assert_eq!(Ledger::settle_trigger(&accounting, &peer), expected);
+
+        accounting.peer_state(peer);
+        assert_eq!(Ledger::settle_trigger(&accounting, &peer), expected);
+    }
+
+    #[test]
+    fn adoption_never_touches_the_serve_line() {
+        // The announcement writes only the settle line: the serve line the peer
+        // owes us by stays at connect_peer's value, and a provide past it still
+        // errs (direction-correctness). Connect as a client so the serve line
+        // (200 under small_config) differs from the clamped adopted value (1000):
+        // a cross-write onto the serve line moves an observable value here.
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+        accounting.connect_peer(peer, SwarmNodeType::Client);
+        assert_eq!(accounting.peer_state(peer).payment_threshold(), au(200));
+
+        accounting.adopt_payment_threshold(peer, au(1_000_000_000));
+
+        assert_eq!(accounting.peer_state(peer).payment_threshold(), au(200));
+        assert!(accounting.prepare_provide(peer, au(200)).is_ok());
+        assert!(matches!(
+            accounting.prepare_provide(peer, au(201)),
+            Err(AccountingError::PaymentThreshold { .. })
+        ));
+    }
+
+    #[test]
+    fn connect_peer_reseed_does_not_clobber_adoption() {
+        // small_config: refresh 0 so the adopted band is [0, 1000]. Adopting 500
+        // and then connecting keeps the settle line (connect_peer writes only the
+        // serve line); the reverse order keeps the serve line. The adoption and
+        // connect-time serve-line writers touch disjoint fields, so they compose
+        // without a race.
+        let accounting = Accounting::new(small_config(), test_identity());
+
+        // adopt then connect: settle line survives, serve line rises to storer.
+        let a = OverlayAddress::from([1u8; 32]);
+        accounting.adopt_payment_threshold(a, au(500));
+        assert_eq!(accounting.peer_state(a).settle_line(), au(500));
+        accounting.connect_peer(a, SwarmNodeType::Storer);
+        assert_eq!(accounting.peer_state(a).settle_line(), au(500));
+        assert_eq!(accounting.peer_state(a).payment_threshold(), au(1000));
+
+        // connect then adopt: serve line survives the adoption.
+        let b = OverlayAddress::from([2u8; 32]);
+        accounting.connect_peer(b, SwarmNodeType::Storer);
+        accounting.adopt_payment_threshold(b, au(500));
+        assert_eq!(accounting.peer_state(b).settle_line(), au(500));
+        assert!(accounting.prepare_provide(b, au(1000)).is_ok());
+        assert!(matches!(
+            accounting.prepare_provide(b, au(1001)),
+            Err(AccountingError::PaymentThreshold { .. })
+        ));
+    }
+
+    #[test]
+    fn adopted_threshold_moves_the_admission_band() {
+        // Adopting 9_000_000 lowers the settle trigger from the config 6_750_000
+        // to 4_500_000, so a projected debt of 5_000_000 that Admits on an
+        // un-announced peer becomes SettleAndAdmit on the adopted one. The serve
+        // line (and thus prepare_provide) is unchanged.
+        let accounting = test_accounting();
+        let adopted = OverlayAddress::from([1u8; 32]);
+        let control = OverlayAddress::from([2u8; 32]);
+
+        accounting.adopt_payment_threshold(adopted, au(9_000_000));
+
+        assert_eq!(accounting.admit(&control, au(5_000_000)), Admission::Admit);
+        assert_eq!(
+            accounting.admit(&adopted, au(5_000_000)),
+            Admission::SettleAndAdmit
+        );
+
+        // The client serve line (13_500_000 / 10) is untouched by adoption.
+        assert!(accounting.prepare_provide(adopted, au(1_350_000)).is_ok());
+        assert!(matches!(
+            accounting.prepare_provide(adopted, au(1_350_001)),
+            Err(AccountingError::PaymentThreshold { .. })
+        ));
     }
 }

--- a/crates/swarm/accounting/core/src/accounting/peer.rs
+++ b/crates/swarm/accounting/core/src/accounting/peer.rs
@@ -48,18 +48,26 @@ pub struct PeerState {
     shadow_reserved_balance: AtomicU64,
     ghost_balance: AtomicU64,
     payment_threshold: AtomicI64,
+    settle_line: AtomicI64,
     disconnect_threshold: Au,
 }
 
 impl PeerState {
     /// Create peer state with the given thresholds in AU.
-    pub fn new(payment_threshold: Au, disconnect_threshold: Au) -> Self {
+    ///
+    /// The serve line (`payment_threshold`) is the debt we let the peer owe us
+    /// before refusing service; the settle line is the debt we let ourselves owe
+    /// the peer before settling, seeded from the local payment threshold and
+    /// tightened by the peer's clamped announcement. The two are distinct fields
+    /// moving in opposite directions.
+    pub fn new(payment_threshold: Au, settle_line: Au, disconnect_threshold: Au) -> Self {
         Self {
             balance: AtomicI64::new(0),
             reserved_balance: AtomicU64::new(0),
             shadow_reserved_balance: AtomicU64::new(0),
             ghost_balance: AtomicU64::new(0),
             payment_threshold: AtomicI64::new(payment_threshold.get()),
+            settle_line: AtomicI64::new(settle_line.get()),
             disconnect_threshold,
         }
     }
@@ -130,6 +138,17 @@ impl PeerState {
         self.payment_threshold.store(line.get(), Ordering::Relaxed);
     }
 
+    /// Get the settle line in AU: the debt we let ourselves owe the peer before
+    /// settling toward it.
+    pub fn settle_line(&self) -> Au {
+        Au::new(self.settle_line.load(Ordering::Relaxed))
+    }
+
+    /// Update the settle line from the peer's clamped announcement.
+    pub fn set_settle_line(&self, line: Au) {
+        self.settle_line.store(line.get(), Ordering::Relaxed);
+    }
+
     /// Get the disconnect threshold in AU.
     pub fn disconnect_threshold(&self) -> Au {
         self.disconnect_threshold
@@ -152,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_balance_operations() {
-        let state = PeerState::new(au(1000), au(10000));
+        let state = PeerState::new(au(1000), au(1000), au(10000));
 
         assert_eq!(state.balance(), Au::ZERO);
 
@@ -167,13 +186,13 @@ mod tests {
     fn test_add_balance_saturates_instead_of_wrapping() {
         // Adding into the positive bound saturates rather than wrapping to a
         // negative balance (which would flip owed/owes).
-        let state = PeerState::new(au(1000), au(10000));
+        let state = PeerState::new(au(1000), au(1000), au(10000));
         state.add_balance(Au::new(i64::MAX));
         state.add_balance(au(1000));
         assert_eq!(state.balance(), Au::new(i64::MAX));
 
         // The negative bound saturates too.
-        let state = PeerState::new(au(1000), au(10000));
+        let state = PeerState::new(au(1000), au(1000), au(10000));
         state.add_balance(Au::new(i64::MIN));
         state.add_balance(au(-1000));
         assert_eq!(state.balance(), Au::new(i64::MIN));
@@ -181,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_reserved_operations() {
-        let state = PeerState::new(au(1000), au(10000));
+        let state = PeerState::new(au(1000), au(1000), au(10000));
 
         assert_eq!(state.reserved_balance(), Au::ZERO);
 
@@ -194,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_sub_reserved_saturates_at_zero() {
-        let state = PeerState::new(au(1000), au(10000));
+        let state = PeerState::new(au(1000), au(1000), au(10000));
 
         // Releasing more than is reserved must saturate at zero, never wrap to
         // a near-u64::MAX reserve that would read back as i64::MAX and jam the
@@ -210,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_thresholds() {
-        let state = PeerState::new(au(1000), au(10000));
+        let state = PeerState::new(au(1000), au(1000), au(10000));
 
         assert_eq!(state.payment_threshold(), au(1000));
         assert_eq!(state.disconnect_threshold(), au(10000));
@@ -218,7 +237,7 @@ mod tests {
 
     #[test]
     fn set_payment_threshold_updates_the_serve_line() {
-        let state = PeerState::new(au(1000), au(10000));
+        let state = PeerState::new(au(1000), au(1000), au(10000));
         assert_eq!(state.payment_threshold(), au(1000));
 
         state.set_payment_threshold(au(200));

--- a/crates/swarm/accounting/core/src/accounting/reservation.rs
+++ b/crates/swarm/accounting/core/src/accounting/reservation.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn receive_apply_commits_balance_and_clears_reserve() {
-        let state = Arc::new(PeerState::new(au(1000), au(10000)));
+        let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000)));
         state.add_reserved(au(100));
 
         Reservation::<Receive>::new(Arc::clone(&state), au(100)).apply();
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn receive_drop_releases_reserve_only() {
-        let state = Arc::new(PeerState::new(au(1000), au(10000)));
+        let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000)));
         state.add_reserved(au(100));
 
         drop(Reservation::<Receive>::new(Arc::clone(&state), au(100)));
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn provide_apply_commits_balance_and_clears_shadow_reserve() {
-        let state = Arc::new(PeerState::new(au(1000), au(10000)));
+        let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000)));
         state.add_shadow_reserved(au(100));
 
         Reservation::<Provide>::new(Arc::clone(&state), au(100)).apply();
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn provide_drop_releases_shadow_reserve_only() {
-        let state = Arc::new(PeerState::new(au(1000), au(10000)));
+        let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000)));
         state.add_shadow_reserved(au(100));
 
         drop(Reservation::<Provide>::new(Arc::clone(&state), au(100)));
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn provide_forfeit_releases_shadow_reserve_and_accrues_ghost() {
-        let state = Arc::new(PeerState::new(au(1000), au(10000)));
+        let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000)));
         state.add_shadow_reserved(au(100));
 
         Reservation::<Provide>::new(Arc::clone(&state), au(100)).forfeit();

--- a/crates/swarm/accounting/pseudosettle/src/lib.rs
+++ b/crates/swarm/accounting/pseudosettle/src/lib.rs
@@ -187,7 +187,11 @@ mod tests {
         // A handle-less provider has no wire to send a pseudosettle on, so settle
         // is a no-op even with an outstanding debt.
         let provider = PseudosettleProvider::new(AccountingConfig::default());
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
+        let state = PeerState::new(
+            Au::from_amount(13_500_000),
+            Au::from_amount(13_500_000),
+            Au::from_amount(16_875_000),
+        );
         state.add_balance(Au::new(-10_000));
 
         let settled = provider
@@ -201,7 +205,11 @@ mod tests {
     async fn settle_is_a_noop_when_not_in_debt() {
         // A positive balance means the peer owes us; there is nothing to settle.
         let provider = PseudosettleProvider::new(AccountingConfig::default());
-        let state = PeerState::new(Au::from_amount(13_500_000), Au::from_amount(16_875_000));
+        let state = PeerState::new(
+            Au::from_amount(13_500_000),
+            Au::from_amount(13_500_000),
+            Au::from_amount(16_875_000),
+        );
         state.add_balance(Au::new(1_000_000));
 
         let settled = provider

--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -200,6 +200,12 @@ pub trait SwarmAccounting: Send + Sync {
     fn connect_peer(&self, peer: OverlayAddress, node_type: SwarmNodeType) {
         let _ = (peer, node_type);
     }
+
+    /// Adopt the peer-announced payment threshold as its settle line, clamped by
+    /// the implementation. Inbound announcements only; never widens our serve line.
+    fn adopt_payment_threshold(&self, peer: OverlayAddress, announced: Au) {
+        let _ = (peer, announced);
+    }
 }
 
 /// The object-safe origin dispatch gate over one accounting instance: the

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -244,6 +244,11 @@ pub struct ClientHandler {
     pending_responses: HashMap<u64, StoredResponse>,
     /// Bounded set for async pseudosettle ack sends (prevents blocking poll).
     response_sends: futures_bounded::FuturesSet<Result<(), String>>,
+    /// Latest pricing announcement received while dormant, flushed once the
+    /// handler activates. A peer announces at connect, before the overlay
+    /// round-trips through activation, so without this the connect-time
+    /// announcement is dropped and never reaches accounting.
+    pending_pricing: Option<U256>,
 }
 
 impl ClientHandler {
@@ -282,6 +287,7 @@ impl ClientHandler {
                 RESPONSE_SEND_TIMEOUT,
                 MAX_CONCURRENT_RESPONSE_SENDS,
             ),
+            pending_pricing: None,
         }
     }
 
@@ -350,6 +356,15 @@ impl ClientHandler {
                 self.state = State::Active { overlay };
                 self.pending_events
                     .push_back(HandlerEvent::Activated { overlay });
+                // Flush a pricing announcement that arrived before activation, so
+                // a peer that announces at connect still reaches accounting.
+                if let Some(threshold) = self.pending_pricing.take() {
+                    debug!(%overlay, %threshold, "Flushing buffered pricing");
+                    self.pending_events.push_back(HandlerEvent::Peer {
+                        overlay,
+                        event: PeerEvent::PricingReceived { threshold },
+                    });
+                }
             }
             State::Active { .. } => {
                 warn!("Handler already active, ignoring duplicate activation");
@@ -371,10 +386,11 @@ impl ClientHandler {
                 },
             });
         } else {
-            warn!(
+            debug!(
                 threshold = %threshold.payment_threshold,
-                "Received pricing in dormant state (peer may have cached old protocol list)"
+                "Buffering pricing received before activation"
             );
+            self.pending_pricing = Some(threshold.payment_threshold);
         }
     }
 
@@ -1107,6 +1123,72 @@ mod tests {
             .expect("valid content chunk")
             .into();
         StampedChunk::new(chunk, stamp)
+    }
+
+    struct NoopStore;
+
+    impl vertex_swarm_api::SwarmLocalStore for NoopStore {
+        fn put(
+            &self,
+            _chunk: vertex_swarm_primitives::CachedChunk,
+        ) -> vertex_swarm_api::SwarmResult<()> {
+            Ok(())
+        }
+        fn get(
+            &self,
+            _address: &nectar_primitives::ChunkAddress,
+        ) -> vertex_swarm_api::SwarmResult<Option<vertex_swarm_primitives::CachedChunk>> {
+            Ok(None)
+        }
+        fn contains(&self, _address: &nectar_primitives::ChunkAddress) -> bool {
+            false
+        }
+        fn remove(
+            &self,
+            _address: &nectar_primitives::ChunkAddress,
+        ) -> vertex_swarm_api::SwarmResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pricing_before_activation_is_buffered_and_flushed() {
+        use alloy_primitives::U256;
+        use vertex_swarm_client_protocol::PeerEvent;
+        use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
+
+        use super::{ClientHandler, Config, HandlerEvent};
+        use crate::forward::StubForwarder;
+
+        let mut handler = ClientHandler::new(
+            Config::default(),
+            std::sync::Arc::new(NoopStore),
+            std::sync::Arc::new(StubForwarder),
+            None,
+        );
+
+        // A pricing announcement arriving while dormant is buffered, not dropped.
+        handler.on_pricing_received(vertex_swarm_net_pricing::AnnouncePaymentThreshold::new(
+            U256::from(9_000_000u64),
+        ));
+        assert_eq!(handler.pending_pricing, Some(U256::from(9_000_000u64)));
+
+        // Activation emits Activated first, then flushes the buffered pricing.
+        let overlay = OverlayAddress::from([1u8; 32]);
+        handler.activate(overlay, SwarmNodeType::Storer);
+        assert_eq!(handler.pending_pricing, None);
+
+        assert!(matches!(
+            handler.pending_events.pop(),
+            Some(HandlerEvent::Activated { overlay: o }) if o == overlay
+        ));
+        assert!(matches!(
+            handler.pending_events.pop(),
+            Some(HandlerEvent::Peer {
+                event: PeerEvent::PricingReceived { threshold },
+                ..
+            }) if threshold == U256::from(9_000_000u64)
+        ));
     }
 
     #[test]

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -27,6 +27,11 @@ const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
 
 pub(crate) const DEFAULT_CHANNEL_CAPACITY: usize = 256;
 
+/// Type-erased hook feeding a peer's announced payment threshold into accounting,
+/// which clamps it to the per-peer settle line. The service cannot name the
+/// concrete accounting type, so it holds this instead.
+pub(crate) type ThresholdAdopter = Arc<dyn Fn(OverlayAddress, Au) + Send + Sync>;
+
 /// Handle for sending commands to the network layer.
 ///
 /// Request methods ([`Self::retrieve_chunk`], [`Self::push_chunk`]) thread a
@@ -285,6 +290,9 @@ pub struct ClientService {
     /// Per-PO retrieval-latency estimate shared with the chunk provider; a
     /// completed originated retrieval is recorded here keyed by its proximity.
     retrieval_latency: Option<Arc<RetrievalLatency>>,
+    /// Feeds a peer's announced payment threshold into accounting; absent on the
+    /// lightweight launcher, where no accounting is wired.
+    threshold_adopter: Option<ThresholdAdopter>,
 }
 
 impl ClientService {
@@ -303,6 +311,7 @@ impl ClientService {
             store: None,
             inflight: None,
             retrieval_latency: None,
+            threshold_adopter: None,
         };
 
         (service, event_tx, handle)
@@ -323,6 +332,7 @@ impl ClientService {
             store: None,
             inflight: None,
             retrieval_latency: None,
+            threshold_adopter: None,
         };
 
         (service, handle)
@@ -366,6 +376,14 @@ impl ClientService {
     #[must_use]
     pub(crate) fn with_retrieval_latency(mut self, latency: Arc<RetrievalLatency>) -> Self {
         self.retrieval_latency = Some(latency);
+        self
+    }
+
+    /// Attach the hook that feeds a peer's announced payment threshold into
+    /// accounting, which clamps it to the per-peer settle line.
+    #[must_use]
+    pub(crate) fn with_threshold_adopter(mut self, adopter: ThresholdAdopter) -> Self {
+        self.threshold_adopter = Some(adopter);
         self
     }
 
@@ -449,8 +467,12 @@ impl ClientService {
             } => match event {
                 PeerEvent::PricingReceived { threshold } => {
                     debug!(%peer_id, %peer, %threshold, "Received pricing threshold");
-                    // TODO: Validate threshold against minimum
-                    // TODO: Store peer's threshold for bandwidth accounting
+                    if let Some(adopter) = &self.threshold_adopter {
+                        // An out-of-spec value saturates to the maximum AU; the
+                        // clamp inside accounting caps it at the local threshold.
+                        let announced = Au::try_from(threshold).unwrap_or(Au::new(i64::MAX));
+                        adopter(peer, announced);
+                    }
                 }
 
                 PeerEvent::PricingSent => {
@@ -724,6 +746,52 @@ mod tests {
         let (service, _event_tx, _handle) = ClientService::new();
         let service = service.with_reporter(Arc::clone(&reporter) as Arc<dyn PeerReporter>);
         (service, reporter)
+    }
+
+    fn service_with_adopter() -> (ClientService, Arc<Mutex<Vec<(OverlayAddress, Au)>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&calls);
+        let (service, _event_tx, _handle) = ClientService::new();
+        let service = service.with_threshold_adopter(Arc::new(move |peer, announced| {
+            sink.lock().unwrap().push((peer, announced));
+        }));
+        (service, calls)
+    }
+
+    #[test]
+    fn pricing_received_feeds_the_threshold_adopter() {
+        use alloy_primitives::U256;
+
+        let (service, calls) = service_with_adopter();
+        service.process_event(ClientEvent::Peer {
+            peer: peer(7),
+            peer_id: libp2p::PeerId::random(),
+            event: PeerEvent::PricingReceived {
+                threshold: U256::from(9_000_000u64),
+            },
+        });
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.as_slice(), &[(peer(7), Au::new(9_000_000))]);
+    }
+
+    #[test]
+    fn pricing_received_saturates_an_out_of_range_announcement() {
+        use alloy_primitives::U256;
+
+        // A threshold beyond i64::MAX saturates to the maximum AU here; the clamp
+        // inside accounting caps it at the local payment threshold.
+        let (service, calls) = service_with_adopter();
+        service.process_event(ClientEvent::Peer {
+            peer: peer(8),
+            peer_id: libp2p::PeerId::random(),
+            event: PeerEvent::PricingReceived {
+                threshold: U256::MAX,
+            },
+        });
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.as_slice(), &[(peer(8), Au::new(i64::MAX))]);
     }
 
     #[test]

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -708,6 +708,9 @@ mod tests {
 
     use super::*;
 
+    /// Recorded `(peer, announced threshold)` pairs a test threshold adopter sinks.
+    type AdopterCalls = Arc<Mutex<Vec<(OverlayAddress, Au)>>>;
+
     #[derive(Default)]
     struct RecordingReporter {
         reports: Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
@@ -748,7 +751,7 @@ mod tests {
         (service, reporter)
     }
 
-    fn service_with_adopter() -> (ClientService, Arc<Mutex<Vec<(OverlayAddress, Au)>>>) {
+    fn service_with_adopter() -> (ClientService, AdopterCalls) {
         let calls = Arc::new(Mutex::new(Vec::new()));
         let sink = Arc::clone(&calls);
         let (service, _event_tx, _handle) = ClientService::new();

--- a/crates/swarm/node/src/node/core.rs
+++ b/crates/swarm/node/src/node/core.rs
@@ -208,10 +208,16 @@ pub fn assemble_client_core(ctx: ClientCoreCtx) -> ClientCore {
     // and forgets a peer's in-flight slots on disconnect. The origin debit is
     // reserved and committed by the dispatch gate on the origin-gated handle, not
     // by the service.
+    // The service feeds a peer's announced payment threshold into the one shared
+    // accounting, which clamps it to the per-peer settle line.
+    let adopt = accounting.accounting().clone();
     let client_service = client_service
         .with_reporter(reporter)
         .with_inflight_limiter(Arc::clone(&inflight))
-        .with_retrieval_latency(Arc::clone(&retrieval_latency));
+        .with_retrieval_latency(Arc::clone(&retrieval_latency))
+        .with_threshold_adopter(Arc::new(move |peer, announced| {
+            adopt.adopt_payment_threshold(peer, announced)
+        }));
 
     ClientCore {
         accounting,

--- a/docs/swarm/differences-from-bee.md
+++ b/docs/swarm/differences-from-bee.md
@@ -110,7 +110,7 @@ Vertex prices chunks and tracks per-peer balances with the same arithmetic as Be
 
 **First-contact allowance.** Bee seeds a peer's last-settlement time at the Unix epoch, so on the first pseudosettle the elapsed interval is effectively the whole epoch and the allowance is bounded only by the peer's debt: Bee accepts the full owed amount immediately. Vertex anchors the allowance clock at the moment it first accounts for a peer, so the first grant is bounded by the genuine wall-clock elapsed since first contact and ramps up over a few seconds at the configured refresh rate. This removes an unbounded first-contact grant (the only anti-free-ride brake on first contact and after a reconnect that cleared in-memory state) at the cost of a brief ramp before a fresh peer is granted its full allowance.
 
-**Peer-advertised payment threshold.** Bee lets a peer advertise its own payment threshold and the debtor settles before crossing the advertised value. Vertex currently decides when to settle against its locally configured threshold and does not yet apply a peer-advertised one. With homogeneous default thresholds the two coincide; a peer configured with a lower threshold than the local default is the gap. Honouring the advertised threshold is tracked with the open-loop client accounting work.
+**Peer-advertised payment threshold.** Bee lets a peer advertise its own payment threshold and the debtor settles before crossing the advertised value. Vertex adopts the advertised threshold as a per-peer settle line, clamped to `[2x refresh rate, local payment threshold]`, and settles our debt to that peer against it; the value drives both the per-peer settle trigger the admission band reads and the settle fan-out early break. Two residual divergences remain. Bee disconnects a peer that advertises below its minimum, while vertex clamps the value up to `2x refresh rate` and keeps the peer (a local reaction policy, not a wire change). Bee also adopts an advertised threshold above its own default, while vertex caps adoption at the local payment threshold, so an announcement only ever tightens our settle timing and never widens the debt we let ourselves carry. Vertex still does not advertise its own threshold outbound, so a bee peer paces against its local default when settling toward us.
 
 ## Summary of Key Differences
 
@@ -124,7 +124,7 @@ Vertex prices chunks and tracks per-peer balances with the same arithmetic as Be
 | Hive Gossip | Recipient-targeted composition, client recipients, periodic and depth-decrease broadcasts, inbound rate charged before crypto, no outbound bucket | Random per-bin sample, event-driven only, post-hoc inbound limit, outbound bucket |
 | Disconnect Scoring | Activity-gated early-disconnect penalty, intent-attributed closes | No disconnect penalty |
 | Pseudosettle First Contact | Allowance ramps from first-contact clock | Full debt accepted immediately |
-| Payment Threshold | Local threshold only (peer-advertised not yet applied) | Honours peer-advertised threshold |
+| Payment Threshold | Adopted, clamped to [2x refresh rate, local payment threshold]; still not advertised outbound | Honours peer-advertised threshold, advertises its own |
 
 ## See Also
 


### PR DESCRIPTION
## What

Adopt the peer-announced payment threshold (already parsed from the pricing protocol) as a per-peer debtor settle line in a new disjoint `PeerState::settle_line`, clamped to `[2x refresh rate, local payment threshold]`. The adopted value drives the per-peer settle trigger the admission band reads and the `settle_all` early break, so we settle our debt toward a peer against the line it expects us to pay by. A pricing announcement that arrives while the connection handler is still dormant is buffered and flushed on activation, so a peer that announces at connect is not dropped.

## Why

Closes #490

(H4 under epic #439.) The announced threshold was parsed and logged but never consumed, so we settled against our local config only. Adopting it (clamped) honours the debt line the peer expects us to pay by and moves toward reference interop, while structurally never widening the credit ceiling we extend: the creditor serve line (#560) is a separate field, never written here.

## Note

Strictly the debtor direction. The creditor serve line (#560), `prepare_provide`, and the pricing wire bytes are untouched, and vertex still does not announce its own threshold outbound, so there is no fork gate. A below-minimum announcement is clamped up rather than triggering a disconnect (a local reaction policy), and an announcement above the local default caps at it so adoption only ever tightens our settle timing.


## Testing

`cargo nextest run` across `vertex-swarm-api`, `vertex-swarm-accounting`, `vertex-swarm-accounting-pseudosettle`, `vertex-swarm-node`, and `vertex-swarm-client-behaviour` (incl. the clamp, compose-with-#560, direction-correctness, band-moves, adopter-wiring with U256::MAX saturation, and buffered-flush tests), full `cargo clippy --all-targets --all-features -- -D warnings`, and the `wasm32-unknown-unknown` node build.

## AI Assistance

AI Assistance: Claude Code (Fable 5 design and QA, Opus 4.8 implementation) used for the accounting change, handler buffer, wiring, tests, and docs.


