### PR TITLE
test(swarm-node,swarm-storer-behaviour): migrate onto harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9292,7 +9292,6 @@ dependencies = [
  "vertex-chain",
  "vertex-metrics",
  "vertex-net-local",
- "vertex-net-peer-registry",
  "vertex-net-peer-store",
  "vertex-node-api",
  "vertex-storage-indexeddb",
@@ -9550,7 +9549,6 @@ dependencies = [
  "alloy-primitives",
  "futures",
  "libp2p",
- "libp2p-swarm-test",
  "metrics",
  "nectar-postage",
  "nectar-primitives",
@@ -9558,7 +9556,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "vertex-net-peer-registry",
  "vertex-net-ratelimiter",
  "vertex-swarm-api",
  "vertex-swarm-client-behaviour",
@@ -9567,6 +9564,7 @@ dependencies = [
  "vertex-swarm-net-headers",
  "vertex-swarm-net-pullsync",
  "vertex-swarm-primitives",
+ "vertex-swarm-test-utils",
  "vertex-tasks",
 ]
 

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -141,9 +141,8 @@ vertex-net-peer-store = { workspace = true, features = ["test-utils"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync", "test-util"] }
-vertex-swarm-test-utils = { workspace = true, features = ["cluster"] }
+vertex-swarm-test-utils = { workspace = true, features = ["cluster", "harness"] }
 vertex-swarm-topology.workspace = true
-vertex-net-peer-registry.workspace = true
 eyre.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 libp2p-swarm-test.workspace = true

--- a/crates/swarm/node/src/protocol/behaviour_tests.rs
+++ b/crates/swarm/node/src/protocol/behaviour_tests.rs
@@ -1,77 +1,36 @@
 //! Behaviour-level integration tests for the re-exported [`ClientBehaviour`]
 //! driven through the node-local [`NetworkForwarder`].
 //!
-//! These exercise the real libp2p handler over `libp2p-swarm-test`: cache
+//! These exercise the real libp2p handler over the swarm-test harness: cache
 //! serving, the stub-forwarder reset paths, storer ingest (store and sign), and
 //! the three-node relay that needs the concrete forwarder. They live in the node
 //! crate because the relay tests construct a `NetworkForwarder` (which couples to
 //! accounting and the outbound `ClientHandle`) over the behaviour the
 //! `vertex-swarm-client-behaviour` crate provides.
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::{B256, Signature};
 use alloy_signer_local::PrivateKeySigner;
 use futures::StreamExt;
-use libp2p::swarm::ConnectionId;
 use libp2p::{PeerId, Swarm};
-use libp2p_swarm_test::SwarmExt;
 use nectar_postage::Stamp;
 use nectar_primitives::{AnyChunk, ContentChunk, SingleOwnerChunk};
 use tokio::sync::oneshot;
-use vertex_net_peer_registry::PeerRegistry;
-use vertex_swarm_api::SwarmLocalStore;
+use vertex_swarm_api::{StorageRadius, SwarmLocalStore};
 use vertex_swarm_localstore::{ChunkStore, Clock};
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk, SwarmNodeType};
+use vertex_swarm_test_utils::MockReserve;
+use vertex_swarm_test_utils::harness::{
+    HarnessNode, NodeContext, connect_and_activate, seeded_identity,
+};
 
 use crate::ChunkTransferError;
 use crate::client_service::RetrievalResult;
 use crate::protocol::{
     BehaviourConfig as Config, ClientBehaviour, ClientCommand, PeerCommand, StubForwarder,
 };
-
-/// Identity registry a test swarm's `ClientBehaviour` reads through, keyed by the
-/// swarm's local peer id so `connect_and_activate` can populate the right side.
-/// Topology is absent in these standalone swarms, so the harness is the writer.
-type IdentityRegistry = Arc<PeerRegistry<OverlayAddress, ()>>;
-
-fn identity_registries() -> &'static Mutex<HashMap<PeerId, IdentityRegistry>> {
-    static REGISTRIES: OnceLock<Mutex<HashMap<PeerId, IdentityRegistry>>> = OnceLock::new();
-    REGISTRIES.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-/// Build a fresh identity registry, register it under `local` for later
-/// population, and return the read view to embed in the behaviour.
-fn register_identity(local: PeerId) -> IdentityRegistry {
-    let registry: IdentityRegistry = Arc::new(PeerRegistry::new());
-    identity_registries()
-        .lock()
-        .expect("registry map poisoned")
-        .insert(local, Arc::clone(&registry));
-    registry
-}
-
-/// Distinct connection ids so a registry that activates several peers keeps its
-/// secondary indices unique.
-fn next_conn_id() -> ConnectionId {
-    static N: AtomicUsize = AtomicUsize::new(1);
-    ConnectionId::new_unchecked(N.fetch_add(1, Ordering::Relaxed))
-}
-
-/// Mark `peer`/`overlay` Active in `owner`'s identity registry, mirroring what
-/// topology's connection registry does at handshake completion.
-fn activate_identity(owner: PeerId, peer: PeerId, overlay: OverlayAddress) {
-    let map = identity_registries().lock().expect("registry map poisoned");
-    let registry = map
-        .get(&owner)
-        .expect("registry registered for owner swarm");
-    let conn = next_conn_id();
-    registry.connected_inbound(peer, conn);
-    registry.activate(peer, conn, overlay);
-}
 
 /// Fixed-instant clock for SOC freshness tests.
 struct FixedClock(i64);
@@ -105,50 +64,50 @@ fn overlay(n: u8) -> OverlayAddress {
     OverlayAddress::from([n; 32])
 }
 
-fn swarm_with_store(store: Arc<dyn SwarmLocalStore>) -> Swarm<ClientBehaviour> {
-    Swarm::new_ephemeral_tokio(move |keypair| {
-        let identity = register_identity(keypair.public().to_peer_id());
+/// Build a client-shaped harness node with a caller-chosen overlay.
+///
+/// The seed fixes the libp2p identity; the overlay is set explicitly so
+/// proximity-sensitive relay tests can place a node while the harness still owns
+/// the connection registry the behaviour reads through `ctx.identities`.
+fn node_with_overlay(
+    seed: u8,
+    overlay: OverlayAddress,
+    build: impl FnOnce(&NodeContext) -> ClientBehaviour,
+) -> HarnessNode<ClientBehaviour> {
+    let mut id = seeded_identity(seed, SwarmNodeType::Client);
+    id.overlay = overlay;
+    HarnessNode::new(&id, build)
+}
+
+/// A cache-only client node carrying `overlay` and serving from `store`.
+fn client_node(
+    seed: u8,
+    overlay: OverlayAddress,
+    store: Arc<dyn SwarmLocalStore>,
+) -> HarnessNode<ClientBehaviour> {
+    node_with_overlay(seed, overlay, move |ctx| {
         ClientBehaviour::new(
             Config::for_role(SwarmNodeType::Client),
             store,
             Arc::new(StubForwarder),
-            identity,
+            ctx.identities.clone(),
         )
     })
 }
 
-/// Connect two client swarms and activate both handlers so the
-/// request/serve path is live.
-async fn connect_and_activate(
-    client: &mut Swarm<ClientBehaviour>,
-    server: &mut Swarm<ClientBehaviour>,
-    client_overlay: OverlayAddress,
-    server_overlay: OverlayAddress,
+/// Activation hook for [`connect_and_activate`]: promote the remote peer to
+/// Active in the behaviour so its request/serve path goes live.
+fn activate_client(
+    behaviour: &mut ClientBehaviour,
+    peer_id: PeerId,
+    overlay: OverlayAddress,
+    node_type: SwarmNodeType,
 ) {
-    let client_peer = *client.local_peer_id();
-    let server_peer = *server.local_peer_id();
-    client.listen().with_memory_addr_external().await;
-    server.listen().with_memory_addr_external().await;
-    client.connect(server).await;
-
-    // Each side's registry maps the other peer, as topology would at handshake.
-    activate_identity(client_peer, server_peer, server_overlay);
-    activate_identity(server_peer, client_peer, client_overlay);
-
-    client
-        .behaviour_mut()
-        .on_command(ClientCommand::ActivatePeer {
-            peer_id: server_peer,
-            overlay: server_overlay,
-            node_type: SwarmNodeType::Client,
-        });
-    server
-        .behaviour_mut()
-        .on_command(ClientCommand::ActivatePeer {
-            peer_id: client_peer,
-            overlay: client_overlay,
-            node_type: SwarmNodeType::Client,
-        });
+    behaviour.on_command(ClientCommand::ActivatePeer {
+        peer_id,
+        overlay,
+        node_type,
+    });
 }
 
 async fn drive_until_retrieved(
@@ -179,23 +138,30 @@ async fn serves_a_content_chunk_from_the_cache() {
         Arc::new(ChunkStore::with_budget(1 << 20, 1_000_000_000));
     server_store.put(chunk.clone().into()).unwrap();
 
-    let mut client = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-    let mut server = swarm_with_store(server_store);
-
     let server_overlay = overlay(2);
-    connect_and_activate(&mut client, &mut server, overlay(1), server_overlay).await;
+    let mut client = client_node(
+        1,
+        overlay(1),
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+    let mut server = client_node(2, server_overlay, server_store);
+
+    connect_and_activate(&mut client, &mut server, activate_client).await;
 
     let (tx, rx) = oneshot::channel();
-    client.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: server_overlay,
-        command: PeerCommand::RetrieveChunk {
-            address,
-            response: tx,
-            originated: true,
-        },
-    });
+    client
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: server_overlay,
+            command: PeerCommand::RetrieveChunk {
+                address,
+                response: tx,
+                originated: true,
+            },
+        });
 
-    let result = drive_until_retrieved(&mut client, &mut server, rx).await;
+    let result = drive_until_retrieved(&mut client.swarm, &mut server.swarm, rx).await;
     let delivered = result.expect("served from cache");
     assert_eq!(*delivered.chunk.address(), address);
     assert_eq!(delivered.chunk, *chunk.chunk());
@@ -214,23 +180,30 @@ async fn serves_a_fresh_soc_from_the_cache() {
     ));
     server_store.put(chunk.clone().into()).unwrap();
 
-    let mut client = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-    let mut server = swarm_with_store(server_store);
-
     let server_overlay = overlay(2);
-    connect_and_activate(&mut client, &mut server, overlay(1), server_overlay).await;
+    let mut client = client_node(
+        1,
+        overlay(1),
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+    let mut server = client_node(2, server_overlay, server_store);
+
+    connect_and_activate(&mut client, &mut server, activate_client).await;
 
     let (tx, rx) = oneshot::channel();
-    client.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: server_overlay,
-        command: PeerCommand::RetrieveChunk {
-            address,
-            response: tx,
-            originated: true,
-        },
-    });
+    client
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: server_overlay,
+            command: PeerCommand::RetrieveChunk {
+                address,
+                response: tx,
+                originated: true,
+            },
+        });
 
-    let delivered = drive_until_retrieved(&mut client, &mut server, rx)
+    let delivered = drive_until_retrieved(&mut client.swarm, &mut server.swarm, rx)
         .await
         .expect("fresh SOC served from cache");
     assert_eq!(delivered.chunk, *chunk.chunk());
@@ -251,23 +224,30 @@ async fn expired_soc_is_not_served_and_resets() {
     ));
     server_store.put(chunk.into()).unwrap();
 
-    let mut client = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-    let mut server = swarm_with_store(server_store);
-
     let server_overlay = overlay(2);
-    connect_and_activate(&mut client, &mut server, overlay(1), server_overlay).await;
+    let mut client = client_node(
+        1,
+        overlay(1),
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+    let mut server = client_node(2, server_overlay, server_store);
+
+    connect_and_activate(&mut client, &mut server, activate_client).await;
 
     let (tx, rx) = oneshot::channel();
-    client.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: server_overlay,
-        command: PeerCommand::RetrieveChunk {
-            address,
-            response: tx,
-            originated: true,
-        },
-    });
+    client
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: server_overlay,
+            command: PeerCommand::RetrieveChunk {
+                address,
+                response: tx,
+                originated: true,
+            },
+        });
 
