### PR TITLE
chore(deps): enable libp2p relay and dcutr features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4169,6 +4169,7 @@ dependencies = [
  "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
@@ -4177,6 +4178,7 @@ dependencies = [
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-quic",
+ "libp2p-relay",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
@@ -4251,6 +4253,27 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "unsigned-varint",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dcutr"
+version = "0.15.0"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded 0.3.0",
+ "hashlink 0.11.1",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "libp2p-timer",
+ "prost 0.14.4",
+ "prost-codec",
+ "thiserror 2.0.18",
+ "tracing",
  "web-time",
 ]
 
@@ -4333,9 +4356,11 @@ source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-ping",
+ "libp2p-relay",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client",
@@ -4413,6 +4438,29 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-relay"
+version = "0.22.0"
+source = "git+https://github.com/nxm-rs/rust-libp2p?rev=fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb#fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded 0.3.0",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "libp2p-timer",
+ "prost 0.14.4",
+ "prost-codec",
+ "rand 0.8.6",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,6 +324,8 @@ libp2p = { git = "https://github.com/nxm-rs/rust-libp2p", rev = "fd9cc0d989000d5
     "autonat",
     "mdns",
     "ping",
+    "relay",
+    "dcutr",
 ] }
 quick-protobuf = "0.8"
 quick-protobuf-codec = "0.3.1"


### PR DESCRIPTION
## What

Adds `"relay"` and `"dcutr"` to the workspace `libp2p` feature list in `Cargo.toml`, plus the resulting additive `Cargo.lock` entries: `libp2p-relay` 0.22.0 and `libp2p-dcutr` 0.15.0, both resolved from the pinned nxm-rs fork rev `fd9cc0d989000d5f68c36e2a53bb10d8a3b3edeb` (unchanged, no pin bump).

No `.rs` files are touched. No behaviour composition changes: the relay server behaviour is not composed anywhere, only the Cargo features are enabled.

## Why

Closes #759

The issue asked whether the pinned fork builds relay and dcutr cleanly for the `wasm32-unknown-unknown` target with no cfg-gating required. Enabling the features is the minimal change needed to answer that question.

## Testing

- `cargo fmt --all -- --check`: clean.
- `nix develop` -> `cargo clippy --all-features --all-targets -- -D warnings`: clean across the workspace.
- `nix develop` -> `cargo build --target wasm32-unknown-unknown -p vertex-swarm-node`: finishes with zero warnings.
- `cargo tree` confirms both `libp2p-relay` and `libp2p-dcutr` resolve and compile inside the wasm32 dependency graph (feature unification pulls them in via the cone crates that inherit the workspace `libp2p` dependency).
- `just check-cone`: feature cone guards stay green, no storer/swap/chain/ffi leak.
- Confirmed the `Cargo.lock` diff is purely additive (zero deletions).

This answers the issue's open question: the pinned fork builds relay and dcutr cleanly for wasm32 with no cfg-gating needed.

## AI Assistance

AI Assistance: Claude (Anthropic, Sonnet) used for the feature enablement change, verification of the wasm32 build and cargo tree output, and this PR description.
