### PR TITLE
chore(swarm-sim): ci lane integration and profile defaults

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,28 @@
+# Nextest lanes.
+#
+# The default profile is the fast unit lane. Deterministic simulations run in
+# their own lane:
+#
+#   cargo nextest run -p vertex-swarm-sim --profile sim
+#
+# A failed sim names its seed (seed=N); replay it exactly with
+#
+#   VERTEX_SIM_SEED=N cargo nextest run -p vertex-swarm-sim --profile sim -E 'test(<name>)'
+#
+# A scenario too big even for the sim lane gets excluded by filterset here,
+# never by #[ignore].
+
 [profile.default]
+# Sim scenarios do not belong in the default run; the sim lane owns them.
+default-filter = "not package(vertex-swarm-sim)"
 # A deadlocked test fails by name after ~5 min rather than eating the CI job timeout.
 slow-timeout = { period = "60s", terminate-after = 5 }
+
+[profile.sim]
+default-filter = "package(vertex-swarm-sim)"
+# Whole-node scenarios compress hours of virtual time into real seconds but
+# still do real work per tick: flag a test after a minute, kill it after five.
+slow-timeout = { period = "60s", terminate-after = 5 }
+# Scenario failures carry the seed line and the world trace; print them in
+# full at the end of the run.
+failure-output = "immediate-final"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -207,6 +207,27 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace --all-features --no-tests=warn --locked
 
+  # The deterministic sim lane: seeded turmoil scenarios from vertex-swarm-sim
+  # run under the `sim` nextest profile (.config/nextest.toml), kept out of
+  # the default lane by its default-filter. A failure names its seed; replay
+  # with VERTEX_SIM_SEED=<seed>.
+  sim:
+    name: sim
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444  # v1
+      - uses: ./.github/actions/rust-setup
+      - uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # nextest
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run sim scenarios
+        run: cargo nextest run -p vertex-swarm-sim --profile sim --locked
+
   doc:
     name: doc
     runs-on: ubuntu-latest
@@ -294,12 +315,12 @@ jobs:
     name: ci success
     runs-on: ubuntu-latest
     if: always()
-    needs: [changes, fmt, clippy, features, test, doc, wasm]
+    needs: [changes, fmt, clippy, features, test, sim, doc, wasm]
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
         with:
           # The compile jobs skip a documentation-only change by design, so a skip
-          # of those five is not a failure. Every other job must report success.
-          allowed-skips: clippy, features, test, doc, wasm
+          # of those six is not a failure. Every other job must report success.
+          allowed-skips: clippy, features, test, sim, doc, wasm
           jobs: ${{ toJSON(needs) }}

--- a/crates/swarm/sim/src/lib.rs
+++ b/crates/swarm/sim/src/lib.rs
@@ -5,6 +5,20 @@
 //! network plus a [`SimWorld`] that runs real vertex swarms under a seeded,
 //! virtual-time scheduler with the same drive vocabulary as the seeded
 //! behaviour harness.
