### PR TITLE
feat(topology,swarm-net-handshake): name the address trust tiers and bound advertisement before encoding

### DIFF
--- a/crates/swarm/net/handshake/src/address.rs
+++ b/crates/swarm/net/handshake/src/address.rs
@@ -1,8 +1,65 @@
-//! Address provider trait for NAT-aware address selection.
+//! Address provider trait for NAT-aware address selection, and the
+//! pre-encoding bound on the advertised set.
 
 use std::sync::Arc;
 
 use libp2p::{Multiaddr, PeerId};
+use vertex_swarm_peer::MAX_MULTIADDRS_PER_PEER;
+
+use crate::MAX_HANDSHAKE_BUFFER_SIZE;
+
+/// Frame bytes reserved for everything other than the serialized multiaddr
+/// block and the welcome message: the signature (65), overlay (32), nonce (32),
+/// chequebook (20) and timestamp fields, the network id and node type, the
+/// echoed observed multiaddr in a synack, and protobuf tag/length overhead,
+/// rounded up for margin.
+const FRAME_FIXED_BUDGET: usize = 384;
+
+/// Encoded size of one uvarint.
+fn uvarint_len(mut value: u64) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
+
+/// Serialized size of one entry in the multiaddr list block: the address bytes
+/// plus their uvarint length prefix.
+fn entry_len(addr: &Multiaddr) -> usize {
+    let len = addr.to_vec().len();
+    len + uvarint_len(len as u64)
+}
+
+/// Bound the advertised set before it is signed into the self record.
+///
+/// Keeps the longest prefix of the trust-ordered set that stays within both
+/// the record-level count cap and the byte budget left in the handshake frame
+/// after the fixed fields and the welcome message. Deterministic prefix
+/// truncation: the same input always yields the same output, higher-trust
+/// addresses survive, and a non-empty input never bounds to empty (the record
+/// must carry at least one multiaddr).
+pub(crate) fn bound_advertised(addrs: Vec<Multiaddr>, welcome_bytes: usize) -> Vec<Multiaddr> {
+    let budget = MAX_HANDSHAKE_BUFFER_SIZE
+        .saturating_sub(FRAME_FIXED_BUDGET)
+        .saturating_sub(welcome_bytes);
+
+    // One byte for the list-form block prefix.
+    let mut used = 1usize;
+    let mut bounded = Vec::new();
+    for addr in addrs {
+        if bounded.len() == MAX_MULTIADDRS_PER_PEER {
+            break;
+        }
+        used += entry_len(&addr);
+        if used > budget && !bounded.is_empty() {
+            break;
+        }
+        bounded.push(addr);
+    }
+    bounded
+}
 
 /// Provides addresses for handshake based on peer context.
 ///
