### PR TITLE
feat(swarm-rpc): thread the stamp-validation policy from config into ChunkService

### DIFF
--- a/bin/vertex/src/cli.rs
+++ b/bin/vertex/src/cli.rs
@@ -149,7 +149,8 @@ pub async fn run() -> Result<()> {
                     local_store,
                     chain,
                     swap,
-                );
+                )
+                .with_stamp_validation(config.protocol.rpc_stamp_validation());
 
                 let handle = builder.with_protocol(node_config).launch().await?;
                 if config.infra.api.grpc {
@@ -185,7 +186,8 @@ pub async fn run() -> Result<()> {
                     storage,
                     chain,
                     swap,
-                );
+                )
+                .with_stamp_validation(config.protocol.rpc_stamp_validation());
 
                 let handle = builder.with_protocol(node_config).launch().await?;
                 if config.infra.api.grpc {

--- a/bin/vertex/tests/config_load.rs
+++ b/bin/vertex/tests/config_load.rs
@@ -33,3 +33,23 @@ fn accounting_section_deserializes() {
     let config = FullNodeConfig::<ProtocolConfig>::load(Some(file.path())).unwrap();
     assert_eq!(config.protocol.accounting.payment_threshold, 42);
 }
+
+#[test]
+fn rpc_section_maps_onto_the_stamp_validation_policy() {
+    use vertex_swarm_api::StampValidation;
+
+    let default_config = FullNodeConfig::<ProtocolConfig>::load(None).unwrap();
+    assert_eq!(
+        default_config.protocol.rpc_stamp_validation(),
+        StampValidation::Enforce
+    );
+
+    let mut file = tempfile::NamedTempFile::new().unwrap();
+    writeln!(file, "[rpc]\nstamp_validation = \"per-request\"").unwrap();
+
+    let config = FullNodeConfig::<ProtocolConfig>::load(Some(file.path())).unwrap();
+    assert_eq!(
+        config.protocol.rpc_stamp_validation(),
+        StampValidation::PerRequest
+    );
+}

--- a/crates/swarm/api/src/components/mod.rs
+++ b/crates/swarm/api/src/components/mod.rs
@@ -100,24 +100,55 @@ impl<T: Send + Sync> HasTopology for BootnodeComponents<T> {
     }
 }
 
+/// Server-side policy for the caller-controlled per-request `validate` flag on
+/// chunk uploads. A public endpoint must not let a caller skip stamp-signature
+/// validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StampValidation {
+    /// Always validate, ignoring the request flag. Default for public endpoints.
+    #[default]
+    Enforce,
+    /// Honour the request's `validate` flag. For trusted/private endpoints.
+    PerRequest,
+}
+
+impl StampValidation {
+    /// Effective validate decision for a request whose flag is `requested`.
+    #[must_use]
+    pub fn resolve(self, requested: bool) -> bool {
+        match self {
+            Self::Enforce => true,
+            Self::PerRequest => requested,
+        }
+    }
+}
+
 /// Client components (topology + chunk client).
 ///
 /// Accounting is intentionally absent: it is a builder-wired internal of the
