### PR TITLE
feat(swarm-sim): kademlia scenario library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9539,6 +9539,7 @@ dependencies = [
  "futures",
  "libp2p",
  "parking_lot",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "turmoil",

--- a/crates/swarm/sim/Cargo.toml
+++ b/crates/swarm/sim/Cargo.toml
@@ -18,11 +18,13 @@ alloy-signer-local.workspace = true
 futures.workspace = true
 libp2p = { workspace = true, features = ["plaintext"] }
 parking_lot.workspace = true
+rand.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 turmoil.workspace = true
 vertex-swarm-api.workspace = true
 vertex-swarm-identity.workspace = true
+vertex-swarm-net-handshake.workspace = true
 vertex-swarm-primitives.workspace = true
 vertex-swarm-spec.workspace = true
 vertex-swarm-test-utils = { workspace = true, features = ["harness"] }
@@ -30,6 +32,5 @@ vertex-swarm-topology.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
-vertex-swarm-net-handshake.workspace = true
 vertex-swarm-node = { workspace = true, features = ["storer"] }
 vertex-tasks.workspace = true

--- a/crates/swarm/sim/src/host.rs
+++ b/crates/swarm/sim/src/host.rs
@@ -128,6 +128,20 @@ impl HostContext {
         auth: SimAuth,
         build: impl FnOnce(&Keypair) -> B,
     ) -> Swarm<B> {
+        self.swarm_with_idle(auth, Duration::from_secs(60), build)
+    }
+
+    /// Build a swarm with an explicit idle-connection timeout.
+    ///
+    /// Hosts that must hold otherwise-quiet connections across long virtual
+    /// horizons (scripted scenario peers) need the timeout to outlive the
+    /// scenario schedule.
+    pub fn swarm_with_idle<B: NetworkBehaviour>(
+        &self,
+        auth: SimAuth,
+        idle: Duration,
+        build: impl FnOnce(&Keypair) -> B,
+    ) -> Swarm<B> {
         let keypair = self.keypair();
         let behaviour = build(&keypair);
         let peer_id = keypair.public().to_peer_id();
@@ -135,8 +149,7 @@ impl HostContext {
             stack(auth, &keypair),
             behaviour,
             peer_id,
-            libp2p::swarm::Config::with_tokio_executor()
-                .with_idle_connection_timeout(Duration::from_secs(60)),
+            libp2p::swarm::Config::with_tokio_executor().with_idle_connection_timeout(idle),
         )
     }
 

--- a/crates/swarm/sim/src/lib.rs
+++ b/crates/swarm/sim/src/lib.rs
@@ -16,6 +16,8 @@ use libp2p::{
 mod drive;
 mod host;
 mod node;
+mod probe;
+mod scenario;
 mod trace;
 mod transport;
 mod world;
@@ -23,6 +25,11 @@ mod world;
 pub use drive::{DrivableSwarm, drive};
 pub use host::{HostContext, TracedSwarm, host_keypair, host_nonce, host_signer};
 pub use node::{SimNetworkConfig, transport_override};
+pub use probe::Probe;
+pub use scenario::{
+    Fault, FaultSchedule, Invariants, PeerScript, Placement, Scenario, ScriptedPeer,
+    handshake_summary, placement_nonce,
+};
 pub use trace::{SimTrace, TraceEntry, normalized_event};
 pub use transport::{TurmoilStream, TurmoilTransport};
 pub use world::{HostResult, SimError, SimWorld, SimWorldBuilder, listen_multiaddr};

--- a/crates/swarm/sim/src/node.rs
+++ b/crates/swarm/sim/src/node.rs
@@ -42,6 +42,7 @@ pub struct SimNetworkConfig {
     trusted_peers: Vec<Multiaddr>,
     nat_addrs: Vec<Multiaddr>,
     max_peers: usize,
+    idle_timeout: Duration,
     peer: SimPeerConfig,
     routing: vertex_swarm_topology::KademliaConfig,
 }
@@ -55,9 +56,19 @@ impl SimNetworkConfig {
             trusted_peers: Vec::new(),
             nat_addrs: Vec::new(),
             max_peers,
+            idle_timeout: Duration::from_secs(30),
             peer: SimPeerConfig,
             routing: vertex_swarm_topology::KademliaConfig::default(),
         }
+    }
+
+    /// Override the idle-connection timeout.
+    ///
+    /// Scenario runs hold otherwise-quiet connections across long virtual
+    /// horizons, so the timeout must outlive the scenario schedule.
+    pub fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
+        self.idle_timeout = idle_timeout;
+        self
     }
 }
 
