### PR TITLE
ci: run docker and release builds only on main and tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,15 @@
 name: Docker
 
+# Runs automatically only for main and version tags. Dispatch it manually on a
+# branch for an on-demand smoke build (amd64 only, nothing pushed).
 on:
   push:
     branches: [main]
     tags: ['v*']
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -31,9 +32,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca  # v3.9.0
 
-      # No push on pull requests, so the registry login is skipped there too.
+      # No push on manual dispatch, so the registry login is skipped there too.
       - name: Log in to the Container registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -52,14 +53,14 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      # Pull requests build amd64 only to skip the arm64 emulation cost; main and
-      # tags build the full multi-arch image and push it.
+      # Manual dispatch builds amd64 only to skip the arm64 emulation cost; main
+      # and tags build the full multi-arch image and push it.
       - name: Build and push
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75  # v6.9.0
         with:
           context: .
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: ${{ github.event_name == 'workflow_dispatch' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,13 @@ permissions:
 #
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
+# Deviation from `dist generate` (covered by allow-dirty in dist-workspace.toml):
+# the pull_request trigger is replaced by workflow_dispatch, so PRs no longer
+# build the release matrix automatically. Dispatch the workflow on a branch to
+# get the old PR behaviour: plan, build, and upload throwaway artefacts without
+# publishing anything.
 on:
-  pull_request:
+  workflow_dispatch:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
@@ -50,9 +55,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ github.event_name == 'push' && github.ref_name || '' }}
+      tag-flag: ${{ github.event_name == 'push' && format('--tag={0}', github.ref_name) || '' }}
+      publishing: ${{ github.event_name == 'push' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -77,7 +82,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (github.event_name == 'push' && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,5 +1,8 @@
-# NOTE: after `dist generate`, re-pin the action `uses:` in .github/workflows/release.yml to
-# commit SHAs (repo convention; dist regenerates them as version tags).
+# NOTE: after `dist generate`, re-apply the hand edits in .github/workflows/release.yml:
+# re-pin the action `uses:` to commit SHAs (repo convention; dist regenerates them as
+# version tags), and restore the workflow_dispatch trigger block plus the
+# `github.event_name == 'push'` publishing conditions (dist regenerates a pull_request
+# trigger keyed on `!github.event.pull_request`).
 [workspace]
 members = ["cargo:."]
 
@@ -9,8 +12,9 @@ members = ["cargo:."]
 # ships the bare client and nothing else.
 [dist]
 cargo-dist-version = "0.32.0"
-# The generated release.yml has its action uses hand-pinned to commit SHAs (repo
-# convention), so it deviates from what `dist generate` produces; allow that.
+# The generated release.yml deviates from what `dist generate` produces: action uses
+# are hand-pinned to commit SHAs (repo convention), and the pull_request trigger is
+# replaced by workflow_dispatch so PRs stop building the release matrix automatically.
 allow-dirty = ["ci"]
 # The installers fetch the matching prebuilt archive for the host.
 installers = ["shell", "powershell"]
@@ -22,8 +26,9 @@ targets = [
     "x86_64-pc-windows-msvc",
 ]
 ci = ["github"]
-# Per-PR runs upload throwaway artefacts so reviewers can smoke-test a build
-# without cutting a release.
+# With the pull_request trigger removed from release.yml this only affects manual
+# workflow_dispatch runs, which upload throwaway artefacts so a build can be
+# smoke-tested without cutting a release.
 pr-run-mode = "upload"
 install-path = "CARGO_HOME"
 


### PR DESCRIPTION
## What

Stop the Docker image build and the cargo-dist release matrix from running automatically on every pull request. Both workflows now trigger on push to main and on version tags only, and both gain `workflow_dispatch` so a build can still be run on demand against any branch when a PR genuinely needs a smoke build.

- `docker.yml`: the `pull_request` trigger is removed. A manual dispatch reproduces the old PR behaviour: amd64-only build, no registry login, nothing pushed. The concurrency group keys on `github.ref` now that `head_ref` is never populated.
- `release.yml`: the `pull_request` trigger is replaced by `workflow_dispatch`, and the publishing conditions are re-keyed from `!github.event.pull_request` to `github.event_name == 'push'` so a dispatch run plans, builds and uploads throwaway workflow artefacts without attempting to cut a release from a branch name. Tag pushes publish exactly as before. This hand edit to the generated file is covered by the existing `allow-dirty = ["ci"]`, and the notes in `dist-workspace.toml` now document it for the next `dist generate`.

## Why

Closes #825. These are by far the slowest jobs in the pipeline and they gate nothing a reviewer needs on every push, so they were holding up CI for each PR in a merge train. The `Main` ruleset has no required status checks, so removing the PR triggers cannot strand a PR on a pending check.

## Testing

- `nix-shell -p actionlint --run 'actionlint .github/workflows/docker.yml .github/workflows/release.yml'`: only pre-existing shellcheck style notes in dist-generated script blocks; no trigger or expression errors.
- Verified the `build-local-artifacts` gate still fires on dispatch: `publishing` is false but `pr_run_mode == 'upload'` from the unchanged dist config satisfies its condition.
- Verified via the GitHub API that the `Main` ruleset lists no required status checks referencing these workflows.

## Notes

AI Assistance: Claude Code (Fable 5) used for the workflow edits and this description.