@@ -37,5 +94,91 @@ impl AddressProvider for NoAddresses {
 
     fn local_peer_id(&self) -> Option<&PeerId> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    use vertex_swarm_peer::serialize_multiaddrs;
+
+    use super::*;
+
+    fn ip4_addrs(n: usize) -> Vec<Multiaddr> {
+        (0..n)
+            .map(|i| {
+                format!("/ip4/203.0.113.{}/tcp/1634", i + 1)
+                    .parse()
+                    .expect("valid multiaddr")
+            })
+            .collect()
+    }
+
+    /// A large entry: dns name plus a /p2p/ suffix, as advertised addresses
+    /// carry in practice.
+    fn big_addrs(n: usize) -> Vec<Multiaddr> {
+        let peer_id = PeerId::random();
+        (0..n)
+            .map(|i| {
+                format!(
+                    "/dns4/node-{i:04}.very-long-swarm-hostname.example.org/tcp/1634/p2p/{peer_id}"
+                )
+                .parse()
+                .expect("valid multiaddr")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn small_set_passes_unchanged() {
+        let addrs = ip4_addrs(3);
+        assert_eq!(bound_advertised(addrs.clone(), 0), addrs);
+    }
+
+    #[test]
+    fn count_cap_binds() {
+        let addrs = ip4_addrs(MAX_MULTIADDRS_PER_PEER + 10);
+        let bounded = bound_advertised(addrs.clone(), 0);
+        assert_eq!(bounded.len(), MAX_MULTIADDRS_PER_PEER);
+        assert_eq!(bounded, addrs[..MAX_MULTIADDRS_PER_PEER]);
+    }
+
+    #[test]
+    fn byte_budget_binds_before_count_cap() {
+        let addrs = big_addrs(MAX_MULTIADDRS_PER_PEER);
+        let bounded = bound_advertised(addrs.clone(), 0);
+        assert!(!bounded.is_empty());
+        assert!(bounded.len() < MAX_MULTIADDRS_PER_PEER);
+        // The serialized block fits the budget left after the fixed fields.
+        let budget = MAX_HANDSHAKE_BUFFER_SIZE - FRAME_FIXED_BUDGET;
+        assert!(serialize_multiaddrs(&bounded).len() <= budget);
+        // Prefix truncation: the survivors are the head of the input.
+        assert_eq!(bounded, addrs[..bounded.len()]);
+    }
+
+    #[test]
+    fn welcome_message_shrinks_the_budget() {
+        let addrs = big_addrs(MAX_MULTIADDRS_PER_PEER);
+        let without = bound_advertised(addrs.clone(), 0).len();
+        let with = bound_advertised(addrs, 400).len();
+        assert!(with < without);
+    }
+
+    #[test]
+    fn non_empty_input_never_bounds_to_empty() {
+        // Even a zero budget keeps the first address: the signed record must
+        // carry at least one multiaddr.
+        let addrs = big_addrs(3);
+        let bounded = bound_advertised(addrs.clone(), MAX_HANDSHAKE_BUFFER_SIZE);
+        assert_eq!(bounded, addrs[..1]);
+    }
+
+    #[test]
+    fn bounding_is_deterministic() {
+        let addrs = big_addrs(MAX_MULTIADDRS_PER_PEER);
+        assert_eq!(
+            bound_advertised(addrs.clone(), 0),
+            bound_advertised(addrs, 0)
+        );
     }
 }

--- a/crates/swarm/net/handshake/src/behaviour.rs
+++ b/crates/swarm/net/handshake/src/behaviour.rs
@@ -22,6 +22,7 @@ use vertex_net_peer_registry::ConnectionDirection;
 
 use crate::{
     AddressProvider, HandshakeError, HandshakeInfo, SharedAdmissionControl,
+    address::bound_advertised,
     admission::default_admission_control,
     cache::{CachedSelfRecord, SELF_RECORD_REFRESH_INTERVAL, fingerprint, needs_resign},
     handler::{HandshakeCommand, HandshakeConfig, HandshakeHandler, HandshakeHandlerEvent},
@@ -85,10 +86,12 @@ where
     /// `remote_addr`, reusing the cache when the advertised address set is
     /// unchanged and fresh.
     ///
-    /// Resolves the scope-filtered, ordered advertised set for the peer. An
-    /// empty set yields `None`: the protocol then signs a last-resort record
-    /// over just the peer-observed address during the exchange. A non-empty set
-    /// is fingerprinted; if the fingerprint matches a cached record still inside
+    /// Resolves the scope-filtered, trust-ordered advertised set for the peer
+    /// and bounds it before signing (see `bound_advertised`), so the frame
+    /// always fits a conformant peer's decode buffer. An empty set yields
+    /// `None`: the protocol then signs a last-resort record over just the
+    /// peer-observed address during the exchange. A non-empty set is
+    /// fingerprinted; if the fingerprint matches a cached record still inside
     /// [`SELF_RECORD_REFRESH_INTERVAL`] the cached record is cloned (same
     /// timestamp, same signature), otherwise the record is re-signed with a
     /// current timestamp and cached. Concurrent misses single-flight under the
@@ -97,6 +100,17 @@ where
         let addrs = self.address_provider.addresses_for_peer(remote_addr);
         if addrs.is_empty() {
             return None;
+        }
+
+        let welcome_bytes = self.identity.welcome_message().map_or(0, str::len);
+        let full_len = addrs.len();
+        let addrs = bound_advertised(addrs, welcome_bytes);
+        if addrs.len() < full_len {
+            debug!(
+                advertised = addrs.len(),
+                dropped = full_len - addrs.len(),
+                "advertised address set bounded before signing"
+            );
         }
 
         let fp = fingerprint(&addrs);
@@ -377,6 +391,51 @@ mod tests {
             first.multiaddrs(),
             other.multiaddrs(),
             "a different advertised set yields a different record"
+        );
+    }
+
+    #[test]
+    fn oversized_advertised_set_signs_bounded_record_that_fits_the_frame() {
+        use quick_protobuf::MessageWrite;
+        use vertex_swarm_api::SwarmSpec as _;
+        use vertex_swarm_peer::{MAX_MULTIADDRS_PER_PEER, SwarmNodeType};
+
+        let peer_id = PeerId::random();
+        let addrs: Vec<Multiaddr> = (0..40)
+            .map(|i| {
+                format!(
+                    "/dns4/node-{i:04}.very-long-swarm-hostname.example.org/tcp/1634/p2p/{peer_id}"
+                )
+                .parse()
+                .expect("valid multiaddr")
+            })
+            .collect();
+        let behaviour = behaviour(addrs);
+        let remote = addr("/ip4/198.51.100.4/tcp/1634");
+
+        let record = behaviour
+            .cached_self_record(&remote)
+            .expect("a bounded set still signs, never errors");
+        assert!(!record.multiaddrs().is_empty());
+        assert!(record.multiaddrs().len() <= MAX_MULTIADDRS_PER_PEER);
+
+        // The bounded record encodes into a synack that fits the decode
+        // buffer, even alongside a maximum-length ASCII welcome message and
+        // the echoed observed multiaddr.
+        let welcome = "w".repeat(140);
+        let observed = remote.with(libp2p::multiaddr::Protocol::P2p(peer_id));
+        let synack = crate::codec::encode_synack(
+            &observed,
+            &record,
+            SwarmNodeType::Storer,
+            &welcome,
+            behaviour.identity.spec().network_id(),
+        );
+        assert!(
+            synack.get_size() <= crate::MAX_HANDSHAKE_BUFFER_SIZE,
+            "synack of {} bytes exceeds the {} byte frame buffer",
+            synack.get_size(),
+            crate::MAX_HANDSHAKE_BUFFER_SIZE
         );
     }
 

--- a/crates/swarm/net/handshake/src/lib.rs
+++ b/crates/swarm/net/handshake/src/lib.rs
@@ -25,6 +25,14 @@
 //!   signature-recovery work is spent on it) and fails the upgrade with
 //!   [`HandshakeError::UnexpectedExchange`], a protocol violation the topology
 //!   answers by dropping the connection.
+//! - The advertised multiaddr set is bounded before the self record is signed
+//!   (see `bound_advertised`): at most `MAX_MULTIADDRS_PER_PEER` entries, and a
+//!   serialized block small enough that the whole frame fits a conformant
+//!   peer's decode buffer. The frame limit is enforced on decode by both sides,
+//!   so an unbounded local set (accumulated listen or verified-external
+//!   addresses) would produce a record every peer silently rejects. Bounding is
+//!   deterministic prefix truncation of the trust-ordered set, never an encode
+//!   error.
 
 use std::time::Duration;
 
@@ -70,6 +78,11 @@ pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 ///
 /// Enforced on decode in the codec; an over-long message fails the handshake.
 const MAX_WELCOME_MESSAGE_CHARS: usize = 140;
+
+/// Maximum size for handshake message buffers, enforced on decode by the
+/// framed codec. The advertised-address bound is derived from it so an
+/// outbound frame always fits a conformant peer's buffer.
+pub(crate) const MAX_HANDSHAKE_BUFFER_SIZE: usize = 1024;
 
 /// Information from a completed handshake.
 #[derive(Clone, Debug)]

--- a/crates/swarm/net/handshake/src/protocol.rs
+++ b/crates/swarm/net/handshake/src/protocol.rs
@@ -10,10 +10,7 @@ use vertex_swarm_spec::SwarmSpec;
 use crate::admission::{AdmissionDecision, ConnectionDirection};
 use crate::codec::{decode_ack, decode_syn, decode_synack, encode_ack, encode_syn, encode_synack};
 use crate::metrics::HandshakeMetrics;
-use crate::{HandshakeError, HandshakeInfo, SharedAdmissionControl};
-
-/// Maximum size for handshake message buffers.
-const MAX_HANDSHAKE_BUFFER_SIZE: usize = 1024;
+use crate::{HandshakeError, HandshakeInfo, MAX_HANDSHAKE_BUFFER_SIZE, SharedAdmissionControl};
 
 type Framed = FramedProto<MAX_HANDSHAKE_BUFFER_SIZE>;
 

--- a/crates/swarm/peers/peer/src/lib.rs
+++ b/crates/swarm/peers/peer/src/lib.rs
@@ -16,7 +16,7 @@ pub mod swarm_peer;
 pub mod timestamp_policy;
 
 pub use error::SwarmPeerError;
-pub use serde_multiaddr::{deserialize_multiaddrs, serialize_multiaddrs};
+pub use serde_multiaddr::{MAX_MULTIADDRS_PER_PEER, deserialize_multiaddrs, serialize_multiaddrs};
 pub use swarm_peer::{Nonce, SwarmPeer, SwarmPeerWire, Timestamp};
 pub use timestamp_policy::{
     MAX_CLOCK_SKEW, MIN_UPDATE_INTERVAL, TimestampRejection, check_timestamp,

--- a/crates/swarm/peers/peer/src/serde_multiaddr.rs
+++ b/crates/swarm/peers/peer/src/serde_multiaddr.rs
@@ -21,8 +21,9 @@ const MULTIADDR_LIST_PREFIX: u8 = 0x99;
 /// carrying more is rejected whole, so a peer cannot inflate resident table
 /// memory or amplify dial fan-out by flooding fabricated addresses. Matches the
 /// reference wire cap, so a conformant peer (which advertises a handful) is
-/// never rejected.
-pub(crate) const MAX_MULTIADDRS_PER_PEER: usize = 20;
+/// never rejected. Outbound record producers must bound their advertised set to
+/// this cap or their own record is rejected by every conformant peer.
+pub const MAX_MULTIADDRS_PER_PEER: usize = 20;
 
 /// Serialize multiaddrs to bytes.
 ///

--- a/crates/swarm/topology/src/nat_discovery.rs
+++ b/crates/swarm/topology/src/nat_discovery.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
 use parking_lot::Mutex;
+use strum::IntoEnumIterator;
 use tracing::{debug, info, warn};
 use vertex_net_local::{
     AddressScope, IpCapability, LocalCapabilities, advertise_filter, classify_multiaddr,
@@ -21,6 +22,28 @@ fn strip_peer_id(addr: &Multiaddr) -> Multiaddr {
     addr.iter()
         .filter(|p| !matches!(p, Protocol::P2p(_)))
         .collect()
+}
+
+/// Total order within a trust tier: IPv6 before IPv4, then byte order. The
+/// byte tie-break keeps the advertised list stable across restarts regardless
+/// of set iteration order, so an unchanged node re-signs an unchanged record.
+fn tier_order(a: &Multiaddr, b: &Multiaddr) -> std::cmp::Ordering {
+    family_order(a, b).then_with(|| a.cmp(b))
+}
+
+/// Trust tier of a locally advertised address. Variant order is advertisement
+/// priority: higher tiers lead the signed record, and because the handshake
+/// bounds the set by prefix truncation before signing, they also survive
+/// bounding longest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum::EnumIter)]
+pub(crate) enum AddressTrust {
+    /// Operator-configured static address; explicit intent outranks any
+    /// machine-derived signal.
+    Configured,
+    /// Confirmed reachable by AutoNAT v2 dial-back or a UPnP port mapping.
+    Verified,
+    /// Public-scope listen address, assumed reachable but unverified.
+    AssumedPublic,
 }
 
 /// Manages local addresses for advertisement during handshake.
@@ -214,60 +237,65 @@ impl LocalAddressManager {
     }
 
     /// Select addresses to advertise to peer during handshake, filtered by peer
-    /// scope and ordered by likely reachability.
+    /// scope and ordered by trust tier.
     ///
     /// Does NOT include observed addresses. The handshake signs this set as-is
     /// into a cacheable, peer-independent record and only falls back to the
     /// peer-observed address when this set is empty.
     ///
-    /// The advertised list is built in reachability tiers and then ordered:
-    /// 1. verified-reachable addresses (AutoNAT v2 / UPnP confirmed external),
-    /// 2. public listen addresses,
-    /// 3. static NAT addresses,
-    ///
-    /// and within each tier IPv6 leads IPv4. A peer reads this order as a hint
-    /// only; its own dial preference may reorder families, so leading with
-    /// verified-reachable IPv6 helps without removing any address a peer could
-    /// otherwise use.
+    /// The advertised list is built in [`AddressTrust`] order (configured
+    /// static, then verified external, then public listen), and within each
+    /// tier IPv6 leads IPv4. A peer reads this order as a hint only; its own
+    /// dial preference may reorder families. The order also decides which
+    /// addresses survive the handshake's pre-encoding bound, so the
+    /// operator-configured tier is never truncated in favour of an assumed one.
     pub fn addresses_for_peer(&self, peer_addr: &Multiaddr) -> Vec<Multiaddr> {
         let peer_scope = classify_multiaddr(peer_addr).unwrap_or(AddressScope::Public);
 
-        // Tier 1: verified external addresses (public-scope by construction).
-        // Scope-filter consistently with the rest so they never leak to a
-        // loopback/private peer they do not apply to.
-        let confirmed = self.confirmed_external_addrs.lock();
-        let mut verified = advertise_filter(confirmed.iter(), peer_scope, Some(peer_addr));
-        drop(confirmed);
-
-        // Tier 2: public (or scope-appropriate) listen addresses.
-        let mut listen_addrs = self.local.addresses_for_scope(peer_scope, Some(peer_addr));
-
-        // Tier 3: static NAT addresses for non-loopback peers.
-        let mut nat_addrs: Vec<Multiaddr> = self
-            .nat_addrs
-            .iter()
-            .filter(|_| peer_scope != AddressScope::Loopback)
-            .cloned()
-            .collect();
-
-        // Tier is the primary key; family (IPv6 before IPv4) is the secondary
-        // key within a tier. Stable-sort each tier independently, then chain in
-        // tier order, so a global family sort never reorders across tiers.
-        verified.sort_by(family_order);
-        listen_addrs.sort_by(family_order);
-        nat_addrs.sort_by(family_order);
-
+        // Trust tier is the primary key; family (IPv6 before IPv4) then byte
+        // order is the key within a tier. Sort each tier independently, then
+        // chain in tier order, so a global sort never reorders across tiers.
         // Deduplicate across tiers, preserving tier order.
         let mut seen = HashSet::new();
-        let addrs: Vec<Multiaddr> = verified
-            .into_iter()
-            .chain(listen_addrs)
-            .chain(nat_addrs)
+        let addrs: Vec<Multiaddr> = AddressTrust::iter()
+            .flat_map(|trust| {
+                let mut addrs = self.tier_addresses(trust, peer_scope, peer_addr);
+                addrs.sort_by(tier_order);
+                addrs
+            })
             .filter(|addr| seen.insert(addr.clone()))
             .collect();
 
         // Append /p2p/{local_peer_id} to all addresses
         self.with_peer_id(addrs)
+    }
+
+    /// Addresses in one trust tier, scope-filtered for the peer.
+    fn tier_addresses(
+        &self,
+        trust: AddressTrust,
+        peer_scope: AddressScope,
+        peer_addr: &Multiaddr,
+    ) -> Vec<Multiaddr> {
+        match trust {
+            // Static addresses are for non-loopback peers.
+            AddressTrust::Configured => self
+                .nat_addrs
+                .iter()
+                .filter(|_| peer_scope != AddressScope::Loopback)
+                .cloned()
+                .collect(),
+            // Verified external addresses are public-scope by construction.
+            // Scope-filter consistently with the rest so they never leak to a
+            // loopback/private peer they do not apply to.
+            AddressTrust::Verified => {
+                let confirmed = self.confirmed_external_addrs.lock();
+                advertise_filter(confirmed.iter(), peer_scope, Some(peer_addr))
+            }
+            AddressTrust::AssumedPublic => {
+                self.local.addresses_for_scope(peer_scope, Some(peer_addr))
+            }
+        }
     }
 
     /// Append /p2p/{local_peer_id} to addresses if local PeerId is set.
@@ -283,32 +311,29 @@ impl LocalAddressManager {
             .collect()
     }
 
-    /// All known addresses, ordered by likely reachability.
+    /// All known addresses, ordered by trust tier.
     ///
-    /// Tiers mirror [`Self::addresses_for_peer`]: verified external addresses,
-    /// then listen addresses, then static NAT addresses, with IPv6 leading IPv4
-    /// within each tier. No peer-scope filter is applied here; this is the full
-    /// local view.
+    /// Tiers mirror [`Self::addresses_for_peer`]: [`AddressTrust`] order with
+    /// IPv6 leading IPv4 within each tier. No peer-scope filter is applied
+    /// here; this is the full local view.
     pub fn all_addresses(&self) -> Vec<Multiaddr> {
-        let mut verified: Vec<Multiaddr> = self
-            .confirmed_external_addrs
-            .lock()
-            .iter()
-            .cloned()
-            .collect();
-        let mut listen_addrs = self.local.listen_addrs();
-        let mut nat_addrs = self.nat_addrs.clone();
-
-        verified.sort_by(family_order);
-        listen_addrs.sort_by(family_order);
-        nat_addrs.sort_by(family_order);
-
         // Deduplicate across tiers, preserving tier order.
         let mut seen = HashSet::new();
-        verified
-            .into_iter()
-            .chain(listen_addrs)
-            .chain(nat_addrs)
+        AddressTrust::iter()
+            .flat_map(|trust| {
+                let mut addrs = match trust {
+                    AddressTrust::Configured => self.nat_addrs.clone(),
+                    AddressTrust::Verified => self
+                        .confirmed_external_addrs
+                        .lock()
+                        .iter()
+                        .cloned()
+                        .collect(),
+                    AddressTrust::AssumedPublic => self.local.listen_addrs(),
+                };
+                addrs.sort_by(tier_order);
+                addrs
+            })
             .filter(|addr| seen.insert(addr.clone()))
             .collect()
     }
@@ -431,38 +456,38 @@ mod tests {
     }
 
     #[test]
-    fn test_addresses_for_peer_verified_first_then_ipv6_within_tier() {
+    fn test_addresses_for_peer_trust_order_then_ipv6_within_tier() {
         let local = Arc::new(LocalCapabilities::new());
-        // Public listen addresses, both families.
+        // Public listen addresses (assumed-public tier), both families.
         local.on_new_listen_addr(parse_addr("/ip4/8.8.4.4/tcp/1634"));
         local.on_new_listen_addr(parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"));
 
-        // Static NAT address (tier 3).
+        // Configured static address (highest tier).
         let nat = parse_addr("/ip4/198.51.100.9/tcp/1634");
         let manager = LocalAddressManager::new(local, vec![nat]);
 
-        // Verified external addresses (tier 1), both families.
+        // Verified external addresses (middle tier), both families.
         manager.on_external_addr_confirmed(&parse_addr("/ip4/203.0.113.7/tcp/1634"));
         manager.on_external_addr_confirmed(&parse_addr("/ip6/2001:db8::7/tcp/1634"));
 
         let public_peer = parse_addr("/ip4/8.8.8.8/tcp/5000");
         let addrs = manager.addresses_for_peer(&public_peer);
 
-        // Tier ordering: verified before listen before NAT.
+        // Trust ordering: configured before verified before assumed-public.
+        let configured_v4 = position_of(&addrs, "198.51.100.9").unwrap();
         let verified_v6 = position_of(&addrs, "2001:db8::7").unwrap();
         let verified_v4 = position_of(&addrs, "203.0.113.7").unwrap();
         let listen_v6 = position_of(&addrs, "2606:4700:4700::1111").unwrap();
         let listen_v4 = position_of(&addrs, "8.8.4.4").unwrap();
-        let nat_v4 = position_of(&addrs, "198.51.100.9").unwrap();
 
-        // Within tier 1: IPv6 before IPv4.
+        // Configured tier entirely before verified.
+        assert!(configured_v4 < verified_v6);
+        // Within the verified tier: IPv6 before IPv4.
         assert!(verified_v6 < verified_v4);
-        // Tier 1 entirely before tier 2.
+        // Verified tier entirely before assumed-public.
         assert!(verified_v4 < listen_v6);
-        // Within tier 2: IPv6 before IPv4.
+        // Within the assumed-public tier: IPv6 before IPv4.
         assert!(listen_v6 < listen_v4);
-        // Tier 2 entirely before tier 3.
-        assert!(listen_v4 < nat_v4);
     }
 
     #[test]
@@ -514,7 +539,7 @@ mod tests {
     }
 
     #[test]
-    fn test_all_addresses_orders_verified_first_then_ipv6() {
+    fn test_all_addresses_orders_by_trust_then_ipv6() {
         let local = Arc::new(LocalCapabilities::new());
         local.on_new_listen_addr(parse_addr("/ip4/8.8.4.4/tcp/1634"));
         local.on_new_listen_addr(parse_addr("/ip6/2606:4700:4700::1111/tcp/1634"));
@@ -526,15 +551,42 @@ mod tests {
 
         let all = manager.all_addresses();
 
+        let configured_v4 = position_of(&all, "198.51.100.9").unwrap();
         let verified_v6 = position_of(&all, "2001:db8::7").unwrap();
         let listen_v6 = position_of(&all, "2606:4700:4700::1111").unwrap();
         let listen_v4 = position_of(&all, "8.8.4.4").unwrap();
-        let nat_v4 = position_of(&all, "198.51.100.9").unwrap();
 
-        // Verified tier first, listen tier IPv6-before-IPv4, NAT tier last.
+        // Configured tier first, then verified, then the assumed-public
+        // listen tier IPv6-before-IPv4.
+        assert!(configured_v4 < verified_v6);
         assert!(verified_v6 < listen_v6);
         assert!(listen_v6 < listen_v4);
-        assert!(listen_v4 < nat_v4);
+    }
+
+    #[test]
+    fn test_within_tier_order_is_deterministic() {
+        // Verified addresses live in a set with randomized iteration order;
+        // the byte tie-break makes the advertised order independent of it, so
+        // an unchanged node advertises a stable list.
+        let build = || {
+            let manager = create_manager(vec![]);
+            for i in [7, 3, 9, 1] {
+                manager.on_external_addr_confirmed(&parse_addr(&format!(
+                    "/ip4/203.0.113.{i}/tcp/1634"
+                )));
+            }
+            manager.addresses_for_peer(&parse_addr("/ip4/8.8.8.8/tcp/5000"))
+        };
+
+        let addrs = build();
+        assert_eq!(addrs, build());
+
+        // Within the tier the order is byte order.
+        let positions: Vec<usize> = [1, 3, 7, 9]
+            .iter()
+            .map(|i| position_of(&addrs, &format!("203.0.113.{i}")).unwrap())
+            .collect();
+        assert!(positions.windows(2).all(|w| w[0] < w[1]));
     }
 
     #[test]

--- a/docs/networking/address-management.md
+++ b/docs/networking/address-management.md
@@ -49,12 +49,17 @@ Uses the `netdev` crate supporting Linux, macOS, Windows, Android, iOS, and BSDs
 
 Manages address selection for the Swarm handshake protocol. Located in `vertex-swarm-topology::nat_discovery`.
 
-### Address Sources
+### Address Sources and Trust Tiers
 
-| Source | Priority | Description |
-|--------|----------|-------------|
-| NAT | Highest | Static addresses configured via `--nat-addr` |
-| Listen | Normal | Addresses from libp2p we're listening on |
+Advertised addresses are ordered by the `AddressTrust` tier of their source, highest first. Within a tier the order is IPv6 before IPv4, then byte order, so an unchanged node advertises a stable list (and re-signs an unchanged record) across restarts.
+
+| Trust tier | Source | Description |
+|------------|--------|-------------|
+| `Configured` | Static addresses from `--network.nat-addr` | Explicit operator intent; leads the record and is never truncated in favour of a lower tier |
+| `Verified` | AutoNAT v2 dial-back / UPnP confirmed external | Machine-proven reachable, reversible on expiry |
+| `AssumedPublic` | Public-scope libp2p listen addresses | Assumed reachable, unverified |
+
+The tier order also decides what survives the handshake's pre-encoding bound (see "What we put in our signed record" below): bounding truncates from the low-trust tail.
 
 ### Scope-Based Selection
 
@@ -127,7 +132,7 @@ Two hard boundaries keep this safe:
 NAT-mapped addresses contain ephemeral ports that are connection-specific. Each inbound connection gets a different port assignment from the NAT, so the port reported by peer A only works for the A-to-us connection. If we advertise it to peer C via hive gossip, peer C cannot use it because the NAT mapping does not exist for C. Storing and advertising these addresses causes:
 
 1. **Unbounded growth** - each new connection adds another ephemeral port variant
-2. **Handshake encoding overflow** - too many multiaddrs exceed the 2048-byte protobuf buffer
+2. **Handshake frame overflow** - too many multiaddrs push the frame past the 1024-byte handshake buffer, which conformant peers enforce on decode (along with a 20-multiaddr record cap), so the record would be rejected whole
 3. **Network pollution** - hive gossip propagates unreachable addresses to all peers
 
 ### What Bee Does
@@ -144,11 +149,12 @@ This is what makes the NAT'd outbound-only case clean: such a node runs as a `Cl
 
 ### What we put in our signed record
 
-The record we sign during the handshake is what a full-node peer stores and gossips, so it must be both non-empty (for bee) and free of unreachable junk (to avoid polluting hive). We build it from our scope-filtered advertised addresses (the shared `advertise_filter` rule in `vertex-net-local`, also used by identify) and append the peer-observed address only when it is trustworthy:
+The record we sign during the handshake is what a full-node peer stores and gossips, so it must be both non-empty (for bee) and free of unreachable junk (to avoid polluting hive). We build it from our scope-filtered advertised addresses (the shared `advertise_filter` rule in `vertex-net-local`, also used by identify), ordered by trust tier. The peer-observed address never enters a non-empty record - it stays peer-independent so the signed record can be cached and reused byte-identically across handshakes:
 
-- **Inbound** connection: the peer dialed our actual listen address and reached it, so the observed address is genuinely reachable (this is how a port-forwarded node learns its public address without static config). We append it.
-- **Outbound** connection: the observed address is our ephemeral NAT source port, connection-specific and useless to other peers. We do not append it.
-- **Last resort**: a NAT'd, outbound-only node with no real address still needs one entry to satisfy bee. It includes the observed address. For a `Client` this is harmless (the record is never gossiped). For a `Storer` it means the node is unreachable and would advertise an undialable address, so the handshake logs an operator warning; the entry is transient and is superseded once AutoNAT v2 / UPnP / a static NAT address provides a real one (the newer-timestamp record wins, see the gossip conflict-resolution path).
+- **Last resort only**: a NAT'd, outbound-only node with no real address still needs one entry to satisfy bee, so it signs a record over just the peer-observed address. For a `Client` this is harmless (the record is never gossiped). For a `Storer` it means the node is unreachable and would advertise an undialable address, so the handshake logs an operator warning; the entry is transient and is superseded once AutoNAT v2 / UPnP / a static NAT address provides a real one (the newer-timestamp record wins, see the gossip conflict-resolution path).
+- The NAT-discovery role the inbound observed address used to serve (a port-forwarded node learning its public address) is covered by AutoNAT v2 plus advertising confirmed-external addresses.
+
+**Pre-encoding bound**: before signing, the advertised set is bounded (`bound_advertised` in `vertex-swarm-net-handshake`) to at most 20 multiaddrs (the record cap conformant peers enforce on decode) and to a serialized size that keeps the whole frame inside the 1024-byte handshake buffer after the fixed fields and the welcome message. Bounding is deterministic prefix truncation of the trust-ordered set - the low-trust tail is dropped first, a non-empty set never bounds to empty, and encoding never errors. Without this, a node that accumulated many public-scope addresses (rotating IPv6 privacy addresses, multihoming, long-lived verified externals) would sign a record every conformant peer silently rejects.
 
 ### IPv6 vs IPv4
 


### PR DESCRIPTION
## What

Names the trust hierarchy behind advertised-address selection and bounds the advertised set before the handshake self record is signed. `AddressTrust` (`Configured > Verified > AssumedPublic`) now drives the ordering in the topology address manager, promoting operator-configured static addresses from last place to the top tier, with a byte-order tie-break within tiers so an unchanged node advertises a stable list across restarts. The handshake bounds the trust-ordered set before signing: at most the 20-multiaddr record cap conformant peers enforce on decode, and a serialized size that keeps the whole frame inside the 1024-byte handshake buffer after the fixed fields and the welcome message. Bounding is deterministic prefix truncation, never an encode error, and a non-empty set never bounds to empty.

## Why

Closes #73. Nothing bounded the outbound record: encoding never checks size, so a node that accumulated many public-scope addresses (rotating IPv6 privacy addresses, multihoming, long-lived verified externals) signed a record every conformant peer silently rejected on decode - self-isolation with no local error. The bound fixes that, and it is what makes the hierarchy real rather than a rename: truncation cuts from the low-trust tail, and the previous implicit order placed operator-configured addresses at the tail, so they would have been dropped first. No wire change: only which addresses fill the record changes; the block layout, signature scheme, and proto fields are untouched, and the pinned cross-implementation vectors pass unchanged.

## Testing

- `cargo nextest run -p vertex-swarm-peer -p vertex-swarm-net-handshake -p vertex-swarm-topology -p vertex-swarm-node` (477/477 after linearizing onto the observed-address car), including the pinned handshake interop vectors proving byte-identical signing, new tier-order and determinism tests, and new bound tests covering the count cap, the byte budget, welcome-message interaction, the never-empty guarantee, and a frame-size proof that a bounded record encodes under the buffer
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings` (full workspace)
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node` (the CI client-cone wasm gate)

## Notes

The last of the three adopted children keeping epic #681 open; with #834 and #836 merged this completes the adopted list.

AI Assistance: Claude Code (Fable 5) used for the implementation and this description.

