### PR TITLE
docs(swarm-api): drop the stale peer-reporter note from OriginAccounting

### DIFF
--- a/crates/swarm/api/src/components/bandwidth.rs
+++ b/crates/swarm/api/src/components/bandwidth.rs
@@ -218,8 +218,8 @@ pub trait SwarmAccounting: Send + Sync {
 /// could un-book debt for bytes the wire may still deliver. `debit_received`
 /// therefore commits in one step and `refund_received` reverses it only when
 /// the request provably reached no charge. An `Err` carries the
-/// disconnect-threshold breach the accounting already reported through its
-/// peer reporter.
+/// disconnect-threshold breach, a local pacing refusal that is not scored
+/// against the peer.
 pub trait OriginAccounting: Send + Sync {
     /// Band `price` against the peer's projected debt.
     fn admit(&self, peer: &OverlayAddress, price: Au) -> Admission;


### PR DESCRIPTION
## What

Correct the `OriginAccounting` trait rustdoc: the `Err` disconnect-threshold breach is a local pacing refusal returned as an error, not something reported through a peer reporter.

## Why

The accounting-core peer-reporter path for the disconnect-threshold breach was removed (accounting now holds no reporter; the breach is a local pacing outcome, not peer misbehaviour), so the doc's "already reported through its peer reporter" was stale and misleading. No code change.

## Testing

`cargo doc --no-deps` and `cargo clippy` for `vertex-swarm-api`; docs-only, no test suite per scope.

AI Assistance: Claude Code (Opus 4.8) used for the rustdoc correction.


