### PR TITLE
chore(deps): migrate libp2p fork pin to prod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2283,7 +2283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2714,7 +2714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3621,7 +3621,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3947,7 +3947,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3961,15 +3961,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4159,7 +4150,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libp2p"
 version = "0.57.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "bytes",
  "either",
@@ -4190,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4200,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.16.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4223,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4233,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "either",
  "fnv",
@@ -4257,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "hickory-resolver",
@@ -4271,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4311,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.49.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -4329,7 +4320,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.18.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4345,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.47.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4367,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4382,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.44.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4397,12 +4388,13 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
+ "libp2p-quicreuse",
  "libp2p-timer",
  "libp2p-tls",
  "quinn",
@@ -4416,9 +4408,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-quicreuse"
+version = "0.1.0"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
+dependencies = [
+ "futures",
+ "quinn",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "libp2p-request-response"
 version = "0.30.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "futures-bounded 0.3.0",
@@ -4434,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "either",
  "fnv",
@@ -4457,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.36.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "heck",
  "quote",
@@ -4467,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "async-trait",
  "futures",
@@ -4484,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.45.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "if-watch",
@@ -4499,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "libp2p-timer"
 version = "0.1.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures-bounded 0.3.0",
  "futures-timer",
@@ -4509,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4527,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.7.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "igd-next",
@@ -4541,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket-websys"
 version = "0.6.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "bytes",
  "futures",
@@ -4557,15 +4561,13 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.48.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
- "either",
  "futures",
  "libp2p-core",
  "thiserror 2.0.18",
  "tracing",
- "yamux 0.12.1",
- "yamux 0.13.10",
+ "yamux",
 ]
 
 [[package]]
@@ -4889,7 +4891,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "multistream-select"
 version = "0.14.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "bytes",
  "futures",
@@ -5925,7 +5927,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5945,7 +5947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5961,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "prost-codec"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -5977,7 +5979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5990,7 +5992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6003,7 +6005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6101,9 +6103,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -6113,7 +6115,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6151,7 +6153,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6667,7 +6669,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6725,7 +6727,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6767,7 +6769,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.5.0"
-source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=c8b360fa8e247a2388c644d314fd6dd3fb544ed1#c8b360fa8e247a2388c644d314fd6dd3fb544ed1"
 dependencies = [
  "futures",
  "pin-project",
@@ -7478,7 +7480,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9966,7 +9968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10426,31 +10428,15 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
+checksum = "767113d8f66a81e461362462aa71d8d0108cbf3430d4442fb88a04e31be81165"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.6",
- "static_assertions",
-]
-
-[[package]]
-name = "yamux"
-version = "0.13.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
-dependencies = [
- "futures",
- "log",
- "nohash-hasher",
- "parking_lot",
- "pin-project",
- "rand 0.9.4",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,14 +304,14 @@ opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-proto",
 opentelemetry-appender-tracing = { version = "0.31", features = ["experimental_use_tracing_span_context"] }
 
 ## p2p
-# Pinned to the nxm-rs rust-libp2p fork, branched from upstream rev
-# 3e72d4c071d5ec8815d2f6f7ee3602600ff51798 (master, for libp2p-dns 0.45.0 against
-# hickory 0.26.1, RUSTSEC-2026-0119 / RUSTSEC-2026-0118). The fork carries a single
-# fix on top: `libp2p-websocket-websys` no longer blocks `poll_flush` on the browser
-# WebSocket `bufferedAmount` draining to zero, which stalled the wasm client mid
-# handshake and tore the connection down with `BrokenPipe`. Revisit when the fix is
-# upstreamed and libp2p 0.57 is released.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", features = [
+# Pinned to the nxm-rs rust-libp2p fork `prod` integration branch (rev c8b360fa8,
+# based on upstream b44e1286 / libp2p 0.57, keeping libp2p-dns 0.45.0 against hickory
+# 0.26.1 for RUSTSEC-2026-0119 / RUSTSEC-2026-0118). Carries the websocket-websys
+# browser `poll_flush` and inbound-overflow-wake fixes plus the libp2p-timer pausable
+# sweep that the `start_paused` cluster harness relies on. The fork's
+# webtransport/quic/quicreuse/webrtc crates (and their quinn/wtransport `[patch]`
+# pins) are not compiled by the feature set below, so vertex needs no patch pins.
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1", features = [
     "tokio",
     "noise",
     "tcp",
@@ -328,13 +328,13 @@ libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5
 quick-protobuf = "0.8"
 quick-protobuf-codec = "0.3.1"
 asynchronous-codec = "0.7.0"
-libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb" }
-libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb" }
+libp2p-swarm = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1" }
+libp2p-swarm-test = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1" }
 # Browser websocket transport for the wasm client. Dials the bee AutoTLS
 # `/tls/sni/<host>/ws` form; the browser performs TLS and SNI natively. Pinned to
 # the nxm-rs fork for the `poll_flush` browser WebSocket flush fix (see the `libp2p`
 # entry above).
-libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb" }
+libp2p-websocket-websys = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1" }
 quickcheck = "1.0.3"
 pb-rs = "0.10"
 walkdir = "2.5.0"

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -96,7 +96,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 vertex-tasks = { path = "../../crates/tasks" }
 
 # libp2p Multiaddr only; the trimmed wasm feature set mirrors the node crate.
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false }
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1", default-features = false }
 
 # wasm-bindgen surface and browser bindings.
 wasm-bindgen = "0.2"

