### PR TITLE
feat(swarm-accounting): bound reservation inflation with in-flight caps and a walk deadline

### DIFF
--- a/crates/swarm/accounting/core/src/accounting/mod.rs
+++ b/crates/swarm/accounting/core/src/accounting/mod.rs
@@ -29,6 +29,7 @@ use parking_lot::RwLock;
 use rustc_hash::FxBuildHasher;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use vertex_swarm_api::{
     Au, Debt, Direction, Ledger, LedgerSnapshot, SettlementCredit, SwarmAccounting,
@@ -38,9 +39,36 @@ use vertex_swarm_primitives::OverlayAddress;
 
 use vertex_swarm_api::SwarmSettlementProvider;
 
+use crate::constants::{DEFAULT_MAX_INFLIGHT_GLOBAL, DEFAULT_MAX_INFLIGHT_PER_PEER};
+
 /// The lower clamp on an adopted settle line, in refresh-rate units: a peer
 /// cannot drive our settle timing tighter than twice the refresh rate.
 const MIN_ANNOUNCED_REFRESH_MULTIPLES: u64 = 2;
+
+/// Caps on outstanding reservations: `per_peer` for each leg, `global` across
+/// all peers and both legs.
+///
+/// The threshold projections bound reserved AU per peer, but not the COUNT of
+/// concurrent holds or their total across peers, so a flood of cheap in-flight
+/// forwards could pin reservations and the node resources riding them without
+/// crossing any threshold. The counts are released by the same drop that
+/// releases the reserved balance.
+#[derive(Clone, Copy, Debug)]
+pub struct ReservationCaps {
+    /// Outstanding reservations allowed per peer, per leg.
+    pub per_peer: u64,
+    /// Outstanding reservations allowed across all peers and both legs.
+    pub global: u64,
+}
+
+impl Default for ReservationCaps {
+    fn default() -> Self {
+        Self {
+            per_peer: DEFAULT_MAX_INFLIGHT_PER_PEER,
+            global: DEFAULT_MAX_INFLIGHT_GLOBAL,
+        }
+    }
+}
 
 /// Per-peer accounting with pluggable settlement providers.
 ///
@@ -53,6 +81,10 @@ pub struct Accounting<C, I: SwarmIdentity> {
     // Overlay keys are uniformly random, so a fast non-DoS hasher is safe here
     // and removes SipHash from the per-candidate selection hot path.
     peers: RwLock<HashMap<OverlayAddress, Arc<PeerState>, FxBuildHasher>>,
+    caps: ReservationCaps,
+    /// Outstanding reservations across all peers and both legs, shared into
+    /// every [`Reservation`] so the resolution drop is the single release point.
+    inflight_global: Arc<AtomicU64>,
 }
 
 impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
@@ -63,6 +95,8 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             identity,
             providers: Arc::from(Vec::new()),
             peers: RwLock::new(HashMap::default()),
+            caps: ReservationCaps::default(),
+            inflight_global: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -80,7 +114,15 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             identity,
             providers: Arc::from(providers),
             peers: RwLock::new(HashMap::default()),
+            caps: ReservationCaps::default(),
+            inflight_global: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Override the outstanding-reservation caps.
+    pub fn with_reservation_caps(mut self, caps: ReservationCaps) -> Self {
+        self.caps = caps;
+        self
     }
 
     /// Returns the names of the active settlement providers.
@@ -114,8 +156,27 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             });
         }
 
+        // Absolute reserve bound: a positive balance widens the admission
+        // projection, so without this cap a creditor peer could pin reserved
+        // headroom well past the disconnect line. Check-then-add can overshoot
+        // under concurrency by at most the racing prices; the bound is a soft
+        // flood ceiling, not a ledger invariant.
+        let reserved = state.reserved_balance();
+        let cap = state.disconnect_threshold();
+        if reserved.saturating_add(price) > cap {
+            return Err(AccountingError::ReserveCap {
+                peer,
+                reserved,
+                cap,
+            });
+        }
+        self.acquire_inflight::<Receive>(peer, &state)?;
         state.add_reserved(price);
-        Ok(Reservation::new(state, price))
+        Ok(Reservation::new(
+            state,
+            price,
+            Arc::clone(&self.inflight_global),
+        ))
     }
 
     /// Prepare a provide action (we are providing service, balance increases).
