### PR TITLE
feat(networking): support dual-stack and multiple listen addresses

### DIFF
--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -26,6 +26,10 @@ const DEFAULT_P2P_PORT: u16 = 1634;
 /// Default listen address.
 const DEFAULT_LISTEN_ADDR: &str = "0.0.0.0";
 
+/// IPv6 wildcard counterpart of the default listen address, used when the
+/// default listen set widens to dual-stack.
+const DEFAULT_LISTEN_ADDR_V6: &str = "::";
+
 /// Default maximum established connections, enforced at the transport layer
 /// by the swarm's connection-limits behaviour.
 ///
@@ -85,6 +89,12 @@ pub struct NetworkArgs {
     #[arg(long = "network.trusted-peers", value_delimiter = ',')]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub trusted_peers_raw: Vec<String>,
+
+    /// P2P listen multiaddrs (repeatable or comma-separated). Takes
+    /// precedence over --network.addr and --network.port.
+    #[arg(long = "network.listen-addr", value_delimiter = ',')]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub listen_addrs_raw: Vec<String>,
 
     /// P2P listen port.
     #[arg(long = "network.port", default_value_t = DEFAULT_P2P_PORT)]
@@ -203,6 +213,7 @@ impl Default for NetworkArgs {
             no_trust_local_peers: false,
             bootnodes_raw: Vec::new(),
             trusted_peers_raw: Vec::new(),
+            listen_addrs_raw: Vec::new(),
             port: DEFAULT_P2P_PORT,
             addr: DEFAULT_LISTEN_ADDR.to_string(),
             nat_addrs_raw: Vec::new(),
@@ -260,6 +271,9 @@ impl NetworkArgs {
 #[derive(Debug, Clone)]
 pub struct NetworkConfig<R = KademliaConfig> {
     listen_addrs: Vec<Multiaddr>,
+    /// True while the listen set is the untouched stock default, so a
+    /// node-type default may widen it; any explicit configuration clears it.
+    listen_defaulted: bool,
     bootnodes: Vec<Multiaddr>,
     trusted_peers: Vec<Multiaddr>,
     nat_addrs: Vec<Multiaddr>,
@@ -319,6 +333,7 @@ impl<R> NetworkConfig<R> {
     pub fn with_routing<NewR>(self, routing: NewR) -> NetworkConfig<NewR> {
         NetworkConfig {
             listen_addrs: self.listen_addrs,
+            listen_defaulted: self.listen_defaulted,
             bootnodes: self.bootnodes,
             trusted_peers: self.trusted_peers,
             nat_addrs: self.nat_addrs,
@@ -344,6 +359,21 @@ impl<R> NetworkConfig<R> {
     pub fn override_bootnodes(&mut self, bootnodes: Vec<Multiaddr>) {
         self.bootnodes = bootnodes;
     }
+
+    /// Widen an untouched default listen set to dual-stack by adding the IPv6
+    /// wildcard listener next to the stock IPv4 one. No-op when any listen
+    /// address or the legacy address/port pair was configured explicitly, so
+    /// operator configuration always wins.
+    #[allow(clippy::expect_used)]
+    pub fn apply_dual_stack_listen_default(&mut self) {
+        if !self.listen_defaulted {
+            return;
+        }
+        let v6: Multiaddr = format!("/ip6/{DEFAULT_LISTEN_ADDR_V6}/tcp/{DEFAULT_P2P_PORT}")
+            .parse()
+            .expect("default IPv6 listen address is valid");
+        self.listen_addrs.push(v6);
+    }
 }
 
 impl NetworkConfig<KademliaConfig> {
@@ -352,6 +382,7 @@ impl NetworkConfig<KademliaConfig> {
     pub fn dial_only() -> NetworkConfig<KademliaConfig> {
         NetworkConfig {
             listen_addrs: Vec::new(),
+            listen_defaulted: false,
             bootnodes: Vec::new(),
             trusted_peers: Vec::new(),
             nat_addrs: Vec::new(),
@@ -381,6 +412,7 @@ impl Default for NetworkConfig<KademliaConfig> {
                 .expect("default listen address is valid");
         Self {
             listen_addrs: vec![listen_addr],
+            listen_defaulted: true,
             bootnodes: Vec::new(),
             trusted_peers: Vec::new(),
             nat_addrs: Vec::new(),
@@ -412,8 +444,10 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
             return Err(ConfigError::ZeroMaxPeers);
         }
 
-        let listen_addr_str = format!("/ip4/{}/tcp/{}", args.addr, args.port);
-        let listen_addrs =
+        // Explicit multiaddrs win; the legacy address/port pair is a
+        // convenience that expands to exactly one IPv4 entry.
+        let listen_addrs: Vec<Multiaddr> = if args.listen_addrs_raw.is_empty() {
+            let listen_addr_str = format!("/ip4/{}/tcp/{}", args.addr, args.port);
             vec![
                 listen_addr_str
                     .parse()
@@ -422,7 +456,22 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
                         addr: listen_addr_str,
                         source: e,
                     })?,
-            ];
+            ]
+        } else {
+            args.listen_addrs_raw
+                .iter()
+                .map(|s| {
+                    s.parse().map_err(|e| ConfigError::InvalidAddress {
+                        kind: ConfigAddressKind::ListenAddr,
+                        addr: s.clone(),
+                        source: e,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        let listen_defaulted = args.listen_addrs_raw.is_empty()
+            && args.addr == DEFAULT_LISTEN_ADDR
+            && args.port == DEFAULT_P2P_PORT;
 
         let bootnodes = args
             .bootnodes_raw
@@ -462,6 +511,7 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
 
         Ok(Self {
             listen_addrs,
+            listen_defaulted,
             bootnodes,
             trusted_peers,
             nat_addrs,
@@ -594,6 +644,16 @@ mod dial_only_tests {
         assert_eq!(peers.ban_threshold(), default.ban_threshold());
         assert_eq!(peers.warn_threshold(), default.warn_threshold());
         assert_eq!(peers.max_per_bin(), default.max_per_bin());
+    }
+
+    #[test]
+    fn dial_only_ignores_the_dual_stack_listen_default() {
+        let mut config = NetworkConfig::dial_only();
+        config.apply_dual_stack_listen_default();
+        assert!(
+            config.listen_addrs().is_empty(),
+            "a dial-only shape stays listener-free"
+        );
     }
 
     #[test]
@@ -818,6 +878,100 @@ mod tests {
         };
         let config = NetworkConfig::try_from(&args).expect("valid args");
         assert!(!config.mdns_enabled());
+    }
+
+    #[test]
+    fn listen_addr_flag_parses_repeated_and_comma_separated() {
+        use clap::Parser;
+
+        let parsed = TestCli::try_parse_from([
+            "test",
+            "--network.listen-addr",
+            "/ip4/0.0.0.0/tcp/1634,/ip6/::/tcp/1634",
+            "--network.listen-addr",
+            "/ip4/127.0.0.1/tcp/1700",
+        ])
+        .expect("flag should parse");
+        assert_eq!(parsed.network.listen_addrs_raw.len(), 3);
+
+        let config = NetworkConfig::try_from(&parsed.network).expect("valid args");
+        assert_eq!(config.listen_addrs().len(), 3);
+    }
+
+    #[test]
+    fn listen_addr_takes_precedence_over_the_legacy_pair() {
+        let args = NetworkArgs {
+            listen_addrs_raw: vec!["/ip6/::/tcp/1700".to_string()],
+            addr: "127.0.0.1".to_string(),
+            port: 1800,
+            ..Default::default()
+        };
+        let config = NetworkConfig::try_from(&args).expect("valid args");
+
+        let expected: Multiaddr = "/ip6/::/tcp/1700".parse().expect("valid multiaddr");
+        assert_eq!(config.listen_addrs(), std::slice::from_ref(&expected));
+    }
+
+    #[test]
+    fn legacy_pair_expands_to_one_entry() {
+        let args = NetworkArgs {
+            port: 1700,
+            ..Default::default()
+        };
+        let config = NetworkConfig::try_from(&args).expect("valid args");
+
+        let expected: Multiaddr = "/ip4/0.0.0.0/tcp/1700".parse().expect("valid multiaddr");
+        assert_eq!(config.listen_addrs(), std::slice::from_ref(&expected));
+    }
+
+    #[test]
+    fn network_config_fails_on_invalid_listen_multiaddr() {
+        let args = NetworkArgs {
+            listen_addrs_raw: vec!["not-a-multiaddr".to_string()],
+            ..Default::default()
+        };
+        assert!(NetworkConfig::try_from(&args).is_err());
+    }
+
+    #[test]
+    fn dual_stack_default_widens_the_untouched_listen_set() {
+        let mut config =
+            NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
+        config.apply_dual_stack_listen_default();
+
+        let v4: Multiaddr = "/ip4/0.0.0.0/tcp/1634".parse().expect("valid multiaddr");
+        let v6: Multiaddr = "/ip6/::/tcp/1634".parse().expect("valid multiaddr");
+        assert_eq!(config.listen_addrs(), [v4, v6]);
+    }
+
+    #[test]
+    fn dual_stack_default_respects_explicit_configuration() {
+        // An explicit multiaddr pins the listen set.
+        let args = NetworkArgs {
+            listen_addrs_raw: vec!["/ip4/0.0.0.0/tcp/1634".to_string()],
+            ..Default::default()
+        };
+        let mut config = NetworkConfig::try_from(&args).expect("valid args");
+        config.apply_dual_stack_listen_default();
+        assert_eq!(config.listen_addrs().len(), 1);
+
+        // So does a changed legacy address/port pair.
+        let args = NetworkArgs {
+            port: 1700,
+            ..Default::default()
+        };
+        let mut config = NetworkConfig::try_from(&args).expect("valid args");
+        config.apply_dual_stack_listen_default();
+        assert_eq!(config.listen_addrs().len(), 1);
+    }
+
+    #[test]
+    fn dual_stack_default_survives_with_routing() {
+        let config =
+            NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
+        let mut swapped = config.with_routing(KademliaConfig::default());
+        swapped.apply_dual_stack_listen_default();
+        assert_eq!(swapped.listen_addrs().len(), 2);
     }
 
     #[test]

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -369,6 +369,9 @@ impl<R> NetworkConfig<R> {
         if !self.listen_defaulted {
             return;
         }
+        // Widening consumes the stock-default status, so a repeat call is a
+        // no-op rather than appending a duplicate listener.
+        self.listen_defaulted = false;
         let v6: Multiaddr = format!("/ip6/{DEFAULT_LISTEN_ADDR_V6}/tcp/{DEFAULT_P2P_PORT}")
             .parse()
             .expect("default IPv6 listen address is valid");
@@ -937,6 +940,18 @@ mod tests {
     fn dual_stack_default_widens_the_untouched_listen_set() {
         let mut config =
             NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
+        config.apply_dual_stack_listen_default();
+
+        let v4: Multiaddr = "/ip4/0.0.0.0/tcp/1634".parse().expect("valid multiaddr");
+        let v6: Multiaddr = "/ip6/::/tcp/1634".parse().expect("valid multiaddr");
+        assert_eq!(config.listen_addrs(), [v4, v6]);
+    }
+
+    #[test]
+    fn dual_stack_default_is_idempotent() {
+        let mut config =
+            NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
+        config.apply_dual_stack_listen_default();
         config.apply_dual_stack_listen_default();
 
         let v4: Multiaddr = "/ip4/0.0.0.0/tcp/1634".parse().expect("valid multiaddr");

--- a/crates/swarm/node/src/config.rs
+++ b/crates/swarm/node/src/config.rs
@@ -42,8 +42,15 @@ pub struct ProtocolConfig {
 
 impl ProtocolConfig {
     /// Create validated network configuration.
+    ///
+    /// A bootnode left on the stock listen set widens it to dual-stack
+    /// (IPv4 plus IPv6 wildcard listeners); explicit configuration wins.
     pub fn network_config(&self) -> Result<NetworkConfig, ConfigError> {
-        NetworkConfig::try_from(&self.network)
+        let mut config = NetworkConfig::try_from(&self.network)?;
+        if matches!(self.node_type, SwarmNodeType::Bootnode) {
+            config.apply_dual_stack_listen_default();
+        }
+        Ok(config)
     }
 
     /// Create identity from keystore or ephemeral.
@@ -106,5 +113,39 @@ impl NodeProtocolConfig for ProtocolConfig {
         self.chain = args.chain.clone();
         self.swap = args.swap.clone();
         self.rpc = args.rpc;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vertex_swarm_api::{Multiaddr, SwarmNetworkConfig};
+
+    #[test]
+    fn bootnode_defaults_to_dual_stack_listeners() {
+        let mut config = ProtocolConfig::default();
+        config.override_node_type(SwarmNodeType::Bootnode);
+
+        let network = config.network_config().expect("default config is valid");
+        let v6: Multiaddr = "/ip6/::/tcp/1634".parse().expect("valid multiaddr");
+        assert_eq!(network.listen_addrs().len(), 2);
+        assert!(network.listen_addrs().contains(&v6));
+    }
+
+    #[test]
+    fn client_keeps_the_single_ipv4_listener() {
+        let config = ProtocolConfig::default();
+        let network = config.network_config().expect("default config is valid");
+        assert_eq!(network.listen_addrs().len(), 1);
+    }
+
+    #[test]
+    fn explicit_listen_addrs_override_the_bootnode_default() {
+        let mut config = ProtocolConfig::default();
+        config.override_node_type(SwarmNodeType::Bootnode);
+        config.network.listen_addrs_raw = vec!["/ip4/127.0.0.1/tcp/1700".to_string()];
+
+        let network = config.network_config().expect("valid config");
+        assert_eq!(network.listen_addrs().len(), 1);
     }
 }

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -104,13 +104,25 @@ impl<I: SwarmIdentity, B: NetworkBehaviour> BaseNode<I, B> {
         self.connected_peers() > 0
     }
 
+    /// Start every configured listener.
+    ///
+    /// A partial failure only warns so a dual-stack listen set still comes up
+    /// on a single-stack host; failing every listener is an error. A dial-only
+    /// node with no listen addresses succeeds trivially.
     #[must_use = "listen failures should be checked"]
     pub fn start_listening(&mut self) -> Result<()> {
+        let mut bound = 0usize;
         for addr in &self.listen_addrs {
             match self.swarm.listen_on(addr.clone()) {
-                Ok(_) => info!(%addr, "Listening on address"),
+                Ok(_) => {
+                    info!(%addr, "Listening on address");
+                    bound += 1;
+                }
                 Err(e) => warn!(%addr, %e, "Failed to listen on address"),
             }
+        }
+        if bound == 0 && !self.listen_addrs.is_empty() {
+            eyre::bail!("failed to listen on any configured address");
         }
         Ok(())
     }


### PR DESCRIPTION
## What

Adds a repeatable/comma-separated `--network.listen-addr` multiaddr flag (`listen_addrs_raw` on `NetworkArgs`) in `crates/swarm/node/src/args/network.rs`, which takes precedence over the legacy `--network.addr`/`--network.port` pair. That pair remains as a convenience which expands to exactly one IPv4 entry.

`NetworkConfig` now tracks whether its listen set is still the untouched stock default (`listen_defaulted`), and exposes `apply_dual_stack_listen_default()`, which widens the set to `/ip4/0.0.0.0/tcp/1634` plus `/ip6/::/tcp/1634`. The method is a no-op once the set has already been widened or once any listen address (or a changed legacy address/port pair) was configured explicitly, so operator configuration always wins and the call is idempotent.

`ProtocolConfig::network_config` (`crates/swarm/node/src/config.rs`) calls `apply_dual_stack_listen_default()` only for `SwarmNodeType::Bootnode`, so clients and storers keep the single IPv4 listener while bootnodes default to dual-stack.

`BaseNode::start_listening` (`crates/swarm/node/src/node/base.rs`) now counts successful binds: a partial bind failure only warns (so a dual-stack default still comes up on a v4-only host), and it errors only when every configured listener fails to bind. A dial-only node with no listen addresses still succeeds trivially.

## Why

Closes #753

Bootnodes need to be reachable over both IPv4 and IPv6 by default without forcing every node type onto a wider listen surface, and operators need a way to configure arbitrary listen multiaddrs (not just one IPv4 host/port) when the legacy flag pair is not expressive enough.

## Testing

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --lib --all-features -- -D warnings` and `cargo clippy --workspace --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`: both clean, zero warnings.
- Default-cone clippy on the touched crate after a clean rebuild (`cargo clean -p vertex-swarm-node && cargo clippy -p vertex-swarm-node ...`): clean.
- New unit tests cover: repeated/comma-separated flag parsing, listen-addr precedence over the legacy pair, legacy-pair expansion to one entry, invalid multiaddr rejection, dual-stack widening of an untouched default, idempotency of the widening call (regression test for a fixed bug where a double call duplicated the IPv6 listener), preservation of the widened default across `with_routing`, dial-only configs ignoring the widening call, bootnode defaulting to dual-stack listeners, clients keeping a single IPv4 listener, and explicit listen addresses overriding the bootnode default.
- Full test suite: 196/196 passing.

## AI Assistance

AI Assistance: Claude (Anthropic) used for implementation, red-team review (including finding and fixing the non-idempotent `apply_dual_stack_listen_default` bug plus its regression test), and independent verification of the gates above.