--- a/crates/swarm/client-behaviour/Cargo.toml
+++ b/crates/swarm/client-behaviour/Cargo.toml
@@ -60,7 +60,7 @@ tracing.workspace = true
 libp2p.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/node/Cargo.toml
+++ b/crates/swarm/node/Cargo.toml
@@ -119,7 +119,7 @@ vertex-swarm-storer-behaviour = { workspace = true, optional = true }
 vertex-swarm-puller = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1", default-features = false, features = [
     "noise",
     "yamux",
     "macros",

--- a/crates/swarm/topology/Cargo.toml
+++ b/crates/swarm/topology/Cargo.toml
@@ -80,7 +80,7 @@ vertex-net-dnsaddr.workspace = true
 # `vertex-net-dnsaddr-doh` (DNS-over-HTTPS) with the embedded wss snapshot as
 # the fallback.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb", default-features = false, features = [
+libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "c8b360fa8e247a2388c644d314fd6dd3fb544ed1", default-features = false, features = [
     "noise",
     "yamux",
     "macros",


### PR DESCRIPTION
## What

Migrate the `nxm-rs/rust-libp2p` fork pin from `fd9cc0d98` (the previous timer-core lineage, branched off upstream `3e72d4c07`) to the `prod` integration branch `c8b360fa8`. The rev is bumped in the root workspace `Cargo.toml` and in the per-crate wasm-target manifests (`crates/swarm/{node,topology,client-behaviour}`, `bin/swarm-demo`), and `Cargo.lock` is regenerated.

## Why

`prod` is the consolidated, rebased and GPG-signed fork train (the `nxm-rs/rust-libp2p` #31-#37 stack). It is based on the newer upstream `b44e1286` (libp2p 0.57) and carries the same `libp2p-websocket-websys` browser fixes and the `libp2p-timer` pausable-timer sweep that the `start_paused` cluster harness depends on, while keeping `libp2p-dns 0.45.0` for the hickory RUSTSEC-2026-0118/0119 advisories. Standardising vertex on `prod` keeps a single fork branch to track.

The enabled feature set (`tcp`, `yamux`, `dns`, `noise`, `identify`, `upnp`, `autonat`, `mdns`, `ping`) compiles no quic/webtransport/quicreuse/webrtc crates, so no `[patch.crates-io]` quinn/wtransport pins are required. Note for later: enabling those transports will require replicating prod's quinn and wtransport `[patch.crates-io]` pins in this workspace, because a patch table does not propagate from a git dependency.

## Testing

`cargo update` re-resolves the whole graph onto `prod` at identical crate versions (libp2p 0.57.0, core 0.44.0, swarm 0.48.0, dns 0.45.0) with no conflicts and no patch pins. `cargo check -p vertex-swarm-node --tests` is green (compiles the swarm cone and the `vertex-swarm-test-utils` harness). The full matrix runs here in CI.

## AI Assistance

Claude Code used for the fork-diff analysis, the pin bump, and the dependency-resolution plus compile validation.
