### PR TITLE
feat(swarm-net-handshake): drop peers that attempt more than one handshake exchange per connection

### DIFF
--- a/crates/swarm/net/handshake/src/error.rs
+++ b/crates/swarm/net/handshake/src/error.rs
@@ -80,6 +80,15 @@ pub enum HandshakeError {
     /// the handler can report it without string-matching.
     #[error("admission rejected: {0}")]
     AdmissionRejected(AdmissionRejection),
+
+    /// An extra handshake exchange was attempted on a connection.
+    ///
+    /// The exchange runs once per connection: a dialer connection accepts no
+    /// inbound exchange and a listener connection accepts only the first.
+    /// Denied before any frame is read, so no signature recovery is spent on
+    /// the violating substream.
+    #[error("unexpected handshake exchange")]
+    UnexpectedExchange,
 }
 
 impl From<Infallible> for HandshakeError {

--- a/crates/swarm/net/handshake/src/handler.rs
+++ b/crates/swarm/net/handshake/src/handler.rs
@@ -1,7 +1,10 @@
 //! Per-connection handler for handshake protocol.
 
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     task::{Context, Poll},
     time::Duration,
 };
@@ -19,13 +22,53 @@ use libp2p::{
     },
 };
 use tracing::{debug, warn};
+use vertex_metrics::labels::direction;
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_peer::SwarmPeer;
 
 use crate::{
     AddressProvider, ConnectionDirection, HANDSHAKE_TIMEOUT, HandshakeError, HandshakeInfo,
-    PROTOCOL, SharedAdmissionControl, protocol::HandshakeProtocol,
+    PROTOCOL, SharedAdmissionControl, metrics::record_unexpected_exchange,
+    protocol::HandshakeProtocol,
 };
+
+/// Admission of inbound handshake exchanges on one connection.
+///
+/// The exchange runs once per connection: a dialer connection never accepts
+/// an inbound exchange, and a listener connection accepts only the first
+/// substream to claim its slot. A denied substream fails the upgrade before
+/// any frame is read.
+#[derive(Clone)]
+enum InboundExchangeGate {
+    /// We dialed this connection: no inbound exchange is ever legitimate.
+    Dialer,
+    /// We listened: the first claim wins, every later attempt is denied.
+    Listener { claimed: Arc<AtomicBool> },
+}
+
+impl InboundExchangeGate {
+    fn listener() -> Self {
+        Self::Listener {
+            claimed: Arc::default(),
+        }
+    }
+
+    /// Claim the connection's single inbound exchange; `false` denies.
+    fn try_claim(&self) -> bool {
+        match self {
+            Self::Dialer => false,
+            Self::Listener { claimed } => !claimed.swap(true, Ordering::AcqRel),
+        }
+    }
+
+    /// Metric label for a denial: which side of the connection we play.
+    fn direction_label(&self) -> &'static str {
+        match self {
+            Self::Dialer => direction::OUTBOUND,
+            Self::Listener { .. } => direction::INBOUND,
+        }
+    }
+}
 
 /// Configuration for handshake handler.
 #[derive(Debug, Clone)]
@@ -97,6 +140,9 @@ pub struct HandshakeHandler<I, A> {
     /// advertised set is empty, in which case the protocol signs a last-resort
     /// record over the peer-observed address.
     self_record: Option<SwarmPeer>,
+    /// Once-per-connection admission for inbound exchanges, shared with every
+    /// upgrade this handler constructs.
+    inbound_gate: InboundExchangeGate,
     state: State,
     pending_event: Option<HandshakeHandlerEvent>,
     should_initiate: bool,
@@ -126,6 +172,7 @@ where
             address_provider,
             admission_control,
             self_record,
+            inbound_gate: InboundExchangeGate::listener(),
             state: State::Pending,
             pending_event: None,
             should_initiate: false,
@@ -151,6 +198,7 @@ where
             address_provider,
             admission_control,
             self_record,
+            inbound_gate: InboundExchangeGate::Dialer,
             state: State::Pending,
             pending_event: None,
             should_initiate: true,
@@ -166,6 +214,7 @@ where
             address_provider: self.address_provider.clone(),
             admission_control: self.admission_control.clone(),
             self_record: self.self_record.clone(),
+            inbound_gate: self.inbound_gate.clone(),
             direction,
             purpose: self.config.purpose,
         }
