### PR TITLE
chore(deps): bump libp2p fork pins to the merged swarm-test rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,7 +4158,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "bytes",
  "either",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "either",
  "fnv",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4418,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "futures-bounded 0.3.0",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "either",
  "fnv",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "heck",
  "quote",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "async-trait",
  "futures",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4516,7 +4516,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket-websys"
 version = "0.6.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "bytes",
  "futures",
@@ -4546,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "either",
  "futures",
@@ -4878,7 +4878,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "bytes",
  "futures",
@@ -5950,7 +5950,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6756,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=6454fdf3450f91fdbb6e3306daa7a9a4e633c133#6454fdf3450f91fdbb6e3306daa7a9a4e633c133"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
 dependencies = [
  "futures",
  "pin-project",
@@ -9183,6 +9183,7 @@ dependencies = [
  "vertex-swarm-net-headers",
  "vertex-swarm-net-proto",
  "vertex-swarm-primitives",
+ "vertex-swarm-test-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ opentelemetry-appender-tracing = { version = "0.31", features = ["experimental_u
 # WebSocket `bufferedAmount` draining to zero, which stalled the wasm client mid
 # handshake and tore the connection down with `BrokenPipe`. Revisit when the fix is
 # upstreamed and libp2p 0.57 is released.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", features = [
     "tokio",
     "noise",
     "tcp",
@@ -328,13 +328,13 @@ libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91f
 quick-protobuf = "0.8"
 quick-protobuf-codec = "0.3.1"
 asynchronous-codec = "0.7.0"
-libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133" }
-libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133" }
+libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929" }
+libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929" }
 # Browser websocket transport for the wasm client. Dials the bee AutoTLS
 # `/tls/sni/<host>/ws` form; the browser performs TLS and SNI natively. Pinned to
 # the nxm-rs fork for the `poll_flush` browser WebSocket flush fix (see the `libp2p`
 # entry above).
-libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133" }
+libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929" }
 quickcheck = "1.0.3"
 pb-rs = "0.10"
 walkdir = "2.5.0"

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -96,7 +96,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 vertex-tasks = { path = "../../crates/tasks" }
 
 # libp2p Multiaddr only; the trimmed wasm feature set mirrors the node crate.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", default-features = false }
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false }
 
 # wasm-bindgen surface and browser bindings.
 wasm-bindgen = "0.2"

--- a/crates/swarm/client-behaviour/Cargo.toml
+++ b/crates/swarm/client-behaviour/Cargo.toml
@@ -60,7 +60,7 @@ tracing.workspace = true
 libp2p.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -119,7 +119,7 @@ vertex-swarm-storer-behaviour = { workspace = true, optional = true }
 vertex-swarm-puller = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -80,7 +80,7 @@ vertex-net-dnsaddr.workspace = true
 # `vertex-net-dnsaddr-doh` (DNS-over-HTTPS) with the embedded wss snapshot as
 # the fallback.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "6454fdf3450f91fdbb6e3306daa7a9a4e633c133", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false, features = [
     "noise",
     "yamux",
     "macros",


### PR DESCRIPTION
## What

Bumps every nxm-rs/rust-libp2p git pin (workspace root, swarm-demo, and the wasm-specific entries in client-behaviour, node, and topology) from 6454fdf to 570774ff, the merged head of the fork's pinned branch, and refreshes Cargo.lock.

## Why

Closes #841. The fork now carries the swarm-test upgrades this epic needs: a constructor accepting a caller-supplied keypair, memory-only transport constructors, and the predicate and deadline drive helpers (nxm-rs/rust-libp2p#6). This bump makes them available to the harness work that follows.

## Testing

cargo nextest run for the libp2p-swarm-test consumers (vertex-swarm-storer-behaviour, vertex-swarm-node: 154 passed), cargo clippy --all-targets --all-features -D warnings clean, and a wasm32-unknown-unknown build of vertex-swarm-node since the websocket-websys pin moves with the rest.

AI Assistance: Claude Code used for the rev bump, verification, and PR text under human direction.