+//!
+//! # Replaying a failure
+//!
+//! Every failure names the world seed (`seed=N`). Replay it exactly:
+//!
+//! ```sh
+//! VERTEX_SIM_SEED=N cargo nextest run -p vertex-swarm-sim --profile sim -E 'test(<name>)'
+//! ```
+//!
+//! The override applies to every world built through
+//! [`SimWorldBuilder::seed`], so derive host material from [`SimWorld::seed`]
+//! after build, never from the literal passed to the builder. Determinism
+//! proofs that compare distinct seeds pin theirs with
+//! [`SimWorldBuilder::fixed_seed`].
 
 use libp2p::{
     PeerId, Transport as _,
@@ -32,7 +46,7 @@ pub use scenario::{
 };
 pub use trace::{SimTrace, TraceEntry, normalized_event};
 pub use transport::{TurmoilStream, TurmoilTransport};
-pub use world::{HostResult, SimError, SimWorld, SimWorldBuilder, listen_multiaddr};
+pub use world::{HostResult, SEED_ENV, SimError, SimWorld, SimWorldBuilder, listen_multiaddr};
 
 /// Authentication upgrade a simulated stack negotiates.
 ///

--- a/crates/swarm/sim/src/scenario/script.rs
+++ b/crates/swarm/sim/src/scenario/script.rs
@@ -452,8 +452,9 @@ mod tests {
     #[test]
     fn churn_selection_is_seeded() {
         fn victims(seed: u64) -> Vec<String> {
+            // Fixed: this test compares distinct seeds.
             let mut world = SimWorld::builder()
-                .seed(seed)
+                .fixed_seed(seed)
                 .duration(Duration::from_secs(10))
                 .build();
             let mut scenario = Scenario::new(&world, test_spec());

--- a/crates/swarm/sim/src/world.rs
+++ b/crates/swarm/sim/src/world.rs
@@ -17,6 +17,19 @@ use crate::trace::{SimTrace, TraceEntry};
 /// Outcome a host future reports to the world.
 pub type HostResult = turmoil::Result;
 
+/// Environment variable forcing a replay seed onto every world built with
+/// [`SimWorldBuilder::seed`].
+pub const SEED_ENV: &str = "VERTEX_SIM_SEED";
+
+#[allow(clippy::panic)]
+fn env_seed() -> Option<u64> {
+    let value = std::env::var(SEED_ENV).ok()?;
+    match value.parse() {
+        Ok(seed) => Some(seed),
+        Err(_) => panic!("{SEED_ENV} must be a u64, got {value:?}"),
+    }
+}
+
 /// A failed run, carrying the seed that replays it exactly.
 #[derive(Debug, thiserror::Error)]
 #[error("sim failed (seed={seed}): {message}")]
@@ -43,6 +56,7 @@ pub fn listen_multiaddr(port: u16) -> Multiaddr {
 #[derive(Debug, Clone, Default)]
 pub struct SimWorldBuilder {
     seed: u64,
+    seed_pinned: bool,
     duration: Option<Duration>,
     tick: Option<Duration>,
     latency: Option<(Duration, Duration)>,
@@ -53,8 +67,20 @@ pub struct SimWorldBuilder {
 impl SimWorldBuilder {
     /// Seed for the whole world: message latencies, drop draws, and every
     /// host identity derive from it. Defaults to 0.
+    ///
+    /// [`SEED_ENV`] overrides it at build, so a failed run replays exactly
+    /// from its reported seed. Derive host material from
+    /// [`SimWorld::seed`], never from the value passed here.
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
+        self
+    }
+
+    /// Seed exempt from the [`SEED_ENV`] override, for determinism proofs
+    /// that compare worlds built from distinct seeds.
+    pub fn fixed_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self.seed_pinned = true;
         self
     }
 
@@ -98,9 +124,13 @@ impl SimWorldBuilder {
     /// dial filter admits without consulting the real host's routing state,
     /// so whole-node dialling stays deterministic across machines.
     pub fn build(self) -> SimWorld {
+        let seed = match (self.seed_pinned, env_seed()) {
+            (false, Some(seed)) => seed,
+            _ => self.seed,
+        };
         let mut builder = turmoil::Builder::new();
         builder.ip_version(turmoil::IpVersion::V6);
-        builder.rng_seed(self.seed);
+        builder.rng_seed(seed);
         if let Some(duration) = self.duration {
             builder.simulation_duration(duration);
         }
@@ -119,7 +149,7 @@ impl SimWorldBuilder {
         }
         SimWorld {
             sim: builder.build(),
-            seed: self.seed,
+            seed,
             trace: SimTrace::default(),
         }
     }
@@ -314,8 +344,21 @@ mod tests {
     }
 
     #[test]
+    fn env_overrides_the_default_seed() {
+        // SAFETY: under nextest every test owns its process; under plain
+        // cargo test the concurrently racing tests are seed-independent.
+        unsafe { std::env::set_var(SEED_ENV, "1234") };
+        let replayed = SimWorld::builder().seed(1).build();
+        let pinned = SimWorld::builder().fixed_seed(1).build();
+        // SAFETY: as above.
+        unsafe { std::env::remove_var(SEED_ENV) };
+        assert_eq!(replayed.seed(), 1234, "the env seed forces the replay");
+        assert_eq!(pinned.seed(), 1, "a fixed seed ignores the override");
+    }
+
+    #[test]
     fn failure_reports_seed() {
-        let mut world = SimWorld::builder().seed(99).build();
+        let mut world = SimWorld::builder().fixed_seed(99).build();
         world.client("boom", |_ctx| async { Err("boom".into()) });
         let error = world.try_run().expect_err("client fails the run");
         let rendered = error.to_string();

--- a/crates/swarm/sim/tests/client_node.rs
+++ b/crates/swarm/sim/tests/client_node.rs
@@ -67,9 +67,11 @@ fn client_node_connects_over_the_sim_transport() {
         .tokio_io()
         .build();
 
+    // Derive from the built world's seed: a replay override changes it.
+    let seed = world.seed();
     world.host("boot", serve_bootnode);
     let boot_addr = world.multiaddr_of("boot", PORT).with(Protocol::P2p(
-        host_keypair(SEED, "boot").public().to_peer_id(),
+        host_keypair(seed, "boot").public().to_peer_id(),
     ));
 
     world.client("node", move |ctx| async move {
@@ -120,8 +122,8 @@ fn client_node_connects_over_the_sim_transport() {
     world.run();
 
     let overlay = Identity::new(
-        host_signer(SEED, "node"),
-        host_nonce(SEED, "node"),
+        host_signer(seed, "node"),
+        host_nonce(seed, "node"),
         spec(),
         SwarmNodeType::Client,
     )

--- a/crates/swarm/sim/tests/handshake.rs
+++ b/crates/swarm/sim/tests/handshake.rs
@@ -68,9 +68,12 @@ async fn drive_to_completion(traced: &mut TracedSwarm<Behaviour>) -> HostResult 
 }
 
 /// Run the two-host handshake sim and return the world trace.
+///
+/// The seed is fixed, not replayable: these tests derive identities from the
+/// literal and compare worlds built from distinct seeds.
 fn run_sim(seed: u64, auth: SimAuth) -> Vec<String> {
     let mut world = SimWorld::builder()
-        .seed(seed)
+        .fixed_seed(seed)
         .duration(Duration::from_secs(120))
         .build();
 

--- a/crates/swarm/sim/tests/kademlia_churn.rs
+++ b/crates/swarm/sim/tests/kademlia_churn.rs
@@ -24,6 +24,8 @@ fn churn_storm_recovers_depth() {
         .tokio_io()
         .build();
     let probe = launch_node(&mut world, KademliaConfig::default());
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     // Two peers of slack per below-depth bin, so a burst that briefly locks a
     // restarted peer into dial backoff cannot starve the refill.
@@ -37,7 +39,7 @@ fn churn_storm_recovers_depth() {
                 &name,
                 STORER,
                 PeerScript::Honest,
-                place(SEED, bin),
+                place(seed, bin),
             );
             names.push(name);
         }
@@ -51,7 +53,7 @@ fn churn_storm_recovers_depth() {
         Duration::from_secs(2),
         || handle.routing_stats().depth == 2,
     );
-    assert!(converged, "fixture never converged (seed={SEED})");
+    assert!(converged, "fixture never converged (seed={seed})");
 
     let always = Invariants::new()
         .phase_counters_consistent()
@@ -86,10 +88,10 @@ fn churn_storm_recovers_depth() {
             );
             assert!(
                 recovered,
-                "depth never returned after a burst (seed={SEED}): {:?}",
+                "depth never returned after a burst (seed={seed}): {:?}",
                 handle.routing_stats()
             );
-            always.assert(&handle.routing_stats(), SEED);
+            always.assert(&handle.routing_stats(), seed);
             // The refilled connections must be blameless for the next burst.
             common::mark_overlays_productive(&handle, &overlays);
         })
@@ -104,5 +106,5 @@ fn churn_storm_recovers_depth() {
         2,
         "table recovers after the storm"
     );
-    always.assert(&handle.routing_stats(), SEED);
+    always.assert(&handle.routing_stats(), seed);
 }

--- a/crates/swarm/sim/tests/kademlia_cold_start.rs
+++ b/crates/swarm/sim/tests/kademlia_cold_start.rs
@@ -23,6 +23,8 @@ fn converges_from_cold_start() {
         .tokio_io()
         .build();
     let probe = launch_node(&mut world, KademliaConfig::default());
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     let sat = usize::from(DEFAULT_SATURATION_PEERS);
     let mut scenario = Scenario::new(&world, spec());
@@ -34,7 +36,7 @@ fn converges_from_cold_start() {
                 &name,
                 STORER,
                 PeerScript::Honest,
-                place(SEED, bin),
+                place(seed, bin),
             );
             names.push(name);
         }
@@ -51,7 +53,7 @@ fn converges_from_cold_start() {
     );
     assert!(
         converged,
-        "honest population never converged to the anchored depth (seed={SEED}): {:?}",
+        "honest population never converged to the anchored depth (seed={seed}): {:?}",
         handle.routing_stats()
     );
 
@@ -64,5 +66,5 @@ fn converges_from_cold_start() {
     Invariants::new()
         .phase_counters_consistent()
         .saturation_floor(sat)
-        .assert(&stats, SEED);
+        .assert(&stats, seed);
 }

--- a/crates/swarm/sim/tests/kademlia_depth_hysteresis.rs
+++ b/crates/swarm/sim/tests/kademlia_depth_hysteresis.rs
@@ -24,6 +24,8 @@ fn one_peer_flap_never_moves_depth() {
         .tokio_io()
         .build();
     let probe = launch_node(&mut world, KademliaConfig::default());
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     // Bins 0 and 1 sit exactly at saturation, so one bounced bin-1 peer dips
     // the bin exactly one peer below the frontier: the marginal deficit the
@@ -38,7 +40,7 @@ fn one_peer_flap_never_moves_depth() {
                 &name,
                 STORER,
                 PeerScript::Honest,
-                place(SEED, bin),
+                place(seed, bin),
             );
             names.push(name);
         }
@@ -52,7 +54,7 @@ fn one_peer_flap_never_moves_depth() {
         Duration::from_secs(2),
         || handle.routing_stats().depth == 2,
     );
-    assert!(converged, "fixture never converged (seed={SEED})");
+    assert!(converged, "fixture never converged (seed={seed})");
 
     // Three flap cycles: bounce one frontier peer, hold the published depth
     // through the whole dip, confirm the peer is re-dialled. The peer has
@@ -68,7 +70,7 @@ fn one_peer_flap_never_moves_depth() {
             assert_eq!(
                 handle.routing_stats().depth,
                 2,
-                "a one-peer flap moved the published depth (cycle {cycle}, seed={SEED})"
+                "a one-peer flap moved the published depth (cycle {cycle}, seed={seed})"
             );
         }
         let recovered = run_until(
@@ -79,7 +81,7 @@ fn one_peer_flap_never_moves_depth() {
         );
         assert!(
             recovered,
-            "the flapped peer was never re-dialled (cycle {cycle}, seed={SEED}): {:?}",
+            "the flapped peer was never re-dialled (cycle {cycle}, seed={seed}): {:?}",
             handle.routing_stats()
         );
     }

--- a/crates/swarm/sim/tests/kademlia_handshake_release.rs
+++ b/crates/swarm/sim/tests/kademlia_handshake_release.rs
@@ -26,6 +26,8 @@ fn handshake_failure_releases_the_reservation() {
         .tokio_io()
         .build();
     let probe = launch_node(&mut world, KademliaConfig::default());
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     let mut scenario = Scenario::new(&world, spec());
     let mut names = Vec::new();
@@ -36,7 +38,7 @@ fn handshake_failure_releases_the_reservation() {
                 &name,
                 STORER,
                 PeerScript::Honest,
-                place(SEED, bin),
+                place(seed, bin),
             );
             names.push(name);
         }
@@ -46,7 +48,7 @@ fn handshake_failure_releases_the_reservation() {
         "failer",
         STORER,
         PeerScript::HandshakeFail,
-        place(SEED, 1),
+        place(seed, 1),
     );
     names.push("failer".to_owned());
     #[allow(clippy::expect_used)]
@@ -73,7 +75,7 @@ fn handshake_failure_releases_the_reservation() {
     };
     assert!(
         failed,
-        "the scripted dial never reached and failed the handshake (seed={SEED})"
+        "the scripted dial never reached and failed the handshake (seed={seed})"
     );
 
     // The honest supply converges around the failure.
@@ -86,7 +88,7 @@ fn handshake_failure_releases_the_reservation() {
             stats.depth == 1 && connected_in_bin(&stats, 1) == 3
         },
     );
-    assert!(converged, "fixture never converged (seed={SEED})");
+    assert!(converged, "fixture never converged (seed={seed})");
 
     // The failure never leaks into later rounds: the failer stays excluded
     // under backoff, only the honest peers count, and no dialing or
@@ -100,23 +102,23 @@ fn handshake_failure_releases_the_reservation() {
         assert_eq!(
             connected_in_bin(&stats, 1),
             3,
-            "only the honest peers count as connected (seed={SEED})"
+            "only the honest peers count as connected (seed={seed})"
         );
         for bin in &stats.bins {
             assert_eq!(
                 (bin.dialing, bin.handshaking),
                 (0, 0),
-                "a settled table carries no phase reservation in bin {} (seed={SEED})",
+                "a settled table carries no phase reservation in bin {} (seed={seed})",
                 bin.bin
             );
         }
         Invariants::new()
             .phase_counters_consistent()
-            .assert(&stats, SEED);
+            .assert(&stats, seed);
     }
     assert!(
         handle.peer_manager().peer_is_in_backoff(&failer),
-        "the failer stays excluded under backoff (seed={SEED})"
+        "the failer stays excluded under backoff (seed={seed})"
     );
     assert_eq!(handle.routing_stats().connected_peers_total, 11);
 }

--- a/crates/swarm/sim/tests/kademlia_partition.rs
+++ b/crates/swarm/sim/tests/kademlia_partition.rs
@@ -25,6 +25,8 @@ fn partition_collapses_then_heals_by_rediscovery() {
         .tokio_io()
         .build();
     let probe = launch_node(&mut world, KademliaConfig::default());
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     let sat = usize::from(DEFAULT_SATURATION_PEERS);
     let mut scenario = Scenario::new(&world, spec());
@@ -37,7 +39,7 @@ fn partition_collapses_then_heals_by_rediscovery() {
                 &name,
                 STORER,
                 PeerScript::Honest,
-                place(SEED, bin),
+                place(seed, bin),
             );
             if bin > 0 {
                 severed.push(name.clone());
@@ -55,7 +57,7 @@ fn partition_collapses_then_heals_by_rediscovery() {
                 &name,
                 STORER,
                 PeerScript::Honest,
-                place(SEED, bin),
+                place(seed, bin),
             );
             heal.push(name);
         }
@@ -69,7 +71,7 @@ fn partition_collapses_then_heals_by_rediscovery() {
         Duration::from_secs(2),
         || handle.routing_stats().depth == 2,
     );
-    assert!(converged, "fixture never converged (seed={SEED})");
+    assert!(converged, "fixture never converged (seed={seed})");
 
     // Partition: the far side of the cut is gone, not merely disconnected.
     for name in &severed {
@@ -85,7 +87,7 @@ fn partition_collapses_then_heals_by_rediscovery() {
     );
     assert!(
         collapsed,
-        "a multi-bin loss must lower the published depth at once (seed={SEED}): {:?}",
+        "a multi-bin loss must lower the published depth at once (seed={seed}): {:?}",
         handle.routing_stats()
     );
 
@@ -99,7 +101,7 @@ fn partition_collapses_then_heals_by_rediscovery() {
             .expect("world advances");
         assert!(
             handle.routing_stats().depth <= 1,
-            "depth must not heal without reachable supply (seed={SEED})"
+            "depth must not heal without reachable supply (seed={seed})"
         );
     }
 
@@ -114,10 +116,10 @@ fn partition_collapses_then_heals_by_rediscovery() {
     );
     assert!(
         healed,
-        "depth never re-climbed from the new supply (seed={SEED}): {:?}",
+        "depth never re-climbed from the new supply (seed={seed}): {:?}",
         handle.routing_stats()
     );
     Invariants::new()
         .phase_counters_consistent()
-        .assert(&handle.routing_stats(), SEED);
+        .assert(&handle.routing_stats(), seed);
 }

--- a/crates/swarm/sim/tests/kademlia_quota.rs
+++ b/crates/swarm/sim/tests/kademlia_quota.rs
@@ -31,13 +31,15 @@ fn outbound_quota_holds_under_inbound_flood() {
     // flood alone satisfies the count and only the outbound quota can
     // justify further dials.
     let probe = launch_node(&mut world, KademliaConfig::default().with_total_target(8));
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
     // The node's libp2p keypair is freshly generated inside the build, so
     // the flood dials the bare address and learns the peer id on the wire.
     let node_addr = world.multiaddr_of(NODE, NODE_PORT);
 
     // Every bin-0 peer shares one sub-prefix slot, so the empty-slot pass
     // stays quiet and the quota is the only path into the flooded bin.
-    let anchor = node_overlay(SEED);
+    let anchor = node_overlay(seed);
     let slot0 = Some(Placement::new(anchor, Bin::new(0).unwrap_or(Bin::MAX)).in_slot(0));
     let mut scenario = Scenario::new(&world, spec());
     let mut anchors = Vec::new();
@@ -86,7 +88,7 @@ fn outbound_quota_holds_under_inbound_flood() {
     );
     assert!(
         flooded,
-        "the inbound flood never met the count target (seed={SEED}): {:?}",
+        "the inbound flood never met the count target (seed={seed}): {:?}",
         handle.routing_stats()
     );
     let supply_dials = |world: &SimWorld| -> usize {
@@ -109,13 +111,13 @@ fn outbound_quota_holds_under_inbound_flood() {
     );
     assert!(
         quota_met,
-        "the quota never pulled outbound dials into the flooded bin (seed={SEED}): {:?}",
+        "the quota never pulled outbound dials into the flooded bin (seed={seed}): {:?}",
         handle.routing_stats()
     );
     assert_eq!(
         supply_dials(&world),
         QUOTA,
-        "exactly the quota of supply peers is self-dialed (seed={SEED})"
+        "exactly the quota of supply peers is self-dialed (seed={seed})"
     );
 
     // No storm: with the quota met the evaluator falls quiet; the bin holds
@@ -126,7 +128,7 @@ fn outbound_quota_holds_under_inbound_flood() {
     assert_eq!(
         connected_in_bin(&handle.routing_stats(), 0),
         8 + QUOTA,
-        "the quota-filled bin holds without a dial storm (seed={SEED})"
+        "the quota-filled bin holds without a dial storm (seed={seed})"
     );
     assert_eq!(
         supply_dials(&world),
@@ -146,7 +148,7 @@ fn outbound_quota_holds_under_inbound_flood() {
     );
     assert!(
         drained,
-        "the inbound leaver never drained (seed={SEED}): {:?}",
+        "the inbound leaver never drained (seed={seed}): {:?}",
         handle.routing_stats()
     );
     world
@@ -155,11 +157,11 @@ fn outbound_quota_holds_under_inbound_flood() {
     assert_eq!(
         connected_in_bin(&handle.routing_stats(), 0),
         7 + QUOTA,
-        "the drained bin holds steady: the count target is still met (seed={SEED})"
+        "the drained bin holds steady: the count target is still met (seed={seed})"
     );
     assert_eq!(
         supply_dials(&world),
         QUOTA,
-        "an inbound leave never moves the outbound share (seed={SEED})"
+        "an inbound leave never moves the outbound share (seed={seed})"
     );
 }

--- a/crates/swarm/sim/tests/kademlia_readiness.rs
+++ b/crates/swarm/sim/tests/kademlia_readiness.rs
@@ -24,6 +24,8 @@ fn boundary_flap_holds_the_readiness_clock() {
         .tokio_io()
         .build();
     let probe = launch_node(&mut world, KademliaConfig::default());
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     // Bin 0 saturated; the neighbourhood (bins >= 1) holds exactly the
     // saturation threshold: four bin-1 peers plus the flapper, two in bin 2,
@@ -37,7 +39,7 @@ fn boundary_flap_holds_the_readiness_clock() {
                 &name,
                 STORER,
                 PeerScript::Honest,
-                place(SEED, bin),
+                place(seed, bin),
             );
             names.push(name);
         }
@@ -47,7 +49,7 @@ fn boundary_flap_holds_the_readiness_clock() {
         "flapper",
         STORER,
         PeerScript::Honest,
-        place(SEED, 1),
+        place(seed, 1),
     );
     names.push("flapper".to_owned());
 
@@ -66,7 +68,7 @@ fn boundary_flap_holds_the_readiness_clock() {
     );
     assert!(
         converged,
-        "the saturated neighbourhood never carried a readiness clock (seed={SEED}): {:?}",
+        "the saturated neighbourhood never carried a readiness clock (seed={seed}): {:?}",
         handle.readiness()
     );
 
@@ -86,11 +88,11 @@ fn boundary_flap_holds_the_readiness_clock() {
             assert_eq!(
                 readiness.depth.get(),
                 1,
-                "a one-peer flap never moves depth (cycle {cycle}, seed={SEED})"
+                "a one-peer flap never moves depth (cycle {cycle}, seed={seed})"
             );
             assert!(
                 readiness.neighborhood_stable_for.is_some(),
-                "a one-peer flap never zeroes the readiness clock (cycle {cycle}, seed={SEED})"
+                "a one-peer flap never zeroes the readiness clock (cycle {cycle}, seed={seed})"
             );
         }
         let restored = run_until(
@@ -101,7 +103,7 @@ fn boundary_flap_holds_the_readiness_clock() {
         );
         assert!(
             restored,
-            "the flapper was never re-dialled (cycle {cycle}, seed={SEED}): {:?}",
+            "the flapper was never re-dialled (cycle {cycle}, seed={seed}): {:?}",
             handle.readiness()
         );
     }
@@ -119,10 +121,10 @@ fn boundary_flap_holds_the_readiness_clock() {
     );
     assert!(
         observed,
-        "the crashed pair was never observed (seed={SEED})"
+        "the crashed pair was never observed (seed={seed})"
     );
     assert!(
         handle.readiness().neighborhood_stable_for.is_none(),
-        "a multi-peer loss clears the readiness clock immediately (seed={SEED})"
+        "a multi-peer loss clears the readiness clock immediately (seed={seed})"
     );
 }

--- a/crates/swarm/sim/tests/kademlia_saturation_floor.rs
+++ b/crates/swarm/sim/tests/kademlia_saturation_floor.rs
@@ -28,12 +28,14 @@ fn saturation_floor_survives_hostile_taper() {
     // total_target 4 gives a raw taper of one to two peers per below-depth
     // bin; only the saturation floor lets the frontier form.
     let probe = launch_node(&mut world, KademliaConfig::default().with_total_target(4));
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     // Every balanced-bin peer shares sub-prefix slot 0, so a refill can only
     // come through the count-deficit path the floor governs, never through
     // the empty-slot diversity pass.
     let sat = usize::from(DEFAULT_SATURATION_PEERS);
-    let anchor = node_overlay(SEED);
+    let anchor = node_overlay(seed);
     let slot0 =
         |bin: u8| Some(Placement::new(anchor, Bin::new(bin).unwrap_or(Bin::MAX)).in_slot(0));
     let mut scenario = Scenario::new(&world, spec());
@@ -65,7 +67,7 @@ fn saturation_floor_survives_hostile_taper() {
     );
     assert!(
         converged,
-        "the saturation floor must let depth climb despite the hostile taper (seed={SEED}): {:?}",
+        "the saturation floor must let depth climb despite the hostile taper (seed={seed}): {:?}",
         handle.routing_stats()
     );
 
@@ -74,11 +76,11 @@ fn saturation_floor_survives_hostile_taper() {
         .phase_counters_consistent()
         .saturation_floor(sat);
     let stats = handle.routing_stats();
-    floor.assert(&stats, SEED);
+    floor.assert(&stats, seed);
     for bin in 0..2u8 {
         assert!(
             connected_in_bin(&stats, bin) >= sat,
-            "below-depth bin {bin} fell under saturation (seed={SEED}): {stats:?}"
+            "below-depth bin {bin} fell under saturation (seed={seed}): {stats:?}"
         );
     }
 
@@ -95,7 +97,7 @@ fn saturation_floor_survives_hostile_taper() {
     );
     assert!(
         refilled,
-        "the floored bin was never refilled after churn (seed={SEED}): {:?}",
+        "the floored bin was never refilled after churn (seed={seed}): {:?}",
         handle.routing_stats()
     );
     assert_eq!(
@@ -103,5 +105,5 @@ fn saturation_floor_survives_hostile_taper() {
         2,
         "depth holds through the churn"
     );
-    floor.assert(&handle.routing_stats(), SEED);
+    floor.assert(&handle.routing_stats(), seed);
 }

--- a/crates/swarm/sim/tests/kademlia_slots.rs
+++ b/crates/swarm/sim/tests/kademlia_slots.rs
@@ -40,8 +40,10 @@ fn empty_slots_dilute_a_subprefix_monoculture() {
     // sybil family alone satisfies the count and only slot awareness can
     // justify further dials.
     let probe = launch_node(&mut world, KademliaConfig::default().with_total_target(8));
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
-    let anchor = node_overlay(SEED);
+    let anchor = node_overlay(seed);
     let place =
         |slot: u8| Some(Placement::new(anchor, Bin::new(0).unwrap_or(Bin::MAX)).in_slot(slot));
     let mut scenario = Scenario::new(&world, spec());
@@ -99,13 +101,13 @@ fn empty_slots_dilute_a_subprefix_monoculture() {
     );
     assert!(
         monoculture,
-        "the sybil supply never met the count target (seed={SEED}): {:?}",
+        "the sybil supply never met the count target (seed={seed}): {:?}",
         handle.routing_stats()
     );
     assert_eq!(
         bin0_slots(&handle),
         Some(1),
-        "the sole supply shares one slot: sub-prefix monoculture (seed={SEED})"
+        "the sole supply shares one slot: sub-prefix monoculture (seed={seed})"
     );
 
     // Diverse supply arrives. The empty slots pull it in even though the
@@ -119,7 +121,7 @@ fn empty_slots_dilute_a_subprefix_monoculture() {
     );
     assert!(
         diluted,
-        "empty slots never pulled the diverse supply (seed={SEED}): {:?}",
+        "empty slots never pulled the diverse supply (seed={seed}): {:?}",
         handle.routing_stats()
     );
     assert_eq!(
@@ -136,7 +138,7 @@ fn empty_slots_dilute_a_subprefix_monoculture() {
     assert_eq!(
         common::connected_in_bin(&handle.routing_stats(), 0),
         12,
-        "the diverse set holds without oscillation (seed={SEED})"
+        "the diverse set holds without oscillation (seed={seed})"
     );
     assert_eq!(bin0_slots(&handle), Some(5), "slot diversity is retained");
     assert_eq!(

--- a/crates/swarm/sim/tests/kademlia_starvation.rs
+++ b/crates/swarm/sim/tests/kademlia_starvation.rs
@@ -24,6 +24,8 @@ fn all_backoff_is_starvation_without_redial() {
         .tokio_io()
         .build();
     let probe = launch_node(&mut world, KademliaConfig::default());
+    // Derive from the built world seed so a replay override reproduces exactly.
+    let seed = world.seed();
 
     // Half the supply never listens (the dial fails at the transport), half
     // accepts the transport but fails the handshake; both paths arm backoff.
@@ -39,7 +41,7 @@ fn all_backoff_is_starvation_without_redial() {
             &dark,
             STORER,
             PeerScript::Unreachable,
-            place(SEED, bin),
+            place(seed, bin),
         );
         names.push(dark);
         let refuser = format!("refuser-{bin}");
@@ -48,7 +50,7 @@ fn all_backoff_is_starvation_without_redial() {
             &refuser,
             STORER,
             PeerScript::HandshakeFail,
-            place(SEED, bin),
+            place(seed, bin),
         );
         countable.push(refuser.clone());
         names.push(refuser);
@@ -76,7 +78,7 @@ fn all_backoff_is_starvation_without_redial() {
     };
     assert!(
         all_attempted,
-        "every gossiped candidate must be dialled once (seed={SEED})"
+        "every gossiped candidate must be dialled once (seed={seed})"
     );
 
     // The fixed point: across many further evaluation rounds nothing is
@@ -97,7 +99,7 @@ fn all_backoff_is_starvation_without_redial() {
         .collect();
     assert_eq!(
         attempts_before, attempts_after,
-        "an all-backoff table must not re-dial (seed={SEED})"
+        "an all-backoff table must not re-dial (seed={seed})"
     );
 
     // The fixed point is the dial backoff holding every candidate.
@@ -105,7 +107,7 @@ fn all_backoff_is_starvation_without_redial() {
         overlays
             .iter()
             .all(|overlay| handle.peer_manager().peer_is_in_backoff(overlay)),
-        "every failed candidate must arm the dial backoff (seed={SEED})"
+        "every failed candidate must arm the dial backoff (seed={seed})"
     );
     assert_eq!(
         handle.routing_stats().connected_peers_total,

--- a/crates/swarm/sim/tests/scenario.rs
+++ b/crates/swarm/sim/tests/scenario.rs
@@ -47,14 +47,16 @@ fn churn_bursts_hold_the_depth_floor() {
         .tokio_io()
         .build();
 
-    // The node's overlay is derivable up front, so scripted peers can be
-    // placed against it before the node exists.
+    // Derive from the built world's seed: a replay override changes it. The
+    // node's overlay is derivable up front, so scripted peers can be placed
+    // against it before the node exists.
+    let seed = world.seed();
     let node_spec = spec();
     let node_overlay = {
         use vertex_swarm_api::SwarmIdentity as _;
         Identity::new(
-            host_signer(SEED, "node"),
-            vertex_swarm_sim::host_nonce(SEED, "node"),
+            host_signer(seed, "node"),
+            vertex_swarm_sim::host_nonce(seed, "node"),
             node_spec.clone(),
             SwarmNodeType::Client,
         )
@@ -149,13 +151,13 @@ fn churn_bursts_hold_the_depth_floor() {
         }
         assert!(
             world.elapsed() < Duration::from_secs(60),
-            "node never published its topology handle (seed={SEED})"
+            "node never published its topology handle (seed={seed})"
         );
     };
     while handle.routing_stats().depth < 1 {
         assert!(
             world.elapsed() < Duration::from_secs(600),
-            "depth never converged (seed={SEED}): {:?}",
+            "depth never converged (seed={seed}): {:?}",
             handle.routing_stats()
         );
         world
@@ -167,8 +169,8 @@ fn churn_bursts_hold_the_depth_floor() {
         .phase_counters_consistent()
         .saturation_floor(saturation);
     let steady = Invariants::new().depth_floor(1);
-    always.assert(&handle.routing_stats(), SEED);
-    steady.assert(&handle.routing_stats(), SEED);
+    always.assert(&handle.routing_stats(), seed);
+    steady.assert(&handle.routing_stats(), seed);
 
     // The unreachable peer never counts as connected.
     let stats = handle.routing_stats();
@@ -205,8 +207,8 @@ fn churn_bursts_hold_the_depth_floor() {
                 }
             }
             let stats = handle.routing_stats();
-            always.assert(&stats, SEED);
-            steady.assert(&stats, SEED);
+            always.assert(&stats, seed);
+            steady.assert(&stats, seed);
         })
         .expect("schedule applies");
 }

--- a/crates/swarm/sim/tests/storer_node.rs
+++ b/crates/swarm/sim/tests/storer_node.rs
@@ -67,9 +67,11 @@ fn storer_node_connects_over_the_sim_transport() {
         .tokio_io()
         .build();
 
+    // Derive from the built world's seed: a replay override changes it.
+    let seed = world.seed();
     world.host("boot", serve_bootnode);
     let boot_addr = world.multiaddr_of("boot", PORT).with(Protocol::P2p(
-        host_keypair(SEED, "boot").public().to_peer_id(),
+        host_keypair(seed, "boot").public().to_peer_id(),
     ));
 
     world.client("node", move |ctx| async move {
@@ -123,8 +125,8 @@ fn storer_node_connects_over_the_sim_transport() {
     world.run();
 
     let overlay = Identity::new(
-        host_signer(SEED, "node"),
-        host_nonce(SEED, "node"),
+        host_signer(seed, "node"),
+        host_nonce(seed, "node"),
         spec(),
         SwarmNodeType::Storer,
     )

--- a/docs/agents/rust-idiomatic.md
+++ b/docs/agents/rust-idiomatic.md
@@ -92,6 +92,7 @@ A deterministic simulation tier that drives the same behaviours under virtual ti
 
 - Integration tests live in `crates/<name>/tests/` (see `crates/swarm/node/tests`, `crates/swarm/peers/peer/tests`).
 - No `#[ignore]` tests on `main`. If a test is flaky, fix it or delete it.
+- The deterministic sim tier is `vertex-swarm-sim`: seeded turmoil worlds running real swarms and whole nodes on virtual time. It runs in its own nextest lane (`cargo nextest run -p vertex-swarm-sim --profile sim`, the CI `sim` job) and is kept out of the default lane by `.config/nextest.toml`. Every sim failure names its seed (`seed=N`); replay it exactly with `VERTEX_SIM_SEED=N cargo nextest run -p vertex-swarm-sim --profile sim -E 'test(<name>)'`. A scenario too big even for the sim lane gets excluded by filterset in that file, never `#[ignore]`.
 - Tests assert on enum variants (`matches!(err, HandshakeError::NetworkIdMismatch)`), never on `err.to_string()`.
 
 Scope local verification to the change; CI runs the full matrix per PR, so your job is to catch what the change can actually break, not to re-run everything.


### PR DESCRIPTION
## Summary

Give the sim suite its own seeded-replay nextest lane and wire it into CI, and route every scenario seed through the built world so a reported failure replays exactly.

## What

Add `.config/nextest.toml` with two lanes: the default profile excludes `vertex-swarm-sim` from the fast unit run, and a `sim` profile owns it (60s slow-timeout flag with terminate-after 5, immediate-final failure output so the seed line and world trace print in full). Add a dedicated `sim` job to unit.yml running `cargo nextest run -p vertex-swarm-sim --profile sim`, wired into the ci-success needs list.

Route the kademlia scenario seeds through the built world: placements and every seed= diagnostic now derive from `SimWorld::seed` rather than the literal const, so a `VERTEX_SIM_SEED` override replays a reported failure exactly instead of anchoring placements on the wrong overlay. Document the replay workflow in the crate rustdoc and add the sim lane to the testing guidance in docs/agents/rust-idiomatic.md.

## Why

Closes #853

Phase-1 (PRs #881-#884) proves determinism and populates scenarios; this gates them in CI so regressions are caught at push time. Seeded tests are useless without exact replay; deriving all host material and diagnostics from the built world seed makes the printed seed the replay value.

## Testing

Rebase/stitch: `git rebase --onto origin/sim/852-absorb origin/sim/851-scenarios` applied cleanly (no conflicts despite both branches touching scenario.rs/script.rs); train is now linear origin/sim/851 <- 852 (c67498e2) <- 853, verified with `git merge-base --is-ancestor`. Force-pushed with lease to sim/853-ci-lane.

All gates run inside `nix develop` against the shared target dir. `cargo fmt --all` clean. `cargo clean -p vertex-swarm-sim` then `cargo clippy -p vertex-swarm-sim --tests --all-features -- -D warnings`: clean. `cargo nextest run -p vertex-swarm-sim --profile sim`: 40/40 pass (39 from the base plus one added by the seed-routing fix).

Note: unit.yml (including the new sim job) only triggers on base=main, so the sim CI job has never run on this stacked branch; watch it on the retargeted PR's checks before merging.

## Rebase

Rebased onto main. #884 was squash-merged as `18b0166`, so the commits below this PR's own work were already in main under different hashes. The rebase replays the two commits that carry this PR's content.

Unlike the earlier PRs in this series, this one had real conflicts, because #990 rewrote `.github/workflows/unit.yml` and #986 added a default nextest profile:

- `.config/nextest.toml`: kept both sides. `[profile.default]` now carries the sim `default-filter` and main's `slow-timeout`.
- `.github/workflows/unit.yml`: the `sim` job is re-expressed against the current workflow. It takes the toolchain from the `./.github/actions/rust-setup` composite instead of installing stable, passes `--locked`, and is gated on the `changes` job like the other compile jobs. `ci success` needs it, and `allowed-skips` lists it, so a documentation-only change skips the sim lane without turning the aggregate check red.

Post-rebase verification on the 1.94.1 pin:

- `cargo clippy -p vertex-swarm-sim --all-targets --all-features --locked -- -D warnings`: clean.
- `cargo nextest run -p vertex-swarm-sim --profile sim --locked`: 40 tests run, 40 passed.
- `cargo nextest run -p vertex-swarm-sim --locked` on the default profile: 0 tests, 16 binaries skipped by `profile.default.default-filter`, which is the exclusion this PR intends. CI's workspace job keeps `--no-tests=warn`, so that exit code cannot fail the lane.
- `actionlint` reports nothing on the resolved workflow.

AI Assistance: Claude Code used for implementation, adversarial review, and PR text (Fable 5 implementation, Opus 4.8 review, Haiku 4.5 PR text) under human direction.