-    let result = drive_until_retrieved(&mut client, &mut server, rx).await;
+    let result = drive_until_retrieved(&mut client.swarm, &mut server.swarm, rx).await;
     assert!(
         result.is_err(),
         "an expired SOC must not be served; the stream resets so the requester forwards"
@@ -280,23 +260,34 @@ async fn cache_miss_resets_with_stub_forwarder() {
     // serve nor forward, so the substream resets and the requester fails.
     let address = *content_chunk(b"never cached").address();
 
-    let mut client = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-    let mut server = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-
     let server_overlay = overlay(2);
-    connect_and_activate(&mut client, &mut server, overlay(1), server_overlay).await;
+    let mut client = client_node(
+        1,
+        overlay(1),
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+    let mut server = client_node(
+        2,
+        server_overlay,
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+
+    connect_and_activate(&mut client, &mut server, activate_client).await;
 
     let (tx, rx) = oneshot::channel();
-    client.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: server_overlay,
-        command: PeerCommand::RetrieveChunk {
-            address,
-            response: tx,
-            originated: true,
-        },
-    });
+    client
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: server_overlay,
+            command: PeerCommand::RetrieveChunk {
+                address,
+                response: tx,
+                originated: true,
+            },
+        });
 
-    let result = drive_until_retrieved(&mut client, &mut server, rx).await;
+    let result = drive_until_retrieved(&mut client.swarm, &mut server.swarm, rx).await;
     assert!(
         result.is_err(),
         "a cache miss with the stub forwarder must reset the stream"
@@ -309,27 +300,38 @@ async fn inbound_pushsync_resets_with_stub_forwarder() {
     // stub forward fails, the substream resets, and no receipt is signed.
     let chunk = content_chunk(b"pushed chunk");
 
-    let mut client = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-    let mut server = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-
     let server_overlay = overlay(2);
-    connect_and_activate(&mut client, &mut server, overlay(1), server_overlay).await;
+    let mut client = client_node(
+        1,
+        overlay(1),
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+    let mut server = client_node(
+        2,
+        server_overlay,
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+
+    connect_and_activate(&mut client, &mut server, activate_client).await;
 
     let (tx, mut rx) = oneshot::channel();
-    client.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: server_overlay,
-        command: PeerCommand::PushChunk {
-            chunk,
-            response: tx,
-            originated: true,
-        },
-    });
+    client
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: server_overlay,
+            command: PeerCommand::PushChunk {
+                chunk,
+                response: tx,
+                originated: true,
+            },
+        });
 
     let drive = async {
         loop {
             tokio::select! {
-                _ = client.select_next_some() => {}
-                _ = server.select_next_some() => {}
+                _ = client.swarm.select_next_some() => {}
+                _ = server.swarm.select_next_some() => {}
                 res = &mut rx => return res.expect("sender not dropped"),
             }
         }
@@ -348,113 +350,28 @@ async fn inbound_pushsync_resets_with_stub_forwarder() {
 // A storer holds a `StorerCapability`: a responsible delivery is stored and
 // acknowledged with a signed receipt; a non-responsible delivery forwards
 // (verbatim-relay), which resets under the stub forwarder. Both branches run
-// through the real libp2p handler.
+// through the real libp2p handler. The reserve is the canonical `MockReserve`
+// mutable point store: a fixed responsibility flag pins either branch.
 
-/// In-memory `ReserveStore` for the ingest tests. `is_responsible_for` is a
-/// fixed flag so a test can pin either branch; the proximity-axis accounting
-/// methods are stubs since the ingest path only uses `is_responsible_for`,
-/// `put`, and `storage_radius`.
-struct MockReserve {
-    chunks: std::sync::Mutex<
-        std::collections::HashMap<
-            nectar_primitives::ChunkAddress,
-            vertex_swarm_primitives::CachedChunk,
-        >,
-    >,
+/// Storer harness node holding the ingest capability. Returns the node, the
+/// shared reserve (to assert what was stored), the signer and nonce (to assert
+/// the receipt recovers to the storer's overlay).
+///
+/// The node presents as `Client` to the connection registry, matching how a
+/// pusher labels a serving peer; the storer role comes from the behaviour's
+/// `for_role(Storer)` config and its installed capability, not the registry
+/// label.
+fn storer_node(
+    seed: u8,
+    overlay: OverlayAddress,
     responsible: bool,
-    radius: vertex_swarm_api::StorageRadius,
-}
-
-impl MockReserve {
-    fn new(responsible: bool, radius: vertex_swarm_api::StorageRadius) -> Self {
-        Self {
-            chunks: std::sync::Mutex::new(std::collections::HashMap::new()),
-            responsible,
-            radius,
-        }
-    }
-}
-
-impl SwarmLocalStore for MockReserve {
-    fn put(
-        &self,
-        chunk: vertex_swarm_primitives::CachedChunk,
-    ) -> vertex_swarm_api::SwarmResult<()> {
-        self.chunks.lock().unwrap().insert(*chunk.address(), chunk);
-        Ok(())
-    }
-    fn get(
-        &self,
-        address: &nectar_primitives::ChunkAddress,
-    ) -> vertex_swarm_api::SwarmResult<Option<vertex_swarm_primitives::CachedChunk>> {
-        Ok(self.chunks.lock().unwrap().get(address).cloned())
-    }
-    fn contains(&self, address: &nectar_primitives::ChunkAddress) -> bool {
-        self.chunks.lock().unwrap().contains_key(address)
-    }
-    fn remove(
-        &self,
-        address: &nectar_primitives::ChunkAddress,
-    ) -> vertex_swarm_api::SwarmResult<()> {
-        self.chunks.lock().unwrap().remove(address);
-        Ok(())
-    }
-}
-
-impl vertex_swarm_api::ReserveStore for MockReserve {
-    fn storage_radius(&self) -> vertex_swarm_api::StorageRadius {
-        self.radius
-    }
-    fn is_responsible_for(&self, _address: &nectar_primitives::ChunkAddress) -> bool {
-        self.responsible
-    }
-    fn count(&self) -> vertex_swarm_api::SwarmResult<u64> {
-        Ok(self.chunks.lock().unwrap().len() as u64)
-    }
-    fn capacity(&self) -> u64 {
-        u64::MAX
-    }
-    fn count_in(
-        &self,
-        _po: nectar_primitives::ProximityOrder,
-    ) -> vertex_swarm_api::SwarmResult<u64> {
-        Ok(0)
-    }
-    fn evict_furthest(
-        &self,
-    ) -> vertex_swarm_api::SwarmResult<Option<nectar_primitives::ChunkAddress>> {
-        Ok(None)
-    }
-    fn evict_from_bin(
-        &self,
-        _bin: nectar_primitives::Bin,
-        _max: u64,
-    ) -> vertex_swarm_api::SwarmResult<u64> {
-        Ok(0)
-    }
-    fn evict_batch(
-        &self,
-        _batch: vertex_swarm_primitives::BatchId,
-        _up_to_bin: Option<nectar_primitives::Bin>,
-        _max: u64,
-    ) -> vertex_swarm_api::SwarmResult<u64> {
-        Ok(0)
-    }
-}
-
-/// Server swarm holding the storer ingest capability. Returns the swarm, the
-/// shared reserve (to assert what was stored), the signer and nonce (to
-/// assert the receipt recovers to the storer's overlay).
-fn storer_swarm(
-    responsible: bool,
-    radius: vertex_swarm_api::StorageRadius,
+    radius: StorageRadius,
 ) -> (
-    Swarm<ClientBehaviour>,
+    HarnessNode<ClientBehaviour>,
     Arc<MockReserve>,
-    alloy_signer_local::PrivateKeySigner,
+    PrivateKeySigner,
     vertex_swarm_primitives::Nonce,
 ) {
-    use alloy_signer_local::PrivateKeySigner;
     use nectar_primitives::NetworkId;
     use vertex_swarm_identity::Identity;
     use vertex_swarm_primitives::Nonce;
@@ -464,17 +381,16 @@ fn storer_swarm(
     let signer = PrivateKeySigner::random();
     let nonce = Nonce::from([0x5a; 32]);
 
-    let reserve_for_swarm = Arc::clone(&reserve);
-    let signer_for_swarm = signer.clone();
-    let swarm = Swarm::new_ephemeral_tokio(move |keypair| {
-        let identity = register_identity(keypair.public().to_peer_id());
+    let reserve_for_node = Arc::clone(&reserve);
+    let signer_for_node = signer.clone();
+    let node = node_with_overlay(seed, overlay, move |ctx| {
         // The reserve serves on retrieval too, so it is the behaviour's store.
-        let store: Arc<dyn SwarmLocalStore> = Arc::clone(&reserve_for_swarm) as _;
+        let store: Arc<dyn SwarmLocalStore> = Arc::clone(&reserve_for_node) as _;
         let mut behaviour = ClientBehaviour::new(
             Config::for_role(SwarmNodeType::Storer),
             store,
             Arc::new(StubForwarder),
-            identity,
+            ctx.identities.clone(),
         );
         behaviour.set_network_id(NetworkId::MAINNET);
         let spec = Arc::new(
@@ -482,48 +398,54 @@ fn storer_swarm(
                 .network_id(NetworkId::MAINNET.get())
                 .build(),
         );
-        let identity = Identity::new(signer_for_swarm.clone(), nonce, spec, SwarmNodeType::Storer);
+        let identity = Identity::new(signer_for_node.clone(), nonce, spec, SwarmNodeType::Storer);
         let capability = crate::protocol::StorerCapability::new(
-            Arc::clone(&reserve_for_swarm) as Arc<dyn vertex_swarm_api::ReserveStore>,
+            Arc::clone(&reserve_for_node) as Arc<dyn vertex_swarm_api::ReserveStore>,
             Arc::new(identity) as Arc<dyn vertex_swarm_primitives::OverlaySigner + Send + Sync>,
         );
         behaviour.set_storer(capability);
         behaviour
     });
-    (swarm, reserve, signer, nonce)
+    (node, reserve, signer, nonce)
 }
 
 #[tokio::test]
 async fn responsible_storer_stores_and_signs_a_receipt() {
     use nectar_primitives::{NetworkId, compute_overlay};
-    use vertex_swarm_api::StorageRadius;
     use vertex_swarm_primitives::Bin;
 
     let chunk = content_chunk(b"stored by the responsible storer");
     let address = *chunk.address();
     let radius = StorageRadius::new(Bin::new(4).unwrap());
 
-    let (mut storer, reserve, signer, nonce) = storer_swarm(true, radius);
-    let mut pusher = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-
     let storer_overlay = overlay(2);
-    connect_and_activate(&mut pusher, &mut storer, overlay(1), storer_overlay).await;
+    let (mut storer, reserve, signer, nonce) = storer_node(2, storer_overlay, true, radius);
+    let mut pusher = client_node(
+        1,
+        overlay(1),
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+
+    connect_and_activate(&mut pusher, &mut storer, activate_client).await;
 
     let (tx, mut rx) = oneshot::channel();
-    pusher.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: storer_overlay,
-        command: PeerCommand::PushChunk {
-            chunk,
-            response: tx,
-            originated: true,
-        },
-    });
+    pusher
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: storer_overlay,
+            command: PeerCommand::PushChunk {
+                chunk,
+                response: tx,
+                originated: true,
+            },
+        });
 
     let drive = async {
         loop {
             tokio::select! {
-                _ = pusher.select_next_some() => {}
-                _ = storer.select_next_some() => {}
+                _ = pusher.swarm.select_next_some() => {}
+                _ = storer.swarm.select_next_some() => {}
                 res = &mut rx => return res.expect("sender not dropped"),
             }
         }
@@ -550,7 +472,6 @@ async fn responsible_storer_stores_and_signs_a_receipt() {
 
 #[tokio::test]
 async fn non_responsible_storer_forwards_instead_of_storing() {
-    use vertex_swarm_api::StorageRadius;
     use vertex_swarm_primitives::Bin;
 
     // The storer holds the ingest capability but is NOT responsible, so it
@@ -560,27 +481,34 @@ async fn non_responsible_storer_forwards_instead_of_storing() {
     let address = *chunk.address();
     let radius = StorageRadius::new(Bin::new(4).unwrap());
 
-    let (mut storer, reserve, _signer, _nonce) = storer_swarm(false, radius);
-    let mut pusher = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
-
     let storer_overlay = overlay(2);
-    connect_and_activate(&mut pusher, &mut storer, overlay(1), storer_overlay).await;
+    let (mut storer, reserve, _signer, _nonce) = storer_node(2, storer_overlay, false, radius);
+    let mut pusher = client_node(
+        1,
+        overlay(1),
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
+
+    connect_and_activate(&mut pusher, &mut storer, activate_client).await;
 
     let (tx, mut rx) = oneshot::channel();
-    pusher.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: storer_overlay,
-        command: PeerCommand::PushChunk {
-            chunk,
-            response: tx,
-            originated: true,
-        },
-    });
+    pusher
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: storer_overlay,
+            command: PeerCommand::PushChunk {
+                chunk,
+                response: tx,
+                originated: true,
+            },
+        });
 
     let drive = async {
         loop {
             tokio::select! {
-                _ = pusher.select_next_some() => {}
-                _ = storer.select_next_some() => {}
+                _ = pusher.swarm.select_next_some() => {}
+                _ = storer.swarm.select_next_some() => {}
                 res = &mut rx => return res.expect("sender not dropped"),
             }
         }
@@ -656,12 +584,13 @@ fn overlay_at_proximity(
 /// topology) over a `ClientHandle` wired back into B. Returns B and the
 /// receiver carrying B's outbound relay commands.
 fn relay_node(
+    seed: u8,
     store: Arc<dyn SwarmLocalStore>,
     local: OverlayAddress,
     storer: OverlayAddress,
     accounting: Arc<RelayAccounting>,
 ) -> (
-    Swarm<ClientBehaviour>,
+    HarnessNode<ClientBehaviour>,
     tokio::sync::mpsc::Receiver<ClientCommand>,
 ) {
     let (tx, rx) = tokio::sync::mpsc::channel::<ClientCommand>(16);
@@ -680,13 +609,12 @@ fn relay_node(
         crate::NoLatencyHint,
         Arc::new(NoTriggeredSettle),
     );
-    let swarm = Swarm::new_ephemeral_tokio(move |keypair| {
-        let identity = register_identity(keypair.public().to_peer_id());
+    let node = node_with_overlay(seed, local, move |ctx| {
         let mut behaviour = ClientBehaviour::new(
             Config::for_role(SwarmNodeType::Client),
             store,
             Arc::new(StubForwarder),
-            identity,
+            ctx.identities.clone(),
         );
         // Inbound receipts are recovered against this network id; the storer
         // test receipts are ground against it too.
@@ -698,7 +626,7 @@ fn relay_node(
         behaviour.set_forwarder(forwarder);
         behaviour
     });
-    (swarm, rx)
+    (node, rx)
 }
 
 #[tokio::test]
@@ -721,20 +649,25 @@ async fn three_node_retrieval_relays_verifies_and_accounts() {
     c_store.put(chunk.clone().into()).unwrap();
     let b_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
 
-    let mut a = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+    let mut a = client_node(
+        1,
+        a_overlay,
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
     let (mut b, mut b_commands) = relay_node(
+        2,
         Arc::clone(&b_store),
         b_overlay,
         c_overlay,
         Arc::clone(&accounting),
     );
-    let mut c = swarm_with_store(c_store);
+    let mut c = client_node(3, c_overlay, c_store);
 
-    connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
-    connect_and_activate(&mut b, &mut c, b_overlay, c_overlay).await;
+    connect_and_activate(&mut a, &mut b, activate_client).await;
+    connect_and_activate(&mut b, &mut c, activate_client).await;
 
     let (tx, mut rx) = oneshot::channel();
-    a.behaviour_mut().on_command(ClientCommand::Peer {
+    a.swarm.behaviour_mut().on_command(ClientCommand::Peer {
         peer: b_overlay,
         command: PeerCommand::RetrieveChunk {
             address,
@@ -748,10 +681,10 @@ async fn three_node_retrieval_relays_verifies_and_accounts() {
         let drive = async {
             loop {
                 tokio::select! {
-                    _ = a.select_next_some() => {}
-                    _ = b.select_next_some() => {}
-                    _ = c.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
+                    _ = a.swarm.select_next_some() => {}
+                    _ = b.swarm.select_next_some() => {}
+                    _ = c.swarm.select_next_some() => {}
+                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
                     res = &mut rx => return res.expect("sender not dropped"),
                 }
             }
@@ -816,20 +749,25 @@ async fn relay_does_not_cache_a_forwarded_soc() {
     c_store.put(chunk.clone().into()).unwrap();
     let b_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, u64::MAX));
 
-    let mut a = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+    let mut a = client_node(
+        1,
+        a_overlay,
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
     let (mut b, mut b_commands) = relay_node(
+        2,
         Arc::clone(&b_store),
         b_overlay,
         c_overlay,
         Arc::clone(&accounting),
     );
-    let mut c = swarm_with_store(c_store);
+    let mut c = client_node(3, c_overlay, c_store);
 
-    connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
-    connect_and_activate(&mut b, &mut c, b_overlay, c_overlay).await;
+    connect_and_activate(&mut a, &mut b, activate_client).await;
+    connect_and_activate(&mut b, &mut c, activate_client).await;
 
     let (tx, mut rx) = oneshot::channel();
-    a.behaviour_mut().on_command(ClientCommand::Peer {
+    a.swarm.behaviour_mut().on_command(ClientCommand::Peer {
         peer: b_overlay,
         command: PeerCommand::RetrieveChunk {
             address,
@@ -842,10 +780,10 @@ async fn relay_does_not_cache_a_forwarded_soc() {
         let drive = async {
             loop {
                 tokio::select! {
-                    _ = a.select_next_some() => {}
-                    _ = b.select_next_some() => {}
-                    _ = c.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
+                    _ = a.swarm.select_next_some() => {}
+                    _ = b.swarm.select_next_some() => {}
+                    _ = c.swarm.select_next_some() => {}
+                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
                     res = &mut rx => return res.expect("sender not dropped"),
                 }
             }
@@ -884,18 +822,23 @@ async fn relay_without_strictly_closer_peer_resets_rather_than_looping() {
     let accounting = relay_accounting();
     let b_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
 
-    let mut a = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+    let mut a = client_node(
+        1,
+        a_overlay,
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
     let (mut b, mut b_commands) = relay_node(
+        2,
         Arc::clone(&b_store),
         b_overlay,
         sideways,
         Arc::clone(&accounting),
     );
 
-    connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
+    connect_and_activate(&mut a, &mut b, activate_client).await;
 
     let (tx, mut rx) = oneshot::channel();
-    a.behaviour_mut().on_command(ClientCommand::Peer {
+    a.swarm.behaviour_mut().on_command(ClientCommand::Peer {
         peer: b_overlay,
         command: PeerCommand::RetrieveChunk {
             address,
@@ -908,9 +851,9 @@ async fn relay_without_strictly_closer_peer_resets_rather_than_looping() {
         let drive = async {
             loop {
                 tokio::select! {
-                    _ = a.select_next_some() => {}
-                    _ = b.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
+                    _ = a.swarm.select_next_some() => {}
+                    _ = b.swarm.select_next_some() => {}
+                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
                     res = &mut rx => return res.expect("sender not dropped"),
                 }
             }
@@ -982,8 +925,13 @@ async fn three_node_pushsync_relays_receipt_verbatim_and_accounts() {
     let b_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
     let c_store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
 
-    let mut a = swarm_with_store(Arc::new(ChunkStore::with_budget(1 << 20, 1_000)));
+    let mut a = client_node(
+        1,
+        a_overlay,
+        Arc::new(ChunkStore::with_budget(1 << 20, 1_000)),
+    );
     let (mut b, mut b_commands) = relay_node(
+        2,
         Arc::clone(&b_store),
         b_overlay,
         c_overlay,
@@ -994,17 +942,18 @@ async fn three_node_pushsync_relays_receipt_verbatim_and_accounts() {
     let deeper = overlay_at_proximity(&address, 24);
     let c_accounting = relay_accounting();
     let (mut c, mut c_commands) = relay_node(
+        3,
         Arc::clone(&c_store),
         c_overlay,
         deeper,
         Arc::clone(&c_accounting),
     );
 
-    connect_and_activate(&mut a, &mut b, a_overlay, b_overlay).await;
-    connect_and_activate(&mut b, &mut c, b_overlay, c_overlay).await;
+    connect_and_activate(&mut a, &mut b, activate_client).await;
+    connect_and_activate(&mut b, &mut c, activate_client).await;
 
     let (tx, mut rx) = oneshot::channel();
-    a.behaviour_mut().on_command(ClientCommand::Peer {
+    a.swarm.behaviour_mut().on_command(ClientCommand::Peer {
         peer: b_overlay,
         command: PeerCommand::PushChunk {
             chunk,
@@ -1017,10 +966,10 @@ async fn three_node_pushsync_relays_receipt_verbatim_and_accounts() {
         let drive = async {
             loop {
                 tokio::select! {
-                    _ = a.select_next_some() => {}
-                    _ = b.select_next_some() => {}
-                    _ = c.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.behaviour_mut().on_command(cmd),
+                    _ = a.swarm.select_next_some() => {}
+                    _ = b.swarm.select_next_some() => {}
+                    _ = c.swarm.select_next_some() => {}
+                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
                     // C is the storer: answer its outbound push with the
                     // signed receipt instead of forwarding on.
                     Some(cmd) = c_commands.recv() => {

--- a/crates/swarm/node/src/protocol/timeout_repro.rs
+++ b/crates/swarm/node/src/protocol/timeout_repro.rs
@@ -1,9 +1,9 @@
-//! Repro for the retrieval/pushsync liveness invariant (#314).
+//! Repro for the retrieval/pushsync liveness invariant.
 //!
 //! A peer can negotiate the retrieval substream and its headers and then simply
 //! never write the delivery frame. Without a per-request deadline the caller's
 //! outbound future would block on that read forever. This module drives that
-//! exact scenario through `libp2p-swarm-test`: a real [`ClientBehaviour`]
+//! exact scenario through the swarm-test harness: a real [`ClientBehaviour`]
 //! requester against a deliberately withholding server that completes the header
 //! exchange, captures the [`RetrievalResponder`], and drops it on the floor
 //! without responding.
@@ -20,7 +20,6 @@ use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use futures::StreamExt;
-use libp2p::Swarm;
 use libp2p::core::transport::PortUse;
 use libp2p::core::{Endpoint, Multiaddr};
 use libp2p::swarm::{
@@ -28,20 +27,19 @@ use libp2p::swarm::{
     NetworkBehaviour, SubstreamProtocol, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
     handler::{ConnectionEvent, FullyNegotiatedInbound},
 };
-use libp2p_swarm_test::SwarmExt;
 use nectar_primitives::ChunkAddress;
 use tokio::sync::oneshot;
+use vertex_swarm_api::SwarmLocalStore;
 use vertex_swarm_localstore::ChunkStore;
-use vertex_swarm_primitives::{OverlayAddress, SwarmNodeType};
+use vertex_swarm_net_retrieval::{RetrievalInboundProtocol, RetrievalResponder, inbound};
+use vertex_swarm_primitives::SwarmNodeType;
+use vertex_swarm_test_utils::harness::{HarnessNode, connect_and_activate_hetero, seeded_node};
 
 use crate::ChunkTransferError;
 use crate::client_service::RetrievalResult;
 use crate::protocol::{
     BehaviourConfig, ClientBehaviour, ClientCommand, PeerCommand, StubForwarder,
 };
-use vertex_net_peer_registry::PeerRegistry;
-use vertex_swarm_api::SwarmLocalStore;
-use vertex_swarm_net_retrieval::{RetrievalInboundProtocol, RetrievalResponder, inbound};
 
 /// A connection handler that accepts a single retrieval substream, completes the
 /// header exchange (the `RetrievalInboundProtocol` upgrade reads the request and
@@ -149,15 +147,8 @@ impl NetworkBehaviour for WithholdingBehaviour {
 
 /// Build a requester `ClientBehaviour` with a short retrieval deadline so the
 /// withholding peer is bounded in milliseconds, not the shared 30s default.
-fn requester_with_retrieval_timeout(
-    retrieval_timeout: Duration,
-) -> (
-    Swarm<ClientBehaviour>,
-    Arc<PeerRegistry<OverlayAddress, ()>>,
-) {
-    let registry: Arc<PeerRegistry<OverlayAddress, ()>> = Arc::new(PeerRegistry::new());
-    let registry_for_behaviour = Arc::clone(&registry);
-    let swarm = Swarm::new_ephemeral_tokio(move |_| {
+fn requester_node(seed: u8, retrieval_timeout: Duration) -> HarnessNode<ClientBehaviour> {
+    seeded_node(seed, SwarmNodeType::Client, move |ctx| {
         let mut config = BehaviourConfig::for_role(SwarmNodeType::Client);
         config.handler.retrieval_timeout = retrieval_timeout;
         let store: Arc<dyn SwarmLocalStore> = Arc::new(ChunkStore::with_budget(1 << 20, 1_000));
@@ -165,10 +156,9 @@ fn requester_with_retrieval_timeout(
             config,
             store,
             Arc::new(StubForwarder),
-            registry_for_behaviour,
+            ctx.identities.clone(),
         )
-    });
-    (swarm, registry)
+    })
 }
 
 #[tokio::test]
@@ -177,48 +167,49 @@ async fn withholding_peer_resolves_as_timed_out_within_the_deadline() {
     // shared 30s default that the bug would otherwise impose.
     let retrieval_timeout = Duration::from_millis(200);
 
-    let (mut requester, requester_registry) = requester_with_retrieval_timeout(retrieval_timeout);
-    let mut server = Swarm::new_ephemeral_tokio(|_| WithholdingBehaviour);
-
-    let server_peer = *server.local_peer_id();
-
-    requester.listen().with_memory_addr_external().await;
-    server.listen().with_memory_addr_external().await;
-    requester.connect(&mut server).await;
-
+    let mut requester = requester_node(1, retrieval_timeout);
+    let mut server = seeded_node(2, SwarmNodeType::Client, |_| WithholdingBehaviour);
     // The requester must know the server's overlay to dispatch the request; the
-    // overlay value is arbitrary since the server never validates it.
-    let server_overlay = OverlayAddress::from([0x2a; 32]);
-    // Topology is absent here, so mark the server Active directly, as the
-    // connection registry would at handshake completion.
-    let conn = ConnectionId::new_unchecked(1);
-    requester_registry.connected_inbound(server_peer, conn);
-    requester_registry.activate(server_peer, conn, server_overlay);
-    requester
-        .behaviour_mut()
-        .on_command(ClientCommand::ActivatePeer {
-            peer_id: server_peer,
-            overlay: server_overlay,
-            node_type: SwarmNodeType::Client,
-        });
+    // server never validates it, so the harness-seeded overlay is arbitrary.
+    let server_overlay = server.overlay;
+
+    // The withholding server gates on nothing, so only the requester takes an
+    // activation hook (mark the server Active, as the connection registry would
+    // at handshake completion).
+    connect_and_activate_hetero(
+        &mut requester,
+        &mut server,
+        |behaviour, peer_id, overlay, node_type| {
+            behaviour.on_command(ClientCommand::ActivatePeer {
+                peer_id,
+                overlay,
+                node_type,
+            });
+        },
+        |_, _, _, _| {},
+    )
+    .await;
 
     let address = ChunkAddress::new([0x11; 32]);
     let (tx, mut rx) = oneshot::channel::<Result<RetrievalResult, ChunkTransferError>>();
-    requester.behaviour_mut().on_command(ClientCommand::Peer {
-        peer: server_overlay,
-        command: PeerCommand::RetrieveChunk {
-            address,
-            response: tx,
-            originated: true,
-        },
-    });
+    requester
+        .swarm
+        .behaviour_mut()
+        .on_command(ClientCommand::Peer {
+            peer: server_overlay,
+            command: PeerCommand::RetrieveChunk {
+                address,
+                response: tx,
+                originated: true,
+            },
+        });
 
     let start = Instant::now();
     let drive = async {
         loop {
             tokio::select! {
-                _ = requester.select_next_some() => {}
-                _ = server.select_next_some() => {}
+                _ = requester.swarm.select_next_some() => {}
+                _ = server.swarm.select_next_some() => {}
                 res = &mut rx => return res.expect("sender not dropped"),
             }
         }

--- a/crates/swarm/storer-behaviour/Cargo.toml
+++ b/crates/swarm/storer-behaviour/Cargo.toml
@@ -40,6 +40,5 @@ thiserror.workspace = true
 alloy-primitives.workspace = true
 nectar-postage.workspace = true
 nectar-primitives.workspace = true
-libp2p-swarm-test.workspace = true
-vertex-net-peer-registry.workspace = true
+vertex-swarm-test-utils = { workspace = true, features = ["harness"] }
 tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }

--- a/crates/swarm/storer-behaviour/tests/composite.rs
+++ b/crates/swarm/storer-behaviour/tests/composite.rs
@@ -3,146 +3,24 @@
 //! derived composite.
 #![allow(clippy::expect_used, clippy::indexing_slicing)]
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::{B256, Signature};
 use futures::StreamExt;
-use libp2p::Swarm;
-use libp2p_swarm_test::SwarmExt;
+use libp2p::swarm::SwarmEvent;
 use nectar_postage::Stamp;
-use nectar_primitives::{AnyChunk, Bin, ChunkAddress, ContentChunk, ProximityOrder};
-use vertex_net_peer_registry::PeerRegistry;
-use vertex_swarm_api::{
-    BatchId, BinScanItem, PullStorage, StampedChunk, StorageRadius, SwarmLocalStore, SwarmResult,
-};
+use nectar_primitives::{AnyChunk, Bin, ChunkAddress, ContentChunk};
+use vertex_swarm_api::{PullStorage, StampedChunk, SwarmLocalStore};
 use vertex_swarm_client_behaviour::{
     BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, StubForwarder,
 };
-use vertex_swarm_primitives::{CachedChunk, OverlayAddress};
+use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_storer_behaviour::{
     PullsyncBehaviour, PullsyncEvent, StorerBehaviour, StorerBehaviourEvent,
 };
-
-/// A reserve snapshot for one bin: ordered entries plus an address index. Serves
-/// as both the client store and the pullsync server snapshot.
-#[derive(Default)]
-struct MockStorage {
-    bin: u8,
-    epoch: u64,
-    items: Vec<BinScanItem>,
-    chunks: HashMap<ChunkAddress, StampedChunk>,
-}
-
-impl MockStorage {
-    fn with_chunks(bin: Bin, epoch: u64, chunks: Vec<StampedChunk>) -> Self {
-        let mut items = Vec::new();
-        let mut index = HashMap::new();
-        for (i, chunk) in chunks.into_iter().enumerate() {
-            let address = *chunk.address();
-            let stamp_hash = B256::from_slice(address.as_slice());
-            items.push(BinScanItem {
-                seq: i as u64 + 1,
-                address,
-                batch_id: BatchId::repeat_byte(0xbb),
-                stamp_hash,
-            });
-            index.insert(address, chunk);
-        }
-        Self {
-            bin: bin.get(),
-            epoch,
-            items,
-            chunks: index,
-        }
-    }
-}
-
-impl SwarmLocalStore for MockStorage {
-    fn put(&self, _chunk: CachedChunk) -> SwarmResult<()> {
-        Ok(())
-    }
-
-    fn get(&self, address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
-        Ok(self.chunks.get(address).cloned().map(CachedChunk::from))
-    }
-
-    fn contains(&self, address: &ChunkAddress) -> bool {
-        self.chunks.contains_key(address)
-    }
-
-    fn remove(&self, _address: &ChunkAddress) -> SwarmResult<()> {
-        Ok(())
-    }
-}
-
-impl vertex_swarm_api::ReserveStore for MockStorage {
-    fn storage_radius(&self) -> StorageRadius {
-        StorageRadius::ZERO
-    }
-
-    fn is_responsible_for(&self, _address: &ChunkAddress) -> bool {
-        true
-    }
-
-    fn count(&self) -> SwarmResult<u64> {
-        Ok(self.items.len() as u64)
-    }
-
-    fn capacity(&self) -> u64 {
-        u64::MAX
-    }
-
-    fn count_in(&self, _po: ProximityOrder) -> SwarmResult<u64> {
-        Ok(0)
-    }
-
-    fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>> {
-        Ok(None)
-    }
-
-    fn evict_from_bin(&self, _bin: Bin, _max: u64) -> SwarmResult<u64> {
-        Ok(0)
-    }
-
-    fn evict_batch(&self, _batch: BatchId, _up_to_bin: Option<Bin>, _max: u64) -> SwarmResult<u64> {
-        Ok(0)
-    }
-}
-
-impl vertex_swarm_api::BinCursorStore for MockStorage {
-    fn bin_cursor(&self, bin: Bin) -> SwarmResult<u64> {
-        if bin.get() == self.bin {
-            Ok(self.items.last().map(|i| i.seq).unwrap_or(0))
-        } else {
-            Ok(0)
-        }
-    }
-
-    fn scan_bin_from<'a>(
-        &'a self,
-        bin: Bin,
-        start_seq: u64,
-    ) -> SwarmResult<Box<dyn Iterator<Item = SwarmResult<BinScanItem>> + Send + 'a>> {
-        let items: Vec<BinScanItem> = if bin.get() == self.bin {
-            self.items
-                .iter()
-                .filter(|i| i.seq >= start_seq)
-                .cloned()
-                .collect()
-        } else {
-            Vec::new()
-        };
-        Ok(Box::new(items.into_iter().map(Ok)))
-    }
-}
-
-impl PullStorage for MockStorage {
-    fn reserve_epoch(&self) -> u64 {
-        self.epoch
-    }
-}
+use vertex_swarm_test_utils::MockStorage;
+use vertex_swarm_test_utils::harness::{HarnessNode, connect_and_activate, seeded_node};
 
 fn content(payload: &'static [u8]) -> StampedChunk {
     let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
@@ -153,16 +31,14 @@ fn content(payload: &'static [u8]) -> StampedChunk {
     StampedChunk::new(chunk, stamp)
 }
 
-fn storer(storage: MockStorage) -> Swarm<StorerBehaviour> {
+fn storer(seed: u8, storage: MockStorage) -> HarnessNode<StorerBehaviour> {
     let storage = Arc::new(storage);
-    let store = Arc::clone(&storage);
-    Swarm::new_ephemeral_tokio(move |_| {
-        let active_peers = Arc::new(PeerRegistry::<OverlayAddress, ()>::new());
+    seeded_node(seed, SwarmNodeType::Storer, move |ctx| {
         let client = ClientBehaviour::new(
             ClientBehaviourConfig::default(),
-            store.clone(),
+            Arc::clone(&storage) as Arc<dyn SwarmLocalStore>,
             Arc::new(StubForwarder),
-            active_peers,
+            ctx.identities.clone(),
         );
         let pullsync = PullsyncBehaviour::new(Arc::clone(&storage) as Arc<dyn PullStorage>);
         StorerBehaviour { client, pullsync }
@@ -190,15 +66,14 @@ async fn composite_routes_pullsync_range() {
     let bin = Bin::new(3).expect("valid bin");
     let chunks = vec![content(b"range chunk one"), content(b"range chunk two")];
     let addresses: Vec<ChunkAddress> = chunks.iter().map(|c| *c.address()).collect();
-    let mut puller = storer(MockStorage::default());
-    let mut server = storer(MockStorage::with_chunks(bin, 1, chunks));
-    let server_peer = *server.local_peer_id();
+    let mut puller = storer(1, MockStorage::default());
+    let mut server = storer(2, MockStorage::with_chunks(bin, 1, chunks));
+    let server_peer = server.peer_id;
 
-    puller.listen().with_memory_addr_external().await;
-    server.listen().with_memory_addr_external().await;
-    puller.connect(&mut server).await;
+    connect_and_activate(&mut puller, &mut server, |_, _, _, _| {}).await;
 
     puller
+        .swarm
         .behaviour_mut()
         .pullsync
         .sync_range(server_peer, 1, bin, 0);
@@ -206,9 +81,9 @@ async fn composite_routes_pullsync_range() {
     let event = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
             tokio::select! {
-                _ = server.select_next_some() => {}
-                ev = puller.select_next_some() => {
-                    if let libp2p::swarm::SwarmEvent::Behaviour(e) = ev {
+                _ = server.swarm.select_next_some() => {}
+                ev = puller.swarm.select_next_some() => {
+                    if let SwarmEvent::Behaviour(e) = ev {
                         return e;
                     }
                 }

--- a/crates/swarm/storer-behaviour/tests/round_trip.rs
+++ b/crates/swarm/storer-behaviour/tests/round_trip.rs
@@ -1,140 +1,20 @@
 //! Behaviour-level round-trip: a puller behaviour syncs cursors and a range page
-//! from a syncer behaviour backed by a mock [`PullStorage`].
+//! from a syncer behaviour backed by the canonical mock [`PullStorage`].
 #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::get_first)]
 
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::{B256, Signature};
 use futures::StreamExt;
-use libp2p::Swarm;
-use libp2p_swarm_test::SwarmExt;
+use libp2p::swarm::SwarmEvent;
 use nectar_postage::Stamp;
-use nectar_primitives::{AnyChunk, Bin, ChunkAddress, ContentChunk, ProximityOrder};
-use vertex_swarm_api::{
-    BatchId, BinScanItem, PullStorage, StampedChunk, StorageRadius, SwarmResult,
-};
-use vertex_swarm_primitives::CachedChunk;
+use nectar_primitives::{AnyChunk, Bin, ChunkAddress, ContentChunk};
+use vertex_swarm_api::{PullStorage, StampedChunk};
+use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_storer_behaviour::{PullsyncBehaviour, PullsyncEvent};
-
-/// A reserve snapshot for one bin: ordered entries plus an address index.
-#[derive(Default)]
-struct MockPullStorage {
-    bin: u8,
-    epoch: u64,
-    items: Vec<BinScanItem>,
-    chunks: HashMap<ChunkAddress, StampedChunk>,
-}
-
-impl MockPullStorage {
-    fn with_chunks(bin: Bin, epoch: u64, chunks: Vec<StampedChunk>) -> Self {
-        let mut items = Vec::new();
-        let mut index = HashMap::new();
-        for (i, chunk) in chunks.into_iter().enumerate() {
-            let address = *chunk.address();
-            let stamp_hash = B256::from_slice(address.as_slice());
-            items.push(BinScanItem {
-                seq: i as u64 + 1,
-                address,
-                batch_id: BatchId::repeat_byte(0xbb),
-                stamp_hash,
-            });
-            index.insert(address, chunk);
-        }
-        Self {
-            bin: bin.get(),
-            epoch,
-            items,
-            chunks: index,
-        }
-    }
-}
-
-impl vertex_swarm_api::SwarmLocalStore for MockPullStorage {
-    fn put(&self, _chunk: CachedChunk) -> SwarmResult<()> {
-        Ok(())
-    }
-
-    fn get(&self, address: &ChunkAddress) -> SwarmResult<Option<CachedChunk>> {
-        Ok(self.chunks.get(address).cloned().map(CachedChunk::from))
-    }
-
-    fn contains(&self, address: &ChunkAddress) -> bool {
-        self.chunks.contains_key(address)
-    }
-
-    fn remove(&self, _address: &ChunkAddress) -> SwarmResult<()> {
-        Ok(())
-    }
-}
-
-impl vertex_swarm_api::ReserveStore for MockPullStorage {
-    fn storage_radius(&self) -> StorageRadius {
-        StorageRadius::ZERO
-    }
-
-    fn is_responsible_for(&self, _address: &ChunkAddress) -> bool {
-        true
-    }
-
-    fn count(&self) -> SwarmResult<u64> {
-        Ok(self.items.len() as u64)
-    }
-
-    fn capacity(&self) -> u64 {
-        u64::MAX
-    }
-
-    fn count_in(&self, _po: ProximityOrder) -> SwarmResult<u64> {
-        Ok(0)
-    }
-
-    fn evict_furthest(&self) -> SwarmResult<Option<ChunkAddress>> {
-        Ok(None)
-    }
-
-    fn evict_from_bin(&self, _bin: Bin, _max: u64) -> SwarmResult<u64> {
-        Ok(0)
-    }
-
-    fn evict_batch(&self, _batch: BatchId, _up_to_bin: Option<Bin>, _max: u64) -> SwarmResult<u64> {
-        Ok(0)
-    }
-}
-
-impl vertex_swarm_api::BinCursorStore for MockPullStorage {
-    fn bin_cursor(&self, bin: Bin) -> SwarmResult<u64> {
-        if bin.get() == self.bin {
-            Ok(self.items.last().map(|i| i.seq).unwrap_or(0))
-        } else {
-            Ok(0)
-        }
-    }
-
-    fn scan_bin_from<'a>(
-        &'a self,
-        bin: Bin,
-        start_seq: u64,
-    ) -> SwarmResult<Box<dyn Iterator<Item = SwarmResult<BinScanItem>> + Send + 'a>> {
-        let items: Vec<BinScanItem> = if bin.get() == self.bin {
-            self.items
-                .iter()
-                .filter(|i| i.seq >= start_seq)
-                .cloned()
-                .collect()
-        } else {
-            Vec::new()
-        };
-        Ok(Box::new(items.into_iter().map(Ok)))
-    }
-}
-
-impl PullStorage for MockPullStorage {
-    fn reserve_epoch(&self) -> u64 {
-        self.epoch
-    }
-}
+use vertex_swarm_test_utils::MockStorage;
+use vertex_swarm_test_utils::harness::{HarnessNode, connect_and_activate, seeded_node};
 
 fn content(payload: &'static [u8]) -> StampedChunk {
     let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
@@ -145,35 +25,27 @@ fn content(payload: &'static [u8]) -> StampedChunk {
     StampedChunk::new(chunk, stamp)
 }
 
-fn syncer(storage: MockPullStorage) -> Swarm<PullsyncBehaviour> {
+fn syncer(seed: u8, storage: MockStorage) -> HarnessNode<PullsyncBehaviour> {
     let storage: Arc<dyn PullStorage> = Arc::new(storage);
-    Swarm::new_ephemeral_tokio(move |_| PullsyncBehaviour::new(Arc::clone(&storage)))
+    seeded_node(seed, SwarmNodeType::Storer, move |_| {
+        PullsyncBehaviour::new(storage)
+    })
 }
 
-/// Connect a puller and a syncer over an in-memory transport.
-async fn connect(puller: &mut Swarm<PullsyncBehaviour>, syncer: &mut Swarm<PullsyncBehaviour>) {
-    puller.listen().with_memory_addr_external().await;
-    syncer.listen().with_memory_addr_external().await;
-    puller.connect(syncer).await;
-}
-
-#[tokio::test]
-async fn cursor_handshake_round_trips() {
-    let bin = Bin::new(5).expect("valid bin");
-    let chunks = vec![content(b"cursor chunk a"), content(b"cursor chunk b")];
-    let mut puller = syncer(MockPullStorage::default());
-    let mut server = syncer(MockPullStorage::with_chunks(bin, 7, chunks));
-    let server_peer = *server.local_peer_id();
-
-    connect(&mut puller, &mut server).await;
-    puller.behaviour_mut().fetch_cursors(server_peer, 1);
-
-    let event = tokio::time::timeout(Duration::from_secs(10), async {
+/// Drive both nodes until the puller emits a behaviour event, returning it. The
+/// emitted event is the test's outcome, so it is captured directly rather than
+/// asserted through accumulated swarm state.
+async fn next_puller_event(
+    puller: &mut HarnessNode<PullsyncBehaviour>,
+    server: &mut HarnessNode<PullsyncBehaviour>,
+    timeout: Duration,
+) -> PullsyncEvent {
+    tokio::time::timeout(timeout, async {
         loop {
             tokio::select! {
-                _ = server.select_next_some() => {}
-                ev = puller.select_next_some() => {
-                    if let libp2p::swarm::SwarmEvent::Behaviour(e) = ev {
+                _ = server.swarm.select_next_some() => {}
+                ev = puller.swarm.select_next_some() => {
+                    if let SwarmEvent::Behaviour(e) = ev {
                         return e;
                     }
                 }
@@ -181,7 +53,21 @@ async fn cursor_handshake_round_trips() {
         }
     })
     .await
-    .expect("cursors resolved within timeout");
+    .expect("event resolved within timeout")
+}
+
+#[tokio::test]
+async fn cursor_handshake_round_trips() {
+    let bin = Bin::new(5).expect("valid bin");
+    let chunks = vec![content(b"cursor chunk a"), content(b"cursor chunk b")];
+    let mut puller = syncer(1, MockStorage::default());
+    let mut server = syncer(2, MockStorage::with_chunks(bin, 7, chunks));
+    let server_peer = server.peer_id;
+
+    connect_and_activate(&mut puller, &mut server, |_, _, _, _| {}).await;
+    puller.swarm.behaviour_mut().fetch_cursors(server_peer, 1);
+
+    let event = next_puller_event(&mut puller, &mut server, Duration::from_secs(10)).await;
 
     match event {
         PullsyncEvent::CursorsReceived {
@@ -206,27 +92,17 @@ async fn range_exchange_delivers_the_page() {
     let bin = Bin::new(3).expect("valid bin");
     let chunks = vec![content(b"range chunk one"), content(b"range chunk two")];
     let addresses: Vec<ChunkAddress> = chunks.iter().map(|c| *c.address()).collect();
-    let mut puller = syncer(MockPullStorage::default());
-    let mut server = syncer(MockPullStorage::with_chunks(bin, 1, chunks));
-    let server_peer = *server.local_peer_id();
+    let mut puller = syncer(1, MockStorage::default());
+    let mut server = syncer(2, MockStorage::with_chunks(bin, 1, chunks));
+    let server_peer = server.peer_id;
 
-    connect(&mut puller, &mut server).await;
-    puller.behaviour_mut().sync_range(server_peer, 2, bin, 0);
+    connect_and_activate(&mut puller, &mut server, |_, _, _, _| {}).await;
+    puller
+        .swarm
+        .behaviour_mut()
+        .sync_range(server_peer, 2, bin, 0);
 
-    let event = tokio::time::timeout(Duration::from_secs(10), async {
-        loop {
-            tokio::select! {
-                _ = server.select_next_some() => {}
-                ev = puller.select_next_some() => {
-                    if let libp2p::swarm::SwarmEvent::Behaviour(e) = ev {
-                        return e;
-                    }
-                }
-            }
-        }
-    })
-    .await
-    .expect("range resolved within timeout");
+    let event = next_puller_event(&mut puller, &mut server, Duration::from_secs(10)).await;
 
     match event {
         PullsyncEvent::RangeDelivered {
@@ -255,27 +131,17 @@ async fn empty_range_completes_with_no_want() {
     // The syncer holds chunks in a different bin, so the requested bin is empty.
     let other = Bin::new(4).expect("valid bin");
     let chunks = vec![content(b"elsewhere chunk")];
-    let mut puller = syncer(MockPullStorage::default());
-    let mut server = syncer(MockPullStorage::with_chunks(other, 1, chunks));
-    let server_peer = *server.local_peer_id();
+    let mut puller = syncer(1, MockStorage::default());
+    let mut server = syncer(2, MockStorage::with_chunks(other, 1, chunks));
+    let server_peer = server.peer_id;
 
-    connect(&mut puller, &mut server).await;
-    puller.behaviour_mut().sync_range(server_peer, 3, bin, 0);
+    connect_and_activate(&mut puller, &mut server, |_, _, _, _| {}).await;
+    puller
+        .swarm
+        .behaviour_mut()
+        .sync_range(server_peer, 3, bin, 0);
 
-    let event = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            tokio::select! {
-                _ = server.select_next_some() => {}
-                ev = puller.select_next_some() => {
-                    if let libp2p::swarm::SwarmEvent::Behaviour(e) = ev {
-                        return e;
-                    }
-                }
-            }
-        }
-    })
-    .await
-    .expect("empty range resolves promptly, no hang");
+    let event = next_puller_event(&mut puller, &mut server, Duration::from_secs(5)).await;
 
     match event {
         PullsyncEvent::RangeDelivered {

--- a/crates/swarm/test-utils/src/harness.rs
+++ b/crates/swarm/test-utils/src/harness.rs
@@ -207,6 +207,30 @@ where
     B::ToSwarm: std::fmt::Debug,
     A: Fn(&mut B, PeerId, OverlayAddress, SwarmNodeType),
 {
+    // The homogeneous case is the heterogeneous one with a shared hook applied
+    // to each side; `&activate` implements the per-side `FnOnce` bound.
+    connect_and_activate_hetero(a, b, &activate, &activate).await;
+}
+
+/// Connect two seeded nodes whose behaviours differ, marking each peer active in
+/// the other's registry and running a per-side activation hook.
+///
+/// A heterogeneous pair (a real behaviour against a bespoke probe handler, say)
+/// cannot share one activation closure the way [`connect_and_activate`] does, so
+/// each side takes its own; pass a no-op for a side that gates on nothing.
+pub async fn connect_and_activate_hetero<B1, B2, A1, A2>(
+    a: &mut HarnessNode<B1>,
+    b: &mut HarnessNode<B2>,
+    activate_a: A1,
+    activate_b: A2,
+) where
+    B1: NetworkBehaviour + Send,
+    B1::ToSwarm: std::fmt::Debug,
+    B2: NetworkBehaviour + Send,
+    B2::ToSwarm: std::fmt::Debug,
+    A1: FnOnce(&mut B1, PeerId, OverlayAddress, SwarmNodeType),
+    A2: FnOnce(&mut B2, PeerId, OverlayAddress, SwarmNodeType),
+{
     listen_memory(&mut a.swarm).await;
     listen_memory(&mut b.swarm).await;
     a.swarm.connect(&mut b.swarm).await;
@@ -214,8 +238,8 @@ where
     activate_in_registry(&a.identities, b.peer_id, b.overlay);
     activate_in_registry(&b.identities, a.peer_id, a.overlay);
 
-    activate(a.swarm.behaviour_mut(), b.peer_id, b.overlay, b.node_type);
-    activate(b.swarm.behaviour_mut(), a.peer_id, a.overlay, a.node_type);
+    activate_a(a.swarm.behaviour_mut(), b.peer_id, b.overlay, b.node_type);
+    activate_b(b.swarm.behaviour_mut(), a.peer_id, a.overlay, a.node_type);
 }
 
 /// Drive two nodes until `predicate` holds or `timeout` elapses, returning


### PR DESCRIPTION
## What

Migrates the heaviest hand-rolled behaviour suites onto the swarm-test harness (`crates/swarm/test-utils/src/harness.rs`) and the canonical mocks (`MockStorage`/`MockReserve`), deleting the duplicated scaffolding.

## Why

Closes #846

`behaviour_tests.rs` (11 tests: cache serving, stub-forwarder resets, storer ingest, three-node relay) now builds seeded harness nodes via a small `node_with_overlay` helper that sets custom overlays where proximity math needs them, connects through the harness `connect_and_activate`, and uses the canonical `MockReserve`; the process-global `OnceLock` identity-registry map, `register_identity`/`next_conn_id`/`activate_identity`, and the local `connect_and_activate` are gone. `timeout_repro.rs` keeps its bespoke withholding probe handler but drops its inline registry plumbing by connecting through a new heterogeneous helper. Storer-behaviour's `round_trip.rs` and `composite.rs` drop their hand-rolled `MockStorage`/`MockPullStorage` (around 240 lines) for the canonical `MockStorage` and connect through the harness. To support `timeout_repro`'s requester-vs-probe pair, `connect_and_activate_hetero` was added to the harness (a genuine need per the issue's caveat b), and the homogeneous `connect_and_activate` becomes a thin delegate, preserving its behaviour. Suites assert on outcomes (delivered chunk, signed receipt, accounted balances, typed `TimedOut`) rather than event orderings. Behaviour under test is unchanged; only test code and dev-deps move. The now-unused `vertex-net-peer-registry` dev-dep is removed from `node`, and `libp2p-swarm-test`/`vertex-net-peer-registry` are removed from `storer-behaviour`.

## Testing

Adversarial review of the branch found no issues requiring fixes. Independent re-verification from a clean detached checkout at commit `52eee0bc` confirmed: `cargo fmt --all -- --check` passes; `cargo clippy --all-targets --all-features -- -D warnings` passes workspace-wide with zero warnings; `cargo nextest run` on `vertex-swarm-node`, `vertex-swarm-storer-behaviour`, and `vertex-swarm-test-utils` passes 181/181, including the migrated `round_trip`/`composite` suites and the new harness `connect_and_activate_round_trip`/`drive_until_reports_deadline`/`seeded_identity_is_reproducible` tests. Coverage floor checks via `nextest list` show test cardinality unchanged on both crates (node 148, storer-behaviour 6) despite the large line-count reduction from boilerplate collapse onto the shared harness. Sweeps over the changed files found no em-dashes, no "underlay" mentions, no inline issue references, and no bee/reference-implementation mentions; the commit history carries no AI attribution footers. The two suites intentionally left unmigrated (`node/src/node/base.rs`, `node/tests/autonat_dialback.rs`) are byte-unchanged, with multi-node transport-denial and real-TCP dial-back requirements that do not fit the two-node `connect_and_activate` shape.

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Opus 4.8 implementation and review, Sonnet 5 PR text) under human direction.