@@ -152,8 +213,48 @@ impl<C: SwarmAccountingConfig, I: SwarmIdentity> Accounting<C, I> {
             });
         }
 
+        // Absolute reserve bound: our own debt to the peer widens the
+        // exposure, so without this cap a peer we owe could pin shadow
+        // reservations well past its serve line.
+        let reserved = state.shadow_reserved_balance();
+        if reserved.saturating_add(price) > serve_line {
+            return Err(AccountingError::ReserveCap {
+                peer,
+                reserved,
+                cap: serve_line,
+            });
+        }
+        self.acquire_inflight::<Provide>(peer, &state)?;
         state.add_shadow_reserved(price);
-        Ok(Reservation::new(state, price))
+        Ok(Reservation::new(
+            state,
+            price,
+            Arc::clone(&self.inflight_global),
+        ))
+    }
+
+    /// Take one in-flight slot for the leg, or refuse at either cap; the
+    /// matching release is the reservation's resolution drop.
+    fn acquire_inflight<L: reservation::Leg>(
+        &self,
+        peer: OverlayAddress,
+        state: &PeerState,
+    ) -> Result<(), AccountingError> {
+        if self.inflight_global.fetch_add(1, Ordering::Relaxed) >= self.caps.global {
+            self.inflight_global.fetch_sub(1, Ordering::Relaxed);
+            return Err(AccountingError::GlobalInflightCap {
+                cap: self.caps.global,
+            });
+        }
+        if L::inflight(state).fetch_add(1, Ordering::Relaxed) >= self.caps.per_peer {
+            L::inflight(state).fetch_sub(1, Ordering::Relaxed);
+            self.inflight_global.fetch_sub(1, Ordering::Relaxed);
+            return Err(AccountingError::PeerInflightCap {
+                peer,
+                cap: self.caps.per_peer,
+            });
+        }
+        Ok(())
     }
 
     /// Get or create peer state (double-checked locking).
@@ -806,13 +907,24 @@ mod tests {
         handle.record(au(500), Direction::Download);
         assert_eq!(handle.balance(), au(-500));
 
-        // Exposure = max(0, -500 + 1500) = 1000, exactly the threshold: admitted.
-        // The reservation is released on drop, so no shadow balance lingers.
-        assert!(accounting.prepare_provide(peer, au(1500)).is_ok());
+        // The widening applies to committed balance: served in steps, the peer
+        // is provided 1500 in total, past the raw 1000 line, with the exposure
+        // ending exactly at the threshold. A single 1500 reservation would be
+        // refused by the absolute reserve bound instead.
+        accounting
+            .prepare_provide(peer, au(1000))
+            .expect("exposure 500 is within the line")
+            .apply();
+        assert_eq!(handle.balance(), au(500));
+        accounting
+            .prepare_provide(peer, au(500))
+            .expect("exposure lands exactly at the line")
+            .apply();
+        assert_eq!(handle.balance(), au(1000));
 
         // One unit more crosses the threshold and refuses.
         assert!(matches!(
-            accounting.prepare_provide(peer, au(1501)),
+            accounting.prepare_provide(peer, au(1)),
             Err(AccountingError::PaymentThreshold { .. })
         ));
     }