-/// network chunk client, not a served capability.
+/// network chunk client, not a served capability. The stamp-validation policy
+/// rides here because the serve view is projected from the components alone.
 ///
 /// Construction is builder-exclusive; see [`construct`].
 #[derive(Debug, Clone)]
 pub struct ClientComponents<T, C> {
     topology: T,
     chunk_client: C,
+    stamp_validation: StampValidation,
 }
 
 impl<T, C> ClientComponents<T, C> {
-    pub(crate) fn new(topology: T, chunk_client: C) -> Self {
+    pub(crate) fn new(topology: T, chunk_client: C, stamp_validation: StampValidation) -> Self {
         Self {
             topology,
             chunk_client,
+            stamp_validation,
         }
+    }
+
+    /// Stamp-validation policy for the served chunk-upload surface.
+    pub fn stamp_validation(&self) -> StampValidation {
+        self.stamp_validation
     }
 }
 
@@ -150,12 +181,23 @@ pub struct StorerComponents<T, C, S, R> {
 }
 
 impl<T, C, S, R> StorerComponents<T, C, S, R> {
-    pub(crate) fn new(topology: T, chunk_client: C, store: S, reserve: R) -> Self {
+    pub(crate) fn new(
+        topology: T,
+        chunk_client: C,
+        store: S,
+        reserve: R,
+        stamp_validation: StampValidation,
+    ) -> Self {
         Self {
-            client: ClientComponents::new(topology, chunk_client),
+            client: ClientComponents::new(topology, chunk_client, stamp_validation),
             store,
             reserve,
         }
+    }
+
+    /// Stamp-validation policy for the served chunk-upload surface.
+    pub fn stamp_validation(&self) -> StampValidation {
+        self.client.stamp_validation()
     }
 }
 
@@ -207,14 +249,18 @@ impl<T: Send + Sync, C: Send + Sync, S: Send + Sync, R: BinCursorStore> HasReser
 /// API.
 #[doc(hidden)]
 pub mod construct {
-    use super::{BootnodeComponents, ClientComponents, StorerComponents};
+    use super::{BootnodeComponents, ClientComponents, StampValidation, StorerComponents};
 
     pub fn bootnode<T>(topology: T) -> BootnodeComponents<T> {
         BootnodeComponents::new(topology)
     }
 
-    pub fn client<T, C>(topology: T, chunk_client: C) -> ClientComponents<T, C> {
-        ClientComponents::new(topology, chunk_client)
+    pub fn client<T, C>(
+        topology: T,
+        chunk_client: C,
+        stamp_validation: StampValidation,
+    ) -> ClientComponents<T, C> {
+        ClientComponents::new(topology, chunk_client, stamp_validation)
     }
 
     pub fn storer<T, C, S, R>(
@@ -222,7 +268,22 @@ pub mod construct {
         chunk_client: C,
         store: S,
         reserve: R,
+        stamp_validation: StampValidation,
     ) -> StorerComponents<T, C, S, R> {
-        StorerComponents::new(topology, chunk_client, store, reserve)
+        StorerComponents::new(topology, chunk_client, store, reserve, stamp_validation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StampValidation;
+
+    #[test]
+    fn stamp_validation_resolves_per_policy() {
+        assert!(StampValidation::Enforce.resolve(false));
+        assert!(StampValidation::Enforce.resolve(true));
+        assert!(!StampValidation::PerRequest.resolve(false));
+        assert!(StampValidation::PerRequest.resolve(true));
+        assert_eq!(StampValidation::default(), StampValidation::Enforce);
     }
 }

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -41,7 +41,7 @@ pub use self::components::{
     BinCursorStore, BinScanItem, BootnodeComponents, ClientComponents, Commit, CommitOnWrite,
     Direction, HasChunkClient, HasIdentity, HasReserve, HasStore, HasTopology, IntervalStore,
     OriginAccounting, PullChunkVerifier, PullStorage, ReserveStore, SettableRadius,
-    SettlementCredit, StorerComponents, SwarmAccounting, SwarmAccountingConfig,
+    SettlementCredit, StampValidation, StorerComponents, SwarmAccounting, SwarmAccountingConfig,
     SwarmClientAccounting, SwarmLocalStore, SwarmLocalStoreConfig, SwarmPeerAccounting,
     SwarmPeerResolver, SwarmPeerState, SwarmPricing, SwarmPricingBuilder, SwarmPricingConfig,
     SwarmSettlementProvider, SwarmTopology, SwarmTopologyBins, SwarmTopologyCommands,

--- a/crates/swarm/builder/src/config.rs
+++ b/crates/swarm/builder/src/config.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use vertex_node_api::NodeBuildsProtocol;
 use vertex_storage_redb::RedbDatabase;
 use vertex_swarm_accounting::DefaultAccountingConfig;
-use vertex_swarm_api::SwarmLocalStore;
+use vertex_swarm_api::{StampValidation, SwarmLocalStore};
 use vertex_swarm_identity::Identity;
 use vertex_swarm_localstore::LocalStoreConfig;
 use vertex_swarm_node::args::{ChainConfig, NetworkConfig, SwapConfig};
@@ -94,6 +94,7 @@ pub struct ClientConfig {
     chain: ChainConfig,
     swap: SwapConfig,
     cache: Option<CacheSeam>,
+    stamp_validation: StampValidation,
 }
 
 impl ClientConfig {
@@ -115,7 +116,20 @@ impl ClientConfig {
             chain,
             swap,
             cache: None,
+            stamp_validation: StampValidation::default(),
         }
+    }
+
+    /// Override the stamp-validation policy the gRPC chunk service applies to
+    /// uploads. Defaults to [`StampValidation::Enforce`].
+    pub fn with_stamp_validation(mut self, stamp_validation: StampValidation) -> Self {
+        self.stamp_validation = stamp_validation;
+        self
+    }
+
+    /// Stamp-validation policy for the served chunk-upload surface.
+    pub fn stamp_validation(&self) -> StampValidation {
+        self.stamp_validation
     }
 
     /// Override the cache with a pre-built local store, replacing the default
@@ -196,5 +210,40 @@ mod tests {
             agent.contains(vertex_node_core::version::GIT_SHA),
             "agent string {agent} is missing the build sha"
         );
+    }
+}
+
+#[cfg(test)]
+mod stamp_validation_tests {
+    use vertex_swarm_api::{StampValidation, SwarmIdentity};
+    use vertex_swarm_localstore::LocalStoreConfig;
+    use vertex_swarm_node::args::{ChainConfig, SwapConfig};
+    use vertex_swarm_test_utils::test_identity_arc;
+
+    use super::{ClientConfig, DefaultAccountingConfig, NetworkConfig};
+
+    fn client_config() -> ClientConfig {
+        let identity = test_identity_arc();
+        let spec = identity.spec().clone();
+        ClientConfig::new(
+            spec,
+            identity,
+            NetworkConfig::default(),
+            DefaultAccountingConfig::default(),
+            LocalStoreConfig::default(),
+            ChainConfig::default(),
+            SwapConfig::default(),
+        )
+    }
+
+    #[test]
+    fn client_config_defaults_to_enforce() {
+        assert_eq!(client_config().stamp_validation(), StampValidation::Enforce);
+    }
+
+    #[test]
+    fn with_stamp_validation_overrides_the_policy() {
+        let config = client_config().with_stamp_validation(StampValidation::PerRequest);
+        assert_eq!(config.stamp_validation(), StampValidation::PerRequest);
     }
 }

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -471,6 +471,7 @@ async fn build_client(
     SwarmNodeError,
 > {
     let cache = config.take_cache();
+    let stamp_validation = config.stamp_validation();
     let parts = build_client_backed_node(
         ctx,
         ClientNodeParams {
@@ -494,7 +495,7 @@ async fn build_client(
         provider_store: (),
         ..
     } = parts;
-    let providers = construct::client(topology, chunks);
+    let providers = construct::client(topology, chunks, stamp_validation);
     Ok((task, providers))
 }
 

--- a/crates/swarm/builder/src/storer.rs
+++ b/crates/swarm/builder/src/storer.rs
@@ -18,8 +18,8 @@ use vertex_node_api::{InfrastructureContext, NodeBuildsProtocol};
 use vertex_storage_redb::RedbDatabase;
 use vertex_swarm_accounting::DefaultAccountingConfig;
 use vertex_swarm_api::{
-    BinCursorStore, PeerReporter, PullChunkVerifier, PullStorage, ReserveStore, StorageRadius,
-    StorerComponents, SwarmLaunchConfig, SwarmLocalStore, SwarmNodeType, construct,
+    BinCursorStore, PeerReporter, PullChunkVerifier, PullStorage, ReserveStore, StampValidation,
+    StorageRadius, StorerComponents, SwarmLaunchConfig, SwarmLocalStore, SwarmNodeType, construct,
 };
 use vertex_swarm_identity::Identity;
 use vertex_swarm_localstore::LocalStoreConfig;
@@ -74,6 +74,7 @@ pub struct StorerConfig {
     swap: SwapConfig,
     cache: Option<CacheSeam>,
     reserve: Option<ReserveSeam>,
+    stamp_validation: StampValidation,
 }
 
 impl StorerConfig {
@@ -102,7 +103,20 @@ impl StorerConfig {
             swap,
             cache: None,
             reserve: None,
+            stamp_validation: StampValidation::default(),
         }
+    }
+
+    /// Override the stamp-validation policy the gRPC chunk service applies to
+    /// uploads. Defaults to [`StampValidation::Enforce`].
+    pub fn with_stamp_validation(mut self, stamp_validation: StampValidation) -> Self {
+        self.stamp_validation = stamp_validation;
+        self
+    }
+
+    /// Stamp-validation policy for the served chunk-upload surface.
+    pub fn stamp_validation(&self) -> StampValidation {
+        self.stamp_validation
     }
 
     /// Override the cache with a pre-built local store, replacing the default
@@ -233,6 +247,7 @@ pub(crate) async fn build_storer(
 ) -> Result<(NodeTaskFn, StorerProviders), SwarmNodeError> {
     let cache = config.take_cache();
     let reserve = config.take_reserve();
+    let stamp_validation = config.stamp_validation();
     // Reserve capacity is a consensus quantity read from the spec, not local disk:
     // a fixed power-of-two chunk count from which the redistribution game derives
     // storage radius and committed depth, so nodes covering one neighbourhood must
@@ -264,7 +279,13 @@ pub(crate) async fn build_storer(
     .await?;
 
     let (store, reserve) = parts.provider_store;
-    let providers = construct::storer(parts.topology, parts.chunks, store, reserve);
+    let providers = construct::storer(
+        parts.topology,
+        parts.chunks,
+        store,
+        reserve,
+        stamp_validation,
+    );
     Ok((parts.task, providers))
 }
 

--- a/crates/swarm/node/src/args/mod.rs
+++ b/crates/swarm/node/src/args/mod.rs
@@ -9,6 +9,8 @@ mod chain;
 mod network;
 mod peer;
 #[cfg(feature = "cli")]
+mod rpc;
+#[cfg(feature = "cli")]
 mod spec;
 mod swap;
 #[cfg(feature = "cli")]
@@ -22,6 +24,8 @@ pub use network::NetworkConfig;
 #[cfg(feature = "cli")]
 pub use peer::PeerArgs;
 pub use peer::PeerConfig;
+#[cfg(feature = "cli")]
+pub use rpc::{RpcArgs, StampValidationArg};
 #[cfg(feature = "cli")]
 pub use spec::SwarmSpecArgs;
 #[cfg(feature = "cli")]

--- a/crates/swarm/node/src/args/rpc.rs
+++ b/crates/swarm/node/src/args/rpc.rs
@@ -1,0 +1,66 @@
+//! gRPC endpoint CLI arguments.
+
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use vertex_swarm_api::StampValidation;
+
+/// CLI argument for the chunk-upload stamp-validation policy. Maps to
+/// [`StampValidation`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StampValidationArg {
+    /// Always validate uploads, ignoring the request flag.
+    #[default]
+    Enforce,
+    /// Honour each request's `validate` flag. For trusted/private endpoints.
+    PerRequest,
+}
+
+impl From<StampValidationArg> for StampValidation {
+    fn from(arg: StampValidationArg) -> Self {
+        match arg {
+            StampValidationArg::Enforce => StampValidation::Enforce,
+            StampValidationArg::PerRequest => StampValidation::PerRequest,
+        }
+    }
+}
+
+/// gRPC endpoint CLI arguments.
+#[derive(Debug, Default, Args, Clone, Copy, Serialize, Deserialize)]
+#[command(next_help_heading = "RPC")]
+#[serde(default)]
+pub struct RpcArgs {
+    /// Stamp-validation policy for gRPC chunk uploads. A public endpoint
+    /// enforces validation regardless of the request flag.
+    #[arg(
+        long = "rpc.stamp-validation",
+        value_enum,
+        default_value_t = StampValidationArg::Enforce
+    )]
+    pub stamp_validation: StampValidationArg,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_is_enforce() {
+        assert_eq!(
+            StampValidation::from(RpcArgs::default().stamp_validation),
+            StampValidation::Enforce
+        );
+    }
+
+    #[test]
+    fn args_map_onto_the_policy() {
+        assert_eq!(
+            StampValidation::from(StampValidationArg::Enforce),
+            StampValidation::Enforce
+        );
+        assert_eq!(
+            StampValidation::from(StampValidationArg::PerRequest),
+            StampValidation::PerRequest
+        );
+    }
+}

--- a/crates/swarm/node/src/args/swarm.rs
+++ b/crates/swarm/node/src/args/swarm.rs
@@ -12,7 +12,7 @@ use vertex_swarm_primitives::SwarmNodeType;
 #[cfg(feature = "storer")]
 use vertex_swarm_redistribution::RedistributionArgs;
 
-use super::{ChainArgs, NetworkArgs, SwapArgs, SwarmSpecArgs};
+use super::{ChainArgs, NetworkArgs, RpcArgs, SwapArgs, SwarmSpecArgs};
 
 /// CLI argument for node mode selection. Maps to [`SwarmNodeType`].
 #[derive(
@@ -94,4 +94,8 @@ pub struct ProtocolArgs {
     /// SWAP settlement (chequebook, beneficiary, deploy).
     #[command(flatten)]
     pub swap: SwapArgs,
+
+    /// gRPC endpoint policy.
+    #[command(flatten)]
+    pub rpc: RpcArgs,
 }

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -14,10 +14,10 @@ use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_redistribution::{RedistributionArgs, StorageConfig};
 use vertex_swarm_spec::Spec;
 
-use vertex_swarm_api::ConfigError;
+use vertex_swarm_api::{ConfigError, StampValidation};
 
 use crate::args::{
-    ChainArgs, ChainConfig, NetworkArgs, NetworkConfig, ProtocolArgs, SwapArgs, SwapConfig,
+    ChainArgs, ChainConfig, NetworkArgs, NetworkConfig, ProtocolArgs, RpcArgs, SwapArgs, SwapConfig,
 };
 
 /// Swarm protocol configuration (serializable Args layer).
@@ -37,6 +37,7 @@ pub struct ProtocolConfig {
     pub redistribution: RedistributionArgs,
     pub chain: ChainArgs,
     pub swap: SwapArgs,
+    pub rpc: RpcArgs,
 }
 
 impl ProtocolConfig {
@@ -75,6 +76,11 @@ impl ProtocolConfig {
     pub fn swap_config(&self) -> SwapConfig {
         self.swap.swap_config()
     }
+
+    /// Stamp-validation policy for the gRPC chunk service.
+    pub fn rpc_stamp_validation(&self) -> StampValidation {
+        self.rpc.stamp_validation.into()
+    }
 }
 
 impl ProtocolConfig {
@@ -99,5 +105,6 @@ impl NodeProtocolConfig for ProtocolConfig {
         }
         self.chain = args.chain.clone();
         self.swap = args.swap.clone();
+        self.rpc = args.rpc;
     }
 }

--- a/crates/swarm/rpc/src/adapter.rs
+++ b/crates/swarm/rpc/src/adapter.rs
@@ -9,7 +9,8 @@
 use vertex_rpc_server::{GrpcRegistry, RegistersGrpcServices};
 use vertex_swarm_api::{
     BinCursorStore, BootnodeComponents, ClientComponents, HasChunkClient, HasReserve, HasStore,
-    HasTopology, StorerComponents, SwarmTopologyPeers, SwarmTopologyState, SwarmTopologyStats,
+    HasTopology, StampValidation, StorerComponents, SwarmTopologyPeers, SwarmTopologyState,
+    SwarmTopologyStats,
 };
 use vertex_swarm_stream::ChunkClient;
 
@@ -88,8 +89,9 @@ impl<C> GrpcAdapter<C> {
     }
 
     /// Register the chunk upload/download service. The live connected-peer count
-    /// from the topology drives the download pipeline depth.
-    pub fn register_chunk(&self, registry: &mut GrpcRegistry)
+    /// from the topology drives the download pipeline depth; `stamp_validation`
+    /// is the components-carried upload policy.
+    pub fn register_chunk(&self, registry: &mut GrpcRegistry, stamp_validation: StampValidation)
     where
         C: HasChunkClient + HasTopology,
         C::ChunkClient: ChunkClient,
@@ -97,6 +99,7 @@ impl<C> GrpcAdapter<C> {
     {
         let topology = self.components.topology().clone();
         let chunk_service = ChunkService::new(self.components.chunk_client().clone())
+            .with_stamp_validation(stamp_validation)
             .with_peer_count(std::sync::Arc::new(move || {
                 topology.connected_peers_count()
             }));
@@ -134,7 +137,7 @@ where
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
         self.register_node(registry);
-        self.register_chunk(registry);
+        self.register_chunk(registry, self.components.stamp_validation());
     }
 }
 
@@ -149,7 +152,7 @@ where
 {
     fn register_grpc_services(&self, registry: &mut GrpcRegistry) {
         self.register_node(registry);
-        self.register_chunk(registry);
+        self.register_chunk(registry, self.components.stamp_validation());
         self.register_reserve(registry);
     }
 }

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -14,27 +14,7 @@ use vertex_swarm_stream::{
     ChunkClient, ChunkClientExt, StreamConfig, VerifiedChunk, get_stream_from, parse_address,
 };
 
-/// Server-side policy for the caller-controlled per-request `validate` flag. A
-/// public endpoint must not let a caller skip stamp-signature validation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum StampValidation {
-    /// Always validate, ignoring the request flag. Default for public endpoints.
-    #[default]
-    Enforce,
-    /// Honour the request's `validate` flag. For trusted/private endpoints.
-    PerRequest,
-}
-
-impl StampValidation {
-    /// Effective validate decision for a request whose flag is `requested`.
-    #[must_use]
-    pub fn resolve(self, requested: bool) -> bool {
-        match self {
-            Self::Enforce => true,
-            Self::PerRequest => requested,
-        }
-    }
-}
+pub use vertex_swarm_api::StampValidation;
 
 /// gRPC chunk retrieval and upload service.
 pub struct ChunkService<P> {
@@ -419,15 +399,6 @@ mod tests {
 
         let err = parse_stamped_chunk(&req).expect_err("malformed stamp must fail");
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
-    }
-
-    #[test]
-    fn stamp_validation_resolves_per_policy() {
-        assert!(StampValidation::Enforce.resolve(false));
-        assert!(StampValidation::Enforce.resolve(true));
-        assert!(!StampValidation::PerRequest.resolve(false));
-        assert!(StampValidation::PerRequest.resolve(true));
-        assert_eq!(StampValidation::default(), StampValidation::Enforce);
     }
 
     /// A verified item maps onto the wire response with a populated `served_by`,


### PR DESCRIPTION
## What

Thread the gRPC chunk-upload stamp-validation policy from node configuration into `ChunkService`. A new `--rpc.stamp-validation` argument (`enforce` | `per-request`, default `enforce`, also settable as `stamp_validation` under a `[rpc]` config-file section) flows through the validated client and storer configs into the component containers, and the gRPC adapter applies it where the chunk service is registered. The `StampValidation` enum moves to `vertex-swarm-api` so the components can carry it; `vertex-swarm-rpc` re-exports it from its original path and enforcement stays in `ChunkService`.

## Why

Closes #377. The service has always had an `Enforce`/`PerRequest` policy with a `with_stamp_validation` builder, but no construction site could reach it, so a trusted private deployment could not opt into honouring a caller's `validate` flag. The default posture is unchanged: every layer defaults to `Enforce`, so a public endpoint keeps validating uploads regardless of the request flag.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo nextest run -p vertex-swarm-api -p vertex-swarm-rpc -p vertex-swarm-node -p vertex-swarm-builder -p vertex` (220/220), including new tests: enum semantics and default in `vertex-swarm-api`, config default and override in `vertex-swarm-builder`, arg-to-policy mapping in `vertex-swarm-node` (under `cli`), and a config-file round-trip in `bin/vertex/tests/config_load.rs` proving the default is `enforce` and `per-request` parses
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`
- `just check-cone` (default vertex free of the storer, swap, and chain cones)
- `vertex node --help` shows the flag with both values

## Notes


AI Assistance: Claude Code (Fable 5) used for the implementation and this description.

