### PR TITLE
feat(swarm-node): expose a transport injection seam

### DIFF
--- a/crates/swarm/node/src/lib.rs
+++ b/crates/swarm/node/src/lib.rs
@@ -28,8 +28,9 @@ pub use node::{
     AssemblyContext, BaseNode, BuiltInfrastructure, ClientCore, ClientCoreCtx, ClientCoreTail,
     ClientLauncher, ClientNode, ClientNodeBuilder, ClientNodeParts, ClientTailParams,
     IpLimitExceeded, LaunchedClient, NativeChunkProvider, NativeDispatchEngine, NodeBuildError,
-    NodeRunParts, NodeRunTaskFn, PseudosettleWiring, RunTaskFn, SettlementEventSenders,
-    SharedAccounting, assemble_client_core, single_task, spawn_client_command_bridge,
+    NodeRunParts, NodeRunTaskFn, NodeTransport, PseudosettleWiring, RunTaskFn,
+    SettlementEventSenders, SharedAccounting, TransportOverride, assemble_client_core, single_task,
+    spawn_client_command_bridge,
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use node::{BootNode, BootNodeBuilder};

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -279,6 +279,7 @@ pub struct BootNodeBuilder<I: SwarmIdentity + Clone> {
     identity: I,
     infra: Option<BuiltInfrastructure<I>>,
     kademlia_config: Option<KademliaConfig>,
+    transport: Option<super::builder::TransportOverride>,
 }
 
 impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
@@ -287,6 +288,7 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
             identity,
             infra: None,
             kademlia_config: None,
+            transport: None,
         }
     }
 
@@ -297,6 +299,14 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
 
     pub fn with_kademlia_config(mut self, kademlia_config: KademliaConfig) -> Self {
         self.kademlia_config = Some(kademlia_config);
+        self
+    }
+
+    /// Replace the default TCP transport with an injected one. Tests supply a
+    /// memory transport so paused time drives the node; production leaves this
+    /// unset and keeps the default stack.
+    pub fn with_transport(mut self, transport: super::builder::TransportOverride) -> Self {
+        self.transport = Some(transport);
         self
     }
 }
@@ -338,6 +348,7 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
             infra,
             network_config,
             "Bootnode",
+            self.transport,
             move |pk, topology| {
                 let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
                 BootnodeBehaviour::from_parts(

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -3,7 +3,10 @@
 use std::time::Duration;
 
 use eyre::{Result, WrapErr};
-use libp2p::{Multiaddr, Swarm, identity::PublicKey, swarm::NetworkBehaviour};
+use libp2p::core::muxing::StreamMuxerBox;
+use libp2p::core::transport::Boxed;
+use libp2p::identity::Keypair;
+use libp2p::{Multiaddr, PeerId, Swarm, identity::PublicKey, swarm::NetworkBehaviour};
 use tracing::{info, warn};
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_swarm_api::{
@@ -36,6 +39,26 @@ pub(crate) fn identify_config(
 }
 
 pub(crate) type PeerStore = std::sync::Arc<dyn PeerSnapshotStore<PeerSnapshot>>;
+
+/// An authenticated, multiplexed transport the swarm dials and listens on.
+/// Names the output shape a [`TransportOverride`] must produce; the default
+/// native (TCP with DNS) and browser (secure websocket) stacks build one of
+/// these internally.
+pub type NodeTransport = Boxed<(PeerId, StreamMuxerBox)>;
+
+/// Swarm transport injection point. Given the freshly generated node keypair,
+/// yields the transport the swarm runs over. Production leaves this unset and
+/// gets the default stack unchanged; an in-process test supplies a
+/// channel-based memory transport so paused time drives the whole node.
+///
+/// Only the native swarm assembly consults it; the browser stack is fixed.
+pub type TransportOverride = Box<
+    dyn FnOnce(
+            &Keypair,
+        )
+            -> std::result::Result<NodeTransport, Box<dyn std::error::Error + Send + Sync>>
+        + Send,
+>;
 
 /// Pre-built infrastructure components ready for swarm assembly.
 pub struct BuiltInfrastructure<I: SwarmIdentity + Clone> {
@@ -190,6 +213,7 @@ pub(crate) async fn build_base_node<I, B, C, F>(
     mut infra: BuiltInfrastructure<I>,
     network_config: &C,
     node_type_name: &str,
+    transport: Option<TransportOverride>,
     behaviour_fn: F,
 ) -> Result<BaseNode<I, B>>
 where
@@ -218,7 +242,7 @@ where
         ))
     };
 
-    let swarm = build_swarm(idle_timeout, behaviour_builder)?;
+    let swarm = build_swarm(idle_timeout, transport, behaviour_builder)?;
 
     let local_peer_id = *swarm.local_peer_id();
     info!(%local_peer_id, "{} peer ID", node_type_name);
@@ -236,10 +260,20 @@ where
     })
 }
 