@@ -1134,6 +1246,132 @@ mod tests {
         assert_eq!(accounting.admit(&peer, au(601)), Admission::SettleAndAdmit);
         assert_eq!(accounting.admit(&peer, au(1250)), Admission::SettleAndAdmit);
         assert_eq!(accounting.admit(&peer, au(1251)), Admission::Refuse);
+    }
+
+    #[test]
+    fn receive_inflight_cap_refuses_until_a_reservation_resolves() {
+        let accounting = test_accounting().with_reservation_caps(ReservationCaps {
+            per_peer: 2,
+            global: 100,
+        });
+        let peer = test_peer();
+
+        let held = accounting
+            .prepare_receive(peer, au(10), true)
+            .expect("first slot");
+        let second = accounting
+            .prepare_receive(peer, au(10), true)
+            .expect("second slot");
+        assert!(matches!(
+            accounting.prepare_receive(peer, au(10), true),
+            Err(AccountingError::PeerInflightCap { .. })
+        ));
+
+        // A dropped reservation frees its slot; so does an applied one.
+        drop(held);
+        let third = accounting
+            .prepare_receive(peer, au(10), true)
+            .expect("slot freed by the drop");
+        second.apply();
+        assert!(accounting.prepare_receive(peer, au(10), true).is_ok());
+        drop(third);
+    }
+
+    #[test]
+    fn inflight_caps_are_per_leg() {
+        let accounting = test_accounting().with_reservation_caps(ReservationCaps {
+            per_peer: 1,
+            global: 100,
+        });
+        let peer = test_peer();
+
+        let _receive = accounting
+            .prepare_receive(peer, au(10), true)
+            .expect("receive slot");
+        // The provide leg has its own count: a full receive cap does not gate it.
+        let _provide = accounting
+            .prepare_provide(peer, au(10))
+            .expect("provide slot independent of receive");
+        assert!(matches!(
+            accounting.prepare_provide(peer, au(10)),
+            Err(AccountingError::PeerInflightCap { .. })
+        ));
+    }
+
+    #[test]
+    fn global_inflight_cap_spans_peers_and_legs() {
+        let accounting = test_accounting().with_reservation_caps(ReservationCaps {
+            per_peer: 100,
+            global: 2,
+        });
+        let peer1 = OverlayAddress::from([1u8; 32]);
+        let peer2 = OverlayAddress::from([2u8; 32]);
+        let peer3 = OverlayAddress::from([3u8; 32]);
+
+        let held = accounting
+            .prepare_receive(peer1, au(10), true)
+            .expect("first global slot");
+        let _provide = accounting
+            .prepare_provide(peer2, au(10))
+            .expect("second global slot");
+        assert!(matches!(
+            accounting.prepare_receive(peer3, au(10), true),
+            Err(AccountingError::GlobalInflightCap { .. })
+        ));
+
+        drop(held);
+        assert!(accounting.prepare_receive(peer3, au(10), true).is_ok());
+    }
+
+    #[test]
+    fn receive_reserve_total_is_bounded_at_the_disconnect_line() {
+        // Payment 1000, disconnect 1250. The peer owes us 10_000, so the
+        // admission projection (reserved + price - balance) admits far past the
+        // disconnect line; the absolute reserve bound is what refuses.
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+        accounting
+            .for_peer(peer)
+            .record(au(10_000), Direction::Upload);
+
+        let _first = accounting
+            .prepare_receive(peer, au(1000), true)
+            .expect("within the reserve bound");
+        let second = accounting
+            .prepare_receive(peer, au(200), true)
+            .expect("still within the reserve bound");
+        assert!(matches!(
+            accounting.prepare_receive(peer, au(100), true),
+            Err(AccountingError::ReserveCap { .. })
+        ));
+
+        // Releasing a reservation restores reserve headroom.
+        drop(second);
+        assert!(accounting.prepare_receive(peer, au(100), true).is_ok());
+    }
+
+    #[test]
+    fn provide_reserve_total_is_bounded_at_the_serve_line() {
+        // We owe the peer 10_000, so the provide exposure (balance + shadow +
+        // price) stays far below the serve line; the absolute reserve bound is
+        // what refuses. Connect as a storer so the serve line is the full 1000.
+        let accounting = Accounting::new(small_config(), test_identity());
+        let peer = test_peer();
+        accounting.connect_peer(peer, SwarmNodeType::Storer);
+        accounting
+            .for_peer(peer)
+            .record(au(10_000), Direction::Download);
+
+        let first = accounting
+            .prepare_provide(peer, au(600))
+            .expect("within the reserve bound");
+        assert!(matches!(
+            accounting.prepare_provide(peer, au(600)),
+            Err(AccountingError::ReserveCap { .. })
+        ));
+
+        drop(first);
+        assert!(accounting.prepare_provide(peer, au(600)).is_ok());
     }
 
     #[test]