@@ -275,7 +324,12 @@ where
 
             ConnectionEvent::ListenUpgradeError(error) => {
                 warn!(peer_id = %self.peer_id, "Inbound handshake failed: {}", error.error);
-                self.state = State::Failed;
+                // A denied extra exchange is the violating substream's failure,
+                // not this connection's handshake outcome (which may already be
+                // Completed); the behaviour drops the peer on the event.
+                if !matches!(error.error, HandshakeError::UnexpectedExchange) {
+                    self.state = State::Failed;
+                }
                 self.pending_event = Some(HandshakeHandlerEvent::Failed { error: error.error });
             }
 
@@ -310,6 +364,8 @@ pub struct HandshakeUpgrade<I, A> {
     /// advertised set was empty and the protocol must do the last-resort
     /// observed-address sign.
     self_record: Option<SwarmPeer>,
+    /// Handler-shared once-per-connection admission for inbound exchanges.
+    inbound_gate: InboundExchangeGate,
     /// Direction this upgrade was created for; drives which arm of the
     /// protocol runs and which side the admission gate sees.
     direction: ConnectionDirection,
@@ -325,6 +381,7 @@ impl<I, A> Clone for HandshakeUpgrade<I, A> {
             address_provider: self.address_provider.clone(),
             admission_control: self.admission_control.clone(),
             self_record: self.self_record.clone(),
+            inbound_gate: self.inbound_gate.clone(),
             direction: self.direction,
             purpose: self.purpose,
         }
@@ -377,6 +434,13 @@ where
     type Future = BoxFuture<'static, Result<Self::Output, Self::Error>>;
 
     fn upgrade_inbound(self, socket: Stream, _: Self::Info) -> Self::Future {
+        // Gate before any frame is read: a denied substream is dropped
+        // without spending signature-recovery work on it.
+        if !self.inbound_gate.try_claim() {
+            record_unexpected_exchange(self.inbound_gate.direction_label(), self.purpose);
+            drop(socket);
+            return Box::pin(std::future::ready(Err(HandshakeError::UnexpectedExchange)));
+        }
         Box::pin(self.build_protocol().handle_inbound(socket))
     }
 }