@@ -88,7 +99,7 @@ impl vertex_swarm_api::SwarmNetworkConfig for SimNetworkConfig {
         self.max_peers
     }
     fn idle_timeout(&self) -> Duration {
-        Duration::from_secs(30)
+        self.idle_timeout
     }
     fn nat_addrs(&self) -> &[Multiaddr] {
         &self.nat_addrs

--- a/crates/swarm/sim/src/probe.rs
+++ b/crates/swarm/sim/src/probe.rs
@@ -1,0 +1,55 @@
+//! One-slot channel from a host future to the world driver.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+/// Shared slot a host future publishes live handles through.
+///
+/// A whole-node host builds its handles inside the simulation; the driver
+/// clones a probe into the host closure, the host publishes, and the driver
+/// reads between world steps. The single-threaded scheduler parks every host
+/// at an await point while the driver runs, so reads observe settled state.
+pub struct Probe<T>(Arc<Mutex<Option<T>>>);
+
+impl<T> Default for Probe<T> {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(None)))
+    }
+}
+
+impl<T> Clone for Probe<T> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl<T> Probe<T> {
+    /// Publish a value, replacing any previous one.
+    pub fn publish(&self, value: T) {
+        *self.0.lock() = Some(value);
+    }
+
+    /// The latest published value.
+    pub fn get(&self) -> Option<T>
+    where
+        T: Clone,
+    {
+        self.0.lock().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_then_get() {
+        let probe = Probe::default();
+        assert_eq!(probe.get(), None::<u32>);
+        probe.clone().publish(7u32);
+        assert_eq!(probe.get(), Some(7));
+        probe.publish(9);
+        assert_eq!(probe.get(), Some(9));
+    }
+}

--- a/crates/swarm/sim/src/scenario/invariant.rs
+++ b/crates/swarm/sim/src/scenario/invariant.rs
@@ -1,0 +1,202 @@
+//! Reusable invariant checks over live routing statistics.
+//!
+//! Checks run against [`RoutingStats`] snapshots read from a real topology
+//! handle between world steps; the single-threaded scheduler guarantees the
+//! snapshot observes settled state.
+
+use vertex_swarm_topology::RoutingStats;
+
+type Check = Box<dyn Fn(&RoutingStats) -> Result<(), String>>;
+
+/// Named invariants a sim test registers once and checks between steps.
+#[derive(Default)]
+pub struct Invariants {
+    checks: Vec<(&'static str, Check)>,
+}
+
+impl Invariants {
+    /// An empty set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a custom named check.
+    pub fn register(
+        mut self,
+        name: &'static str,
+        check: impl Fn(&RoutingStats) -> Result<(), String> + 'static,
+    ) -> Self {
+        self.checks.push((name, Box::new(check)));
+        self
+    }
+
+    /// The published depth never sits below `floor`.
+    pub fn depth_floor(self, floor: u8) -> Self {
+        self.register("depth-floor", move |stats| {
+            if stats.depth >= floor {
+                Ok(())
+            } else {
+                Err(format!(
+                    "published depth {} sits below the floor {floor}",
+                    stats.depth
+                ))
+            }
+        })
+    }
+
+    /// Per bin the active phase counter equals the connected set, and the
+    /// connected total equals the per-bin sum: no peer is double-counted
+    /// and no lifecycle path leaks a phase counter.
+    pub fn phase_counters_consistent(self) -> Self {
+        self.register("phase-counters", |stats| {
+            for bin in &stats.bins {
+                if bin.active != bin.connected {
+                    return Err(format!(
+                        "bin {}: active counter {} disagrees with connected {}",
+                        bin.bin, bin.active, bin.connected
+                    ));
+                }
+            }
+            let bin_sum: usize = stats.bins.iter().map(|bin| bin.connected).sum();
+            if bin_sum != stats.connected_peers_total {
+                return Err(format!(
+                    "connected total {} disagrees with the per-bin sum {bin_sum}",
+                    stats.connected_peers_total
+                ));
+            }
+            Ok(())
+        })
+    }
+
+    /// Every bin below the published depth keeps its allocation target at or
+    /// above `saturation` (the allocation floor).
+    pub fn saturation_floor(self, saturation: usize) -> Self {
+        self.register("saturation-floor", move |stats| {
+            for bin in &stats.bins {
+                if bin.bin < stats.depth && bin.target < saturation {
+                    return Err(format!(
+                        "below-depth bin {} target {} dropped under saturation {saturation}",
+                        bin.bin, bin.target
+                    ));
+                }
+            }
+            Ok(())
+        })
+    }
+
+    /// Run every check, collecting violations as `name: message` lines.
+    pub fn check(&self, stats: &RoutingStats) -> Result<(), Vec<String>> {
+        let violations: Vec<String> = self
+            .checks
+            .iter()
+            .filter_map(|(name, check)| check(stats).err().map(|msg| format!("{name}: {msg}")))
+            .collect();
+        if violations.is_empty() {
+            Ok(())
+        } else {
+            Err(violations)
+        }
+    }
+
+    /// Panic with every violation and the seed that replays the run.
+    #[allow(clippy::panic)]
+    pub fn assert(&self, stats: &RoutingStats, seed: u64) {
+        if let Err(violations) = self.check(stats) {
+            panic!("invariants violated (seed={seed}): {violations:#?}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use vertex_swarm_topology::BinStats;
+
+    fn bin(bin: u8, connected: usize, active: usize, target: usize) -> BinStats {
+        BinStats {
+            bin,
+            connected,
+            known: connected,
+            dialing: 0,
+            handshaking: 0,
+            active,
+            target,
+            ceiling: target.saturating_add(2),
+            nominal: 4,
+        }
+    }
+
+    fn stats(depth: u8, bins: Vec<BinStats>) -> RoutingStats {
+        let connected_peers_total = bins.iter().map(|b| b.connected).sum();
+        RoutingStats {
+            bins,
+            depth,
+            known_peers_total: 0,
+            connected_peers_total,
+        }
+    }
+
+    #[test]
+    fn healthy_snapshot_passes() {
+        let invariants = Invariants::new()
+            .depth_floor(1)
+            .phase_counters_consistent()
+            .saturation_floor(8);
+        let snapshot = stats(1, vec![bin(0, 8, 8, 8), bin(1, 3, 3, usize::MAX)]);
+        assert!(invariants.check(&snapshot).is_ok());
+    }
+
+    #[test]
+    fn depth_floor_catches_a_collapse() {
+        let invariants = Invariants::new().depth_floor(2);
+        let snapshot = stats(1, vec![bin(0, 8, 8, 8)]);
+        let violations = invariants.check(&snapshot).unwrap_err();
+        assert_eq!(violations.len(), 1);
+        assert!(violations.iter().any(|v| v.starts_with("depth-floor:")));
+    }
+
+    #[test]
+    fn phase_counters_catch_a_leak() {
+        let invariants = Invariants::new().phase_counters_consistent();
+        // Leaked active counter: one more active than connected.
+        let snapshot = stats(0, vec![bin(0, 3, 4, 8)]);
+        let violations = invariants.check(&snapshot).unwrap_err();
+        assert!(violations.iter().any(|v| v.starts_with("phase-counters:")));
+    }
+
+    #[test]
+    fn phase_counters_catch_a_double_count() {
+        let invariants = Invariants::new().phase_counters_consistent();
+        let mut snapshot = stats(0, vec![bin(0, 3, 3, 8)]);
+        snapshot.connected_peers_total = 4;
+        let violations = invariants.check(&snapshot).unwrap_err();
+        assert!(violations.iter().any(|v| v.contains("per-bin sum")));
+    }
+
+    #[test]
+    fn saturation_floor_catches_a_starved_target() {
+        let invariants = Invariants::new().saturation_floor(8);
+        let snapshot = stats(2, vec![bin(0, 8, 8, 8), bin(1, 8, 8, 4)]);
+        let violations = invariants.check(&snapshot).unwrap_err();
+        assert!(
+            violations
+                .iter()
+                .any(|v| v.starts_with("saturation-floor:"))
+        );
+    }
+
+    #[test]
+    fn custom_checks_register() {
+        let invariants = Invariants::new().register("known-nonzero", |stats| {
+            if stats.known_peers_total > 0 {
+                Ok(())
+            } else {
+                Err("no known peers".into())
+            }
+        });
+        let snapshot = stats(0, vec![]);
+        assert!(invariants.check(&snapshot).is_err());
+    }
+}

--- a/crates/swarm/sim/src/scenario/mod.rs
+++ b/crates/swarm/sim/src/scenario/mod.rs
@@ -1,0 +1,13 @@
+//! Scenario vocabulary over the sim world: scripted peer behaviour, seeded
+//! churn and partition schedules, and reusable invariant checks read from
+//! live routing statistics.
+
+mod invariant;
+mod schedule;
+mod script;
+
+pub use invariant::Invariants;
+pub use schedule::{Fault, FaultSchedule};
+pub use script::{
+    PeerScript, Placement, Scenario, ScriptedPeer, handshake_summary, placement_nonce,
+};

--- a/crates/swarm/sim/src/scenario/schedule.rs
+++ b/crates/swarm/sim/src/scenario/schedule.rs
@@ -1,0 +1,167 @@
+//! Fault schedule applied at virtual-time offsets while the world runs.
+
+use std::time::Duration;
+
+use crate::scenario::script::Scenario;
+use crate::world::{SimError, SimWorld};
+
+/// A fault the schedule injects into the running world.
+#[derive(Clone, Debug)]
+pub enum Fault {
+    /// Bounce a seeded fraction of the running scripted peers.
+    Churn {
+        /// Fraction of the running scripted peers to bounce.
+        fraction: f64,
+    },
+    /// Drop all traffic between every host in `a` and every host in `b`.
+    Partition {
+        /// One side of the cut.
+        a: Vec<String>,
+        /// The other side of the cut.
+        b: Vec<String>,
+    },
+    /// Restore traffic between every host in `a` and every host in `b`.
+    Repair {
+        /// One side of the healed cut.
+        a: Vec<String>,
+        /// The other side of the healed cut.
+        b: Vec<String>,
+    },
+    /// Restart one scripted host, dropping its connections and network state.
+    Bounce(String),
+    /// Stop one scripted host without restarting it.
+    Crash(String),
+    /// Change the global message drop probability.
+    FailRate(f64),
+}
+
+/// Faults keyed by offsets on the world clock ([`SimWorld::elapsed`]).
+///
+/// Offsets are absolute virtual times, so a schedule built after a
+/// convergence phase anchors its offsets on the elapsed time at build.
+#[derive(Clone, Debug, Default)]
+pub struct FaultSchedule {
+    events: Vec<(Duration, Fault)>,
+}
+
+impl FaultSchedule {
+    /// An empty schedule.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inject `fault` once the world clock reaches `at`.
+    pub fn at(mut self, at: Duration, fault: Fault) -> Self {
+        self.events.push((at, fault));
+        self
+    }
+
+    /// Drive the world through every fault in offset order, invoking
+    /// `after_each` right after each injection; recovery windows and
+    /// invariant assertions belong in that callback.
+    ///
+    /// The world must hold at least one incomplete client: once every
+    /// client completes, stepping stops advancing virtual time.
+    pub fn apply(
+        mut self,
+        world: &mut SimWorld,
+        scenario: &mut Scenario,
+        mut after_each: impl FnMut(&mut SimWorld, &Fault),
+    ) -> Result<(), SimError> {
+        // Stable sort: same-offset faults inject in insertion order.
+        self.events.sort_by_key(|(at, _)| *at);
+        for (at, fault) in &self.events {
+            let now = world.elapsed();
+            if *at > now {
+                world.run_for(*at - now)?;
+            }
+            inject(world, scenario, fault);
+            after_each(world, fault);
+        }
+        Ok(())
+    }
+}
+
+fn inject(world: &mut SimWorld, scenario: &mut Scenario, fault: &Fault) {
+    match fault {
+        Fault::Churn { fraction } => {
+            scenario.churn_burst(world, *fraction);
+        }
+        Fault::Partition { a, b } => {
+            for left in a {
+                for right in b {
+                    world.partition(left, right);
+                }
+            }
+        }
+        Fault::Repair { a, b } => {
+            for left in a {
+                for right in b {
+                    world.repair(left, right);
+                }
+            }
+        }
+        Fault::Bounce(name) => world.bounce(name),
+        Fault::Crash(name) => world.crash(name),
+        Fault::FailRate(rate) => world.set_fail_rate(*rate),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+    use super::*;
+    use crate::HostContext;
+    use crate::world::HostResult;
+    use vertex_swarm_test_utils::test_spec;
+
+    async fn idle(_ctx: HostContext) -> HostResult {
+        futures::future::pending::<()>().await;
+        Ok(())
+    }
+
+    #[test]
+    fn faults_apply_in_offset_order() {
+        let mut world = SimWorld::builder()
+            .seed(3)
+            .duration(Duration::from_secs(60))
+            .build();
+        world.host("a", idle);
+        world.host("b", idle);
+        // A pending client keeps the world stepping: with every client
+        // complete, `run_for` would finish without advancing virtual time.
+        world.client("driver", |_ctx| async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(())
+        });
+        let mut scenario = Scenario::new(&world, test_spec());
+
+        let mut seen: Vec<(Duration, bool)> = Vec::new();
+        FaultSchedule::new()
+            .at(
+                Duration::from_secs(10),
+                Fault::Repair {
+                    a: vec!["a".into()],
+                    b: vec!["b".into()],
+                },
+            )
+            .at(
+                Duration::from_secs(5),
+                Fault::Partition {
+                    a: vec!["a".into()],
+                    b: vec!["b".into()],
+                },
+            )
+            .apply(&mut world, &mut scenario, |world, fault| {
+                seen.push((world.elapsed(), matches!(fault, Fault::Partition { .. })));
+            })
+            .expect("schedule applies");
+
+        assert_eq!(seen.len(), 2);
+        assert!(seen[0].1, "the earlier partition injects first");
+        assert!(seen[0].0 >= Duration::from_secs(5));
+        assert!(!seen[1].1, "the later repair injects second");
+        assert!(seen[1].0 >= Duration::from_secs(10));
+    }
+}

--- a/crates/swarm/sim/src/scenario/script.rs
+++ b/crates/swarm/sim/src/scenario/script.rs
@@ -1,0 +1,305 @@
+//! Scripted peer behaviour over the simulated network.
+//!
+//! Scripted peers are real networked hosts: each runs a handshake-serving
+//! swarm (or refuses to listen), so the node under test exercises its
+//! production dial, handshake, and disconnect paths against them.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_primitives::{B256, keccak256};
+use libp2p::{Multiaddr, PeerId, multiaddr::Protocol};
+use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
+use vertex_swarm_api::SwarmSpec;
+use vertex_swarm_identity::Identity;
+use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent, NoAddresses};
+use vertex_swarm_primitives::{Bin, Nonce, OverlayAddress, SwarmNodeType, compute_overlay};
+use vertex_swarm_spec::Spec;
+
+use crate::SimAuth;
+use crate::host::{HostContext, host_keypair, host_signer};
+use crate::world::{HostResult, SimWorld, listen_multiaddr};
+
+/// Port every scripted peer listens on; hosts are distinguished by IP.
+const SCRIPTED_PEER_PORT: u16 = 1634;
+
+/// Idle timeout for scripted-peer swarms. Scripted peers exist to hold
+/// topology connections across long virtual horizons, so the timeout must
+/// outlive any scenario schedule.
+const SCRIPTED_PEER_IDLE: Duration = Duration::from_secs(24 * 3600);
+
+/// Scripted wire behaviour for a simulated peer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PeerScript {
+    /// Listens and completes every handshake for the whole run.
+    Honest,
+    /// Registered and resolvable but never listens: every dial to it fails.
+    Unreachable,
+    /// Completes handshakes, then cleanly closes every live connection each
+    /// `hold` of virtual time; it keeps listening, so it stays re-dialable.
+    AcceptThenDrop {
+        /// Virtual time between clean connection drops.
+        hold: Duration,
+    },
+    /// Honest on the wire; the adversarial trait is address-space
+    /// clustering, set up by grinding the peer's overlay into a
+    /// caller-chosen bin via a [`Placement`].
+    Sybil,
+}
+
+/// Address-space placement: grind the peer's nonce until its overlay lands
+/// exactly in `bin` relative to `anchor`.
+#[derive(Clone, Copy, Debug)]
+pub struct Placement {
+    /// Overlay the bin is measured against (usually the node under test).
+    pub anchor: OverlayAddress,
+    /// Exact proximity bin the ground overlay must occupy.
+    pub bin: Bin,
+}
+
+/// A registered scripted peer and the coordinates a test needs to reach it.
+#[derive(Clone, Debug)]
+pub struct ScriptedPeer {
+    /// Host name in the world.
+    pub name: String,
+    /// Wire behaviour the host runs.
+    pub script: PeerScript,
+    /// Node type the peer advertises in its handshake.
+    pub node_type: SwarmNodeType,
+    /// The peer's libp2p identity.
+    pub peer_id: PeerId,
+    /// The peer's overlay address (placement-ground when placed).
+    pub overlay: OverlayAddress,
+    /// Dialable multiaddr including the `/p2p/` component.
+    pub multiaddr: Multiaddr,
+}
+
+/// A scripted population registered into a [`SimWorld`].
+///
+/// Peers register as restartable hosts, so churn can bounce them and each
+/// incarnation keeps its identity. All scripted traffic uses the
+/// entropy-free plaintext stack so runs stay reproducible from the seed.
+pub struct Scenario {
+    spec: Arc<Spec>,
+    seed: u64,
+    rng: StdRng,
+    peers: Vec<ScriptedPeer>,
+}
+
+impl Scenario {
+    /// A scenario over `world`, deriving its churn RNG from the world seed.
+    pub fn new(world: &SimWorld, spec: Arc<Spec>) -> Self {
+        Self {
+            spec,
+            seed: world.seed(),
+            rng: StdRng::seed_from_u64(world.seed()),
+            peers: Vec::new(),
+        }
+    }
+
+    /// Register a scripted peer as a restartable host, grinding its overlay
+    /// into place when `placement` is given.
+    pub fn add_peer(
+        &mut self,
+        world: &mut SimWorld,
+        name: &str,
+        node_type: SwarmNodeType,
+        script: PeerScript,
+        placement: Option<Placement>,
+    ) -> &ScriptedPeer {
+        let nonce = match placement {
+            Some(placement) => placement_nonce(self.seed, name, &self.spec, placement),
+            None => Nonce::new(placement_digest(self.seed, name).0),
+        };
+        let overlay = compute_overlay(
+            &host_signer(self.seed, name).address(),
+            self.spec.network_id(),
+            &nonce,
+        );
+        let peer_id = host_keypair(self.seed, name).public().to_peer_id();
+
+        let spec = Arc::clone(&self.spec);
+        world.host(name, move |ctx| {
+            run_script(ctx, Arc::clone(&spec), node_type, nonce, script)
+        });
+        let multiaddr = world
+            .multiaddr_of(name, SCRIPTED_PEER_PORT)
+            .with(Protocol::P2p(peer_id));
+
+        self.peers.push(ScriptedPeer {
+            name: name.to_owned(),
+            script,
+            node_type,
+            peer_id,
+            overlay,
+            multiaddr,
+        });
+        #[allow(clippy::expect_used)]
+        self.peers.last().expect("peer pushed above")
+    }
+
+    /// The registered population.
+    pub fn peers(&self) -> &[ScriptedPeer] {
+        &self.peers
+    }
+
+    /// Every scripted peer's dialable multiaddr, for a node's bootnode list.
+    pub fn bootnodes(&self) -> Vec<Multiaddr> {
+        self.peers.iter().map(|p| p.multiaddr.clone()).collect()
+    }
+
+    /// Bounce a seeded `fraction` of the running scripted peers, dropping
+    /// their connections and network state; each restarts with the same
+    /// identity. Returns the bounced host names.
+    pub fn churn_burst(&mut self, world: &mut SimWorld, fraction: f64) -> Vec<String> {
+        let mut names: Vec<String> = self
+            .peers
+            .iter()
+            .map(|p| p.name.clone())
+            .filter(|name| world.is_host_running(name))
+            .collect();
+        // Registration order is deterministic, but sort before the seeded
+        // shuffle so the selection never depends on it.
+        names.sort();
+        names.shuffle(&mut self.rng);
+        #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+        #[allow(clippy::cast_sign_loss)]
+        let take = ((names.len() as f64) * fraction) as usize;
+        let victims: Vec<String> = names.into_iter().take(take).collect();
+        for name in &victims {
+            world.bounce(name);
+        }
+        victims
+    }
+}
+
+/// Grind a nonce so the host's overlay lands exactly in the placement bin.
+///
+/// The expected cost doubles per bin, so scenarios place peers in shallow
+/// bins. Deterministic in (seed, host, spec, placement).
+pub fn placement_nonce(world_seed: u64, host: &str, spec: &Spec, placement: Placement) -> Nonce {
+    let address = host_signer(world_seed, host).address();
+    let mut candidate = placement_digest(world_seed, host);
+    loop {
+        let nonce = Nonce::new(candidate.0);
+        let overlay = compute_overlay(&address, spec.network_id(), &nonce);
+        if placement.anchor.proximity(&overlay).get() == placement.bin.get() {
+            return nonce;
+        }
+        candidate = keccak256(candidate);
+    }
+}
+
+fn placement_digest(world_seed: u64, host: &str) -> B256 {
+    const DOMAIN: &str = "vertex-sim/placement/";
+    let mut input = Vec::with_capacity(DOMAIN.len() + 8 + host.len());
+    input.extend_from_slice(DOMAIN.as_bytes());
+    input.extend_from_slice(&world_seed.to_be_bytes());
+    input.extend_from_slice(host.as_bytes());
+    keccak256(&input)
+}
+
+/// Canonical handshake-event normalizer for scripted-peer traces.
+pub fn handshake_summary(event: &HandshakeEvent) -> String {
+    match event {
+        HandshakeEvent::Completed { peer_id, info, .. } => format!(
+            "handshake-completed peer={peer_id} overlay={}",
+            info.swarm_peer.overlay()
+        ),
+        HandshakeEvent::Failed { peer_id, error, .. } => {
+            format!("handshake-failed peer={peer_id} error={error}")
+        }
+    }
+}
+
+async fn run_script(
+    ctx: HostContext,
+    spec: Arc<Spec>,
+    node_type: SwarmNodeType,
+    nonce: Nonce,
+    script: PeerScript,
+) -> HostResult {
+    if matches!(script, PeerScript::Unreachable) {
+        futures::future::pending::<()>().await;
+        return Ok(());
+    }
+
+    let identity = Arc::new(Identity::new(ctx.signer(), nonce, spec, node_type));
+    let swarm = ctx.swarm_with_idle(SimAuth::Plaintext, SCRIPTED_PEER_IDLE, move |_keypair| {
+        HandshakeBehaviour::new(identity, Arc::new(NoAddresses), "sim")
+    });
+    let mut traced = ctx.traced(swarm, handshake_summary);
+    traced
+        .swarm_mut()
+        .listen_on(listen_multiaddr(SCRIPTED_PEER_PORT))?;
+
+    match script {
+        PeerScript::AcceptThenDrop { hold } => loop {
+            traced.drive_for(hold).await;
+            let connected: Vec<PeerId> = traced.swarm().connected_peers().copied().collect();
+            for peer in connected {
+                let _ = traced.swarm_mut().disconnect_peer_id(peer);
+            }
+        },
+        _ => loop {
+            traced.drive_for(Duration::from_secs(3600)).await;
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vertex_swarm_test_utils::test_spec;
+
+    #[test]
+    fn placement_lands_the_exact_bin() {
+        let spec = test_spec();
+        let anchor = OverlayAddress::from([0xAA; 32]);
+        for bin in 0..4u8 {
+            let bin = Bin::new(bin).unwrap_or(Bin::MAX);
+            let placement = Placement { anchor, bin };
+            let nonce = placement_nonce(7, "peer", &spec, placement);
+            let overlay =
+                compute_overlay(&host_signer(7, "peer").address(), spec.network_id(), &nonce);
+            assert_eq!(anchor.proximity(&overlay).get(), bin.get());
+            // Deterministic: the same inputs grind the same nonce.
+            assert_eq!(nonce, placement_nonce(7, "peer", &spec, placement));
+        }
+    }
+
+    #[test]
+    fn churn_selection_is_seeded() {
+        fn victims(seed: u64) -> Vec<String> {
+            let mut world = SimWorld::builder()
+                .seed(seed)
+                .duration(Duration::from_secs(10))
+                .build();
+            let mut scenario = Scenario::new(&world, test_spec());
+            for idx in 0..10 {
+                scenario.add_peer(
+                    &mut world,
+                    &format!("peer-{idx}"),
+                    SwarmNodeType::Storer,
+                    PeerScript::Honest,
+                    None,
+                );
+            }
+            // A pending client keeps the world stepping while the hosts start.
+            world.client("driver", |_ctx| async {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                Ok(())
+            });
+            #[allow(clippy::expect_used)]
+            world
+                .run_for(Duration::from_millis(100))
+                .expect("world advances");
+            scenario.churn_burst(&mut world, 0.4)
+        }
+
+        let first = victims(5);
+        assert_eq!(first.len(), 4, "40% of ten peers is four victims");
+        assert_eq!(first, victims(5), "same seed selects the same victims");
+        assert_ne!(first, victims(6), "a different seed reorders the burst");
+    }
+}

--- a/crates/swarm/sim/tests/scenario.rs
+++ b/crates/swarm/sim/tests/scenario.rs
@@ -1,0 +1,237 @@
+//! A scripted population holds a whole client node's depth floor through
+//! seeded churn bursts, with reusable invariants checked between steps.
+//!
+//! One whole-node host per test process: node background tasks spawn through
+//! the process-global executor, which binds the runtime of the host that
+//! installs it.
+#![allow(clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use vertex_swarm_api::{DEFAULT_SATURATION_PEERS, SwarmTopologyCommands};
+use vertex_swarm_identity::Identity;
+use vertex_swarm_node::ClientNode;
+use vertex_swarm_primitives::{Bin, SwarmNodeType, compute_overlay};
+use vertex_swarm_sim::{
+    Fault, FaultSchedule, Invariants, PeerScript, Placement, Probe, Scenario, SimAuth,
+    SimNetworkConfig, SimWorld, host_signer, placement_nonce, transport_override,
+};
+use vertex_swarm_spec::Spec;
+use vertex_swarm_test_utils::TEST_NETWORK_ID;
+use vertex_swarm_topology::TopologyHandle;
+use vertex_tasks::{TaskExecutor, TaskManager};
+
+const PORT: u16 = 1634;
+const SEED: u64 = 31;
+const STORER: SwarmNodeType = SwarmNodeType::Storer;
+
+fn spec() -> Arc<Spec> {
+    Arc::new(
+        vertex_swarm_spec::SpecBuilder::testnet()
+            .network_id(TEST_NETWORK_ID)
+            .bootnodes(Vec::new())
+            .build(),
+    )
+}
+
+/// Depth 1 needs bin 0 saturated and a low-watermark neighbourhood beyond
+/// it; the scripted population supplies both, plus a cycling boundary peer
+/// and an unreachable peer that must never count.
+#[test]
+fn churn_bursts_hold_the_depth_floor() {
+    let mut world = SimWorld::builder()
+        .seed(SEED)
+        .duration(Duration::from_secs(3600))
+        .tick(Duration::from_millis(50))
+        .tokio_io()
+        .build();
+
+    // The node's overlay is derivable up front, so scripted peers can be
+    // placed against it before the node exists.
+    let node_spec = spec();
+    let node_overlay = {
+        use vertex_swarm_api::SwarmIdentity as _;
+        Identity::new(
+            host_signer(SEED, "node"),
+            vertex_swarm_sim::host_nonce(SEED, "node"),
+            node_spec.clone(),
+            SwarmNodeType::Client,
+        )
+        .overlay_address()
+    };
+    let place = |bin: u8| {
+        Some(Placement {
+            anchor: node_overlay,
+            bin: Bin::new(bin).unwrap_or(Bin::MAX),
+        })
+    };
+
+    let saturation = usize::from(DEFAULT_SATURATION_PEERS);
+    let mut scenario = Scenario::new(&world, spec());
+    for idx in 0..saturation {
+        scenario.add_peer(
+            &mut world,
+            &format!("bin0-{idx}"),
+            STORER,
+            PeerScript::Honest,
+            place(0),
+        );
+    }
+    // Three clustered peers anchor the neighbourhood at the low watermark.
+    for idx in 0..3 {
+        scenario.add_peer(
+            &mut world,
+            &format!("sybil-{idx}"),
+            STORER,
+            PeerScript::Sybil,
+            place(1),
+        );
+    }
+    scenario.add_peer(
+        &mut world,
+        "flapper",
+        STORER,
+        PeerScript::AcceptThenDrop {
+            hold: Duration::from_secs(45),
+        },
+        place(1),
+    );
+    scenario.add_peer(
+        &mut world,
+        "dark",
+        STORER,
+        PeerScript::Unreachable,
+        place(0),
+    );
+
+    let bootnodes = scenario.bootnodes();
+    let probe: Probe<TopologyHandle<Identity>> = Probe::default();
+    let publish = probe.clone();
+    world.client("node", move |ctx| async move {
+        // Bind the executor to this host's runtime before any node build.
+        let _task_manager = TaskManager::current();
+
+        let identity = ctx.identity(spec(), SwarmNodeType::Client);
+        let config = SimNetworkConfig::new(PORT, bootnodes, 64)
+            .with_idle_timeout(Duration::from_secs(24 * 3600));
+        let (mut node, _service, _handle) = ClientNode::builder(identity)
+            .with_transport(transport_override(SimAuth::Plaintext))
+            .build(&config, None)
+            .await
+            .map_err(|e| format!("build client node: {e:#}"))?;
+        node.start_listening()
+            .map_err(|e| format!("start listening: {e:#}"))?;
+        let topology = node.topology_handle().clone();
+        publish.publish(topology.clone());
+
+        let executor = TaskExecutor::current();
+        let _run =
+            executor.spawn_with_graceful_shutdown_signal("sim-node", move |graceful| async move {
+                let _ = node.run(graceful).await;
+            });
+
+        // Re-dial for the whole run: already-tracked peers are skipped, so
+        // this only re-establishes what churn tears down.
+        loop {
+            let _ = topology.connect_bootnodes().await;
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    });
+
+    // Converge: the node publishes its handle, then climbs to depth 1.
+    let handle = loop {
+        world
+            .run_for(Duration::from_secs(5))
+            .expect("world advances");
+        if let Some(handle) = probe.get() {
+            break handle;
+        }
+        assert!(
+            world.elapsed() < Duration::from_secs(60),
+            "node never published its topology handle (seed={SEED})"
+        );
+    };
+    while handle.routing_stats().depth < 1 {
+        assert!(
+            world.elapsed() < Duration::from_secs(600),
+            "depth never converged (seed={SEED}): {:?}",
+            handle.routing_stats()
+        );
+        world
+            .run_for(Duration::from_secs(5))
+            .expect("world advances");
+    }
+
+    let always = Invariants::new()
+        .phase_counters_consistent()
+        .saturation_floor(saturation);
+    let steady = Invariants::new().depth_floor(1);
+    always.assert(&handle.routing_stats(), SEED);
+    steady.assert(&handle.routing_stats(), SEED);
+
+    // The unreachable peer never counts as connected.
+    let stats = handle.routing_stats();
+    assert_eq!(
+        stats
+            .bins
+            .first()
+            .map(|bin| bin.connected)
+            .unwrap_or_default(),
+        saturation,
+        "bin 0 holds the honest supply and never the unreachable peer"
+    );
+
+    // Two seeded churn bursts: each bounces ~30% of the population; the
+    // node re-dials the restarted peers and the depth floor returns.
+    let start = world.elapsed();
+    FaultSchedule::new()
+        .at(
+            start + Duration::from_secs(10),
+            Fault::Churn { fraction: 0.3 },
+        )
+        .at(
+            start + Duration::from_secs(150),
+            Fault::Churn { fraction: 0.3 },
+        )
+        .apply(&mut world, &mut scenario, |world, _fault| {
+            // Recovery window: poll until the depth floor returns.
+            for _ in 0..24 {
+                world
+                    .run_for(Duration::from_secs(5))
+                    .expect("world advances");
+                if handle.routing_stats().depth >= 1 {
+                    break;
+                }
+            }
+            let stats = handle.routing_stats();
+            always.assert(&stats, SEED);
+            steady.assert(&stats, SEED);
+        })
+        .expect("schedule applies");
+}
+
+/// The placement grinder and the scripted identity agree: a peer placed in
+/// bin 2 of an anchor really lands there with the identity the host derives.
+#[test]
+fn placement_matches_the_hosted_identity() {
+    use vertex_swarm_api::SwarmSpec as _;
+
+    let spec = spec();
+    let anchor = compute_overlay(
+        &host_signer(SEED, "anchor").address(),
+        spec.network_id(),
+        &vertex_swarm_sim::host_nonce(SEED, "anchor"),
+    );
+    let placement = Placement {
+        anchor,
+        bin: Bin::new(2).unwrap_or(Bin::MAX),
+    };
+    let nonce = placement_nonce(SEED, "placed", &spec, placement);
+    let overlay = compute_overlay(
+        &host_signer(SEED, "placed").address(),
+        spec.network_id(),
+        &nonce,
+    );
+    assert_eq!(anchor.proximity(&overlay).get(), 2);
+}

--- a/crates/swarm/sim/tests/scenario.rs
+++ b/crates/swarm/sim/tests/scenario.rs
@@ -235,3 +235,71 @@ fn placement_matches_the_hosted_identity() {
     );
     assert_eq!(anchor.proximity(&overlay).get(), 2);
 }
+
+/// The `AcceptThenDrop` script does more than name a variant: a dialer that
+/// completes the handshake is observed being cleanly dropped once the hold
+/// elapses, so the fault the schedule leans on actually fires on the wire.
+#[test]
+fn accept_then_drop_is_observed_dropping() {
+    use libp2p::swarm::SwarmEvent;
+    use vertex_swarm_net_handshake::{HandshakeBehaviour, HandshakeEvent, NoAddresses};
+    use vertex_swarm_sim::handshake_summary;
+
+    const HOLD: Duration = Duration::from_secs(5);
+
+    let mut world = SimWorld::builder()
+        .seed(SEED)
+        .duration(Duration::from_secs(120))
+        .build();
+
+    let mut scenario = Scenario::new(&world, spec());
+    scenario.add_peer(
+        &mut world,
+        "flapper",
+        STORER,
+        PeerScript::AcceptThenDrop { hold: HOLD },
+        None,
+    );
+    let target = scenario
+        .peers()
+        .first()
+        .expect("one scripted peer")
+        .multiaddr
+        .clone();
+
+    world.client("dialer", move |ctx| async move {
+        let identity = Arc::new(ctx.identity(spec(), SwarmNodeType::Client));
+        let swarm = ctx.swarm(SimAuth::Plaintext, move |_keypair| {
+            HandshakeBehaviour::new(identity, Arc::new(NoAddresses), "sim")
+        });
+        let mut traced = ctx.traced(swarm, handshake_summary);
+        // Fixed virtual delay so the scripted peer is always listening first.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        traced.swarm_mut().dial(target)?;
+
+        let completed = traced
+            .drive_until(Duration::from_secs(30), |event| {
+                matches!(
+                    event,
+                    SwarmEvent::Behaviour(HandshakeEvent::Completed { .. })
+                )
+            })
+            .await;
+        if !completed {
+            return Err("handshake never completed against the scripted peer".into());
+        }
+
+        // The peer holds the connection for `HOLD`, then closes it cleanly.
+        let dropped = traced
+            .drive_until(HOLD + Duration::from_secs(30), |event| {
+                matches!(event, SwarmEvent::ConnectionClosed { .. })
+            })
+            .await;
+        if !dropped {
+            return Err("scripted peer never dropped the connection".into());
+        }
+        Ok(())
+    });
+
+    world.run();
+}


### PR DESCRIPTION
## Summary

Port the scenario vocabulary onto the sim world: scripted peer populations run as real networked hosts over the simulated transport, with seeded churn, a virtual-time fault schedule, and reusable invariant checks read from live routing statistics.

## What

Add the `scenario` module to `vertex-swarm-sim`. `PeerScript` behaviours (`Honest`, `Unreachable`, `AcceptThenDrop`, `Sybil`) are served by real hosts over the turmoil transport; `Scenario`/`ScriptedPeer` build seeded populations with overlay `Placement` grinding; `FaultSchedule` injects `Fault`s (churn bursts, partitions, repairs) at virtual-time offsets; `Invariants` (depth floor, phase-counter consistency, saturation floor) read live routing statistics. Add `Probe` for handing state out of a host future. Two integration scenarios prove the vocabulary: `churn_bursts_hold_the_depth_floor` drives a whole client node through two seeded churn bursts and holds its depth floor, and `accept_then_drop_is_observed_dropping` dials a scripted `AcceptThenDrop` peer and asserts the drop actually fires on the wire, so the fault the schedule leans on is proven rather than merely named.

## Why

Closes #851

Scenarios isolate kademlia properties into reproducible seeded units driven over the simulated network, replacing "does the node work" with one invariant per test.

## Testing

Scoped to the touched crate (miser mode). All commands run under nix develop with build.target-dir pinned to the shared target.

- cargo fmt --all: clean.
- cargo clean -p vertex-swarm-sim then cargo clippy -p vertex-swarm-sim --all-targets --all-features -- -D warnings: clean (cleaned first to defeat warm-cache false-cleans).
- cargo nextest run -p vertex-swarm-sim: 27/27 pass, including the new accept_then_drop_is_observed_dropping and churn_bursts_hold_the_depth_floor scenarios.
- Determinism spot-check: reran the suite twice with identical results; churn_selection_is_seeded proves same-seed reproduction and different-seed divergence.
- Non-vacuity: the invariant unit tests each feed a broken snapshot (collapsed depth, leaked or double-counted phase, starved saturation target) and assert the corresponding check fails.

## Rebase

Rebased onto main. #882 was squash-merged as `a42ff22`, so the four commits below this PR's own work were already in main under different hashes and the branch read as conflicting. The rebase replays only the two commits that carry this PR's content, so the branch is now two commits on top of main. Main's `crates/swarm/sim/**` is byte-identical to the pre-squash base, so nothing was lost, and `Cargo.lock` auto-merged.

Post-rebase verification on the 1.94.1 pin:

- `cargo clippy -p vertex-swarm-sim --all-targets --all-features --locked -- -D warnings`: clean.
- `cargo nextest run -p vertex-swarm-sim --all-features --locked`: 27 tests run, 27 passed.
- `cargo metadata --locked` resolves, so the auto-merged lockfile is consistent.

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Fable 5 implementation, Opus 4.8 review, Haiku 4.5 PR text) under human direction.

