### PR TITLE
test(swarm-test-utils,swarm-node): drive N sources through one variadic helper

### DIFF
--- a/crates/swarm/node/src/protocol/behaviour_tests.rs
+++ b/crates/swarm/node/src/protocol/behaviour_tests.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 
 use alloy_primitives::{B256, Signature};
 use alloy_signer_local::PrivateKeySigner;
-use futures::StreamExt;
 use libp2p::{PeerId, Swarm};
 use nectar_postage::Stamp;
 use nectar_primitives::{AnyChunk, ContentChunk, SingleOwnerChunk};
@@ -23,7 +22,8 @@ use vertex_swarm_localstore::{ChunkStore, Clock};
 use vertex_swarm_primitives::{OverlayAddress, StampedChunk, SwarmNodeType};
 use vertex_swarm_test_utils::MockReserve;
 use vertex_swarm_test_utils::harness::{
-    HarnessNode, NodeContext, connect_and_activate, seeded_identity,
+    CommandPump, DrivableSwarm, HarnessNode, NodeContext, connect_and_activate, drive_until_signal,
+    seeded_identity,
 };
 
 use crate::ChunkTransferError;
@@ -115,16 +115,8 @@ async fn drive_until_retrieved(
     server: &mut Swarm<ClientBehaviour>,
     mut rx: oneshot::Receiver<Result<RetrievalResult, ChunkTransferError>>,
 ) -> Result<RetrievalResult, ChunkTransferError> {
-    let drive = async {
-        loop {
-            tokio::select! {
-                _ = client.select_next_some() => {}
-                _ = server.select_next_some() => {}
-                res = &mut rx => return res.expect("sender not dropped"),
-            }
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(10), drive)
+    let mut drivables: [&mut dyn DrivableSwarm; 2] = [client, server];
+    drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
         .await
         .expect("retrieval resolved within timeout")
 }
@@ -327,16 +319,8 @@ async fn inbound_pushsync_resets_with_stub_forwarder() {
             },
         });
 
-    let drive = async {
-        loop {
-            tokio::select! {
-                _ = client.swarm.select_next_some() => {}
-                _ = server.swarm.select_next_some() => {}
-                res = &mut rx => return res.expect("sender not dropped"),
-            }
-        }
-    };
-    let result = tokio::time::timeout(Duration::from_secs(10), drive)
+    let mut drivables: [&mut dyn DrivableSwarm; 2] = [&mut client, &mut server];
+    let result = drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
         .await
         .expect("push resolved within timeout");
     assert!(
@@ -441,16 +425,8 @@ async fn responsible_storer_stores_and_signs_a_receipt() {
             },
         });
 
-    let drive = async {
-        loop {
-            tokio::select! {
-                _ = pusher.swarm.select_next_some() => {}
-                _ = storer.swarm.select_next_some() => {}
-                res = &mut rx => return res.expect("sender not dropped"),
-            }
-        }
-    };
-    let result = tokio::time::timeout(Duration::from_secs(10), drive)
+    let mut drivables: [&mut dyn DrivableSwarm; 2] = [&mut pusher, &mut storer];
+    let result = drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
         .await
         .expect("push resolved within timeout");
 
@@ -504,16 +480,8 @@ async fn non_responsible_storer_forwards_instead_of_storing() {
             },
         });
 
-    let drive = async {
-        loop {
-            tokio::select! {
-                _ = pusher.swarm.select_next_some() => {}
-                _ = storer.swarm.select_next_some() => {}
-                res = &mut rx => return res.expect("sender not dropped"),
-            }
-        }
-    };
-    let result = tokio::time::timeout(Duration::from_secs(10), drive)
+    let mut drivables: [&mut dyn DrivableSwarm; 2] = [&mut pusher, &mut storer];
+    let result = drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
         .await
         .expect("push resolved within timeout");
 
