### PR TITLE
chore(deps): bump libp2p fork pins to the timer-core rev

### DIFF
--- a/.github/scripts/upstream-track.sh
+++ b/.github/scripts/upstream-track.sh
@@ -102,6 +102,8 @@ Detail:
 ${detail}
 \`\`\`
 
+Recovery runbook: if the failing stage is the rebase and the conflict sits in the mechanical timer-sweep commit (trailer \`Regenerate: scripts/retimer.sh\`), do NOT hand-merge it. Drop that commit, rebase the remaining series, re-run \`scripts/retimer.sh\` in the fork checkout, recommit the sweep with the same trailer, and re-verify. Push the result to a candidate branch for review; never force-push the pinned branch without sign-off. Hand-merge only conflicts in the hand-written commits (the timer crate, the swarm reroll, the websocket-websys and swarm-test patches).
+
 This issue is maintained automatically by the \`upstream-track\` workflow and will be closed when the series verifies cleanly again.
 EOF
 )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b604752cefc5aa3ab98992a107a8bd99465d2825c1584e0b60cb6957b21e19d7"
 dependencies = [
+ "futures-timer",
  "futures-util",
  "tokio",
 ]
@@ -4158,12 +4159,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "bytes",
  "either",
  "futures",
- "futures-timer",
  "getrandom 0.2.17",
  "libp2p-allow-block-list",
  "libp2p-autonat",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4200,17 +4200,17 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures",
  "futures-bounded 0.3.0",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-request-response",
  "libp2p-swarm",
+ "libp2p-timer",
  "prost 0.14.4",
  "prost-codec",
  "rand 0.8.6",
@@ -4223,7 +4223,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4233,13 +4233,13 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-timer",
  "libp2p-identity",
+ "libp2p-timer",
  "multiaddr",
  "multihash",
  "multistream-select",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4271,16 +4271,16 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures",
  "futures-bounded 0.3.0",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
+ "libp2p-timer",
  "prost 0.14.4",
  "prost-codec",
  "smallvec",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4329,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4367,13 +4367,13 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
+ "libp2p-timer",
  "rand 0.8.6",
  "tracing",
  "web-time",
@@ -4382,7 +4382,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4397,13 +4397,13 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
- "futures-timer",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
+ "libp2p-timer",
  "libp2p-tls",
  "quinn",
  "rand 0.8.6",
@@ -4418,13 +4418,14 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
  "futures-bounded 0.3.0",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
+ "libp2p-timer",
  "rand 0.8.6",
  "smallvec",
  "tracing",
@@ -4433,17 +4434,17 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-timer",
  "getrandom 0.2.17",
  "hashlink 0.11.1",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
+ "libp2p-timer",
  "multistream-select",
  "rand 0.8.6",
  "smallvec",
@@ -4456,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "heck",
  "quote",
@@ -4466,40 +4467,49 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "async-trait",
  "futures",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-plaintext",
  "libp2p-swarm",
  "libp2p-tcp",
+ "libp2p-timer",
  "libp2p-yamux",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
- "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
+ "libp2p-timer",
  "socket2 0.6.4",
  "tokio",
  "tracing",
 ]
 
 [[package]]
+name = "libp2p-timer"
+version = "0.1.0"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+dependencies = [
+ "futures-bounded 0.3.0",
+ "futures-timer",
+ "tokio",
+]
+
+[[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4517,13 +4527,13 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
- "futures-timer",
  "igd-next",
  "libp2p-core",
  "libp2p-swarm",
+ "libp2p-timer",
  "tokio",
  "tracing",
 ]
@@ -4531,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket-websys"
 version = "0.6.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "bytes",
  "futures",
@@ -4547,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "either",
  "futures",
@@ -4879,7 +4889,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "bytes",
  "futures",
@@ -5951,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6757,7 +6767,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=0994625afa6b81e49456a8f740db4725b347ea73#0994625afa6b81e49456a8f740db4725b347ea73"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ opentelemetry-appender-tracing = { version = "0.31", features = ["experimental_u
 # WebSocket `bufferedAmount` draining to zero, which stalled the wasm client mid
 # handshake and tore the connection down with `BrokenPipe`. Revisit when the fix is
 # upstreamed and libp2p 0.57 is released.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", features = [
     "tokio",
     "noise",
     "tcp",
@@ -328,13 +328,13 @@ libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e
 quick-protobuf = "0.8"
 quick-protobuf-codec = "0.3.1"
 asynchronous-codec = "0.7.0"
-libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73" }
-libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73" }
+libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb" }
+libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb" }
 # Browser websocket transport for the wasm client. Dials the bee AutoTLS
 # `/tls/sni/<host>/ws` form; the browser performs TLS and SNI natively. Pinned to
 # the nxm-rs fork for the `poll_flush` browser WebSocket flush fix (see the `libp2p`
 # entry above).
-libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73" }
+libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb" }
 quickcheck = "1.0.3"
 pb-rs = "0.10"
 walkdir = "2.5.0"

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -96,7 +96,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 vertex-tasks = { path = "../../crates/tasks" }
 
 # libp2p Multiaddr only; the trimmed wasm feature set mirrors the node crate.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false }
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false }
 
 # wasm-bindgen surface and browser bindings.
 wasm-bindgen = "0.2"

--- a/crates/swarm/client-behaviour/Cargo.toml
+++ b/crates/swarm/client-behaviour/Cargo.toml
@@ -60,7 +60,7 @@ tracing.workspace = true
 libp2p.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -119,7 +119,7 @@ vertex-swarm-storer-behaviour = { workspace = true, optional = true }
 vertex-swarm-puller = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -80,7 +80,7 @@ vertex-net-dnsaddr.workspace = true
 # `vertex-net-dnsaddr-doh` (DNS-over-HTTPS) with the embedded wss snapshot as
 # the fallback.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "0994625afa6b81e49456a8f740db4725b347ea73", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false, features = [
     "noise",
     "yamux",
     "macros",


### PR DESCRIPTION
## What

Bumps every nxm-rs/rust-libp2p git pin from 0994625a to fd9cc0d9, the merged head carrying the whole-tree timer migration (the libp2p-timer crate, the swarm reroll, and the script-regenerated sweep), refreshes Cargo.lock (libp2p-timer 0.1.0 enters the graph), and extends the upstream-track drift issue template with the recovery runbook the regenerable sweep dictates: drop the trailer-marked sweep commit, re-run scripts/retimer.sh, recommit, re-verify, and push only to a candidate branch.

## Why

Closes #875. Every libp2p-enforced deadline in the fork now rides the tokio clock on native (first-poll runtime detection, futures-timer off-runtime and on wasm), so deterministic tests can pause and advance through any protocol timeout, and the latent browser-wasm panic in the futures-bounded stream timeouts (identify and friends) is fixed at the pinned rev.

## Testing

cargo nextest run for the swarm-test consumers (vertex-swarm-node, vertex-swarm-storer-behaviour: 158 passed), cargo fmt --check clean, cargo clippy --all-targets --all-features -D warnings clean, a wasm32-unknown-unknown build of vertex-swarm-node, and shellcheck on the amended upstream-track script.

AI Assistance: Claude Code used for the rev bump, the runbook update, verification, and PR text under human direction.
