### PR TITLE
fix(net-local): gate memory dial admission on an injected transport

### DIFF
--- a/crates/net/local/src/capabilities.rs
+++ b/crates/net/local/src/capabilities.rs
@@ -57,6 +57,9 @@ pub struct LocalCapabilities {
     /// can never derive a capability from listeners, yet can dial whatever
     /// address family their host stack routes.
     dial_only: bool,
+    /// Admit `/memory/<port>` multiaddrs in the dial filter. Set only when an
+    /// in-process memory transport is injected; production nodes leave it off.
+    allow_memory: bool,
 }
 
 impl LocalCapabilities {
@@ -76,6 +79,17 @@ impl LocalCapabilities {
             dial_only: true,
             ..Self::default()
         }
+    }
+
+    /// Admit `/memory/<port>` multiaddrs in the dial filter.
+    ///
+    /// Set by the node builder only when an in-process memory transport is
+    /// injected, so its channel addresses (received via config or gossip)
+    /// dial. Production nodes leave this off, so a self-signed record
+    /// advertising only memory addresses is rejected pre-dial.
+    pub fn with_memory_dialing(mut self, allow: bool) -> Self {
+        self.allow_memory = allow;
+        self
     }
 
     /// Handle new listen address from libp2p.
@@ -146,6 +160,7 @@ impl LocalCapabilities {
         crate::DialCapability {
             ip: self.capability(),
             transport: crate::TransportCapability::platform(),
+            allow_memory: self.allow_memory,
         }
     }
 
@@ -213,6 +228,19 @@ mod tests {
         // did the pin holds: capability stays Dual.
         cap.on_new_listen_addr(parse_addr("/ip4/127.0.0.1/tcp/1634"));
         assert_eq!(cap.capability(), IpCapability::Dual);
+    }
+
+    #[test]
+    fn memory_dialing_defaults_off_and_flows_into_dial_capability() {
+        let mem = parse_addr("/memory/1234");
+
+        let default = LocalCapabilities::new();
+        assert!(!default.dial_capability().allow_memory);
+        assert!(!default.dial_capability().can_dial(&mem));
+
+        let with_memory = LocalCapabilities::dial_only().with_memory_dialing(true);
+        assert!(with_memory.dial_capability().allow_memory);
+        assert!(with_memory.dial_capability().can_dial(&mem));
     }
 
     #[test]