-/// Assemble the libp2p [`Swarm`] for native targets over a TCP transport with
-/// DNS resolution, Noise authentication, and Yamux multiplexing.
+/// Assemble the libp2p [`Swarm`] for native targets.
+///
+/// With no override this is a TCP transport with DNS resolution, Noise
+/// authentication, and Yamux multiplexing; production always takes this path,
+/// so its bytes are unchanged. A [`TransportOverride`] (tests only) replaces
+/// the TCP stack wholesale with the supplied transport, which is why
+/// [`TransportCapability::platform`](vertex_net_local::TransportCapability::platform)
+/// keeps mirroring the default TCP stack rather than the override.
 #[cfg(not(target_arch = "wasm32"))]
-fn build_swarm<B, F>(idle_timeout: Duration, behaviour_builder: F) -> Result<Swarm<B>>
+fn build_swarm<B, F>(
+    idle_timeout: Duration,
+    transport: Option<TransportOverride>,
+    behaviour_builder: F,
+) -> Result<Swarm<B>>
 where
     B: NetworkBehaviour,
     F: FnOnce(
@@ -247,6 +281,16 @@ where
     ) -> std::result::Result<B, Box<dyn std::error::Error + Send + Sync>>,
 {
     use libp2p::{SwarmBuilder, noise, tcp, yamux};
+
+    if let Some(transport) = transport {
+        let swarm = SwarmBuilder::with_new_identity()
+            .with_tokio()
+            .with_other_transport(transport)?
+            .with_behaviour(behaviour_builder)?
+            .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_timeout))
+            .build();
+        return Ok(swarm);
+    }
 
     let swarm = SwarmBuilder::with_new_identity()
         .with_tokio()
@@ -284,7 +328,11 @@ where
 /// regular `V1` response, so this stays wire-compatible; it only removes the
 /// synchronous flush barrier the browser transport cannot satisfy.
 #[cfg(target_arch = "wasm32")]