--- a/crates/swarm/accounting/core/src/accounting/peer.rs
+++ b/crates/swarm/accounting/core/src/accounting/peer.rs
@@ -52,7 +52,7 @@ fn next_checkpoint(checkpoint: Au, rate: Au) -> Au {
 /// Plain `fetch_sub` wraps to near `u64::MAX` on underflow, which readers clamp
 /// to `i64::MAX` and subtract from every allowance, jamming the peer into
 /// permanent denial; a compare-exchange loop floors a mismatched release at zero.
-fn saturating_fetch_sub(atomic: &AtomicU64, delta: u64) {
+pub(super) fn saturating_fetch_sub(atomic: &AtomicU64, delta: u64) {
     let mut current = atomic.load(Ordering::Relaxed);
     loop {
         let next = current.saturating_sub(delta);
@@ -75,6 +75,10 @@ pub struct PeerState {
     reserved_balance: AtomicU64,
     shadow_reserved_balance: AtomicU64,
     ghost_balance: AtomicU64,
+    // Outstanding reservation counts per leg: begun at prepare, ended exactly
+    // once when the reservation resolves (apply or drop).
+    inflight_receive: AtomicU64,
+    inflight_provide: AtomicU64,
     serve_line: AtomicI64,
     settle_line: AtomicI64,
     disconnect_threshold: Au,
@@ -105,6 +109,8 @@ impl PeerState {
             reserved_balance: AtomicU64::new(0),
             shadow_reserved_balance: AtomicU64::new(0),
             ghost_balance: AtomicU64::new(0),
+            inflight_receive: AtomicU64::new(0),
+            inflight_provide: AtomicU64::new(0),
             serve_line: AtomicI64::new(serve_line.get()),
             settle_line: AtomicI64::new(settle_line.get()),
             disconnect_threshold,
@@ -112,6 +118,16 @@ impl PeerState {
             cumulative_repayment: AtomicU64::new(0),
             growth_checkpoint: AtomicI64::new(first_checkpoint(allowance_rate).get()),
         }
+    }
+
+    /// The receive leg's outstanding-reservation counter.
+    pub(super) fn inflight_receive(&self) -> &AtomicU64 {
+        &self.inflight_receive
+    }
+
+    /// The provide leg's outstanding-reservation counter.
+    pub(super) fn inflight_provide(&self) -> &AtomicU64 {
+        &self.inflight_provide
     }
 
     /// Get the current balance in AU.

--- a/crates/swarm/accounting/core/src/accounting/reservation.rs
+++ b/crates/swarm/accounting/core/src/accounting/reservation.rs
@@ -9,10 +9,12 @@
 
 use std::marker::PhantomData;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use vertex_swarm_api::Au;
 
 use super::PeerState;
+use super::peer::saturating_fetch_sub;
 
 mod sealed {
     pub trait Sealed {}
@@ -27,6 +29,10 @@ pub trait Leg: sealed::Sealed {
     /// Release the leg's reserved counter.
     #[doc(hidden)]
     fn release(state: &PeerState, price: Au);
+
+    /// The leg's outstanding-reservation counter.
+    #[doc(hidden)]
+    fn inflight(state: &PeerState) -> &AtomicU64;
 }
 
 /// Receiving service: we owe the peer. Reserves `reserved_balance`.
@@ -47,6 +53,10 @@ impl Leg for Receive {
     fn release(state: &PeerState, price: Au) {
         state.sub_reserved(price);
     }
+
+    fn inflight(state: &PeerState) -> &AtomicU64 {
+        state.inflight_receive()
+    }
 }
 
 impl Leg for Provide {
@@ -57,6 +67,10 @@ impl Leg for Provide {
 
     fn release(state: &PeerState, price: Au) {
         state.sub_shadow_reserved(price);
+    }
+
+    fn inflight(state: &PeerState) -> &AtomicU64 {
+        state.inflight_provide()
     }
 }
 
@@ -69,15 +83,20 @@ pub struct Reservation<L: Leg> {
     state: Arc<PeerState>,
     price: Au,
     applied: bool,
+    /// The owning ledger's outstanding-reservation total, decremented exactly
+    /// once on resolution (apply or drop) together with the leg's per-peer
+    /// count; the matching increments happen at prepare time.
+    global_inflight: Arc<AtomicU64>,
     _leg: PhantomData<L>,
 }
 
 impl<L: Leg> Reservation<L> {
-    pub(super) fn new(state: Arc<PeerState>, price: Au) -> Self {
+    pub(super) fn new(state: Arc<PeerState>, price: Au, global_inflight: Arc<AtomicU64>) -> Self {
         Self {
             state,
             price,
             applied: false,
+            global_inflight,
             _leg: PhantomData,
         }
     }
@@ -106,6 +125,10 @@ impl<L: Leg> Drop for Reservation<L> {
         if !self.applied {
             L::release(&self.state, self.price);
         }
+        // The in-flight hold ends however the reservation resolves; saturation
+        // guards a hold that was never begun (direct construction in tests).
+        saturating_fetch_sub(L::inflight(&self.state), 1);
+        saturating_fetch_sub(&self.global_inflight, 1);
     }
 }
 
@@ -133,12 +156,16 @@ mod tests {
         Au::new(value)
     }
 
+    fn global() -> Arc<AtomicU64> {
+        Arc::new(AtomicU64::new(0))
+    }
+
     #[test]
     fn receive_apply_commits_balance_and_clears_reserve() {
         let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000), au(100)));
         state.add_reserved(au(100));
 
-        Reservation::<Receive>::new(Arc::clone(&state), au(100)).apply();
+        Reservation::<Receive>::new(Arc::clone(&state), au(100), global()).apply();
 
         assert_eq!(state.balance(), au(-100));
         assert_eq!(state.reserved_balance(), Au::ZERO);
@@ -149,7 +176,11 @@ mod tests {
         let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000), au(100)));
         state.add_reserved(au(100));
 
-        drop(Reservation::<Receive>::new(Arc::clone(&state), au(100)));
+        drop(Reservation::<Receive>::new(
+            Arc::clone(&state),
+            au(100),
+            global(),
+        ));
 
         assert_eq!(state.balance(), Au::ZERO);
         assert_eq!(state.reserved_balance(), Au::ZERO);
@@ -160,7 +191,7 @@ mod tests {
         let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000), au(100)));
         state.add_shadow_reserved(au(100));
 
-        Reservation::<Provide>::new(Arc::clone(&state), au(100)).apply();
+        Reservation::<Provide>::new(Arc::clone(&state), au(100), global()).apply();
 
         assert_eq!(state.balance(), au(100));
         assert_eq!(state.shadow_reserved_balance(), Au::ZERO);
@@ -171,7 +202,11 @@ mod tests {
         let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000), au(100)));
         state.add_shadow_reserved(au(100));
 
