### PR TITLE
test(swarm-test-utils): add canonical storage and reserve mocks

### DIFF
--- a/crates/swarm/net/handshake/src/cache.rs
+++ b/crates/swarm/net/handshake/src/cache.rs
@@ -84,18 +84,15 @@ mod tests {
         // The record body is irrelevant to `needs_resign`; only the fingerprint
         // and timestamp drive the decision. Build a placeholder via a real sign
         // so the type is well formed.
-        use vertex_swarm_identity::Identity;
-        use vertex_swarm_peer::{SwarmNodeType, SwarmPeer};
-        use vertex_swarm_test_utils::test_spec_isolated as test_spec;
+        use vertex_swarm_peer::SwarmNodeType;
+        use vertex_swarm_test_utils::{test_signed_swarm_peer, test_spec_isolated as test_spec};
 
-        let identity = Identity::random(test_spec(), SwarmNodeType::Storer);
-        let record = SwarmPeer::sign(
-            &identity,
+        let record = test_signed_swarm_peer(
+            test_spec(),
+            SwarmNodeType::Storer,
             vec!["/ip4/127.0.0.1/tcp/1634".parse().expect("valid multiaddr")],
             Timestamp::from_seconds(signed_at.max(1)),
-            None,
-        )
-        .expect("sign record");
+        );
         CachedSelfRecord {
             fingerprint,
             signed_at: Timestamp::from_seconds(signed_at),

--- a/crates/swarm/net/handshake/src/codec/ack.rs
+++ b/crates/swarm/net/handshake/src/codec/ack.rs
@@ -115,15 +115,16 @@ mod tests {
     use super::*;
     use libp2p::Multiaddr;
     use vertex_swarm_api::SwarmSpec;
-    use vertex_swarm_identity::Identity;
-    use vertex_swarm_test_utils::test_spec_isolated as test_spec;
+    use vertex_swarm_test_utils::{test_signed_swarm_peer, test_spec_isolated as test_spec};
 
     fn create_test_peer() -> SwarmPeer {
-        let spec = test_spec();
-        let identity = Identity::random(spec.clone(), SwarmNodeType::Storer);
         let multiaddr: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
-        SwarmPeer::sign(&identity, vec![multiaddr], Timestamp::now(), None)
-            .expect("should sign peer")
+        test_signed_swarm_peer(
+            test_spec(),
+            SwarmNodeType::Storer,
+            vec![multiaddr],
+            Timestamp::now(),
+        )
     }
 
     #[test]

--- a/crates/swarm/net/handshake/src/codec/synack.rs
+++ b/crates/swarm/net/handshake/src/codec/synack.rs
@@ -46,17 +46,19 @@ pub(crate) fn encode_synack(
 mod tests {
     use super::*;
     use vertex_swarm_api::SwarmSpec;
-    use vertex_swarm_identity::Identity;
     use vertex_swarm_peer::Timestamp;
-    use vertex_swarm_test_utils::test_spec_isolated as test_spec;
+    use vertex_swarm_test_utils::{test_signed_swarm_peer, test_spec_isolated as test_spec};
 
     fn create_test_data() -> (Multiaddr, SwarmPeer, NetworkId) {
         let spec = test_spec();
-        let identity = Identity::random(spec.clone(), SwarmNodeType::Storer);
         let observed: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
         let peer_addr: Multiaddr = "/ip4/192.168.1.1/tcp/5678".parse().unwrap();
-        let peer = SwarmPeer::sign(&identity, vec![peer_addr], Timestamp::now(), None)
-            .expect("should sign peer");
+        let peer = test_signed_swarm_peer(
+            spec.clone(),
+            SwarmNodeType::Storer,
+            vec![peer_addr],
+            Timestamp::now(),
+        );
         (observed, peer, spec.network_id())
     }
 

--- a/crates/swarm/test-utils/src/lib.rs
+++ b/crates/swarm/test-utils/src/lib.rs
@@ -28,15 +28,17 @@ pub mod cluster;
 pub mod identity;
 pub mod peer;
 pub mod spec;
+pub mod storage;
 pub mod topology;
 
 // Re-exports for convenience
 pub use identity::{MockIdentity, test_identity, test_identity_arc, test_identity_with_type};
 pub use peer::{
-    make_overlay, make_swarm_peer_minimal, test_overlay, test_peer, test_peer_id, test_swarm_peer,
-    test_swarm_peer_with_timestamp,
+    make_overlay, make_swarm_peer_minimal, test_overlay, test_peer, test_peer_id,
+    test_signed_swarm_peer, test_swarm_peer, test_swarm_peer_with_timestamp,
 };
 pub use spec::{TEST_NETWORK_ID, test_spec, test_spec_isolated, test_spec_with_network_id};
+pub use storage::{MockReserve, MockStorage};
 pub use topology::MockTopology;
 
 // Re-export commonly used types for convenience

--- a/crates/swarm/test-utils/src/peer.rs
+++ b/crates/swarm/test-utils/src/peer.rs
@@ -1,10 +1,15 @@
 //! Test helpers for creating peer fixtures.
 
+use std::sync::Arc;
+
 use alloy_primitives::{Address, B256, Signature, U256};
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId};
 use nectar_primitives::SwarmAddress;
+use vertex_swarm_api::SwarmNodeType;
+use vertex_swarm_identity::Identity;
 use vertex_swarm_peer::{SwarmPeer, Timestamp};
 use vertex_swarm_primitives::{Nonce, OverlayAddress};
+use vertex_swarm_spec::Spec;
 
 /// Create a test overlay address from a single byte.
 ///
@@ -116,6 +121,22 @@ pub fn test_swarm_peer_with_timestamp(n: u8, timestamp: i64, port: u16) -> Swarm
         None,
         Address::ZERO,
     )
+}
+
+/// Sign a `SwarmPeer` record with a fresh random identity under `spec`.
+///
+/// Unlike [`test_swarm_peer`], the returned record carries a real EIP-191
+/// signature that re-parses under `spec.network_id()`, so it round-trips
+/// through the handshake codec. The overlay is derived from the random signer,
+/// not caller-controlled.
+pub fn test_signed_swarm_peer(
+    spec: Arc<Spec>,
+    node_type: SwarmNodeType,
+    multiaddrs: Vec<Multiaddr>,
+    timestamp: Timestamp,
+) -> SwarmPeer {
+    let identity = Identity::random(spec, node_type);
+    SwarmPeer::sign(&identity, multiaddrs, timestamp, None).expect("sign test peer")
 }
 
 /// Create a SwarmAddress with a specific first byte.

--- a/crates/swarm/test-utils/src/storage.rs
+++ b/crates/swarm/test-utils/src/storage.rs
@@ -1,0 +1,221 @@
+//! Configurable storage and reserve mocks for behaviour tests.
+//!
+//! Two shapes cover the recurring stubs. [`MockStorage`] is a read-only reserve
+//! snapshot for one bin: it serves a fixed set of pre-stamped chunks and the
+//! per-bin cursor index the pullsync server reads, so its `put` is a no-op.
+//! [`MockReserve`] is a mutable point store with a configurable responsibility
+//! radius, for the ingest path that actually persists what it accepts.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use alloy_primitives::B256;
+use nectar_primitives::{Bin, ChunkAddress, ProximityOrder};
+use vertex_swarm_api::{
+    BatchId, BinCursorStore, BinScanItem, PullStorage, ReserveStore, StampedChunk, StorageRadius,
+    SwarmLocalStore, SwarmResult,
+};
+use vertex_swarm_primitives::CachedChunk;
+
+/// A read-only reserve snapshot for a single bin.
+///
+/// Holds an ordered set of pre-stamped chunks plus their per-bin insertion
+/// sequence, serving both the client-store read path and the pullsync server
+/// snapshot. `put`/`remove` are no-ops: the snapshot is fixed at construction,
+/// so a test drives it entirely through [`with_chunks`](Self::with_chunks).
+#[derive(Default)]
+pub struct MockStorage {
+    bin: u8,
+    epoch: u64,
+    items: Vec<BinScanItem>,
+    chunks: HashMap<ChunkAddress, StampedChunk>,
+}
+
+impl MockStorage {
+    /// Snapshot `chunks` into `bin` under reserve `epoch`, assigning each a
+    /// one-based insertion sequence in the given order.
+    pub fn with_chunks(bin: Bin, epoch: u64, chunks: Vec<StampedChunk>) -> Self {
+        let mut items = Vec::with_capacity(chunks.len());
+        let mut index = HashMap::with_capacity(chunks.len());
+        for (i, chunk) in chunks.into_iter().enumerate() {
+            let address = *chunk.address();
+            let stamp_hash = B256::from_slice(address.as_slice());
+            items.push(BinScanItem {
+                seq: i as u64 + 1,
+                address,
+                batch_id: BatchId::repeat_byte(0xbb),
+                stamp_hash,
+            });
+            index.insert(address, chunk);
+        }
+        Self {
+            bin: bin.get(),
+            epoch,
+            items,
+            chunks: index,
+        }
+    }
+}
+
+impl SwarmLocalStore for MockStorage {
+    fn put(&self, _chunk: CachedChunk) -> SwarmResult<()> {
+        Ok(())
+    }
+
+    fn get(&self, address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
+        Ok(self.chunks.get(address).cloned().map(CachedChunk::from))
+    }
+
+    fn contains(&self, address: &ChunkAddress) -> bool {
+        self.chunks.contains_key(address)
+    }
+
+    fn remove(&self, _address: &ChunkAddress) -> SwarmResult<()> {
+        Ok(())
+    }
+}
+
+impl ReserveStore for MockStorage {
+    fn storage_radius(&self) -> StorageRadius {
+        StorageRadius::ZERO
+    }
+
+    fn is_responsible_for(&self, _address: &ChunkAddress) -> bool {
+        true
+    }
+
+    fn count(&self) -> SwarmResult<u64> {
+        Ok(self.items.len() as u64)
+    }
+
+    fn capacity(&self) -> u64 {
+        u64::MAX
+    }
+
+    fn count_in(&self, _po: ProximityOrder) -> SwarmResult<u64> {
+        Ok(0)
+    }
+
+    fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>> {
+        Ok(None)
+    }
+
+    fn evict_from_bin(&self, _bin: Bin, _max: u64) -> SwarmResult<u64> {
+        Ok(0)
+    }
+
+    fn evict_batch(&self, _batch: BatchId, _up_to_bin: Option<Bin>, _max: u64) -> SwarmResult<u64> {
+        Ok(0)
+    }
+}
+
+impl BinCursorStore for MockStorage {
+    fn bin_cursor(&self, bin: Bin) -> SwarmResult<u64> {
+        if bin.get() == self.bin {
+            Ok(self.items.last().map(|i| i.seq).unwrap_or(0))
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn scan_bin_from<'a>(
+        &'a self,
+        bin: Bin,
+        start_seq: u64,
+    ) -> SwarmResult<Box<dyn Iterator<Item = SwarmResult<BinScanItem>> + Send + 'a>> {
+        let items: Vec<BinScanItem> = if bin.get() == self.bin {
+            self.items
+                .iter()
+                .filter(|i| i.seq >= start_seq)
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        Ok(Box::new(items.into_iter().map(Ok)))
+    }
+}
+
+impl PullStorage for MockStorage {
+    fn reserve_epoch(&self) -> u64 {
+        self.epoch
+    }
+}
+
+/// A mutable point store with a configurable responsibility radius.
+///
+/// Unlike [`MockStorage`], `put`/`remove` mutate the backing map, so the ingest
+/// path can be asserted against what was stored. `is_responsible_for` and
+/// `storage_radius` return the fixed values chosen at [`new`](Self::new),
+/// letting a test exercise both the responsible and the forwarding branch.
+pub struct MockReserve {
+    chunks: Mutex<HashMap<ChunkAddress, CachedChunk>>,
+    responsible: bool,
+    radius: StorageRadius,
+}
+
+impl MockReserve {
+    /// A reserve that reports `responsible` for every address and advertises
+    /// `radius`.
+    pub fn new(responsible: bool, radius: StorageRadius) -> Self {
+        Self {
+            chunks: Mutex::new(HashMap::new()),
+            responsible,
+            radius,
+        }
+    }
+}
+
+impl SwarmLocalStore for MockReserve {
+    fn put(&self, chunk: CachedChunk) -> SwarmResult<()> {
+        self.chunks.lock().unwrap().insert(*chunk.address(), chunk);
+        Ok(())
+    }
+
+    fn get(&self, address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
+        Ok(self.chunks.lock().unwrap().get(address).cloned())
+    }
+
+    fn contains(&self, address: &ChunkAddress) -> bool {
+        self.chunks.lock().unwrap().contains_key(address)
+    }
+
+    fn remove(&self, address: &ChunkAddress) -> SwarmResult<()> {
+        self.chunks.lock().unwrap().remove(address);
+        Ok(())
+    }
+}
+
+impl ReserveStore for MockReserve {
+    fn storage_radius(&self) -> StorageRadius {
+        self.radius
+    }
+
+    fn is_responsible_for(&self, _address: &ChunkAddress) -> bool {
+        self.responsible
+    }
+
+    fn count(&self) -> SwarmResult<u64> {
+        Ok(self.chunks.lock().unwrap().len() as u64)
+    }
+
+    fn capacity(&self) -> u64 {
+        u64::MAX
+    }
+
+    fn count_in(&self, _po: ProximityOrder) -> SwarmResult<u64> {
+        Ok(0)
+    }
+
+    fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>> {
+        Ok(None)
+    }
+
+    fn evict_from_bin(&self, _bin: Bin, _max: u64) -> SwarmResult<u64> {
+        Ok(0)
+    }
+
+    fn evict_batch(&self, _batch: BatchId, _up_to_bin: Option<Bin>, _max: u64) -> SwarmResult<u64> {
+        Ok(0)
+    }
+}


### PR DESCRIPTION
## What
Adds two canonical, configurable mocks to `crates/swarm/test-utils` in a new `storage.rs` module, re-exported from `lib.rs` alongside `MockIdentity` and `MockTopology`: `MockStorage` is a read-only single-bin reserve snapshot (`SwarmLocalStore` + `ReserveStore` + `BinCursorStore` + `PullStorage`) built via `with_chunks(bin, epoch, chunks)` with a `Default`, and `MockReserve` is a mutable point store with a configurable responsible flag and radius via `new(responsible, radius)`. Also adds `test_signed_swarm_peer` to the peer-fixture family and routes the ack, synack, and cache handshake fixtures through it.
## Why
Closes #844. Three hand-rolled stubs (`MockStorage`/`MockPullStorage` in `storer-behaviour/tests/{composite,round_trip}.rs` and `MockReserve` in `node/src/protocol/behaviour_tests.rs`) duplicated the same reserve and point-store logic; consolidating them into canonical, configurable mocks in test-utils removes that duplication and gives future test suites a single, correct implementation to build on. The consuming suites are deliberately not migrated in this PR, tracked as a separate later issue, but the new mocks match the existing constructor and `Default` surfaces so that swap is mechanical. Separately, the three handshake fixtures inlined `Identity::random` + `SwarmPeer::sign` copies to build a signed record; `test_signed_swarm_peer` replaces them with one shared helper, since the existing `test_swarm_peer` helper emits an unverifiable fake signature and cannot be reused for handshake round-trips.
## Testing
`cargo fmt --all --check` clean. `cargo clippy --all-targets --all-features -- -D warnings` clean. `cargo nextest run` for the two touched crates (`vertex-swarm-net-handshake`, `vertex-swarm-test-utils`): 56 passed, 0 failed. Verified the new mocks are byte-for-byte equivalent in logic to the three hand-rolled stubs they replace, against `origin/main`. Swept changed files for em-dashes, `underlay`, issue references, and inline bee/reference-implementation mentions: all empty. Swept commit messages for attribution footers: empty.

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Opus 4.8 implementation and review, Sonnet 5 PR text) under human direction.
