### PR TITLE
obs: collapse duplicate failure logs, continue field-vocab sweep

### DIFF
--- a/crates/swarm/client-behaviour/src/behaviour.rs
+++ b/crates/swarm/client-behaviour/src/behaviour.rs
@@ -260,7 +260,7 @@ impl ClientBehaviour {
                     && let Some(tx) = &self.pseudosettle_event_tx
                     && tx.send(PseudosettleEvent::Failed { peer }).is_err()
                 {
-                    warn!(%peer, "Pseudosettle event channel closed");
+                    warn!(overlay = %peer, "Pseudosettle event channel closed");
                 }
                 #[cfg(feature = "swap")]
                 if let Some(peer) = overlay
@@ -268,7 +268,7 @@ impl ClientBehaviour {
                     && let Some(tx) = &self.swap_event_tx
                     && tx.send(SwapEvent::Failed { peer }).is_err()
                 {
-                    warn!(%peer, "Swap event channel closed");
+                    warn!(overlay = %peer, "Swap event channel closed");
                 }
                 self.pending_events
                     .push_back(ToSwarm::GenerateEvent(ClientEvent::ProtocolError {

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -864,7 +864,6 @@ impl ConnectionHandler for ClientHandler {
                     ClientOutboundInfo::Pricing => {
                         self.announce_in_flight = false;
                         self.requeue_superseded_announce();
-                        warn!(protocol = "pricing", %error, "Client dial upgrade error");
                         self.push_event(HandlerEvent::Error {
                             overlay: self.overlay(),
                             protocol: "pricing",
@@ -891,7 +890,6 @@ impl ConnectionHandler for ClientHandler {
                                 "Retrieval timed out waiting on a withholding peer"
                             );
                         }
-                        warn!(protocol = "retrieval", %address, %error, ?kind, "Client dial upgrade error");
                         if let Some(overlay) = self.overlay() {
                             self.push_event(HandlerEvent::Peer {
                                 overlay,
@@ -927,7 +925,6 @@ impl ConnectionHandler for ClientHandler {
                                 "Pushsync timed out waiting on a withholding peer"
                             );
                         }
-                        warn!(protocol = "pushsync", %address, %error, ?kind, "Client dial upgrade error");
                         if let Some(overlay) = self.overlay() {
                             self.push_event(HandlerEvent::Peer {
                                 overlay,
@@ -946,7 +943,6 @@ impl ConnectionHandler for ClientHandler {
                         let _ = response.send(Err(outcome));
                     }
                     ClientOutboundInfo::Pseudosettle { .. } => {
-                        warn!(protocol = "pseudosettle", %error, "Client dial upgrade error");
                         self.push_event(HandlerEvent::Error {
                             overlay: self.overlay(),
                             protocol: "pseudosettle",
@@ -955,7 +951,6 @@ impl ConnectionHandler for ClientHandler {
                     }
                     #[cfg(feature = "swap")]
                     ClientOutboundInfo::Swap => {
-                        warn!(protocol = "swap", %error, "Client dial upgrade error");
                         self.push_event(HandlerEvent::Error {
                             overlay: self.overlay(),
                             protocol: "swap",
@@ -970,7 +965,6 @@ impl ConnectionHandler for ClientHandler {
                 // reconstruction at decode and surfaces here; classify so the
                 // offending peer is scored. The chunk is already rejected.
                 let kind = e.error.inbound_failure_kind();
-                warn!(error = %e.error, ?kind, "Client listen upgrade error");
                 match (kind, self.overlay()) {
                     (FailureKind::InvalidChunk, Some(overlay)) => {
                         let protocol = match &e.error {

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -884,7 +884,7 @@ impl ConnectionHandler for ClientHandler {
                             // Sole emission site for the retrieval timeout counter.
                             metrics::counter!("swarm_client_retrieval_timeouts_total").increment(1);
                             debug!(
-                                peer_overlay = ?self.overlay(),
+                                overlay = ?self.overlay(),
                                 %address,
                                 elapsed = ?requested_at.elapsed(),
                                 "Retrieval timed out waiting on a withholding peer"
@@ -919,7 +919,7 @@ impl ConnectionHandler for ClientHandler {
                             // Sole emission site for the pushsync timeout counter.
                             metrics::counter!("swarm_client_pushsync_timeouts_total").increment(1);
                             debug!(
-                                peer_overlay = ?self.overlay(),
+                                overlay = ?self.overlay(),
                                 %address,
                                 elapsed = ?requested_at.elapsed(),
                                 "Pushsync timed out waiting on a withholding peer"

--- a/crates/swarm/client-behaviour/src/serve.rs
+++ b/crates/swarm/client-behaviour/src/serve.rs
@@ -274,7 +274,7 @@ impl ServeOp for PushServe {
         // drop `provide`, releasing without a trace: they are our failures,
         // not the pusher's.
         if let Err(e) = storer.reserve.put(CachedChunk::from(self.chunk.clone())) {
-            debug!(peer = %self.overlay, %address, error = %e, "Reserve put failed; not acknowledging");
+            debug!(overlay = %self.overlay, %address, error = %e, "Reserve put failed; not acknowledging");
             return Local::Refuse;
         }
 
@@ -291,7 +291,7 @@ impl ServeOp for PushServe {
                 // Stored, but cannot prove custody. Reset rather than send an
                 // unsigned ack; the pusher retries (the reserve put is
                 // content-addressed, so a re-delivery is a no-op).
-                debug!(peer = %self.overlay, %address, error = %e, "Receipt sign failed; not acknowledging");
+                debug!(overlay = %self.overlay, %address, error = %e, "Receipt sign failed; not acknowledging");
                 Local::Refuse
             }
         }

--- a/crates/swarm/client-behaviour/src/serve.rs
+++ b/crates/swarm/client-behaviour/src/serve.rs
@@ -125,7 +125,7 @@ async fn respond_and_commit<Op: ServeOp>(
         }
         Err(e) => {
             debug!(
-                peer = %op.peer(),
+                overlay = %op.peer(),
                 address = %op.address(),
                 error = %e,
                 "serve delivery refused by the peer"

--- a/crates/swarm/net/handshake/src/behaviour.rs
+++ b/crates/swarm/net/handshake/src/behaviour.rs
@@ -230,7 +230,7 @@ where
         _role_override: libp2p::core::Endpoint,
         _port_use: libp2p::core::transport::PortUse,
     ) -> Result<THandler<Self>, libp2p::swarm::ConnectionDenied> {
-        debug!(%peer, ?connection_id, %addr, "Creating outbound handshake handler");
+        debug!(%peer, ?connection_id, remote_addr = %addr, "Creating outbound handshake handler");
         self.connection_directions
             .insert(connection_id, ConnectionDirection::Outbound);
         let self_record = self.cached_self_record(addr);
@@ -271,7 +271,6 @@ where
 
         match event {
             HandshakeHandlerEvent::Completed { info } => {
-                debug!(%peer_id, ?connection_id, ?direction, "Handshake completed");
                 self.events
                     .push_back(ToSwarm::GenerateEvent(HandshakeEvent::Completed {
                         peer_id,
@@ -281,7 +280,6 @@ where
                     }));
             }
             HandshakeHandlerEvent::Failed { error } => {
-                debug!(%peer_id, ?connection_id, ?direction, ?error, "Handshake failed");
                 self.events
                     .push_back(ToSwarm::GenerateEvent(HandshakeEvent::Failed {
                         peer_id,

--- a/crates/swarm/net/handshake/src/handler.rs
+++ b/crates/swarm/net/handshake/src/handler.rs
@@ -21,7 +21,7 @@ use libp2p::{
         },
     },
 };
-use tracing::{debug, warn};
+use tracing::debug;
 use vertex_metrics::labels::direction;
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_peer::SwarmPeer;
@@ -316,14 +316,12 @@ where
 
             ConnectionEvent::DialUpgradeError(error) => {
                 self.outbound_pending = false;
-                warn!(peer_id = %self.peer_id, "Outbound handshake failed: {}", error.error);
                 self.state = State::Failed;
                 let error = extract_error(error.error);
                 self.pending_event = Some(HandshakeHandlerEvent::Failed { error });
             }
 
             ConnectionEvent::ListenUpgradeError(error) => {
-                warn!(peer_id = %self.peer_id, "Inbound handshake failed: {}", error.error);
                 // A denied extra exchange is the violating substream's failure,
                 // not this connection's handshake outcome (which may already be
                 // Completed); the behaviour drops the peer on the event.

--- a/crates/swarm/net/hive/src/behaviour.rs
+++ b/crates/swarm/net/hive/src/behaviour.rs
@@ -18,7 +18,6 @@ use libp2p::{
     },
 };
 use strum::IntoStaticStr;
-use tracing::debug;
 use vertex_net_ratelimiter::KeyedRateLimiter;
 use vertex_swarm_api::SwarmIdentity;
 use vertex_swarm_net_headers::ProtocolStreamError;
@@ -172,7 +171,6 @@ where
                     }));
             }
             HiveHandlerEvent::Error(error) => {
-                debug!(%peer_id, %error, "hive error");
                 self.events
                     .push_back(ToSwarm::GenerateEvent(HiveEvent::Error {
                         peer_id,

--- a/crates/swarm/net/hive/src/handler.rs
+++ b/crates/swarm/net/hive/src/handler.rs
@@ -210,7 +210,6 @@ where
             ConnectionEvent::ListenUpgradeError(ListenUpgradeError { error, .. }) => {
                 let hive_error =
                     UpgradeError::record_and_convert(error, "hive", direction::INBOUND);
-                warn!(error = %hive_error, "Hive inbound stream error");
                 self.core.push_event(HiveHandlerEvent::Error(hive_error));
             }
 
@@ -218,7 +217,6 @@ where
                 self.core.set_outbound_pending(false);
                 let hive_error =
                     UpgradeError::record_and_convert(error.error, "hive", direction::OUTBOUND);
-                warn!(error = %hive_error, "Hive outbound error");
                 self.core.push_event(HiveHandlerEvent::Error(hive_error));
             }
 

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -449,7 +449,7 @@ impl ClientService {
                 error,
             } => {
                 warn!(
-                    peer = ?peer,
+                    overlay = ?peer,
                     peer_id = ?peer_id,
                     %protocol,
                     %error,
@@ -464,7 +464,7 @@ impl ClientService {
                 event,
             } => match event {
                 PeerEvent::PaymentThresholdReceived { threshold } => {
-                    debug!(%peer_id, %peer, %threshold, "Received payment threshold");
+                    debug!(%peer_id, overlay = %peer, %threshold, "Received payment threshold");
                     if let Some(adopter) = &self.threshold_adopter {
                         // An out-of-spec value saturates to the maximum AU; the
                         // clamp inside accounting caps it at the local threshold.
@@ -474,7 +474,7 @@ impl ClientService {
                 }
 
                 PeerEvent::PaymentThresholdSent => {
-                    debug!(%peer, "Payment threshold sent");
+                    debug!(overlay = %peer, "Payment threshold sent");
                 }
 
                 PeerEvent::ChunkReceived {
@@ -490,7 +490,7 @@ impl ClientService {
                     // is committed by the dispatch reservation, not here; a relay leg
                     // is accounted by the forwarder. Cache and scoring apply to every
                     // delivery.
-                    debug!(%peer, %address, ?latency, "Chunk received");
+                    debug!(overlay = %peer, %address, ?latency, "Chunk received");
                     // Feed the per-PO latency estimate so the chunk provider can pace
                     // its staggered race to the forwarding distance. Only originated
                     // retrievals: a relay leg's latency is the requester's chain, not
@@ -511,32 +511,32 @@ impl ClientService {
                 }
 
                 PeerEvent::InboundServed => {
-                    debug!(%peer, "Served inbound retrieval from cache");
+                    debug!(overlay = %peer, "Served inbound retrieval from cache");
                     metrics::counter!("swarm_client_inbound_served_total").increment(1);
                 }
 
                 PeerEvent::InboundForwarded => {
-                    debug!(%peer, "Forwarded inbound retrieval to a closer peer");
+                    debug!(overlay = %peer, "Forwarded inbound retrieval to a closer peer");
                     metrics::counter!("swarm_client_inbound_forwarded_total").increment(1);
                 }
 
                 PeerEvent::InboundMissed { address } => {
-                    debug!(%peer, %address, "Inbound retrieval missed (substream reset)");
+                    debug!(overlay = %peer, %address, "Inbound retrieval missed (substream reset)");
                     metrics::counter!("swarm_client_inbound_missed_total").increment(1);
                 }
 
                 PeerEvent::InboundRelayed => {
-                    debug!(%peer, "Relayed pushsync receipt to pusher");
+                    debug!(overlay = %peer, "Relayed pushsync receipt to pusher");
                     metrics::counter!("swarm_client_inbound_relayed_total").increment(1);
                 }
 
                 PeerEvent::InboundStored => {
-                    debug!(%peer, "Stored inbound pushsync delivery and signed a receipt");
+                    debug!(overlay = %peer, "Stored inbound pushsync delivery and signed a receipt");
                     metrics::counter!("swarm_client_inbound_stored_total").increment(1);
                 }
 
                 PeerEvent::InboundPushFailed { address } => {
-                    debug!(%peer, %address, "Inbound pushsync failed (substream reset)");
+                    debug!(overlay = %peer, %address, "Inbound pushsync failed (substream reset)");
                     metrics::counter!("swarm_client_inbound_push_failed_total").increment(1);
                 }
 
@@ -549,7 +549,7 @@ impl ClientService {
                     // scoring. The origin debit is committed by the dispatch
                     // reservation, not here; a relay leg is accounted by the
                     // forwarder.
-                    debug!(%peer, %address, ?latency, "Receipt received");
+                    debug!(overlay = %peer, %address, ?latency, "Receipt received");
                     self.report(
                         &peer,
                         SwarmScoringEvent::PushSuccess { latency },
@@ -568,7 +568,7 @@ impl ClientService {
                     // download's flood of misses cannot decay the peer set past the
                     // disconnect threshold; the staggered race steers around an
                     // unhelpful candidate within a request instead.
-                    warn!(%peer, %address, %error, ?kind, "Retrieval failed");
+                    warn!(overlay = %peer, %address, %error, ?kind, "Retrieval failed");
                     match kind {
                         FailureKind::InvalidChunk => {
                             metrics::counter!(
@@ -596,7 +596,7 @@ impl ClientService {
                 } => {
                     // Same scoring policy as retrieval: a malformed receipt is
                     // scored, a plain `Protocol` failure is blameless.
-                    warn!(%peer, %address, %error, ?kind, "Push failed");
+                    warn!(overlay = %peer, %address, %error, ?kind, "Push failed");
                     match kind {
                         FailureKind::InvalidChunk => {
                             metrics::counter!(
@@ -619,7 +619,7 @@ impl ClientService {
                 PeerEvent::InboundInvalidData { protocol } => {
                     // Decode rejected a malformed inbound chunk or request before
                     // relay; score the sender adversely.
-                    warn!(%peer, %protocol, "Inbound malformed data rejected");
+                    warn!(overlay = %peer, %protocol, "Inbound malformed data rejected");
                     metrics::counter!(
                         "swarm_client_invalid_chunk_total",
                         "protocol" => protocol,
@@ -638,23 +638,23 @@ impl ClientService {
                     // `route_pseudosettle_events`: it validates against the time
                     // allowance, credits the ledger, and acks the clamped
                     // amount. Acking here too would race it for the wire.
-                    debug!(%peer, %peer_id, %amount, %request_id, "Pseudosettle received");
+                    debug!(overlay = %peer, %peer_id, %amount, %request_id, "Pseudosettle received");
                 }
 
                 PeerEvent::PseudosettleSent { ack } => {
-                    debug!(%peer, %peer_id, amount = %ack.accepted, timestamp = ack.timestamp, "Pseudosettle sent, received ack");
+                    debug!(overlay = %peer, %peer_id, amount = %ack.accepted, timestamp = ack.timestamp, "Pseudosettle sent, received ack");
                 }
 
                 #[cfg(feature = "swap")]
                 PeerEvent::SwapChequeReceived { peer_rate, .. } => {
                     // The swap settlement service consumes cheques via the dedicated
                     // channel configured with `route_swap_events`.
-                    debug!(%peer, %peer_id, %peer_rate, "Swap cheque received");
+                    debug!(overlay = %peer, %peer_id, %peer_rate, "Swap cheque received");
                 }
 
                 #[cfg(feature = "swap")]
                 PeerEvent::SwapChequeSent { peer_rate } => {
-                    debug!(%peer, %peer_id, %peer_rate, "Swap cheque sent");
+                    debug!(overlay = %peer, %peer_id, %peer_rate, "Swap cheque sent");
                 }
 
                 // `PeerEvent` carries swap variants when `client-protocol/swap`

--- a/crates/swarm/node/src/dispatch.rs
+++ b/crates/swarm/node/src/dispatch.rs
@@ -1221,7 +1221,7 @@ fn accept_origin_receipt(
     let verdict = receipt.verify_depth(local_depth, neighbourhood_credible);
     if let DepthVerdict::Shallow(err) = &verdict {
         warn!(
-            %peer,
+            overlay = %peer,
             address = %receipt.address,
             error = <&'static str>::from(err),
             "rejected shallow custody receipt; retrying another route"

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -108,8 +108,8 @@ impl<I: SwarmIdentity, B: NetworkBehaviour> BaseNode<I, B> {
     pub fn start_listening(&mut self) -> Result<()> {
         for addr in &self.listen_addrs {
             match self.swarm.listen_on(addr.clone()) {
-                Ok(_) => info!(%addr, "Listening on address"),
-                Err(e) => warn!(%addr, %e, "Failed to listen on address"),
+                Ok(_) => info!(multiaddr = %addr, "Listening on address"),
+                Err(e) => warn!(multiaddr = %addr, error = %e, "Failed to listen on address"),
             }
         }
         Ok(())

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -254,7 +254,7 @@ where
     let swarm = build_swarm(idle_timeout, transport, behaviour_builder)?;
 
     let local_peer_id = *swarm.local_peer_id();
-    info!(%local_peer_id, "{} peer ID", node_type_name);
+    info!(%local_peer_id, node_type = node_type_name, "Local peer ID");
     info!(overlay = %infra.identity.overlay_address(), "Overlay address");
 
     if infra.topology_handle.connect_bootnodes().await.is_err() {

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -268,7 +268,7 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
                     dialed += 1;
                 }
                 Err(e) => {
-                    warn!(addr = %addr_str, %e, "Invalid multiaddr, skipping");
+                    warn!(multiaddr = %addr_str, error = %e, "Invalid multiaddr, skipping");
                 }
             }
         }
@@ -426,7 +426,7 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
 
     fn route_client_event(&self, event: ClientEvent) {
         if let Err(e) = self.client_event_tx.try_send(event) {
-            warn!(%e, "Failed to send client event to service");
+            warn!(error = %e, "Failed to send client event to service");
             metrics::counter!("swarm_client_events_dropped_total").increment(1);
         }
     }

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -337,7 +337,7 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
                     dialed += 1;
                 }
                 Err(e) => {
-                    warn!(addr = %addr_str, %e, "Invalid multiaddr, skipping");
+                    warn!(multiaddr = %addr_str, error = %e, "Invalid multiaddr, skipping");
                 }
             }
         }
@@ -516,7 +516,7 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
 
     fn route_client_event(&self, event: ClientEvent) {
         if let Err(e) = self.client_event_tx.try_send(event) {
-            warn!(%e, "Failed to send client event to service");
+            warn!(error = %e, "Failed to send client event to service");
             metrics::counter!("swarm_client_events_dropped_total").increment(1);
         }
     }

--- a/crates/swarm/node/src/selection.rs
+++ b/crates/swarm/node/src/selection.rs
@@ -123,7 +123,7 @@ where
 {
     fn trigger_settlement(&self, peer: OverlayAddress) {
         let Ok(executor) = TaskExecutor::try_current() else {
-            debug!(%peer, "no task executor; settlement not triggered");
+            debug!(overlay = %peer, "no task executor; settlement not triggered");
             return;
         };
         // Skip if a settle to this peer is already running; the entry is cleared
@@ -143,7 +143,7 @@ where
         executor.spawn(async move {
             let _guard = guard;
             if let Err(error) = handle.settle().await {
-                debug!(%peer, %error, "best-effort settlement failed");
+                debug!(overlay = %peer, %error, "best-effort settlement failed");
             }
         });
     }


### PR DESCRIPTION
## What

Logging-convention sweep for #281, stacked on #280. Three collapses of duplicate failure logs to a single owner-level log, each achieved by having the lower layer propagate the failure as an event and stop logging it itself:

1. **Handshake**: removed the two interpolated `warn!` calls in the connection handler (`ConnectionEvent::DialUpgradeError` / `ListenUpgradeError`) and the two outcome `debug!` calls in the behaviour (`Completed` / `Failed`), leaving topology's `on_handshake_failed` warn as the sole owner log.
2. **Hive**: removed the handler's inbound/outbound stream-error `warn!` calls and the behaviour's `"hive error"` `debug!`, leaving topology's `"Hive error"` warn as the sole owner log. The now-unused `tracing::debug` import was dropped from `hive/behaviour.rs`.
3. **Client protocol upgrades**: removed the six per-protocol `"Client dial/listen upgrade error"` warns in the client handler (pricing, retrieval, pushsync, pseudosettle, swap, listen-upgrade). These already push a `HandlerEvent` that surfaces at `client_service` as `ProtocolError`/`RetrievalFailed`/`PushFailed`/`InboundMalformed` warns, carrying the same protocol/address/error/kind fields, so no signal is lost.

Alongside the collapses, this branch continues the field-vocabulary work from #280:

- Disambiguates `peer` into `overlay` (an `OverlayAddress`) versus `peer_id` (a libp2p `PeerId`) at each remaining call site across `client-behaviour` (`behaviour.rs`, `serve.rs`), `client_service.rs`, `dispatch.rs`, and `selection.rs`.
- Renames ad hoc `addr`/`e` fields to the shared vocabulary `multiaddr`/`error` in `node/base.rs`, `node/client.rs`, and `node/storer.rs`.
- Rewrites the peer-ID startup log in `node/builder.rs` from an interpolated `"{} peer ID"` message to a structured `node_type` field with a fixed `"Local peer ID"` message.

## Why

Several failure paths were logged twice or three times (handler, behaviour, and owner), which is noisy and makes triage harder, without adding information the owner-level log did not already have. Collapsing to one log per failure at the layer that has full context (the peer/route, not just the transient handler state) reduces log volume while preserving every field consumers rely on. The `peer` vs `peer_id` vs `overlay`/`multiaddr` renames continue #280's push toward one field name per concept so downstream log queries and dashboards are consistent.

## Testing

- `cargo fmt --all -- --check` - pass, no diff.
- `nix develop --command cargo clippy --all-features --all-targets -- -D warnings` - pass, zero warnings across the full workspace.
- `cargo clippy --all-targets -- -D warnings` after `cargo clean` of the four touched crates (`vertex-swarm-client-behaviour`, `vertex-swarm-net-handshake`, `vertex-swarm-net-hive`, `vertex-swarm-node`) - pass, clean recompile with zero warnings.
- `cargo nextest run` over the four touched crates - pass.

AI Assistance: Claude Code used for implementation, red-team review, and independent verification (gate re-run) of this change.

Closes #281