-        drop(Reservation::<Provide>::new(Arc::clone(&state), au(100)));
+        drop(Reservation::<Provide>::new(
+            Arc::clone(&state),
+            au(100),
+            global(),
+        ));
 
         assert_eq!(state.balance(), Au::ZERO);
         assert_eq!(state.shadow_reserved_balance(), Au::ZERO);
@@ -183,7 +218,7 @@ mod tests {
         let state = Arc::new(PeerState::new(au(1000), au(1000), au(10000), au(100)));
         state.add_shadow_reserved(au(100));
 
-        Reservation::<Provide>::new(Arc::clone(&state), au(100)).forfeit();
+        Reservation::<Provide>::new(Arc::clone(&state), au(100), global()).forfeit();
 
         assert_eq!(state.balance(), Au::ZERO, "never committed");
         assert_eq!(state.shadow_reserved_balance(), Au::ZERO, "released");

--- a/crates/swarm/accounting/core/src/constants.rs
+++ b/crates/swarm/accounting/core/src/constants.rs
@@ -14,3 +14,9 @@ pub(crate) const DEFAULT_EARLY_PAYMENT_PERCENT: u64 = 50;
 
 /// Default scaling factor for client-only nodes.
 pub(crate) const DEFAULT_CLIENT_ONLY_FACTOR: u64 = 10;
+
+/// Default cap on outstanding reservations per peer, per leg.
+pub(crate) const DEFAULT_MAX_INFLIGHT_PER_PEER: u64 = 128;
+
+/// Default cap on outstanding reservations across all peers and both legs.
+pub(crate) const DEFAULT_MAX_INFLIGHT_GLOBAL: u64 = 4096;

--- a/crates/swarm/accounting/core/src/lib.rs
+++ b/crates/swarm/accounting/core/src/lib.rs
@@ -52,6 +52,7 @@ mod settlement;
 
 pub use accounting::{
     Accounting, AccountingError, AccountingPeerHandle, PeerState, Provide, Receive, Reservation,
+    ReservationCaps,
 };
 #[cfg(feature = "cli")]
 pub use args::AccountingArgs;

--- a/crates/swarm/api/src/error.rs
+++ b/crates/swarm/api/src/error.rs
@@ -40,6 +40,34 @@ pub enum AccountingError {
     /// Channel closed (service stopped).
     #[error("channel closed")]
     ChannelClosed,
+
+    /// The peer is at its cap of outstanding reservations for the leg.
+    #[error("peer {peer} is at its in-flight reservation cap {cap}")]
+    PeerInflightCap {
+        /// The peer at its cap.
+        peer: OverlayAddress,
+        /// The per-peer outstanding-reservation cap.
+        cap: u64,
+    },
+
+    /// Outstanding reservations across all peers are at the global cap.
+    #[error("in-flight reservations are at the global cap {cap}")]
+    GlobalInflightCap {
+        /// The global outstanding-reservation cap.
+        cap: u64,
+    },
+
+    /// The reservation would push the peer's total reserved balance past the
+    /// leg's absolute cap, independent of the committed balance.
+    #[error("peer {peer} reserved {reserved} plus this price exceeds the reserve cap {cap}")]
+    ReserveCap {
+        /// The peer whose reserve total would overflow.
+        peer: OverlayAddress,
+        /// The peer's currently reserved balance for the leg.
+        reserved: Au,
+        /// The absolute reserve cap for the leg.
+        cap: Au,
+    },
 }
 
 impl AccountingError {

--- a/crates/swarm/client-behaviour/src/forward.rs
+++ b/crates/swarm/client-behaviour/src/forward.rs
@@ -92,6 +92,11 @@ pub enum ForwardError {
     /// on drop.
     #[error("accounting refused the relay")]
     AccountingRefused,
+
+    /// The relay walk hit its wall-clock bound before any candidate answered.
+    /// Dropping the walk releases every reservation it pinned.
+    #[error("relay walk deadline exceeded")]
+    DeadlineExceeded,
 }
 
 /// Relays a retrieval or a pushsync to a closer peer on behalf of an inbound

--- a/crates/swarm/node/src/dispatch.rs
+++ b/crates/swarm/node/src/dispatch.rs
@@ -19,7 +19,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use std::future::Future;
+use std::pin::pin;
 
+use futures::future::{Either, select};
+use futures_timer::Delay;
 use metrics::{counter, histogram};
 use nectar_primitives::SwarmAddress;
 use tokio::sync::OwnedSemaphorePermit;
@@ -140,6 +143,14 @@ const NEVER_STAGGER: Duration = Duration::from_secs(3600);
 
 /// Number of closest peers to try when pushing a chunk before giving up.
 const PUSH_CANDIDATE_COUNT: usize = 5;
+
+/// Wall-clock bound on a whole relay walk.
+///
+/// The walk pins the upstream provide reservation, and one downstream receive
+/// reservation at a time, for its whole life; without a bound a stalled
+/// downstream peer pins them indefinitely. Matches the origin retrieval
+/// deadline: past the requester's own patience the relay serves no one.
+const RELAY_WALK_DEADLINE: Duration = Duration::from_secs(30);
 
 /// Report source for shallow receipts caught on the origin upload path.
 const PUSHSYNC_SOURCE: ReportSource = ReportSource::Protocol("pushsync");
@@ -520,7 +531,8 @@ where
             handle: self.client_handle.clone(),
             address,
         };
-        self.relay_walk(op, accounting, address, exclude).await
+        self.relay_walk(op, accounting, address, exclude, RELAY_WALK_DEADLINE)
+            .await
     }
 
     /// Relay an inbound pushsync delivery to a strictly-closer peer on behalf
