### PR TITLE
feat(tasks,ratelimiter,swarm-node): Send-safe pausable sleep for behaviour timers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8494,10 +8494,10 @@ name = "vertex-net-ratelimiter"
 version = "0.1.0"
 dependencies = [
  "futures",
- "futures-timer",
  "parking_lot",
  "thiserror 2.0.18",
  "tokio",
+ "vertex-tasks",
  "vertex-util-runtime",
 ]
 
@@ -9671,6 +9671,7 @@ version = "0.1.0"
 dependencies = [
  "auto_impl",
  "dyn-clone",
+ "futures-timer",
  "futures-util",
  "gloo-timers 0.3.0",
  "metrics",

--- a/crates/net/ratelimiter/Cargo.toml
+++ b/crates/net/ratelimiter/Cargo.toml
@@ -13,10 +13,11 @@ thiserror.workspace = true
 # Monotonic clock via web-time so the GCRA limiter runs in the wasm cone instead
 # of reaching the std clock, which panics on wasm32-unknown-unknown.
 vertex-util-runtime.workspace = true
-# Delay timer for the outbound self-limiter's parking queue. The wasm-bindgen
-# feature routes the timer through the browser clock on wasm32 instead of the
-# std clock, which panics on wasm32-unknown-unknown.
-futures-timer = { workspace = true }
+# Send-bounded, re-armable timer (SendDelay) for the outbound self-limiter's
+# parking queue. vertex-tasks is the one timer home: it drives the tokio clock on
+# native (so paused-time tests control the parking) and the browser clock on
+# wasm32, where the std clock panics.
+vertex-tasks.workspace = true
 
 [dev-dependencies]
 futures.workspace = true

--- a/crates/net/ratelimiter/src/self_limiter.rs
+++ b/crates/net/ratelimiter/src/self_limiter.rs
@@ -116,6 +116,9 @@ impl<K: Eq + Hash + Clone, T> SelfRateLimiter<K, T> {
     /// returned; it will later surface from [`Self::poll_ready`] once the bucket
     /// has refilled. `Err(value)` hands the value back when the cost exceeds the
     /// bucket capacity and so can never be admitted.
+    ///
+    /// Parking arms a [`SendDelay`], which on native builds a tokio timer, so a
+    /// call that parks must run inside a tokio runtime context.
     pub fn enqueue(&mut self, key: K, cost: u32, value: T) -> Result<Option<T>, T> {
         if self.cost_exceeds_capacity(key.clone(), cost) {
             return Err(value);

--- a/crates/net/ratelimiter/src/self_limiter.rs
+++ b/crates/net/ratelimiter/src/self_limiter.rs
@@ -18,7 +18,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use futures_timer::Delay;
+use vertex_tasks::time::SendDelay;
 
 use crate::{KeyedRateLimiter, Quota, RateLimitedErr};
 
@@ -49,7 +49,7 @@ struct Item<T> {
 /// admitted and re-armed whenever the head changes.
 struct Parked<T> {
     queue: VecDeque<Item<T>>,
-    timer: Delay,
+    timer: SendDelay,
 }
 
 /// Outbound self-rate-limiter keyed by `K` (typically a `PeerId`).
@@ -137,7 +137,7 @@ impl<K: Eq + Hash + Clone, T> SelfRateLimiter<K, T> {
                     queue.push_back(Item { cost, value });
                     e.insert(Parked {
                         queue,
-                        timer: Delay::new(d),
+                        timer: SendDelay::new(d),
                     });
                     Ok(None)
                 }
@@ -353,8 +353,10 @@ mod tests {
         assert_eq!(rl.parked_keys(), 0);
     }
 
-    #[test]
-    fn enqueue_parks_when_over_budget() {
+    // Parking arms a `SendDelay`, which builds a tokio timer on native and so
+    // needs a runtime in scope; a bare `#[test]` has none.
+    #[tokio::test]
+    async fn enqueue_parks_when_over_budget() {
         let mut rl = SelfRateLimiter::<&'static str, u32>::new(quota_n_per(1, 60_000));
         assert_eq!(rl.enqueue("alice", 1, 10), Ok(Some(10)));
         // Second item cannot be admitted now; it is parked.
@@ -402,8 +404,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn clear_releases_key_and_parked_items() {
+    // Parking arms a `SendDelay`, which builds a tokio timer on native and so
+    // needs a runtime in scope; a bare `#[test]` has none.
+    #[tokio::test]
+    async fn clear_releases_key_and_parked_items() {
         let mut rl = SelfRateLimiter::<&'static str, u32>::new(quota_n_per(1, 60_000));
         assert_eq!(rl.enqueue("alice", 1, 1), Ok(Some(1)));
         assert_eq!(rl.enqueue("alice", 1, 2), Ok(None));
@@ -417,8 +421,9 @@ mod tests {
     #[tokio::test]
     async fn parked_item_drains_after_replenish() {
         // One token per 30 ms: the parked item becomes ready a short, bounded
-        // wait later. A real timer drives this (futures-timer), so the assertion
-        // is "becomes ready within a generous bound" rather than an exact tick.
+        // wait later. The bucket refills on the monotonic wall clock, so the
+        // assertion is "becomes ready within a generous bound" rather than an
+        // exact tick.
         let mut rl = SelfRateLimiter::<&'static str, u32>::new(quota_n_per(1, 30));
         assert_eq!(rl.enqueue("alice", 1, 10), Ok(Some(10)));
         assert_eq!(rl.enqueue("alice", 1, 20), Ok(None));

--- a/crates/swarm/node/src/dispatch.rs
+++ b/crates/swarm/node/src/dispatch.rs
@@ -35,7 +35,7 @@ use vertex_swarm_api::{
 };
 use vertex_swarm_client_behaviour::{ForwardError, closer_candidates};
 use vertex_swarm_net_pushsync::{DepthVerdict, Receipt};
-use vertex_tasks::time::Duration;
+use vertex_tasks::time::{Duration, send_sleep};
 
 use crate::retrieval_latency::{RetrievalLatency, adaptive_stagger};
 use crate::selection::SettlementTrigger;
@@ -854,10 +854,11 @@ where
                 }
                 settle_drives += 1;
                 counter!("swarm.client.retrieval_settle_drive").increment(1);
-                // `futures_timer::Delay`, not `vertex_tasks::time::sleep`: the
-                // latter is `!Send` on wasm and this future carries the async-trait
-                // `Send` bound. `Delay` is the Send-safe timer the race staggers use.
-                futures_timer::Delay::new(RETRIEVE_SETTLE_DRIVE_BACKOFF).await;
+                // `send_sleep`, not `vertex_tasks::time::sleep`: this future carries
+                // the async-trait `Send` bound and `sleep` is `!Send` on wasm.
+                // `send_sleep` is `Send` on both targets and, unlike a wall-clock
+                // timer, follows the tokio clock so paused-time tests control it.
+                send_sleep(RETRIEVE_SETTLE_DRIVE_BACKOFF).await;
                 continue;
             }
 

--- a/crates/swarm/node/src/staggered_race.rs
+++ b/crates/swarm/node/src/staggered_race.rs
@@ -40,7 +40,7 @@ use futures::{
     future::{self, Either},
     stream::FuturesUnordered,
 };
-use futures_timer::Delay;
+use vertex_tasks::time::SendDelay;
 
 /// Default stagger between retrieval candidates joining a [`race_candidates`]
 /// race.
@@ -213,11 +213,11 @@ where
         return Err(RaceFailure::NoCandidates);
     }
 
-    let mut stagger_tick = Delay::new(stagger).fuse();
+    let mut stagger_tick = SendDelay::new(stagger).fuse();
     // No deadline: a never-ready arm the select never wakes on, so the race is
     // bounded only by the budget and the candidate source.
     let mut deadline_tick = match deadline {
-        Some(deadline) => Either::Left(Delay::new(deadline)),
+        Some(deadline) => Either::Left(SendDelay::new(deadline)),
         None => Either::Right(future::pending::<()>()),
     }
     .fuse();
@@ -246,7 +246,7 @@ where
                 if in_flight.len() >= max_in_flight
                     || dispatch_next(&mut in_flight, &mut dispatched)
                 {
-                    stagger_tick = Delay::new(stagger).fuse();
+                    stagger_tick = SendDelay::new(stagger).fuse();
                 }
             },
             _ = deadline_tick => {
@@ -339,6 +339,30 @@ mod tests {
             .await;
 
         assert!(matches!(outcome, Err(RaceFailure::NoCandidates)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stagger_tick_rides_the_tokio_clock() {
+        // The head withholds forever; the second can only win once the stagger
+        // tick fires. Under paused time that tick rides the tokio clock, so
+        // auto-advance resolves the race at exactly one stagger with no
+        // wall-clock wait, proving the migrated timer is controllable.
+        let stagger = Duration::from_secs(2);
+        let start = tokio::time::Instant::now();
+        let outcome = race_candidates(0..2u32, stagger, |candidate| async move {
+            if candidate == 0 {
+                std::future::pending::<()>().await;
+            }
+            Ok::<u32, &str>(candidate)
+        })
+        .await;
+
+        assert_eq!(outcome.ok(), Some(1), "the staggered second wins");
+        assert_eq!(
+            start.elapsed(),
+            stagger,
+            "the race resolves exactly on the stagger tick"
+        );
     }
 
     #[tokio::test]

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -42,6 +42,10 @@ wasm-bindgen-futures = { workspace = true }
 # unsupported-platform clock and panics), so wasm timers use the browser's
 # setTimeout through gloo-timers instead. See the `time` module.
 gloo-timers = { workspace = true, features = ["futures"] }
+# `send_sleep` needs a `Send` timer on wasm32; gloo-timers' future is `!Send`, so
+# the browser side of `send_sleep`/`SendDelay` uses futures-timer's `Send` Delay
+# (routed through gloo-timers by its wasm-bindgen feature). See the `time` module.
+futures-timer = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "rt", "rt-multi-thread", "time", "macros", "test-util"] }

--- a/crates/tasks/src/time/mod.rs
+++ b/crates/tasks/src/time/mod.rs
@@ -8,7 +8,9 @@
 //!
 //! This module is the one import path for timer code in the wasm cone:
 //!
-//! - [`sleep`] waits for a duration.
+//! - [`sleep`] waits for a duration; [`send_sleep`] and its re-armable
+//!   [`SendDelay`] wrapper do the same on a `Send` future for timers held across
+//!   an `await` inside a `Send`-bounded behaviour future.
 //! - [`interval`] and [`interval_after`] build an [`Interval`] for periodic
 //!   work, with [`Interval::poll_tick`] for behaviour poll loops and
 //!   [`Interval::tick`] for async tasks.
@@ -21,6 +23,8 @@
 mod interval;
 
 use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 pub use interval::{Interval, interval, interval_after};
 pub use vertex_util_runtime::time::{
@@ -79,6 +83,72 @@ pub fn sleep(duration: Duration) -> impl Future<Output = ()> + 'static {
     // an absurdly long duration still produces a (very long) timer.
     let millis = u32::try_from(duration.as_millis()).unwrap_or(u32::MAX);
     gloo_timers::future::TimeoutFuture::new(millis)
+}
+
+/// Wait for `duration`, then resolve, on a future that is `Send` on both
+/// targets.
+///
+/// Prefer [`sleep`] for timer code that stays on one task. Reach for this only
+/// where the timer is held across an `await` inside a future that carries a
+/// `Send` bound, as async-trait behaviour futures do: [`sleep`] is `!Send` on
+/// `wasm32` and cannot cross those bounds.
+///
+/// On native this is `tokio::time::sleep`, so it follows the tokio clock and is
+/// controllable under `tokio::time::pause` and `tokio::time::advance`. On
+/// `wasm32` it is `futures_timer::Delay`, the `Send` browser timer, driven by
+/// the wall clock.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn send_sleep(duration: Duration) -> impl Future<Output = ()> + Send + 'static {
+    tokio::time::sleep(duration)
+}
+
+/// Wait for `duration`, then resolve, on a future that is `Send` on both
+/// targets.
+///
+/// Prefer [`sleep`] for timer code that stays on one task. Reach for this only
+/// where the timer is held across an `await` inside a future that carries a
+/// `Send` bound, as async-trait behaviour futures do: [`sleep`] is `!Send` on
+/// `wasm32` and cannot cross those bounds.
+///
+/// On native this is `tokio::time::sleep`, so it follows the tokio clock and is
+/// controllable under `tokio::time::pause` and `tokio::time::advance`. On
+/// `wasm32` it is `futures_timer::Delay`, the `Send` browser timer, driven by
+/// the wall clock.
+#[cfg(target_arch = "wasm32")]
+pub fn send_sleep(duration: Duration) -> impl Future<Output = ()> + Send + 'static {
+    futures_timer::Delay::new(duration)
+}
+
+/// A re-armable [`send_sleep`] timer for struct fields.
+///
+/// Holds a boxed [`send_sleep`], so it is `Send` and `Unpin` on both targets: it
+/// can be stored in a struct, polled through `Pin::new`, and re-armed in place
+/// where tokio's `!Unpin` `Sleep` could not be. [`Self::reset`] re-arms it to
+/// fire `duration` from the reset instant, the same as a fresh [`Self::new`].
+pub struct SendDelay {
+    inner: Pin<Box<dyn Future<Output = ()> + Send>>,
+}
+
+impl SendDelay {
+    /// Arm a timer to fire after `duration`.
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            inner: Box::pin(send_sleep(duration)),
+        }
+    }
+
+    /// Re-arm to fire `duration` from now, discarding any pending deadline.
+    pub fn reset(&mut self, duration: Duration) {
+        self.inner = Box::pin(send_sleep(duration));
+    }
+}
+
+impl Future for SendDelay {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        self.inner.as_mut().poll(cx)
+    }
 }
 
 /// Error returned by [`timeout`] when the deadline elapses before the wrapped
@@ -172,5 +242,24 @@ mod tests {
     fn elapsed_metric_label() {
         let label: &'static str = (&Elapsed).into();
         assert_eq!(label, "elapsed");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn send_sleep_completes_under_tokio_advance() {
+        let start = Instant::now();
+        send_sleep(Duration::from_secs(30)).await;
+        assert_eq!(start.elapsed(), Duration::from_secs(30));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn send_delay_reset_re_arms_from_now() {
+        let start = Instant::now();
+        let mut timer = SendDelay::new(Duration::from_secs(5));
+        tokio::time::advance(Duration::from_secs(2)).await;
+        // Re-arm before it fires: the new deadline is measured from now, so the
+        // total wait is the elapsed 2s plus the fresh 10s.
+        timer.reset(Duration::from_secs(10));
+        timer.await;
+        assert_eq!(start.elapsed(), Duration::from_secs(12));
     }
 }


### PR DESCRIPTION
## What

Adds `vertex_tasks::time::send_sleep` and a re-armable `SendDelay` wrapper, then migrates the three behaviour-path timer sites off `futures_timer::Delay`: the settle-drive backoff (`dispatch.rs`), the stagger and deadline ticks in `staggered_race.rs`, and the self-limiter parking timer (`self_limiter.rs`).

On native, `send_sleep` wraps `tokio::time::sleep`, which is `Send` and rides the tokio clock, so `start_paused`/`advance` control it in tests.
On wasm32, it wraps `futures_timer::Delay`, the `Send` timer in that cone.
`SendDelay` is a boxed, `Unpin` re-armable wrapper (`new`/`reset`) for struct fields where tokio's `!Unpin` `Sleep` cannot sit; it recreates the inner timer on reset, preserving the prior "fire from reset instant" semantics.

`futures-timer` becomes a wasm32-only dependency of `vertex-tasks`; `vertex-net-ratelimiter` drops its own `futures-timer` dependency in favour of `vertex-tasks`.

## Why

Closes #870

The settle-drive backoff and related behaviour-path timers previously used `futures_timer::Delay` purely for its `Send` bound, at the cost of not following the tokio clock, so tests could not pause or advance them deterministically. `send_sleep` and `SendDelay` keep the `Send` bound on both targets while letting native code ride the tokio clock.

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean, including after `cargo clean -p vertex-tasks vertex-net-ratelimiter vertex-swarm-node vertex vertex-swarm-builder` to rule out a cache false-clean.
- `cargo nextest run -p vertex-tasks -p vertex-net-ratelimiter -p vertex-swarm-node`: 205 run, 205 passed. New paused-time regression tests: `send_sleep_completes_under_tokio_advance`, `send_delay_reset_re_arms_from_now`, `stagger_tick_rides_the_tokio_clock`.
- `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`: clean, proving the `Send` bound holds on wasm32.
- `just check-cone`: all four cone guards pass.

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Opus 4.8 implementation and review, Sonnet 5 PR text) under human direction.