@@ -678,18 +646,11 @@ async fn three_node_retrieval_relays_verifies_and_accounts() {
 
     // B's forwarder commands are pumped back into B.
     let result = {
-        let drive = async {
-            loop {
-                tokio::select! {
-                    _ = a.swarm.select_next_some() => {}
-                    _ = b.swarm.select_next_some() => {}
-                    _ = c.swarm.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
-                    res = &mut rx => return res.expect("sender not dropped"),
-                }
-            }
-        };
-        tokio::time::timeout(Duration::from_secs(10), drive)
+        let mut b_pump = CommandPump::new(&mut b.swarm, &mut b_commands, |behaviour, command| {
+            behaviour.on_command(command);
+        });
+        let mut drivables: [&mut dyn DrivableSwarm; 3] = [&mut a, &mut b_pump, &mut c];
+        drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
             .await
             .expect("retrieval resolved within timeout")
     };
@@ -777,18 +738,11 @@ async fn relay_does_not_cache_a_forwarded_soc() {
     });
 
     let result = {
-        let drive = async {
-            loop {
-                tokio::select! {
-                    _ = a.swarm.select_next_some() => {}
-                    _ = b.swarm.select_next_some() => {}
-                    _ = c.swarm.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
-                    res = &mut rx => return res.expect("sender not dropped"),
-                }
-            }
-        };
-        tokio::time::timeout(Duration::from_secs(10), drive)
+        let mut b_pump = CommandPump::new(&mut b.swarm, &mut b_commands, |behaviour, command| {
+            behaviour.on_command(command);
+        });
+        let mut drivables: [&mut dyn DrivableSwarm; 3] = [&mut a, &mut b_pump, &mut c];
+        drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
             .await
             .expect("retrieval resolved within timeout")
     };
@@ -848,17 +802,11 @@ async fn relay_without_strictly_closer_peer_resets_rather_than_looping() {
     });
 
     let result = {
-        let drive = async {
-            loop {
-                tokio::select! {
-                    _ = a.swarm.select_next_some() => {}
-                    _ = b.swarm.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
-                    res = &mut rx => return res.expect("sender not dropped"),
-                }
-            }
-        };
-        tokio::time::timeout(Duration::from_secs(10), drive)
+        let mut b_pump = CommandPump::new(&mut b.swarm, &mut b_commands, |behaviour, command| {
+            behaviour.on_command(command);
+        });
+        let mut drivables: [&mut dyn DrivableSwarm; 2] = [&mut a, &mut b_pump];
+        drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
             .await
             .expect("retrieval resolved within timeout")
     };