@@ -543,7 +555,8 @@ where
             neighbourhood_credible: self.topology.neighbourhood_credible(),
             reporter: self.topology.reporter(),
         };
-        self.relay_walk(op, accounting, address, exclude).await
+        self.relay_walk(op, accounting, address, exclude, RELAY_WALK_DEADLINE)
+            .await
     }
 
     /// The relay role profile: the shared strictly-closer walk over one
@@ -567,7 +580,34 @@ where
     /// Each leg holds the shared per-peer in-flight permit best-effort: the
     /// origin race sees relay load against the same cap, but a relay is never
     /// declined for lack of a permit.
+    ///
+    /// The whole walk is bounded by `deadline`: a stalled downstream peer
+    /// cannot pin the reservations past it, because dropping the timed-out walk
+    /// releases them.
     async fn relay_walk<Op: RelayOp, A: SwarmClientAccounting>(
+        &self,
+        op: Op,
+        accounting: &A,
+        address: ChunkAddress,
+        exclude: OverlayAddress,
+        deadline: Duration,
+    ) -> Result<
+        (
+            Op::Output,
+            <A::Accounting as SwarmAccounting>::ProvideAction,
+        ),
+        ForwardError,
+    > {
+        let walk = pin!(self.walk_candidates(op, accounting, address, exclude));
+        match select(walk, pin!(Delay::new(deadline))).await {
+            Either::Left((result, _)) => result,
+            Either::Right(_) => Err(ForwardError::DeadlineExceeded),
+        }
+    }
+
+    /// The unbounded candidate walk [`Self::relay_walk`] races against its
+    /// deadline.
+    async fn walk_candidates<Op: RelayOp, A: SwarmClientAccounting>(
         &self,
         op: Op,
         accounting: &A,
@@ -1772,6 +1812,105 @@ mod tests {
                 RETRIEVE_SETTLE_DRIVES * peers.len(),
                 "each of the bounded drive rounds settles the full gated set"
             );
+        }
+    }
+
+    /// The relay walk deadline: a downstream peer that never answers must not
+    /// pin the walk's reservations past the wall-clock bound.
+    mod relay_deadline {
+        use std::num::NonZeroUsize;
+        use std::sync::Arc;
+
+        use vertex_swarm_accounting::{
+            Accounting, ClientAccounting, DefaultAccountingConfig, FixedPricer,
+        };
+        use vertex_swarm_api::{
+            Au, Bin, ChunkAddress, OverlayAddress, SwarmAccounting, SwarmPeerAccounting,
+        };
+        use vertex_swarm_client_behaviour::ForwardError;
+        use vertex_swarm_test_utils::{MockTopology, test_identity_arc};
+        use vertex_tasks::time::Duration;
+
+        use super::super::{
+            DispatchEngine, NoLatencyHint, ProximityOnly, RetrievalTopology, RetrieveRelay,
+        };
+        use crate::inflight::PeerInflightLimiter;
+        use crate::selection::SettlementTrigger;
+        use crate::{ClientCommand, ClientHandle};
+
+        struct NoSettle;
+        impl SettlementTrigger for NoSettle {
+            fn trigger_settlement(&self, _peer: OverlayAddress) {}
+        }
+
+        /// An overlay sharing exactly `leading_bits` leading bits with `address`
+        /// (the next bit is flipped), placing a peer at a controlled proximity.
+        fn overlay_at_proximity(address: &ChunkAddress, leading_bits: usize) -> OverlayAddress {
+            let mut bytes = address.0.0;
+            let byte = leading_bits / 8;
+            let bit = 7 - (leading_bits % 8);
+            if let Some(b) = bytes.get_mut(byte) {
+                *b ^= 1 << bit;
+            }
+            OverlayAddress::from(bytes)
+        }
+
+        #[tokio::test]
+        async fn relay_walk_deadline_releases_reservations() {
+            let address = ChunkAddress::new([0x42; 32]);
+            let requester = overlay_at_proximity(&address, 2);
+            let closer = overlay_at_proximity(&address, 16);
+            let local = OverlayAddress::from([0xee; 32]);
+
+            let bandwidth = Arc::new(Accounting::new(
+                DefaultAccountingConfig::default(),
+                test_identity_arc(),
+            ));
+            let acct = ClientAccounting::new(
+                Arc::clone(&bandwidth),
+                FixedPricer::new(10_000, vertex_swarm_spec::init_mainnet()),
+            );
+
+            let topology: Arc<dyn RetrievalTopology> = Arc::new(
+                MockTopology::default()
+                    .with_closest(vec![closer])
+                    .with_overlay(local),
+            );
+            // The command receiver is held open but never answered: the
+            // downstream attempt stalls until the walk's deadline fires.
+            let (tx, rx) = tokio::sync::mpsc::channel::<ClientCommand>(4);
+            let engine = DispatchEngine::new(
+                ClientHandle::new(tx),
+                topology,
+                Bin::new(31).unwrap(),
+                ProximityOnly,
+                Arc::new(PeerInflightLimiter::new(NonZeroUsize::new(4).unwrap())),
+                NoLatencyHint,
+                Arc::new(NoSettle),
+            );
+
+            let op = RetrieveRelay {
+                handle: engine.client_handle.clone(),
+                address,
+            };
+            let result = engine
+                .relay_walk(op, &acct, address, requester, Duration::from_millis(50))
+                .await;
+            assert!(
+                matches!(result, Err(ForwardError::DeadlineExceeded)),
+                "a stalled walk resolves at the deadline"
+            );
+
+            // Dropping the timed-out walk released both legs: nothing stays
+            // reserved and nothing was committed.
+            let upstream = bandwidth.for_peer(requester);
+            assert_eq!(upstream.state().shadow_reserved_balance(), Au::ZERO);
+            assert_eq!(upstream.balance(), Au::ZERO);
+            let downstream = bandwidth.for_peer(closer);
+            assert_eq!(downstream.state().reserved_balance(), Au::ZERO);
+            assert_eq!(downstream.balance(), Au::ZERO);
+
+            drop(rx);
         }
     }
 }