-fn build_swarm<B, F>(idle_timeout: Duration, behaviour_builder: F) -> Result<Swarm<B>>
+fn build_swarm<B, F>(
+    idle_timeout: Duration,
+    transport: Option<TransportOverride>,
+    behaviour_builder: F,
+) -> Result<Swarm<B>>
 where
     B: NetworkBehaviour,
     F: FnOnce(
@@ -292,6 +340,10 @@ where
     ) -> std::result::Result<B, Box<dyn std::error::Error + Send + Sync>>,
 {
     use libp2p::{SwarmBuilder, Transport as _, core::upgrade::Version, noise, yamux};
+
+    // The browser assembles a fixed websocket stack with no injection point,
+    // so an override (only ever supplied by native tests) is ignored here.
+    let _ = transport;
 
     let swarm = SwarmBuilder::with_new_identity()
         .with_wasm_bindgen()
@@ -310,6 +362,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use libp2p::identity::Keypair;
     use vertex_swarm_api::SwarmNetworkConfig;
@@ -332,5 +385,73 @@ mod tests {
         let network = NetworkConfig::default();
         let config = identify_config(pk, network.agent_version());
         assert_eq!(config.agent_version(), identify::AGENT_VERSION);
+    }
+
+    /// The injection seam: a supplied transport replaces the default TCP stack
+    /// wholesale, so two swarms built through it connect over channel-based
+    /// memory addresses with no OS sockets bound.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn injected_memory_transport_connects_two_swarms() {
+        use std::time::Duration;
+
+        use futures::StreamExt;
+        use libp2p::swarm::{SwarmEvent, dummy};
+        use libp2p::{Multiaddr, Transport as _, core::upgrade::Version, noise, yamux};
+
+        use super::{TransportOverride, build_swarm};
+
+        fn memory_override() -> TransportOverride {
+            Box::new(|keypair: &Keypair| {
+                let transport = libp2p::core::transport::MemoryTransport::default()
+                    .upgrade(Version::V1)
+                    .authenticate(noise::Config::new(keypair)?)
+                    .multiplex(yamux::Config::default())
+                    .boxed();
+                Ok(transport)
+            })
+        }
+
+        let idle = Duration::from_secs(5);
+        let mut listener = build_swarm(idle, Some(memory_override()), |_kp| Ok(dummy::Behaviour))
+            .expect("listener swarm builds over the injected transport");
+        let mut dialer = build_swarm(idle, Some(memory_override()), |_kp| Ok(dummy::Behaviour))
+            .expect("dialer swarm builds over the injected transport");
+
+        listener
+            .listen_on("/memory/0".parse::<Multiaddr>().unwrap())
+            .expect("listen on a memory address");
+
+        let listen_addr = loop {
+            match listener.select_next_some().await {
+                SwarmEvent::NewListenAddr { address, .. } => break address,
+                _ => continue,
+            }
+        };
+
+        dialer.dial(listen_addr).expect("dial the memory address");
+
+        let mut dialer_up = false;
+        let mut listener_up = false;
+        let converge = async {
+            while !(dialer_up && listener_up) {
+                tokio::select! {
+                    event = listener.select_next_some() => {
+                        if let SwarmEvent::ConnectionEstablished { .. } = event {
+                            listener_up = true;
+                        }
+                    }
+                    event = dialer.select_next_some() => {
+                        if let SwarmEvent::ConnectionEstablished { .. } = event {
+                            dialer_up = true;
+                        }
+                    }
+                }
+            }
+        };
+
+        tokio::time::timeout(Duration::from_secs(5), converge)
+            .await
+            .expect("both swarms establish the memory connection");
     }
 }

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -96,23 +96,30 @@ async fn build_client_base<I, C>(
     infra: BuiltInfrastructure<I>,
     network_config: &C,
     store: Arc<dyn SwarmLocalStore>,
+    transport: Option<super::builder::TransportOverride>,
 ) -> Result<BaseNode<I, ClientNodeBehaviour<I>>>
 where
     I: SwarmIdentity + Clone,
     C: SwarmNetworkConfig,
 {
     let limits = super::base::build_admission_limits(network_config);
-    super::builder::build_base_node(infra, network_config, "Client node", move |pk, topology| {
-        let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
-        ClientNodeBehaviour::from_parts(
-            pk,
-            topology,
-            nat,
-            limits,
-            store,
-            network_config.agent_version(),
-        )
-    })
+    super::builder::build_base_node(
+        infra,
+        network_config,
+        "Client node",
+        transport,
+        move |pk, topology| {
+            let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
+            ClientNodeBehaviour::from_parts(
+                pk,
+                topology,
+                nat,
+                limits,
+                store,
+                network_config.agent_version(),
+            )
+        },
+    )
     .await
 }
 
@@ -443,6 +450,7 @@ pub struct ClientNodeBuilder<I: SwarmIdentity + Clone> {
     infra: Option<BuiltInfrastructure<I>>,
     kademlia_config: Option<KademliaConfig>,
     store: Option<Arc<dyn SwarmLocalStore>>,
+    transport: Option<super::builder::TransportOverride>,
     pseudosettle_event_tx: Option<mpsc::UnboundedSender<PseudosettleEvent>>,
     #[cfg(feature = "swap")]
     swap_event_tx: Option<mpsc::UnboundedSender<crate::protocol::SwapEvent>>,
@@ -455,6 +463,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
             infra: None,
             kademlia_config: None,
             store: None,
+            transport: None,
             pseudosettle_event_tx: None,
             #[cfg(feature = "swap")]
             swap_event_tx: None,
@@ -475,6 +484,14 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
 
     pub fn with_kademlia_config(mut self, kademlia_config: KademliaConfig) -> Self {
         self.kademlia_config = Some(kademlia_config);
+        self
+    }
+
+    /// Replace the default TCP transport with an injected one. Tests supply a
+    /// memory transport so paused time drives the node; production leaves this
+    /// unset and keeps the default stack.
+    pub fn with_transport(mut self, transport: super::builder::TransportOverride) -> Self {
+        self.transport = Some(transport);
         self
     }
 
@@ -531,7 +548,8 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
             ))
         });
 
