### PR TITLE
ci: retry the Pages deploy when the backend refuses transiently

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,8 +63,20 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment_retry.outputs.page_url || steps.deployment.outputs.page_url }}
     steps:
+      # The Pages backend intermittently refuses a deployment created while the
+      # previous one is still propagating ("Deployment failed, try again later"),
+      # which happens under rapid successive pushes to main. One paused retry
+      # absorbs it; the job fails only if both attempts fail.
       - name: Deploy to GitHub Pages
         id: deployment
+        continue-on-error: true
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5
+      - name: Pause before retrying the deploy
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 60
+      - name: Deploy to GitHub Pages (retry)
+        id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5


### PR DESCRIPTION
## What

Retry the Pages deploy once, after a one-minute pause, when the first attempt fails. The first `deploy-pages` step becomes `continue-on-error`, a pause step runs only on its failure, and a second `deploy-pages` attempt follows; the job fails only if both attempts fail. The environment URL falls back across the two steps. No trigger, permission, or concurrency change: runs stay serialized without cancelling an in-flight deploy, and the build still verifies every push.

## Why

Closes #839. Ten of the last forty `pages.yml` runs failed with one identical signature: the build succeeds, `actions/deploy-pages` creates the deployment, and the Pages backend reports "Deployment failed, try again later" about five seconds later. The failures cluster in periods of rapid successive pushes to main (a merge train) and interleave with successes, and the same commit deploys fine on re-run, so this is upstream backend contention, not an artifact or build problem. The action polls deployment status but never retries a failed deployment, so a single transient refusal failed the whole run.

## Testing

- `nix-shell -p actionlint --run 'actionlint .github/workflows/pages.yml'` (clean)
- The retry path is exercised by the next transient backend refusal; the success path is the workflow's normal run on merge, which this change leaves as a single attempt.

AI Assistance: Claude Code (Fable 5) used for the diagnosis and the fix.