@@ -392,5 +456,110 @@ where
 
     fn upgrade_outbound(self, socket: Stream, _: Self::Info) -> Self::Future {
         Box::pin(self.build_protocol().handle_outbound(socket))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::swarm::handler::ListenUpgradeError;
+    use vertex_swarm_peer::SwarmNodeType;
+    use vertex_swarm_test_utils::{test_identity_arc, test_swarm_peer};
+
+    use super::*;
+    use crate::{NoAddresses, default_admission_control};
+
+    #[test]
+    fn dialer_gate_denies_every_inbound_exchange() {
+        let gate = InboundExchangeGate::Dialer;
+        assert!(!gate.try_claim());
+        assert!(!gate.try_claim());
+    }
+
+    #[test]
+    fn listener_gate_admits_exactly_one_exchange() {
+        let gate = InboundExchangeGate::listener();
+        assert!(gate.try_claim());
+        assert!(!gate.try_claim());
+        assert!(!gate.try_claim());
+    }
+
+    #[test]
+    fn listener_gate_clones_share_the_claim() {
+        // `listen_protocol` constructs one upgrade per inbound substream, so
+        // the clones must contend for the same slot.
+        let gate = InboundExchangeGate::listener();
+        let clone = gate.clone();
+        assert!(clone.try_claim());
+        assert!(!gate.try_claim());
+    }
+
+    fn listener_handler() -> HandshakeHandler<impl SwarmIdentity + 'static, NoAddresses> {
+        HandshakeHandler::new_inbound(
+            Arc::new(HandshakeConfig::new("test")),
+            test_identity_arc(),
+            PeerId::random(),
+            "/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr"),
+            Arc::new(NoAddresses),
+            default_admission_control(),
+            None,
+        )
+    }
+
+    fn completed_info(peer_id: PeerId) -> HandshakeInfo {
+        HandshakeInfo {
+            peer_id,
+            swarm_peer: test_swarm_peer(1),
+            node_type: SwarmNodeType::Client,
+            welcome_message: String::new(),
+            observed_multiaddr: "/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr"),
+        }
+    }
+
+    #[test]
+    fn denied_exchange_does_not_clobber_a_completed_handshake() {
+        let mut handler = listener_handler();
+        let mut cx = Context::from_waker(std::task::Waker::noop());
+
+        handler.on_connection_event(ConnectionEvent::FullyNegotiatedInbound(
+            FullyNegotiatedInbound {
+                protocol: completed_info(PeerId::random()),
+                info: (),
+            },
+        ));
+        assert!(matches!(
+            handler.poll(&mut cx),
+            Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                HandshakeHandlerEvent::Completed { .. }
+            ))
+        ));
+
+        handler.on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
+            info: (),
+            error: HandshakeError::UnexpectedExchange,
+        }));
+
+        // The connection's own handshake outcome stands; the violation still
+        // surfaces so the behaviour can drop the peer.
+        assert!(handler.connection_keep_alive());
+        assert!(matches!(
+            handler.poll(&mut cx),
+            Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                HandshakeHandlerEvent::Failed {
+                    error: HandshakeError::UnexpectedExchange
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn ordinary_listen_failure_still_fails_the_handshake() {
+        let mut handler = listener_handler();
+
+        handler.on_connection_event(ConnectionEvent::ListenUpgradeError(ListenUpgradeError {
+            info: (),
+            error: HandshakeError::NetworkIdMismatch,
+        }));
+
+        assert!(!handler.connection_keep_alive());
     }
 }

--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -19,6 +19,12 @@
 //!   message fails the handshake with a validation error rather than being
 //!   truncated. Bounding it stops an untrusted peer from spending our memory on
 //!   a field that carries no protocol meaning.
+//! - The exchange runs exactly once per connection. A dialer connection
+//!   accepts no inbound exchange and a listener connection accepts only the
+//!   first; any further attempt is denied before a frame is read (no
+//!   signature-recovery work is spent on it) and fails the upgrade with
+//!   [`HandshakeError::UnexpectedExchange`], a protocol violation the topology
+//!   answers by dropping the connection.
 
 use std::time::Duration;
 

--- a/crates/swarm/net/handshake/src/metrics.rs
+++ b/crates/swarm/net/handshake/src/metrics.rs
@@ -43,6 +43,19 @@ pub enum HandshakeStage {
     Failed,
 }
 
+/// Record an inbound exchange denied by the once-per-connection rule.
+///
+/// `direction` is the connection direction (which side we play on it), not
+/// the violating substream's.
+pub fn record_unexpected_exchange(direction: &'static str, purpose: &'static str) {
+    counter!(
+        "handshake_unexpected_exchange_total",
+        "direction" => direction,
+        "purpose" => purpose
+    )
+    .increment(1);
+}
+
 /// Tracks metrics for a single handshake operation with stage transitions.
 pub struct HandshakeMetrics {
     direction: &'static str,

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -1508,6 +1508,49 @@ mod tests {
             assert_eq!(behaviour.connection_registry.pending_count(), 0);
         }
 
+        /// An extra handshake exchange is a protocol violation: the peer is
+        /// dropped through the close choke point with the recorded reason,
+        /// and the registry teardown is left to the close handler.
+        #[tokio::test]
+        async fn unexpected_exchange_closes_the_connection_as_protocol_violation() {
+            let mut behaviour = test_behaviour();
+            let overlay = test_overlay(1);
+            let peer_id = activate_connection(&behaviour, overlay);
+
+            let c1 = ConnectionId::new_unchecked(1);
+            behaviour.process_protocol_event(
+                peer_id,
+                c1,
+                ProtocolEvent::Handshake(HandshakeEvent::Failed {
+                    peer_id,
+                    connection_id: c1,
+                    direction: ConnectionDirection::Inbound,
+                    error: HandshakeError::UnexpectedExchange,
+                }),
+            );
+
+            assert_eq!(
+                behaviour.pending_closes.get(&peer_id),
+                Some(&DisconnectReason::ProtocolViolation)
+            );
+            match next_action(&mut behaviour).await {
+                ToSwarm::CloseConnection {
+                    peer_id: closed, ..
+                } => assert_eq!(closed, peer_id),
+                _ => panic!("expected CloseConnection for the violating peer"),
+            }
+
+            // The active entry survives until the close lands; the close
+            // handler owns the teardown.
+            assert!(
+                behaviour
+                    .connection_registry
+                    .get(&overlay)
+                    .expect("active entry survives until the close")
+                    .is_active()
+            );
+        }
+
         /// A failed handshake on the peer's sole connection still removes its
         /// registry entry exactly as before.
         #[tokio::test]

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -316,6 +316,25 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
                 .update_from_handshake(peer_id, false);
         }
 
+        // An extra exchange denied by the once-per-connection rule is a
+        // protocol violation on a live connection, not a failed dial: score
+        // it and drop the peer through the close choke point, leaving the
+        // registry and routing teardown to the close handler.
+        if matches!(
+            error,
+            vertex_swarm_net_handshake::HandshakeError::UnexpectedExchange
+        ) {
+            if let Some(overlay) = self.connection_registry.resolve_id(&peer_id) {
+                self.peer_manager.report_peer(
+                    &overlay,
+                    SwarmScoringEvent::ProtocolError,
+                    ReportSource::Handshake,
+                );
+            }
+            self.close_peer(peer_id, DisconnectReason::ProtocolViolation);
+            return;
+        }
+
         // Remove only the entry recorded for the failing connection and release
         // its routing capacity. Scoping to the connection keeps a healthy
         // connection's Active entry when a duplicate connection to the same peer
@@ -486,6 +505,7 @@ fn is_peer_fault(error: &vertex_swarm_net_handshake::HandshakeError) -> bool {
             | E::InvalidOverlay
             | E::InvalidObservedAddress
             | E::Protobuf(_)
+            | E::UnexpectedExchange
     )
 }
 
@@ -514,6 +534,15 @@ mod tests {
 
     const TCP: &str = "/ip4/8.8.8.8/tcp/1634";
     const WSS: &str = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws";
+
+    #[test]
+    fn unexpected_exchange_is_a_peer_fault() {
+        use vertex_swarm_net_handshake::HandshakeError;
+        // The once-per-connection denial is solely the peer's doing; a
+        // timeout stays blameless because our own side can cause it.
+        assert!(is_peer_fault(&HandshakeError::UnexpectedExchange));
+        assert!(!is_peer_fault(&HandshakeError::Timeout));
+    }
 
     #[test]
     fn wss_only_client_rejects_tcp_only_records() {


### PR DESCRIPTION
## What

Enforce the handshake as a strictly once-per-connection exchange. The connection handler now carries a per-connection gate: on a connection we dialed no inbound handshake exchange is ever accepted, and on a connection we accepted only the first inbound substream may run the exchange. A denied substream fails the upgrade before any frame is read, so no EIP-191 signature recovery is spent on it, and surfaces as the new `HandshakeError::UnexpectedExchange` with a `handshake_unexpected_exchange_total{direction,purpose}` counter. The topology classifies the violation as a peer fault (reachability and scoring via the single report path) and drops the peer through its close choke point with `DisconnectReason::ProtocolViolation`.

## Why

Closes #126. Every inbound Ack and SynAck runs full secp256k1 recovery, and nothing bounded how often an established peer could open fresh handshake substreams, so a peer could burn our CPU on repeated recoveries. An earlier revision of this PR metered such exchanges with a per-peer rate limiter; review established that the handshake is a once-per-connection protocol, so a repeat exchange is non-compliant behaviour to be dropped outright, not metered. This revision supersedes the rate-limit approach: the limiter, its quota, error variant, metric, and dependency edge are gone.

Successful handshakes are wire-unchanged; only the local response to non-compliant extra exchanges differs, so no fork gate is needed. Simultaneous dials remain legal: they produce two connections, each with its own single exchange.

## Testing

Unit tests cover the gate (dialer connections deny every inbound exchange; listener connections admit exactly one, shared across upgrade clones), the handler (a denied exchange does not clobber a completed handshake and still surfaces the violation; ordinary listen failures still fail the handshake), and the topology consequence (the violation event records `ProtocolViolation` and emits `CloseConnection` while leaving the registry teardown to the close handler; `UnexpectedExchange` classifies as a peer fault). `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run -p vertex-swarm-net-handshake -p vertex-swarm-topology -p vertex-swarm-peer` (320 passed, the pinned cross-implementation handshake vectors byte-identical), and `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` are all green.

## Notes

Together with #833 this is the last open item on epic #667's hardening checklist.

AI Assistance: Claude Code (Fable 5) used for the implementation and this description.