-        let mut base = build_client_base(infra, network_config, Arc::clone(&store)).await?;
+        let mut base =
+            build_client_base(infra, network_config, Arc::clone(&store), self.transport).await?;
 
         base.swarm
             .behaviour()

--- a/crates/swarm/node/src/node/mod.rs
+++ b/crates/swarm/node/src/node/mod.rs
@@ -34,7 +34,7 @@ pub(crate) mod task;
 pub use base::BaseNode;
 #[cfg(not(target_arch = "wasm32"))]
 pub use bootnode::{BootNode, BootNodeBuilder};
-pub use builder::BuiltInfrastructure;
+pub use builder::{BuiltInfrastructure, NodeTransport, TransportOverride};
 pub use client::{ClientNode, ClientNodeBuilder};
 pub use core::{
     AssemblyContext, ClientCore, ClientCoreCtx, ClientCoreTail, ClientNodeParts, ClientTailParams,

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -158,24 +158,31 @@ async fn build_storer_base<I, C>(
     network_config: &C,
     store: Arc<dyn SwarmLocalStore>,
     pullsync_storage: Arc<dyn PullStorage>,
+    transport: Option<super::builder::TransportOverride>,
 ) -> Result<BaseNode<I, StorerNodeBehaviour<I>>>
 where
     I: SwarmIdentity + Clone,
     C: SwarmNetworkConfig,
 {
     let limits = super::base::build_admission_limits(network_config);
-    super::builder::build_base_node(infra, network_config, "Storer node", move |pk, topology| {
-        let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
-        StorerNodeBehaviour::from_parts(
-            pk,
-            topology,
-            nat,
-            limits,
-            store,
-            pullsync_storage,
-            network_config.agent_version(),
-        )
-    })
+    super::builder::build_base_node(
+        infra,
+        network_config,
+        "Storer node",
+        transport,
+        move |pk, topology| {
+            let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
+            StorerNodeBehaviour::from_parts(
+                pk,
+                topology,
+                nat,
+                limits,
+                store,
+                pullsync_storage,
+                network_config.agent_version(),
+            )
+        },
+    )
     .await
 }
 
@@ -586,6 +593,7 @@ pub struct StorerNodeBuilder<I: SwarmIdentity + Clone> {
     kademlia_config: Option<KademliaConfig>,
     store: Option<Arc<dyn SwarmLocalStore>>,
     pullsync_storage: Option<Arc<dyn PullStorage>>,
+    transport: Option<super::builder::TransportOverride>,
     pseudosettle_event_tx: Option<mpsc::UnboundedSender<PseudosettleEvent>>,
     #[cfg(feature = "swap")]
     swap_event_tx: Option<mpsc::UnboundedSender<crate::protocol::SwapEvent>>,
@@ -598,6 +606,7 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
             kademlia_config: None,
             store: None,
             pullsync_storage: None,
+            transport: None,
             pseudosettle_event_tx: None,
             #[cfg(feature = "swap")]
             swap_event_tx: None,
@@ -618,6 +627,14 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
     /// Inject the reserve snapshot the inbound pullsync syncer serves from.
     pub fn with_pullsync_storage(mut self, storage: Arc<dyn PullStorage>) -> Self {
         self.pullsync_storage = Some(storage);
+        self
+    }
+
+    /// Replace the default TCP transport with an injected one. Tests supply a
+    /// memory transport so paused time drives the node; production leaves this
+    /// unset and keeps the default stack.
+    pub fn with_transport(mut self, transport: super::builder::TransportOverride) -> Self {
+        self.transport = Some(transport);
         self
     }
 
@@ -678,8 +695,14 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
             ))
         });
 
