### PR TITLE
fix(networking): profile NAT stack per node type for bootnodes

### DIFF
--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -190,7 +190,8 @@ pub trait SwarmNetworkConfig {
 
     /// Whether AutoNAT v2 (dial-back reachability verification) is enabled
     /// (default: true). Runs both the client (verify our own addresses) and
-    /// the server (verify peers') roles for every node type.
+    /// the server (verify peers') roles; a bootnode's addresses are static and
+    /// public, so it runs the server role only.
     fn autonat_enabled(&self) -> bool {
         true
     }

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -53,8 +53,9 @@ pub(crate) struct BootnodeBehaviour<I: SwarmIdentity + Clone> {
     /// behaviour.
     pub(crate) ip_limits: IpConnectionLimits,
     pub(crate) identify: identify::Behaviour,
-    /// NAT traversal (AutoNAT v2, UPnP) and LAN discovery (mDNS), composed as
-    /// one sub-behaviour.
+    /// Bootnode NAT profile: AutoNAT v2 server only (dial-back verification of
+    /// peers). The self-probing client and mDNS stay disabled because the
+    /// bootnode's addresses are static and public.
     pub(crate) nat: NatBehaviour,
     /// Before topology: reads the active-peers view at connection close while the
     /// registry entry is live.
@@ -354,7 +355,11 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
             "Bootnode",
             self.transport,
             move |pk, topology| {
-                let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
+                let nat = NatBehaviour::from_config(
+                    network_config,
+                    pk.to_peer_id(),
+                    SwarmNodeType::Bootnode,
+                );
                 BootnodeBehaviour::from_parts(
                     pk,
                     topology,

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -109,7 +109,11 @@ where
         "Client node",
         transport,
         move |pk, topology| {
-            let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
+            let nat = NatBehaviour::from_config(
+                network_config,
+                pk.to_peer_id(),
+                vertex_swarm_api::SwarmNodeType::Client,
+            );
             ClientNodeBehaviour::from_parts(
                 pk,
                 topology,

--- a/crates/swarm/node/src/node/nat.rs
+++ b/crates/swarm/node/src/node/nat.rs
@@ -14,7 +14,7 @@ use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::upnp;
 use libp2p::{Multiaddr, PeerId};
 use tracing::{debug, info, warn};
-use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
+use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig, SwarmNodeType};
 use vertex_swarm_topology::{TopologyBehaviour, TopologyCommand};
 
 /// NAT traversal (AutoNAT v2, UPnP) and LAN discovery (mDNS), composed as one
@@ -34,18 +34,28 @@ pub(crate) struct NatBehaviour {
 }
 
 impl NatBehaviour {
-    /// Build the NAT behaviours from a network configuration.
+    /// Build the NAT behaviours from a network configuration, profiled by node
+    /// type.
     ///
-    /// AutoNAT v2 and mDNS are enabled by default for every node type; UPnP is
-    /// opt-in. mDNS needs the local [`PeerId`], so the behaviour is built where
-    /// the swarm's public key is available.
-    pub(crate) fn from_config(config: &impl SwarmNetworkConfig, local_peer_id: PeerId) -> Self {
+    /// AutoNAT v2 and mDNS are enabled by default; UPnP is opt-in. A bootnode
+    /// listens on static public addresses, so it keeps only the AutoNAT server
+    /// (dial-back verification of peers) and drops the self-probing client and
+    /// multicast mDNS. mDNS needs the local [`PeerId`], so the behaviour is
+    /// built where the swarm's public key is available.
+    pub(crate) fn from_config(
+        config: &impl SwarmNetworkConfig,
+        local_peer_id: PeerId,
+        node_type: SwarmNodeType,
+    ) -> Self {
         let autonat = config.autonat_enabled();
+        let bootnode = matches!(node_type, SwarmNodeType::Bootnode);
         Self {
-            autonat_client: Toggle::from(autonat.then(autonat::client::Behaviour::default)),
+            autonat_client: Toggle::from(
+                (autonat && !bootnode).then(autonat::client::Behaviour::default),
+            ),
             autonat_server: Toggle::from(autonat.then(autonat::server::Behaviour::default)),
             upnp: Toggle::from(config.upnp_enabled().then(upnp::tokio::Behaviour::default)),
-            mdns: build_mdns_toggle(config.mdns_enabled(), local_peer_id),
+            mdns: build_mdns_toggle(config.mdns_enabled() && !bootnode, local_peer_id),
         }
     }
 }
@@ -219,12 +229,117 @@ fn handle_upnp_event(event: upnp::Event) {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
+    use std::time::Duration;
+
     use libp2p::identity::Keypair;
 
     use super::*;
 
     fn random_peer_id() -> PeerId {
         Keypair::generate_ed25519().public().to_peer_id()
+    }
+
+    /// Config relying on the trait defaults (AutoNAT on, mDNS on, UPnP off),
+    /// with mDNS forced off where a test must not bind a multicast socket.
+    struct TestConfig {
+        empty_addrs: Vec<Multiaddr>,
+        mdns: bool,
+    }
+
+    impl TestConfig {
+        fn new(mdns: bool) -> Self {
+            Self {
+                empty_addrs: Vec::new(),
+                mdns,
+            }
+        }
+    }
+
+    impl SwarmNetworkConfig for TestConfig {
+        fn listen_addrs(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn bootnodes(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn trusted_peers(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn discovery_enabled(&self) -> bool {
+            true
+        }
+        fn max_peers(&self) -> usize {
+            32
+        }
+        fn idle_timeout(&self) -> Duration {
+            Duration::from_secs(60)
+        }
+        fn mdns_enabled(&self) -> bool {
+            self.mdns
+        }
+    }
+
+    /// The bootnode profile keeps the AutoNAT server and drops the client and
+    /// mDNS even when the config enables them.
+    #[test]
+    fn bootnode_profile_keeps_autonat_server_only() {
+        let config = TestConfig::new(true);
+
+        let nat = NatBehaviour::from_config(&config, random_peer_id(), SwarmNodeType::Bootnode);
+
+        assert!(nat.autonat_server.is_enabled());
+        assert!(!nat.autonat_client.is_enabled());
+        assert!(!nat.mdns.is_enabled());
+        assert!(!nat.upnp.is_enabled());
+    }
+
+    /// A client node keeps both AutoNAT roles.
+    #[test]
+    fn client_profile_runs_both_autonat_roles() {
+        let config = TestConfig::new(false);
+
+        let nat = NatBehaviour::from_config(&config, random_peer_id(), SwarmNodeType::Client);
+
+        assert!(nat.autonat_server.is_enabled());
+        assert!(nat.autonat_client.is_enabled());
+    }
+
+    /// Disabling AutoNAT in the config also disables the bootnode's server.
+    #[test]
+    fn autonat_off_disables_bootnode_server() {
+        struct AutonatOff(TestConfig);
+        impl SwarmNetworkConfig for AutonatOff {
+            fn listen_addrs(&self) -> &[Multiaddr] {
+                self.0.listen_addrs()
+            }
+            fn bootnodes(&self) -> &[Multiaddr] {
+                self.0.bootnodes()
+            }
+            fn trusted_peers(&self) -> &[Multiaddr] {
+                self.0.trusted_peers()
+            }
+            fn discovery_enabled(&self) -> bool {
+                true
+            }
+            fn max_peers(&self) -> usize {
+                32
+            }
+            fn idle_timeout(&self) -> Duration {
+                Duration::from_secs(60)
+            }
+            fn autonat_enabled(&self) -> bool {
+                false
+            }
+            fn mdns_enabled(&self) -> bool {
+                false
+            }
+        }
+        let config = AutonatOff(TestConfig::new(false));
+
+        let nat = NatBehaviour::from_config(&config, random_peer_id(), SwarmNodeType::Bootnode);
+
+        assert!(!nat.autonat_server.is_enabled());
+        assert!(!nat.autonat_client.is_enabled());
     }
 
     #[test]

--- a/crates/swarm/node/src/node/nat_wasm.rs
+++ b/crates/swarm/node/src/node/nat_wasm.rs
@@ -10,7 +10,7 @@ use std::convert::Infallible;
 
 use libp2p::PeerId;
 use libp2p::swarm::NetworkBehaviour;
-use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
+use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig, SwarmNodeType};
 use vertex_swarm_topology::TopologyBehaviour;
 
 /// No-op NAT sub-behaviour for the browser client.
@@ -21,9 +21,14 @@ pub(crate) struct NatBehaviour {
 }
 
 impl NatBehaviour {
-    /// Build the no-op NAT behaviour. The configuration and local [`PeerId`]
-    /// are accepted and ignored so the call site matches the native sibling.
-    pub(crate) fn from_config(_config: &impl SwarmNetworkConfig, _local_peer_id: PeerId) -> Self {
+    /// Build the no-op NAT behaviour. The configuration, local [`PeerId`], and
+    /// node type are accepted and ignored so the call site matches the native
+    /// sibling.
+    pub(crate) fn from_config(
+        _config: &impl SwarmNetworkConfig,
+        _local_peer_id: PeerId,
+        _node_type: SwarmNodeType,
+    ) -> Self {
         Self {
             inner: libp2p::swarm::dummy::Behaviour,
         }

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -171,7 +171,11 @@ where
         "Storer node",
         transport,
         move |pk, topology| {
-            let nat = NatBehaviour::from_config(network_config, pk.to_peer_id());
+            let nat = NatBehaviour::from_config(
+                network_config,
+                pk.to_peer_id(),
+                vertex_swarm_api::SwarmNodeType::Storer,
+            );
             StorerNodeBehaviour::from_parts(
                 pk,
                 topology,

--- a/docs/networking/address-management.md
+++ b/docs/networking/address-management.md
@@ -107,10 +107,10 @@ The swarm broadcasts every `ExternalAddrConfirmed` to all behaviours, so the top
 
 | Behaviour | Default | Flag |
 |-----------|---------|------|
-| AutoNAT v2 (client + server) | enabled for all node types | `--network.autonat` |
+| AutoNAT v2 (client + server) | enabled; bootnodes run the server role only | `--network.autonat` |
 | UPnP port mapping | disabled (opt-in) | `--network.upnp` |
 
-AutoNAT v2 runs both roles on every node type, including bootnodes, so the network always has dial-back verifiers. UPnP is opt-in because it actively probes the LAN gateway, which only helps home and NAT'd nodes and is noise on directly-routable hosts. Each behaviour is wrapped in a libp2p `Toggle`, so disabling one leaves an inert behaviour rather than changing the composed type.
+AutoNAT v2 runs both roles on clients and storers, so the network always has dial-back verifiers. A bootnode listens on static, public addresses, so it keeps only the server role: self-probing its own addresses is redundant, and mDNS multicast discovery is likewise disabled on bootnodes because a datacentre host has no LAN peers to discover. UPnP is opt-in because it actively probes the LAN gateway, which only helps home and NAT'd nodes and is noise on directly-routable hosts. Each behaviour is wrapped in a libp2p `Toggle`, so disabling one leaves an inert behaviour rather than changing the composed type.
 
 ### Interop
 


### PR DESCRIPTION
## What

`NatBehaviour::from_config` now takes a `SwarmNodeType` parameter and profiles the NAT stack at runtime instead of applying the same defaults to every node type.

For `SwarmNodeType::Bootnode` the AutoNAT v2 server (dial-back verification of peers) stays on, but the self-probing AutoNAT client and mDNS are disabled regardless of the mDNS config default. Clients and storers are unchanged: both AutoNAT roles plus mDNS remain on by default, and UPnP stays opt-in for every node type. The `autonat_enabled()` master toggle still gates the bootnode server too, so turning AutoNAT off disables it everywhere.

The wasm sibling `nat_wasm.rs` gains the same parameter, ignored, purely for signature parity with the native module. All three production call sites (`bootnode.rs`, `client.rs`, `storer.rs`) pass their node type explicitly; no cargo feature is involved.

Stale rustdoc is updated in three places: `SwarmNetworkConfig::autonat_enabled`, the `BootnodeBehaviour::nat` field doc, and `docs/networking/address-management.md`, which now explains that a bootnode's addresses are static and public, so self-probing and LAN mDNS discovery are redundant for it.

## Why

Closes #750

A bootnode listens on static, public addresses. Running the AutoNAT client to self-probe those addresses and running mDNS to discover LAN peers is pointless overhead for a datacentre host with no LAN peers, whereas the AutoNAT server role is still needed so the bootnode can keep verifying dial-back reachability for the peers that contact it.

## Testing

Three unit tests were added in `nat.rs`, each built on a minimal `TestConfig` implementing `SwarmNetworkConfig` so no multicast socket is bound:

- `bootnode_profile_keeps_autonat_server_only`: with AutoNAT and mDNS both enabled in config, a `Bootnode` ends up with only the AutoNAT server toggle enabled; client, mDNS, and UPnP are all disabled.
- `client_profile_runs_both_autonat_roles`: a `Client` keeps both the AutoNAT client and server enabled.
- `autonat_off_disables_bootnode_server`: with `autonat_enabled()` returning `false`, a `Bootnode` has both the AutoNAT client and server disabled, confirming the master toggle still gates the bootnode's server role.

The change was independently verified in an isolated worktree from the single commit, with all gates re-run from scratch (build, tests, lints); nothing needed fixing.

## AI Assistance

Claude (Sonnet 5, via Claude Code) was used for the implementation, the adversarial red-team review, and the independent verification pass described above.