--- a/crates/net/local/src/transport.rs
+++ b/crates/net/local/src/transport.rs
@@ -23,9 +23,10 @@ pub enum TransportRequirement {
     /// TLS websocket: `/tls/ws` (with or without `/sni`) or the legacy
     /// `/wss` form.
     SecureWebsocket,
-    /// In-process memory transport (`/memory/<port>`). Only ever produced by
-    /// the channel-based transport an integration harness injects; a live peer
-    /// never advertises one.
+    /// In-process memory transport (`/memory/<port>`). Dialable only by a node
+    /// that has a channel-based memory transport injected; the default TCP and
+    /// websocket stacks carry none, so a self-signed record advertising one is
+    /// rejected pre-dial rather than admitted for a dial that always fails.
     Memory,
     /// Anything else (QUIC, relay-only); dialable by no transport stack vertex
     /// currently assembles.
@@ -93,17 +94,16 @@ impl TransportCapability {
 
     /// Whether this stack can dial `addr` at the transport layer.
     ///
-    /// A `/memory/<port>` address is admitted by either stack so a hermetic
-    /// cluster can dial over an injected memory transport. Peer records are
-    /// self-signed, so a live peer can gossip one too; on a stack with no
-    /// memory transport such a dial fails immediately with an unsupported
-    /// multiaddr, bounding the cost to a wasted dial attempt.
+    /// Covers only the statically assembled suites (TCP or secure websockets).
+    /// A `/memory/<port>` address is never dialable through the platform stack;
+    /// memory admission is a property of the combined
+    /// [`DialCapability::allow_memory`] bit, set only when an in-process memory
+    /// transport is injected.
     pub fn can_dial(&self, addr: &Multiaddr) -> bool {
         matches!(
             (self, TransportRequirement::of(addr)),
             (Self::Tcp, TransportRequirement::Tcp)
                 | (Self::SecureWebsocket, TransportRequirement::SecureWebsocket)
-                | (_, TransportRequirement::Memory)
         )
     }
 }
@@ -120,13 +120,29 @@ pub struct DialCapability {
     pub ip: crate::IpCapability,
     /// Transport suites the assembled stack can dial.
     pub transport: TransportCapability,
+    /// Admit `/memory/<port>` multiaddrs. Off by default: the platform TCP and
+    /// websocket stacks carry no memory transport, so a gossiped memory-only
+    /// record dies at intake. Set only when an in-process memory transport is
+    /// injected (the integration harness), so its channel addresses dial.
+    pub allow_memory: bool,
 }
 
 impl DialCapability {
-    /// Whether `addr` is dialable: the transport stack supports it and
+    /// Whether `addr` is dialable: the transport half supports it and
     /// [`crate::is_dialable`] passes for the IP half.
     pub fn can_dial(&self, addr: &Multiaddr) -> bool {
-        self.transport.can_dial(addr) && crate::is_dialable(addr, self.ip)
+        self.transport_can_dial(addr) && crate::is_dialable(addr, self.ip)
+    }
+
+    /// Whether the assembled transport stack can dial `addr`, ignoring the IP
+    /// half. Memory addresses are admitted only when [`Self::allow_memory`] is
+    /// set. Callers that must apply the transport filter before the IP
+    /// capability is known use this directly.
+    pub fn transport_can_dial(&self, addr: &Multiaddr) -> bool {
+        if matches!(TransportRequirement::of(addr), TransportRequirement::Memory) {
+            return self.allow_memory;
+        }
+        self.transport.can_dial(addr)
     }
 
     /// Whether at least one of `addrs` is dialable.
@@ -207,11 +223,12 @@ mod tests {
     }
 
     #[test]
-    fn memory_is_dialable_by_either_stack() {
+    fn memory_classification_survives_p2p_suffix() {
         let mem = addr("/memory/1234");
         assert_eq!(TransportRequirement::of(&mem), TransportRequirement::Memory);
-        assert!(TransportCapability::Tcp.can_dial(&mem));
-        assert!(TransportCapability::SecureWebsocket.can_dial(&mem));
+        // The platform transport half never admits memory on its own.
+        assert!(!TransportCapability::Tcp.can_dial(&mem));
+        assert!(!TransportCapability::SecureWebsocket.can_dial(&mem));
 
         // A /p2p/ suffix does not change the classification.
         let with_peer = addr("/memory/1234/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg");
@@ -219,14 +236,39 @@ mod tests {
             TransportRequirement::of(&with_peer),
             TransportRequirement::Memory
         );
+    }
 
-        // The combined filter admits it even when the IP half is unknown, since
-        // a memory address carries no IP to reach.
+    #[test]
+    fn default_capability_rejects_memory() {
+        // Without the memory bit a production node drops a memory address, even
+        // one carrying no IP, so a gossiped memory-only record dies at intake.
         let cap = DialCapability {
             ip: IpCapability::None,
             transport: TransportCapability::Tcp,
+            allow_memory: false,
         };
+        assert!(!cap.can_dial(&addr("/memory/1234")));
+    }
+
+    #[test]
+    fn memory_bit_admits_memory_regardless_of_ip() {
+        // With the bit set an injected memory transport dials the channel
+        // address; a memory address carries no IP to reach, so the IP half
+        // never blocks it.
+        let cap = DialCapability {
+            ip: IpCapability::None,
+            transport: TransportCapability::Tcp,
+            allow_memory: true,
+        };
+        let mem = addr("/memory/1234");
         assert!(cap.can_dial(&mem));
+        assert!(cap.transport_can_dial(&mem));
+
+        // The bit does not widen the platform transport suite: a TCP stack
+        // still rejects a websocket-only address.
+        assert!(!cap.can_dial(&addr(
+            "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws"
+        )));
     }
 
     #[test]
@@ -235,6 +277,7 @@ mod tests {
         let browser = DialCapability {
             ip: IpCapability::Dual,
             transport: TransportCapability::SecureWebsocket,
+            allow_memory: false,
         };
         let wss = addr("/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws");
         let tcp = addr("/ip4/8.8.8.8/tcp/1634");
@@ -247,6 +290,7 @@ mod tests {
         let native_v4 = DialCapability {
             ip: IpCapability::V4Only,
             transport: TransportCapability::Tcp,
+            allow_memory: false,
         };
         assert!(native_v4.can_dial(&tcp));
         assert!(!native_v4.can_dial(&addr("/ip6/2001:db8::1/tcp/1634")));
@@ -258,6 +302,7 @@ mod tests {
         let cap = DialCapability {
             ip: IpCapability::None,
             transport: TransportCapability::Tcp,
+            allow_memory: false,
         };
         assert!(!cap.can_dial(&addr("/ip4/8.8.8.8/tcp/1634")));
     }

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -329,6 +329,9 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
 
         info!("Initializing bootnode P2P network...");
 
+        // An injected transport (the integration harness supplies a memory
+        // transport) admits `/memory` dials; the default stack does not.
+        let allow_memory = self.transport.is_some();
         let infra = match self.infra {
             Some(infra) => infra,
             None => {
@@ -339,6 +342,7 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
                     network_config,
                     topology_config,
                     peer_store,
+                    allow_memory,
                 )?
             }
         };

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -83,11 +83,17 @@ impl<I: SwarmIdentity + Clone> BuiltInfrastructure<I> {
 
 impl<I: SwarmIdentity + Clone> BuiltInfrastructure<I> {
     /// Build infrastructure from network configuration.
+    ///
+    /// `allow_memory` admits `/memory/<port>` multiaddrs in the dial filter; the
+    /// node builder sets it only when an in-process memory transport is
+    /// injected, so a production node with the default stack rejects them
+    /// pre-dial.
     pub fn from_config<C>(
         identity: I,
         network_config: &C,
         topology_config: TopologyConfig,
         peer_store: Option<PeerStore>,
+        allow_memory: bool,
     ) -> Result<Self>
     where
         I: HasSpec,
@@ -105,7 +111,8 @@ impl<I: SwarmIdentity + Clone> BuiltInfrastructure<I> {
         };
 
         let mut builder = TopologyBehaviourBuilder::new(identity.clone(), &config_with_bootnodes)
-            .with_config(topology_config);
+            .with_config(topology_config)
+            .with_memory_dialing(allow_memory);
         if let Some(store) = peer_store {
             builder = builder.with_peer_store(store);
         }

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -527,6 +527,9 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
     {
         info!("Initializing client P2P network...");
 
+        // An injected transport (the integration harness supplies a memory
+        // transport) admits `/memory` dials; the default stack does not.
+        let allow_memory = self.transport.is_some();
         let infra = match self.infra {
             Some(infra) => infra,
             None => {
@@ -537,6 +540,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBuilder<I> {
                     network_config,
                     topology_config,
                     peer_store,
+                    allow_memory,
                 )?
             }
         };

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -679,6 +679,9 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
             .pullsync_storage
             .ok_or_else(|| eyre::eyre!("storer node requires a pullsync reserve snapshot"))?;
 
+        // An injected transport (the integration harness supplies a memory
+        // transport) admits `/memory` dials; the default stack does not.
+        let allow_memory = self.transport.is_some();
         let topology_config =
             TopologyConfig::new().with_kademlia(self.kademlia_config.unwrap_or_default());
         let infra = BuiltInfrastructure::from_config(
@@ -686,6 +689,7 @@ impl<I: SwarmIdentity + Clone> StorerNodeBuilder<I> {
             network_config,
             topology_config,
             peer_store,
+            allow_memory,
         )?;
 
         let store: Arc<dyn SwarmLocalStore> = self.store.unwrap_or_else(|| {

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -61,6 +61,9 @@ pub struct TopologyBehaviourBuilder<I: SwarmIdentity + Clone> {
     /// No listen addresses configured: the node is dial-only, so its IP
     /// capability is pinned instead of listener-derived.
     dial_only: bool,
+    /// Admit `/memory/<port>` multiaddrs in the dial filter. Set only when the
+    /// node builder injects an in-process memory transport.
+    allow_memory: bool,
     trust_local_peers: bool,
     scoring_config: SwarmScoringConfig,
     max_per_bin: usize,
@@ -85,6 +88,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             trusted_peers: network_config.trusted_peers().to_vec(),
             nat_addrs: network_config.nat_addrs().to_vec(),
             dial_only: network_config.listen_addrs().is_empty(),
+            allow_memory: false,
             trust_local_peers: network_config.trust_local_peers(),
             scoring_config: SwarmScoringConfig::builder()
                 .ban_threshold(peer_config.ban_threshold())
@@ -99,6 +103,16 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
     /// Set the topology configuration (kademlia, dial cadence, save interval).
     pub fn with_config(mut self, config: TopologyConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Admit `/memory/<port>` multiaddrs in this node's dial filter.
+    ///
+    /// The node builder sets this only when an in-process memory transport is
+    /// injected. Left off, the node rejects memory addresses pre-dial, so a
+    /// gossiped memory-only record never enters the known table.
+    pub fn with_memory_dialing(mut self, allow: bool) -> Self {
+        self.allow_memory = allow;
         self
     }
 
@@ -177,11 +191,14 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
         // filter would reject every ip4/dns4 address. Pin it to dual-stack
         // instead: an outbound-only node dials whatever its host stack
         // routes (the browser target applies the same pin globally).
-        let local_capabilities = Arc::new(if self.dial_only {
-            LocalCapabilities::dial_only()
-        } else {
-            LocalCapabilities::new()
-        });
+        let local_capabilities = Arc::new(
+            if self.dial_only {
+                LocalCapabilities::dial_only()
+            } else {
+                LocalCapabilities::new()
+            }
+            .with_memory_dialing(self.allow_memory),
+        );
 
         // LocalAddressManager handles NAT address advertisement. Peer-observed
         // addresses never enter it: their ports are connection-specific NAT

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -482,7 +482,7 @@ fn record_dialable(
     } else {
         peer.multiaddrs()
             .iter()
-            .any(|addr| capability.transport.can_dial(addr))
+            .any(|addr| capability.transport_can_dial(addr))
     }
 }
 
@@ -534,6 +534,48 @@ mod tests {
 
     const TCP: &str = "/ip4/8.8.8.8/tcp/1634";
     const WSS: &str = "/ip4/5.78.94.214/tcp/1635/tls/sni/example.libp2p.direct/ws";
+    const MEMORY: &str = "/memory/1234";
+
+    #[test]
+    fn default_node_drops_memory_only_gossip_record() {
+        // A production node (default TCP stack, no injected memory transport)
+        // never admits a self-signed memory-only record: it is filtered here at
+        // hive intake, so it never reaches the dialer. Both the known-IP and
+        // unknown-IP branches reject it.
+        let known = DialCapability {
+            ip: IpCapability::Dual,
+            transport: TransportCapability::Tcp,
+            allow_memory: false,
+        };
+        assert!(!record_dialable(&record_with_addrs(&[MEMORY]), known));
+
+        let unknown = DialCapability {
+            ip: IpCapability::None,
+            transport: TransportCapability::Tcp,
+            allow_memory: false,
+        };
+        assert!(!record_dialable(&record_with_addrs(&[MEMORY]), unknown));
+    }
+
+    #[test]
+    fn injected_memory_transport_admits_memory_gossip_record() {
+        // A cluster node with a memory transport injected admits the gossiped
+        // memory address so peers learned via hive dial each other. Its memory
+        // listener leaves the IP half unknown, so exercise that branch too.
+        let unknown = DialCapability {
+            ip: IpCapability::None,
+            transport: TransportCapability::Tcp,
+            allow_memory: true,
+        };
+        assert!(record_dialable(&record_with_addrs(&[MEMORY]), unknown));
+
+        let known = DialCapability {
+            ip: IpCapability::Dual,
+            transport: TransportCapability::Tcp,
+            allow_memory: true,
+        };
+        assert!(record_dialable(&record_with_addrs(&[MEMORY]), known));
+    }
 
     #[test]
     fn unexpected_exchange_is_a_peer_fault() {
@@ -550,6 +592,7 @@ mod tests {
         let capability = DialCapability {
             ip: IpCapability::Dual,
             transport: TransportCapability::SecureWebsocket,
+            allow_memory: false,
         };
         assert!(!record_dialable(&record_with_addrs(&[TCP]), capability));
         assert!(record_dialable(&record_with_addrs(&[WSS]), capability));
@@ -561,6 +604,7 @@ mod tests {
         let capability = DialCapability {
             ip: IpCapability::Dual,
             transport: TransportCapability::Tcp,
+            allow_memory: false,
         };
         assert!(record_dialable(&record_with_addrs(&[TCP]), capability));
         assert!(!record_dialable(&record_with_addrs(&[WSS]), capability));
@@ -575,6 +619,7 @@ mod tests {
         let capability = DialCapability {
             ip: IpCapability::None,
             transport: TransportCapability::Tcp,
+            allow_memory: false,
         };
         assert!(record_dialable(&record_with_addrs(&[TCP]), capability));
         assert!(!record_dialable(&record_with_addrs(&[WSS]), capability));
@@ -585,6 +630,7 @@ mod tests {
         let capability = DialCapability {
             ip: IpCapability::V4Only,
             transport: TransportCapability::Tcp,
+            allow_memory: false,
         };
         let v6_only = record_with_addrs(&["/ip6/2001:db8::1/tcp/1634"]);
         assert!(!record_dialable(&v6_only, capability));


### PR DESCRIPTION
## What

Gates `/memory` multiaddr dial admission behind an explicit, injected bit instead of always allowing it.

`DialCapability` (crates/net/local/src/transport.rs) gains a public `allow_memory` field, defaulted off.
Memory admission moves out of `TransportCapability::can_dial` (which now only matches the statically assembled TCP/SecureWebsocket suites) into a new `DialCapability::transport_can_dial` helper, which `can_dial` delegates to.
`LocalCapabilities` carries the flag via `with_memory_dialing(bool)`, and `dial_capability()` threads it into the built `DialCapability`.
`TopologyBehaviourBuilder` gains `with_memory_dialing`, forwarded through a new `allow_memory` parameter on `BuiltInfrastructure::from_config`.
The client, storer, and bootnode builders set `allow_memory = self.transport.is_some()`, so only a node with an injected `TransportOverride` admits memory dials.
`protocol_handlers::record_dialable`'s unknown-IP branch now calls `transport_can_dial` so the hive-intake filter respects the same bit.

## Why

Closes #865

Production nodes never expose a `/memory` transport, but the dial-admission path previously accepted `/memory` addresses unconditionally. That left a gap between what a node can actually dial and what topology would admit from a gossiped record, with no way for a real node to reject a memory-only record pre-dial. Scoping admission to an explicitly injected transport keeps the in-process cluster harness working while closing that gap for shipped nodes.

## Testing

Unit tests added in `vertex-net-local` (`default_capability_rejects_memory`, `memory_bit_admits_memory_regardless_of_ip`, `memory_classification_survives_p2p_suffix`, `memory_dialing_defaults_off_and_flows_into_dial_capability`) and in `vertex-swarm-topology` (`default_node_drops_memory_only_gossip_record`, `injected_memory_transport_admits_memory_gossip_record`).

Ran under `nix develop` with a shared target directory:
- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features -- -D warnings`: pass, including after `cargo clean -p vertex-net-local -p vertex-swarm-node -p vertex-swarm-topology` to rule out a stale cache
- `cargo nextest run -p vertex-net-local -p vertex-swarm-node -p vertex-swarm-topology`: 485/485 pass
- `just check-cone`: pass (ffi/storer/swap/chain cone guards clean)
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`: pass
- `cargo nextest run -p vertex-swarm-node --test bootnode_cluster`: 3/3 pass (`storer_cluster_smoke`, `three_node_convergence`, `tcp_cluster_smoke`)

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Opus 4.8 implementation and review, Sonnet 5 PR text) under human direction.