-        let mut base =
-            build_storer_base(infra, network_config, Arc::clone(&store), pullsync_storage).await?;
+        let mut base = build_storer_base(
+            infra,
+            network_config,
+            Arc::clone(&store),
+            pullsync_storage,
+            self.transport,
+        )
+        .await?;
 
         base.swarm
             .behaviour()

--- a/crates/swarm/test-utils/src/cluster.rs
+++ b/crates/swarm/test-utils/src/cluster.rs
@@ -13,12 +13,13 @@
 //! - **Persistent identity.** Each node is constructed from a single
 //!   [`Identity`] generated up front and cloned into the builder. This
 //!   models a bootnode whose overlay address survives restarts.
-//! - **TCP transport.** The current `BootNodeBuilder` / `ClientNodeBuilder`
-//!   hardwire `libp2p::tcp::tokio::Transport` (see
-//!   `vertex_swarm_node::node::builder::build_base_node`). Hermetic memory
-//!   transport would require a public builder hook that does not exist in
-//!   `main` yet — the workaround is to bind on `127.0.0.1` with
-//!   OS-assigned ports.
+//! - **TCP transport.** The node builders expose a
+//!   [`with_transport`](vertex_swarm_node::ClientNodeBuilder::with_transport)
+//!   seam that swaps the default TCP stack for an injected one (a memory
+//!   transport for hermetic tests). This harness still binds `127.0.0.1` with
+//!   OS-assigned ports because adopting the memory transport also needs the
+//!   dial-eligibility filter to admit `/memory/` addresses, tracked
+//!   separately.
 //! - **Wall-clock timeouts.** Because real TCP I/O is involved, integration
 //!   tests use bounded `tokio::time::timeout` rather than
 //!   `tokio::time::pause()`; pause would freeze timers without freezing the


### PR DESCRIPTION
## What

Exposes a transport injection seam so in-process tests can run node clusters over a channel-based memory transport instead of real loopback TCP.

Adds two public type aliases in `vertex-swarm-node`'s builder module: `NodeTransport` (the authenticated, multiplexed `Boxed<(PeerId, StreamMuxerBox)>` the swarm runs over) and `TransportOverride` (a boxed `FnOnce(&Keypair) -> Result<NodeTransport, ...> + Send`). `build_swarm` now takes `Option<TransportOverride>`: when `Some` it uses `SwarmBuilder::with_other_transport`, when `None` it takes exactly today's TCP+DNS+Noise+Yamux path, so production wire behaviour is byte-unchanged. The override is threaded from all three node builders (`ClientNodeBuilder`, `BootNodeBuilder`, `StorerNodeBuilder` via a new `with_transport` setter) through `build_base_node` into `build_swarm`.

## Why

Closes #842

No cargo feature is added, since this is an injection point rather than a capability. `TransportCapability::platform()` in `vertex-net-local` is left untouched (still Tcp/SecureWebsocket) because the default stack is unchanged, which is documented at the `build_swarm` rustdoc. `vertex-swarm-builder` stays libp2p-free (it only drives the node builders and names no transport type), which is why the seam lives in the node crate rather than the builder crate per the issue title. The memory-transport constructor lives only in a `#[cfg(test)]` proof in `builder.rs` so no test dependency leaks into shipped cones. The wasm `build_swarm` ignores the override since the browser stack is fixed. The cluster harness module doc has also been refreshed, removing a stale "hook does not exist yet" note and an em-dash, to point at the new seam and record that full cluster adoption additionally needs the dial-eligibility filter to admit `/memory/` addresses.

## Testing

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --all-targets --all-features -- -D warnings`: pass, workspace clean.
- `cargo nextest run -p vertex-swarm-node -p vertex-swarm-test-utils`: 164 tests run, 164 passed, 0 skipped, including a new internal test that builds two swarms through the seam over `MemoryTransport` and asserts they establish a connection on `/memory` addresses with no OS sockets (a TCP fallback would fail `listen_on(/memory/0)`).
- `just check-cone`: pass (ffi free of observability/storer cone; default vertex free of storer and swap/chain cone).
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`: pass.
- Changed-file sweeps for em-dashes, "underlay", issue references, and reference-implementation mentions: none introduced by this diff.

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Opus 4.8 implementation and review, Sonnet 5 PR text) under human direction.