--- a/docs/design/accounting-seam.md
+++ b/docs/design/accounting-seam.md
@@ -7,7 +7,7 @@ The trait and type surface of bandwidth accounting, designed from the responsibi
 Accounting does five things and nothing else:
 
 1. Ledger. A signed per-peer balance in AU (`+` the peer owes us, `-` we owe), committed by `record`, read as a balance or as a non-negative `Debt`.
-2. Reservation. In-flight holds so our debt view matches the creditor's shadow reserve: a receive leg (we owe) and a provide leg (they owe), each reserve then apply-on-success then drop-to-release.
+2. Reservation. In-flight holds so our debt view matches the creditor's shadow reserve: a receive leg (we owe) and a provide leg (they owe), each reserve then apply-on-success then drop-to-release. Holds are bounded against reservation flooding: per-peer and global outstanding-count caps (`ReservationCaps`) and an absolute per-peer reserve total (receive at the disconnect line, provide at the serve line) are enforced at prepare time, and the node's relay walk carries a wall-clock deadline so a stalled downstream walk drops and releases its holds.
 3. Admission. The band decision over committed plus reserved against the payment and disconnect thresholds.
 4. Settlement. A composable provider fan-out (pseudosettle, then swap) that reduces committed debt, plus the single-in-flight settle per peer.
 5. Scoring. Reporting genuine peer misbehaviour, never our own debt. Scoring stays the peer manager's authority and is not part of this seam.


