### PR TITLE
chore(deps): bump libp2p fork pins to the pausable-timer rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,7 +4158,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "bytes",
  "either",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4200,7 +4200,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "either",
  "fnv",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4397,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4418,7 +4418,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "futures-bounded 0.3.0",
@@ -4433,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "either",
  "fnv",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "heck",
  "quote",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "async-trait",
  "futures",
@@ -4477,13 +4477,14 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4498,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4516,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4530,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket-websys"
 version = "0.6.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "bytes",
  "futures",
@@ -4546,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "either",
  "futures",
@@ -4878,7 +4879,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "bytes",
  "futures",
@@ -5950,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6756,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=570774ff4368b8401040825f5da9efda8211e929#570774ff4368b8401040825f5da9efda8211e929"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ opentelemetry-appender-tracing = { version = "0.31", features = ["experimental_u
 # WebSocket `bufferedAmount` draining to zero, which stalled the wasm client mid
 # handshake and tore the connection down with `BrokenPipe`. Revisit when the fix is
 # upstreamed and libp2p 0.57 is released.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", features = [
     "tokio",
     "noise",
     "tcp",
@@ -328,13 +328,13 @@ libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b84
 quick-protobuf = "0.8"
 quick-protobuf-codec = "0.3.1"
 asynchronous-codec = "0.7.0"
-libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929" }
-libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929" }
+libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73" }
+libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73" }
 # Browser websocket transport for the wasm client. Dials the bee AutoTLS
 # `/tls/sni/<host>/ws` form; the browser performs TLS and SNI natively. Pinned to
 # the nxm-rs fork for the `poll_flush` browser WebSocket flush fix (see the `libp2p`
 # entry above).
-libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929" }
+libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73" }
 quickcheck = "1.0.3"
 pb-rs = "0.10"
 walkdir = "2.5.0"

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -96,7 +96,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 vertex-tasks = { path = "../../crates/tasks" }
 
 # libp2p Multiaddr only; the trimmed wasm feature set mirrors the node crate.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false }
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false }
 
 # wasm-bindgen surface and browser bindings.
 wasm-bindgen = "0.2"

--- a/crates/swarm/client-behaviour/Cargo.toml
+++ b/crates/swarm/client-behaviour/Cargo.toml
@@ -60,7 +60,7 @@ tracing.workspace = true
 libp2p.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -119,7 +119,7 @@ vertex-swarm-storer-behaviour = { workspace = true, optional = true }
 vertex-swarm-puller = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/node/src/protocol/timeout_repro.rs
+++ b/crates/swarm/node/src/protocol/timeout_repro.rs
@@ -161,10 +161,9 @@ fn requester_node(seed: u8, retrieval_timeout: Duration) -> HarnessNode<ClientBe
     })
 }
 
-// Live clock on purpose: the per-request deadline is a libp2p substream
-// timeout running on a wall-clock timer, so under `start_paused` the outer
-// tokio guard would auto-advance and fire before the deadline ever could.
-#[tokio::test]
+// Paused time: the libp2p substream deadline rides the tokio clock on native,
+// so the whole reproduction resolves on logical time with no wall-clock wait.
+#[tokio::test(start_paused = true)]
 async fn withholding_peer_resolves_as_timed_out_within_the_deadline() {
     // A 200ms retrieval deadline: short enough to assert against, far below the
     // shared 30s default that the bug would otherwise impose.

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -80,7 +80,7 @@ vertex-net-dnsaddr.workspace = true
 # `vertex-net-dnsaddr-doh` (DNS-over-HTTPS) with the embedded wss snapshot as
 # the fallback.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "570774ff4368b8401040825f5da9efda8211e929", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false, features = [
     "noise",
     "yamux",
     "macros",


### PR DESCRIPTION
## What

Bumps every nxm-rs/rust-libp2p git pin (workspace root, swarm-demo, and the wasm-specific entries in client-behaviour, node, and topology) from 570774ff to 0994625a, the merged head of the fork's pinned branch, refreshes Cargo.lock, and flips the withholding-peer timeout reproduction to `start_paused`.

## Why

Closes #869. Closes #866. The fork now routes libp2p-swarm's substream and keep-alive deadlines and swarm-test's event deadline through the tokio clock on native (wasm32 keeps futures-timer), and swarm-test's `listen()` is safe for memory-only swarms. With the pin bumped, the timeout reproduction no longer needs the live clock: it resolves on logical time in 7ms instead of burning its 200ms deadline in real wall-clock.

## Testing

cargo nextest run for the swarm-test consumers (vertex-swarm-node, vertex-swarm-storer-behaviour: 156 passed, the flipped reproduction completing in 0.007s), cargo fmt --check clean, cargo clippy --all-targets --all-features -D warnings clean, and a wasm32-unknown-unknown build of vertex-swarm-node since the websocket-websys pin moves with the rest.

AI Assistance: Claude Code used for the rev bump, the paused-time flip, verification, and PR text under human direction.