@@ -963,29 +911,22 @@ async fn three_node_pushsync_relays_receipt_verbatim_and_accounts() {
     });
 
     let result = {
-        let drive = async {
-            loop {
-                tokio::select! {
-                    _ = a.swarm.select_next_some() => {}
-                    _ = b.swarm.select_next_some() => {}
-                    _ = c.swarm.select_next_some() => {}
-                    Some(cmd) = b_commands.recv() => b.swarm.behaviour_mut().on_command(cmd),
-                    // C is the storer: answer its outbound push with the
-                    // signed receipt instead of forwarding on.
-                    Some(cmd) = c_commands.recv() => {
-                        if let ClientCommand::Peer {
-                            command: PeerCommand::PushChunk { response, .. },
-                            ..
-                        } = cmd
-                        {
-                            let _ = response.send(Ok(receipt_for_c.clone()));
-                        }
-                    }
-                    res = &mut rx => return res.expect("sender not dropped"),
-                }
+        let mut b_pump = CommandPump::new(&mut b.swarm, &mut b_commands, |behaviour, command| {
+            behaviour.on_command(command);
+        });
+        // C is the storer: answer its outbound push with the signed receipt
+        // instead of forwarding on.
+        let mut c_pump = CommandPump::new(&mut c.swarm, &mut c_commands, |_behaviour, command| {
+            if let ClientCommand::Peer {
+                command: PeerCommand::PushChunk { response, .. },
+                ..
+            } = command
+            {
+                let _ = response.send(Ok(receipt_for_c.clone()));
             }
-        };
-        tokio::time::timeout(Duration::from_secs(10), drive)
+        });
+        let mut drivables: [&mut dyn DrivableSwarm; 3] = [&mut a, &mut b_pump, &mut c_pump];
+        drive_until_signal(&mut drivables, Duration::from_secs(10), &mut rx)
             .await
             .expect("push resolved within timeout")
     };

--- a/crates/swarm/test-utils/src/harness.rs
+++ b/crates/swarm/test-utils/src/harness.rs
@@ -10,8 +10,10 @@
 //! transport, but no test-facing signature names it, so a later deterministic
 //! simulation can slot under the same surface.
 
+use std::future::poll_fn;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::StreamExt;
@@ -19,6 +21,7 @@ use libp2p::multiaddr::Protocol;
 use libp2p::swarm::{ConnectionId, NetworkBehaviour, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt;
+use tokio::sync::{mpsc, oneshot};
 use vertex_net_peer_registry::PeerRegistry;
 use vertex_swarm_api::SwarmNodeType;
 use vertex_swarm_primitives::OverlayAddress;
@@ -303,6 +306,136 @@ where
     drive_until(a, b, duration, |_, _| false).await;
 }
 
+/// A source the [`drive`] loop can advance: a [`Swarm`], a [`HarnessNode`], or a
+/// [`CommandPump`] adapter.
+///
+/// `poll_drive` advances the source once and reports `Ready` when it made
+/// progress, so a driver races several sources without naming their transport.
+/// The signature is runtime-free (no timer, no executor, no transport), so a
+/// deterministic simulation can drive the same sources under virtual time; the
+/// paused-clock deadline is the driver's concern, not the trait's.
+pub trait DrivableSwarm {
+    /// Poll the source once, returning `Ready` when it produced an event or
+    /// otherwise made progress this poll.
+    fn poll_drive(&mut self, cx: &mut Context<'_>) -> Poll<()>;
+}
+
+impl<B: NetworkBehaviour> DrivableSwarm for Swarm<B> {
+    fn poll_drive(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        // The swarm stream never terminates; a yielded event is progress, its
+        // payload discarded because callers assert on accumulated state.
+        match self.poll_next_unpin(cx) {
+            Poll::Ready(Some(_)) => Poll::Ready(()),
+            Poll::Ready(None) | Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<B: NetworkBehaviour> DrivableSwarm for HarnessNode<B> {
+    fn poll_drive(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        self.swarm.poll_drive(cx)
+    }
+}
+
+/// A [`DrivableSwarm`] that drains a command channel into a swarm's behaviour
+/// before polling the swarm.
+///
+/// It folds a manual command pump into a driver's poll set, so a relay test that
+/// feeds a node's own outbound commands back into it (or answers them) need not
+/// hand-roll a recv-and-apply `select!` branch. Co-locating the channel with the
+/// swarm in one owner keeps the pump out of the driver's terminal hook, which
+/// already borrows the poll set.
+pub struct CommandPump<'a, B: NetworkBehaviour, C, F> {
+    swarm: &'a mut Swarm<B>,
+    commands: &'a mut mpsc::Receiver<C>,
+    apply: F,
+}
+
+impl<'a, B, C, F> CommandPump<'a, B, C, F>
+where
+    B: NetworkBehaviour,
+    F: FnMut(&mut B, C),
+{
+    /// Drain `commands` into `swarm`'s behaviour through `apply` on every poll,
+    /// then poll the swarm.
+    pub fn new(swarm: &'a mut Swarm<B>, commands: &'a mut mpsc::Receiver<C>, apply: F) -> Self {
+        Self {
+            swarm,
+            commands,
+            apply,
+        }
+    }
+}
+
+impl<B, C, F> DrivableSwarm for CommandPump<'_, B, C, F>
+where
+    B: NetworkBehaviour,
+    F: FnMut(&mut B, C),
+{
+    fn poll_drive(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        let mut progressed = false;
+        while let Poll::Ready(Some(command)) = self.commands.poll_recv(cx) {
+            (self.apply)(self.swarm.behaviour_mut(), command);
+            progressed = true;
+        }
+        // A drained command schedules swarm work that resolves on a later poll,
+        // so report progress to keep the driver looping rather than parking.
+        match self.swarm.poll_drive(cx) {
+            Poll::Ready(()) => Poll::Ready(()),
+            Poll::Pending if progressed => Poll::Ready(()),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Drive every source in `drivables`, calling `hook` after each poll round,
+/// until the hook yields a value or `timeout` elapses; returns the hook's value,
+/// or `None` on timeout.
+///
+/// The deadline runs on the tokio clock, so under `#[tokio::test(start_paused =
+/// true)]` an idle set auto-advances rather than burning real time. The hook
+/// observes external state (a response channel, a counter); fold a command
+/// channel into `drivables` with a [`CommandPump`] rather than into the hook.
+pub async fn drive<T>(
+    drivables: &mut [&mut dyn DrivableSwarm],
+    timeout: Duration,
+    mut hook: impl FnMut() -> Option<T>,
+) -> Option<T> {
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+    loop {
+        if let Some(value) = hook() {
+            return Some(value);
+        }
+        let step = poll_fn(|cx| {
+            let mut progress = Poll::Pending;
+            for drivable in drivables.iter_mut() {
+                if drivable.poll_drive(cx).is_ready() {
+                    progress = Poll::Ready(());
+                }
+            }
+            progress
+        });
+        tokio::select! {
+            () = &mut deadline => return hook(),
+            () = step => {}
+        }
+    }
+}
+
+/// Drive `drivables` until `signal` resolves or `timeout` elapses, returning the
+/// resolved value (or `None` on timeout).
+///
+/// The terminal condition every relay and completion test shares: a response
+/// arrives on a oneshot while the swarms (and any [`CommandPump`]s) run.
+pub async fn drive_until_signal<T>(
+    drivables: &mut [&mut dyn DrivableSwarm],
+    timeout: Duration,
+    signal: &mut oneshot::Receiver<T>,
+) -> Option<T> {
+    drive(drivables, timeout, || signal.try_recv().ok()).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -362,5 +495,56 @@ mod tests {
         // A predicate already true returns immediately.
         let held = drive_until(&mut a, &mut b, Duration::from_secs(30), |_, _| true).await;
         assert!(held);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drive_until_signal_resolves_or_times_out() {
+        let mut a = dummy_node(9);
+        let mut b = dummy_node(10);
+        connect_and_activate(&mut a, &mut b, |_, _, _, _| {}).await;
+
+        // A signal that never fires times out; the idle pair auto-advances.
+        let (_tx, mut rx) = oneshot::channel::<u8>();
+        {
+            let mut drivables: [&mut dyn DrivableSwarm; 2] = [&mut a, &mut b];
+            let out = drive_until_signal(&mut drivables, Duration::from_secs(5), &mut rx).await;
+            assert_eq!(out, None);
+        }
+
+        // An already-fired signal resolves to its value.
+        let (tx, mut rx) = oneshot::channel::<u8>();
+        tx.send(42).unwrap();
+        let mut drivables: [&mut dyn DrivableSwarm; 2] = [&mut a, &mut b];
+        let out = drive_until_signal(&mut drivables, Duration::from_secs(5), &mut rx).await;
+        assert_eq!(out, Some(42));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn command_pump_applies_before_polling() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let mut node = dummy_node(11);
+        let (tx, mut rx) = mpsc::channel::<u8>(4);
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        drop(tx);
+
+        let applied = Rc::new(RefCell::new(Vec::new()));
+        let sink = Rc::clone(&applied);
+        let mut pump = CommandPump::new(
+            &mut node.swarm,
+            &mut rx,
+            move |_behaviour: &mut dummy::Behaviour, command: u8| {
+                sink.borrow_mut().push(command);
+            },
+        );
+
+        let (_never_tx, mut never) = oneshot::channel::<()>();
+        let mut drivables: [&mut dyn DrivableSwarm; 1] = [&mut pump];
+        let out = drive_until_signal(&mut drivables, Duration::from_secs(1), &mut never).await;
+
+        assert_eq!(out, None);
+        assert_eq!(*applied.borrow(), vec![1, 2]);
     }
 }


### PR DESCRIPTION
## What

Adds a variadic driver to the test-utils harness and migrates the seven bespoke `tokio::select!` loops in the node behaviour tests onto it.

New surface in `crates/swarm/test-utils/src/harness.rs`:

- `DrivableSwarm` trait: object-safe `poll_drive(&mut self, cx) -> Poll<()>`, runtime- and transport-free in its signature. Implemented for `Swarm<B>` (discards the yielded event, never terminates) and `HarnessNode<B>` (delegates to its swarm). Paused-time awareness stays in the driver (a `tokio::time::sleep` deadline), not the trait, so a deterministic sim scheduler can implement the same trait and drive the same sources under virtual time.
- `CommandPump<'a, B, C, F>`: a `DrivableSwarm` adapter co-locating an `mpsc::Receiver<C>` with a `&mut Swarm<B>` and an `apply: FnMut(&mut B, C)`. Each poll drains the channel into the behaviour then polls the swarm, folding a manual command pump into the poll set. Co-locating the channel with the swarm sidesteps the aliasing that would arise from feeding a node also held in the slice.
- `drive<T>(drivables: &mut [&mut dyn DrivableSwarm], timeout, hook: FnMut() -> Option<T>) -> Option<T>`: the general per-iteration-hook driver, racing all sources against a paused-aware deadline via a single `poll_fn` round.
- `drive_until_signal<T>(drivables, timeout, signal: &mut oneshot::Receiver<T>) -> Option<T>`: the oneshot-terminal convenience every relay/completion test shares.

Migration of `crates/swarm/node/src/protocol/behaviour_tests.rs`: rewrote `drive_until_retrieved` (shared by four tests) and the seven inline `tokio::select!` loops (inbound pushsync reset, two storer ingest branches, two three-node retrieval relays, the no-strictly-closer reset, and the three-node pushsync verbatim relay) onto `drive_until_signal` plus `CommandPump` for the B/C command channels. Removed the now-unused `futures::StreamExt` import. All assertions and messages are unchanged; the seven `tokio::select!` blocks are gone.

Added three harness unit tests (`drive_until_signal` resolve/timeout, `CommandPump` drain-before-poll) to keep coverage on the new code.

## Why

Closes #867

Seven near-identical `tokio::select!` loops in the node behaviour tests each hand-rolled the same race-and-drain pattern for a swarm plus a command channel. Factoring that into one variadic, object-safe driver removes the duplication and gives future multi-node tests (and, eventually, a deterministic sim scheduler under virtual time) a single well-tested primitive instead of another bespoke loop.

## Testing

Independent re-verification on a detached checkout of HEAD (5e9a0091), from scratch, via `nix develop` with a shared target directory.

- `cargo fmt --all -- --check`: pass.
- `cargo clippy --all-targets --all-features -- -D warnings`: pass, clean workspace build.
- Cache false-clean check: `cargo clean -p vertex vertex-swarm-builder vertex-swarm-node vertex-swarm-test-utils`, then re-ran clippy for those crates with `--all-targets -D warnings`: pass on a genuinely rebuilt tree.
- `cargo nextest run -p vertex-swarm-node -p vertex-swarm-test-utils`: 179 tests run, 179 passed, 0 skipped, 0 failed.
- Coverage floor: `nextest list` count for `vertex-swarm-node` is 150 on both HEAD and the pre-migration commit, so the migration does not drop any test.
- Swept the diff and commit range for em-dashes, "underlay", inline issue references, standalone "bee" mentions, and AI-attribution footers: none found. Author and committer are both `mfw78 <mfw78@nxm.rs>`.

An adversarial review of the branch confirmed the design is sound, including that `CommandPump` reporting progress after draining commands even when the swarm itself is `Pending` is a required invariant (exercised by the three-node relay tests under `start_paused`), and that waker registration across the `poll_fn` round has no lost-wakeup or busy-loop regression versus the original `select!` loops. The module lives behind the dev-only `harness` feature, so there is no wasm or `Send` exposure. Two nits were raised (an under-locked unit-test invariant already covered by integration tests, and a negligible dropped-sender diagnostic under `start_paused`); neither warranted a change.

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Opus 4.8 implementation and review, Sonnet 5 PR text) under human direction.