### PR DESCRIPTION
## What

Balance reservations could be inflated into a denial of service: `prepare_receive`/`prepare_provide` reserve balance and release on drop, the two-leg relay pins a provide reservation across the whole downstream walk, and nothing bounded how many reservations could be in flight or for how long. This PR bounds all three axes. It re-stacks the original branch onto the open accounting train, re-expressed against the reshaped surface (banded gates from a single peer-state fetch, the per-peer serve and settle lines, the announced-threshold adoption).

In the accounting core: per-peer per-leg (default 128) and global (default 4096) in-flight reservation caps enforced at prepare time, with counters held per leg on `PeerState` plus a shared global counter carried by every `Reservation`, released exactly once on drop.

Also in the accounting core: per-peer reserve totals bounded at prepare time, the receive reserve at the peer's disconnect threshold and the provide shadow reserve at the peer's serve line (the handshake-keyed, growth-raised line the provide gate enforces), closing the hole where a favourable committed balance widens headroom without bound. Committed balance still widens serve headroom across applied provides; only the un-committed reservation total is capped.

In the node: a 30 second deadline on the whole relay walk in `DispatchEngine::relay_walk` (matching the retrieve deadline, using the crate's established wasm-clean timer), so a stalled downstream walk drops and releases its pinned upstream provide and downstream receive reservations by RAII; new `ForwardError::DeadlineExceeded`.

Cap refusals surface as three new typed `AccountingError` variants (`PeerInflightCap`, `GlobalInflightCap`, `ReserveCap`) with snake_case metric labels. One sentence added to `docs/design/accounting-seam.md`.

## Why

This closes the last open item under the accounting hardening epic (#439), milestoned M7. Closes #492

## Testing

Six tests ported from the original branch: per-peer receive cap refusal with drop and apply both restoring headroom, per-leg cap independence, global cap spanning peers and legs, receive reserve bounded at the disconnect line under a widened projection, provide reserve bounded at the serve line, and relay-walk deadline releasing both legs with nothing committed. The pre-existing widened-headroom test now proves the widening through committed steps alongside the reservation bound. Verified with `cargo fmt --all --check`, full-workspace `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run` over the four touched crates (279 passed), and the wasm cone build of `vertex-swarm-node`.

## Notes


AI Assistance: Claude Code (Fable 5) used for the rebase resolution and this description.

