### PR TITLE
feat(topology): re-resolve dnsaddr bootnodes periodically

### DIFF
--- a/crates/net/dnsaddr/src/lib.rs
+++ b/crates/net/dnsaddr/src/lib.rs
@@ -1,9 +1,10 @@
 //! Recursive `/dnsaddr/` multiaddr resolution (resolves ALL TXT records, unlike libp2p's DNS transport).
 
 use std::collections::HashSet;
+use std::time::{Duration, Instant};
 
-use hickory_resolver::Resolver;
 use hickory_resolver::proto::rr::RData;
+use hickory_resolver::{Resolver, TokioResolver};
 use libp2p::Multiaddr;
 use libp2p::multiaddr::Protocol;
 use tracing::{debug, warn};
@@ -17,34 +18,152 @@ pub fn is_dnsaddr(addr: &Multiaddr) -> bool {
     addr.iter().any(|p| matches!(p, Protocol::Dnsaddr(_)))
 }
 
-/// Resolve a batch of multiaddrs, expanding every `/dnsaddr/` entry.
+/// Failure to construct the resolver from the system DNS configuration.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to build system DNS resolver: {0}")]
+pub struct ResolverError(#[from] hickory_resolver::net::NetError);
+
+/// Outcome of a batch resolution.
+#[derive(Debug, Clone)]
+pub struct Resolution {
+    /// Expanded multiaddrs; an entry that failed to resolve falls back to its
+    /// original form.
+    pub addrs: Vec<Multiaddr>,
+    /// Time until the earliest consulted DNS record expires, for scheduling
+    /// re-resolution. `None` when no lookup succeeded.
+    pub min_ttl: Option<Duration>,
+}
+
+/// Recursive `/dnsaddr/` resolver over one shared system resolver.
 ///
-/// - Non-dnsaddr inputs pass through unchanged.
-/// - A shared seen-set deduplicates across the whole batch.
-/// - On resolution failure the original address is kept as fallback.
-pub async fn resolve_all(addrs: impl IntoIterator<Item = &Multiaddr>) -> Vec<Multiaddr> {
-    let mut resolved = Vec::new();
-    let mut seen = HashSet::new();
+/// Build once and share (clones are cheap handles to the same resolver):
+/// lookups are cached per record TTL across calls, so repeated resolution
+/// honours DNS caching instead of re-querying every time.
+#[derive(Clone)]
+pub struct DnsaddrResolver {
+    resolver: TokioResolver,
+}
 
-    for addr in addrs {
-        if !is_dnsaddr(addr) {
-            resolved.push(addr.clone());
-            continue;
-        }
-
-        match resolve_one(addr, &mut seen).await {
-            Ok(addrs) => {
-                debug!(addr = %addr, resolved_count = addrs.len(), "Resolved dnsaddr");
-                resolved.extend(addrs);
-            }
-            Err(e) => {
-                warn!(addr = %addr, error = %e, "Failed to resolve dnsaddr, keeping original");
-                resolved.push(addr.clone());
-            }
-        }
+impl DnsaddrResolver {
+    /// Build from the system DNS configuration.
+    pub fn from_system_conf() -> Result<Self, ResolverError> {
+        Ok(Self {
+            resolver: Resolver::builder_tokio()?.build()?,
+        })
     }
 
-    resolved
+    /// Resolve a batch of multiaddrs, expanding every `/dnsaddr/` entry.
+    ///
+    /// - Non-dnsaddr inputs pass through unchanged.
+    /// - A shared seen-set deduplicates across the whole batch.
+    /// - On resolution failure the original address is kept as fallback.
+    pub async fn resolve_all(&self, addrs: impl IntoIterator<Item = &Multiaddr>) -> Resolution {
+        let mut resolution = Resolution {
+            addrs: Vec::new(),
+            min_ttl: None,
+        };
+        let mut seen = HashSet::new();
+
+        for addr in addrs {
+            if !is_dnsaddr(addr) {
+                resolution.addrs.push(addr.clone());
+                continue;
+            }
+
+            match self
+                .resolve_recursive(addr, &mut seen, &mut resolution.min_ttl, 0)
+                .await
+            {
+                Ok(addrs) => {
+                    debug!(addr = %addr, resolved_count = addrs.len(), "Resolved dnsaddr");
+                    resolution.addrs.extend(addrs);
+                }
+                Err(e) => {
+                    warn!(addr = %addr, error = %e, "Failed to resolve dnsaddr, keeping original");
+                    resolution.addrs.push(addr.clone());
+                }
+            }
+        }
+
+        resolution
+    }
+
+    fn resolve_recursive<'a>(
+        &'a self,
+        addr: &'a Multiaddr,
+        seen: &'a mut HashSet<String>,
+        min_ttl: &'a mut Option<Duration>,
+        depth: usize,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Vec<Multiaddr>, ResolveError>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            if depth > MAX_RECURSION_DEPTH {
+                return Err(ResolveError::MaxRecursionDepth);
+            }
+
+            let domain = match extract_domain(addr) {
+                Some(d) => d,
+                None => return Ok(vec![addr.clone()]),
+            };
+
+            let txt_name = format!("_dnsaddr.{}", domain);
+            if seen.contains(&txt_name) {
+                debug!(domain = %domain, "Skipping already-seen dnsaddr domain");
+                return Ok(vec![]);
+            }
+            seen.insert(txt_name.clone());
+
+            debug!(name = %txt_name, "Querying DNS TXT records");
+
+            let txt_records = self
+                .resolver
+                .txt_lookup(&txt_name)
+                .await
+                .map_err(|e| ResolveError::DnsLookup(format!("lookup {txt_name}: {e}")))?;
+
+            // The lookup's validity horizon is the remaining TTL, so a cached
+            // response schedules the next re-resolution at the record's true
+            // expiry rather than a full TTL from now.
+            let ttl = txt_records
+                .valid_until()
+                .saturating_duration_since(Instant::now());
+            *min_ttl = Some(min_ttl.map_or(ttl, |current| current.min(ttl)));
+
+            let mut results = Vec::new();
+
+            for record in txt_records.answers() {
+                let RData::TXT(txt) = &record.data else {
+                    continue;
+                };
+                for bytes in txt.txt_data.iter() {
+                    let txt_str = String::from_utf8_lossy(bytes);
+
+                    if let Some(value) = txt_str.strip_prefix("dnsaddr=") {
+                        debug!(record = %value, "Found dnsaddr TXT record");
+
+                        match value.parse::<Multiaddr>() {
+                            Ok(resolved_addr) => {
+                                let nested = self
+                                    .resolve_recursive(&resolved_addr, seen, min_ttl, depth + 1)
+                                    .await?;
+                                results.extend(nested);
+                            }
+                            Err(e) => {
+                                warn!(
+                                    value = %value,
+                                    error = %e,
+                                    "Failed to parse multiaddr from TXT record"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
+            Ok(results)
+        })
+    }
 }
 
 /// Internal dnsaddr resolution errors.
@@ -57,89 +176,11 @@ enum ResolveError {
     MaxRecursionDepth,
 }
 
-/// Resolve a single dnsaddr, reusing a shared `seen` set.
-async fn resolve_one(
-    addr: &Multiaddr,
-    seen: &mut HashSet<String>,
-) -> Result<Vec<Multiaddr>, ResolveError> {
-    resolve_recursive(addr, seen, 0).await
-}
-
 /// Extract domain from the first `/dnsaddr/{domain}` component.
 fn extract_domain(addr: &Multiaddr) -> Option<String> {
     addr.iter().find_map(|p| match p {
         Protocol::Dnsaddr(domain) => Some(domain.to_string()),
         _ => None,
-    })
-}
-
-fn resolve_recursive<'a>(
-    addr: &'a Multiaddr,
-    seen: &'a mut HashSet<String>,
-    depth: usize,
-) -> std::pin::Pin<
-    Box<dyn std::future::Future<Output = Result<Vec<Multiaddr>, ResolveError>> + Send + 'a>,
-> {
-    Box::pin(async move {
-        if depth > MAX_RECURSION_DEPTH {
-            return Err(ResolveError::MaxRecursionDepth);
-        }
-
-        let domain = match extract_domain(addr) {
-            Some(d) => d,
-            None => return Ok(vec![addr.clone()]),
-        };
-
-        let cache_key = format!("_dnsaddr.{}", domain);
-        if seen.contains(&cache_key) {
-            debug!(domain = %domain, "Skipping already-seen dnsaddr domain");
-            return Ok(vec![]);
-        }
-        seen.insert(cache_key.clone());
-
-        let resolver = Resolver::builder_tokio()
-            .map_err(|e| ResolveError::DnsLookup(format!("failed to create resolver: {e}")))?
-            .build()
-            .map_err(|e| ResolveError::DnsLookup(format!("failed to build resolver: {e}")))?;
-
-        let txt_name = format!("_dnsaddr.{}", domain);
-        debug!(name = %txt_name, "Querying DNS TXT records");
-
-        let txt_records = resolver
-            .txt_lookup(&txt_name)
-            .await
-            .map_err(|e| ResolveError::DnsLookup(format!("lookup {txt_name}: {e}")))?;
-
-        let mut results = Vec::new();
-
-        for record in txt_records.answers() {
-            let RData::TXT(txt) = &record.data else {
-                continue;
-            };
-            for bytes in txt.txt_data.iter() {
-                let txt_str = String::from_utf8_lossy(bytes);
-
-                if let Some(value) = txt_str.strip_prefix("dnsaddr=") {
-                    debug!(record = %value, "Found dnsaddr TXT record");
-
-                    match value.parse::<Multiaddr>() {
-                        Ok(resolved_addr) => {
-                            let nested = resolve_recursive(&resolved_addr, seen, depth + 1).await?;
-                            results.extend(nested);
-                        }
-                        Err(e) => {
-                            warn!(
-                                value = %value,
-                                error = %e,
-                                "Failed to parse multiaddr from TXT record"
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(results)
     })
 }
 
@@ -182,16 +223,23 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_all_passes_non_dnsaddr_through() {
+        let resolver = DnsaddrResolver::from_system_conf().expect("system DNS configuration");
         let addr: Multiaddr = "/ip4/127.0.0.1/tcp/1634".parse().unwrap();
-        let resolved = resolve_all(std::slice::from_ref(&addr)).await;
-        assert_eq!(resolved, vec![addr]);
+        let resolution = resolver.resolve_all(std::slice::from_ref(&addr)).await;
+        assert_eq!(resolution.addrs, vec![addr]);
+        assert_eq!(resolution.min_ttl, None, "no lookup performed, no TTL");
     }
 
     #[tokio::test]
-    async fn resolve_one_returns_non_dnsaddr_unchanged() {
+    async fn resolve_recursive_returns_non_dnsaddr_unchanged() {
+        let resolver = DnsaddrResolver::from_system_conf().expect("system DNS configuration");
         let addr: Multiaddr = "/ip4/127.0.0.1/tcp/1634".parse().unwrap();
         let mut seen = HashSet::new();
-        let resolved = resolve_one(&addr, &mut seen).await.unwrap();
+        let mut min_ttl = None;
+        let resolved = resolver
+            .resolve_recursive(&addr, &mut seen, &mut min_ttl, 0)
+            .await
+            .unwrap();
         assert_eq!(resolved, vec![addr]);
     }
 }

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -41,15 +41,31 @@ use vertex_net_peer_registry::{ActivePeers, PeerRegistry};
 
 pub(crate) type ConnectionRegistry = PeerRegistry<OverlayAddress, Option<DialReason>>;
 
+/// Resolved bootnode and trusted-peer multiaddrs plus the earliest remaining
+/// DNS TTL across the lookups, which schedules the next re-resolution.
+pub(crate) struct ResolvedBootnodes {
+    pub(crate) bootnodes: Vec<Multiaddr>,
+    pub(crate) trusted: Vec<Multiaddr>,
+    /// `None` when no lookup reported a TTL (nothing resolved, or the
+    /// resolution path carries no TTL information).
+    pub(crate) min_ttl: Option<Duration>,
+}
+
 /// Boxed future that resolves `/dnsaddr/` bootnodes and trusted peers into
-/// dialable multiaddrs (resolved bootnodes, resolved trusted).
+/// dialable multiaddrs.
 ///
 /// The `Send` bound follows the platform executor via
 /// [`vertex_tasks::MaybeSendBoxFuture`]: `Send` on native, unbounded on wasm32
 /// where DNS-over-HTTPS resolution is backed by `fetch`, whose future is
 /// `!Send`, and the swarm is single-threaded.
-pub(crate) type BootnodeResolutionFuture =
-    vertex_tasks::MaybeSendBoxFuture<(Vec<Multiaddr>, Vec<Multiaddr>)>;
+pub(crate) type BootnodeResolutionFuture = vertex_tasks::MaybeSendBoxFuture<ResolvedBootnodes>;
+
+/// In-flight dnsaddr resolution, tagged with how it started: a periodic
+/// refresh dials only newly appearing addresses, a connect dials everything.
+pub(crate) struct PendingBootnodeResolution {
+    pub(crate) future: BootnodeResolutionFuture,
+    pub(crate) refresh: bool,
+}
 use crate::TopologyCommand;
 use crate::builder::PendingTopologyTasks;
 use crate::composed::ProtocolBehaviours;
@@ -244,8 +260,22 @@ pub struct TopologyBehaviour<I: SwarmIdentity + Clone> {
     /// evaluation tick.
     pub(crate) dial_rate_timer: Option<vertex_tasks::time::BoxTimerFuture>,
 
-    // Pending dnsaddr resolution for bootnodes (resolved_bootnodes, resolved_trusted)
-    pub(crate) pending_bootnode_resolution: Option<BootnodeResolutionFuture>,
+    // Pending dnsaddr resolution for bootnodes and trusted peers
+    pub(crate) pending_bootnode_resolution: Option<PendingBootnodeResolution>,
+
+    /// Shared dnsaddr resolver, built lazily on the first resolution and
+    /// reused so DNS responses cache per record TTL across re-resolutions.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) dnsaddr_resolver: Option<vertex_net_dnsaddr::DnsaddrResolver>,
+
+    /// Armed after a dnsaddr resolution completes; fires the TTL-aware
+    /// re-resolution so a rotated bootnode address is picked up by a healthy
+    /// node instead of waiting for isolation.
+    pub(crate) dnsaddr_refresh_timer: Option<vertex_tasks::time::BoxTimerFuture>,
+
+    /// Multiaddrs produced by the previous dnsaddr resolution; a refresh
+    /// dials only addresses outside this set.
+    pub(crate) resolved_bootnode_addrs: HashSet<Multiaddr>,
 
     /// Isolation probe state: `(next_probe_at, current_delay)` while the
     /// table is drained (nothing connected or pending, no candidate queued),
@@ -987,16 +1017,20 @@ impl<I: SwarmIdentity + Clone + 'static> NetworkBehaviour for TopologyBehaviour<
         }
 
         // Poll pending dnsaddr resolution for bootnodes
-        if let Some(ref mut future) = self.pending_bootnode_resolution
-            && let Poll::Ready((resolved_bootnodes, resolved_trusted)) = future.as_mut().poll(cx)
+        if let Some(pending) = &mut self.pending_bootnode_resolution
+            && let Poll::Ready(resolved) = pending.future.as_mut().poll(cx)
         {
-            info!(
-                bootnodes = resolved_bootnodes.len(),
-                trusted = resolved_trusted.len(),
-                "dnsaddr resolution complete, dialing bootnodes"
-            );
+            let refresh = pending.refresh;
             self.pending_bootnode_resolution = None;
-            self.dial_bootnodes(resolved_bootnodes, resolved_trusted);
+            self.on_bootnode_resolution_complete(resolved, refresh);
+        }
+
+        // A fired refresh timer starts the TTL-scheduled dnsaddr re-resolution.
+        if let Some(timer) = self.dnsaddr_refresh_timer.as_mut()
+            && timer.as_mut().poll(cx).is_ready()
+        {
+            self.dnsaddr_refresh_timer = None;
+            self.refresh_bootnode_resolution();
         }
 
         // Drive the gossip engine's timers (the neighbourhood refresh and due

--- a/crates/swarm/topology/src/builder.rs
+++ b/crates/swarm/topology/src/builder.rs
@@ -264,6 +264,10 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviourBuilder<I> {
             dial_rate: RateLimiter::new(dial_quota),
             dial_rate_timer: None,
             pending_bootnode_resolution: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            dnsaddr_resolver: None,
+            dnsaddr_refresh_timer: None,
+            resolved_bootnode_addrs: HashSet::new(),
             isolation_probe: None,
             evaluator_handle,
             dial_tracker: DialTracker::new(DialTrackerConfig {

--- a/crates/swarm/topology/src/dialing.rs
+++ b/crates/swarm/topology/src/dialing.rs
@@ -12,7 +12,7 @@ use vertex_swarm_primitives::SwarmNodeType;
 use vertex_util_runtime::rand::non_crypto_rng;
 
 use crate::DialReason;
-use crate::behaviour::BootnodeResolutionFuture;
+use crate::behaviour::{BootnodeResolutionFuture, PendingBootnodeResolution, ResolvedBootnodes};
 use crate::kademlia::RoutingCapacity;
 
 use crate::behaviour::{DialTarget, TopologyBehaviour};
@@ -22,6 +22,25 @@ const ISOLATION_PROBE_INITIAL: std::time::Duration = std::time::Duration::from_s
 
 /// Ceiling on the isolation probe interval.
 const ISOLATION_PROBE_MAX: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// Floor on the dnsaddr re-resolution interval, so a very short record TTL
+/// cannot turn the refresh into a DNS hammer.
+const DNSADDR_REFRESH_MIN: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Ceiling on the dnsaddr re-resolution interval for very long record TTLs.
+const DNSADDR_REFRESH_MAX: std::time::Duration = std::time::Duration::from_secs(3600);
+
+/// Re-resolution interval when no lookup reported a TTL (resolution failed,
+/// or the resolution path carries no TTL information).
+const DNSADDR_REFRESH_FALLBACK: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Interval until the next dnsaddr re-resolution: the earliest reported TTL
+/// clamped to sane bounds, or the fallback when no TTL is known.
+fn dnsaddr_refresh_interval(min_ttl: Option<std::time::Duration>) -> std::time::Duration {
+    min_ttl.map_or(DNSADDR_REFRESH_FALLBACK, |ttl| {
+        ttl.clamp(DNSADDR_REFRESH_MIN, DNSADDR_REFRESH_MAX)
+    })
+}
 
 impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     /// Dial a known SwarmPeer for discovery.
@@ -180,10 +199,84 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         // can be dialed. Native does this over the system resolver; the browser
         // does it over DNS-over-HTTPS. When nothing needs resolving the helper
         // returns `None` and we dial the literal addresses immediately.
-        match start_bootnode_resolution(bootnodes.clone(), trusted_peers.clone()) {
-            Some(future) => self.pending_bootnode_resolution = Some(future),
+        match self.start_bootnode_resolution(bootnodes.clone(), trusted_peers.clone()) {
+            Some(future) => {
+                self.pending_bootnode_resolution = Some(PendingBootnodeResolution {
+                    future,
+                    refresh: false,
+                })
+            }
             None => self.dial_bootnodes(bootnodes, trusted_peers),
         }
+    }
+
+    /// Start the TTL-scheduled dnsaddr re-resolution.
+    ///
+    /// Unlike a connect, the completed refresh dials only addresses absent
+    /// from the previous resolution, so a healthy node picks up a rotated
+    /// bootnode address without redialing the stable set.
+    pub(crate) fn refresh_bootnode_resolution(&mut self) {
+        if self.pending_bootnode_resolution.is_some() {
+            // The in-flight resolution re-arms the refresh timer on completion.
+            return;
+        }
+
+        if let Some(future) =
+            self.start_bootnode_resolution(self.bootnodes.clone(), self.trusted_peers.clone())
+        {
+            metrics::counter!("topology_dnsaddr_refresh_total").increment(1);
+            self.pending_bootnode_resolution = Some(PendingBootnodeResolution {
+                future,
+                refresh: true,
+            });
+        }
+    }
+
+    /// Dial the outcome of a dnsaddr resolution and arm the next refresh.
+    ///
+    /// A connect dials every resolved address; a refresh dials only the
+    /// addresses that were not in the previous resolution (`dial` additionally
+    /// deduplicates peers that are already tracked).
+    pub(crate) fn on_bootnode_resolution_complete(
+        &mut self,
+        resolved: ResolvedBootnodes,
+        refresh: bool,
+    ) {
+        let ResolvedBootnodes {
+            mut bootnodes,
+            mut trusted,
+            min_ttl,
+        } = resolved;
+
+        let next_resolved: std::collections::HashSet<Multiaddr> =
+            bootnodes.iter().chain(trusted.iter()).cloned().collect();
+
+        if refresh {
+            bootnodes.retain(|addr| !self.resolved_bootnode_addrs.contains(addr));
+            trusted.retain(|addr| !self.resolved_bootnode_addrs.contains(addr));
+            if bootnodes.is_empty() && trusted.is_empty() {
+                debug!("dnsaddr re-resolution found no new addresses");
+            } else {
+                info!(
+                    new_bootnodes = bootnodes.len(),
+                    new_trusted = trusted.len(),
+                    "dnsaddr re-resolution found new addresses, dialing"
+                );
+            }
+        } else {
+            info!(
+                bootnodes = bootnodes.len(),
+                trusted = trusted.len(),
+                "dnsaddr resolution complete, dialing bootnodes"
+            );
+        }
+
+        self.resolved_bootnode_addrs = next_resolved;
+        self.dial_bootnodes(bootnodes, trusted);
+
+        let refresh_in = dnsaddr_refresh_interval(min_ttl);
+        debug!(?refresh_in, "scheduling dnsaddr re-resolution");
+        self.dnsaddr_refresh_timer = Some(Box::pin(vertex_tasks::time::sleep(refresh_in)));
     }
 
     /// Dial bootnodes and trusted peers (called after dnsaddr resolution if needed).
@@ -209,87 +302,331 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     pub(crate) fn is_peer_tracked(&self, peer_id: &PeerId) -> bool {
         self.connection_registry.contains_peer(peer_id) || self.dial_tracker.contains_peer(peer_id)
     }
-}
 
-/// Start resolving `/dnsaddr/` bootnode and trusted-peer entries to dialable
-/// multiaddrs, using the system resolver.
-///
-/// Returns `None` when no entry needs resolution so the caller dials the literal
-/// addresses directly. Bootnodes and trusted peers are resolved separately so
-/// the caller can preserve the per-list dial reason.
-#[cfg(not(target_arch = "wasm32"))]
-fn start_bootnode_resolution(
-    bootnodes: Vec<Multiaddr>,
-    trusted_peers: Vec<Multiaddr>,
-) -> Option<BootnodeResolutionFuture> {
-    use vertex_net_dnsaddr::{is_dnsaddr, resolve_all};
-
-    let needs_resolution = bootnodes.iter().any(is_dnsaddr) || trusted_peers.iter().any(is_dnsaddr);
-    if !needs_resolution {
-        return None;
+    /// The shared dnsaddr resolver, built on first use and reused afterwards
+    /// so DNS responses cache per record TTL across re-resolutions.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn dnsaddr_resolver(&mut self) -> Option<vertex_net_dnsaddr::DnsaddrResolver> {
+        if self.dnsaddr_resolver.is_none() {
+            match vertex_net_dnsaddr::DnsaddrResolver::from_system_conf() {
+                Ok(resolver) => self.dnsaddr_resolver = Some(resolver),
+                Err(e) => warn!(error = %e, "Failed to build the dnsaddr resolver"),
+            }
+        }
+        self.dnsaddr_resolver.clone()
     }
 
-    info!(
-        bootnodes = bootnodes.len(),
-        trusted = trusted_peers.len(),
-        "Resolving dnsaddr entries for bootnodes..."
-    );
+    /// Start resolving `/dnsaddr/` bootnode and trusted-peer entries to
+    /// dialable multiaddrs, using the shared system resolver.
+    ///
+    /// Returns `None` when no entry needs resolution (or no resolver could be
+    /// built) so the caller dials the literal addresses directly. Bootnodes
+    /// and trusted peers are resolved separately so the caller can preserve
+    /// the per-list dial reason.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn start_bootnode_resolution(
+        &mut self,
+        bootnodes: Vec<Multiaddr>,
+        trusted_peers: Vec<Multiaddr>,
+    ) -> Option<BootnodeResolutionFuture> {
+        use vertex_net_dnsaddr::is_dnsaddr;
 
-    Some(Box::pin(async move {
-        let resolved_bootnodes = resolve_all(bootnodes.iter()).await;
-        let resolved_trusted = resolve_all(trusted_peers.iter()).await;
-        (resolved_bootnodes, resolved_trusted)
-    }))
-}
+        let needs_resolution =
+            bootnodes.iter().any(is_dnsaddr) || trusted_peers.iter().any(is_dnsaddr);
+        if !needs_resolution {
+            return None;
+        }
 
-/// Start resolving `/dnsaddr/` bootnodes over DNS-over-HTTPS for the browser
-/// client.
-///
-/// A browser cannot issue raw DNS TXT lookups, so the mainnet `/dnsaddr/`
-/// indirection is resolved over DoH (Cloudflare by default) with the embedded
-/// wss snapshot ([`vertex_swarm_spec::mainnet_wss_bootnodes`]) as the fallback
-/// whenever the live path yields nothing. Trusted peers are expected to be
-/// literal browser-dialable multiaddrs; any `/dnsaddr/` trusted entry is dropped
-/// because the browser resolves only the mainnet name.
-///
-/// Returns `None` when no bootnode needs resolution so the caller dials the
-/// literal addresses directly.
-#[cfg(target_arch = "wasm32")]
-fn start_bootnode_resolution(
-    bootnodes: Vec<Multiaddr>,
-    trusted_peers: Vec<Multiaddr>,
-) -> Option<BootnodeResolutionFuture> {
-    use libp2p::multiaddr::Protocol;
-    use vertex_net_dnsaddr_doh::{DohClient, resolve_mainnet_wss_bootnodes};
+        let resolver = self.dnsaddr_resolver()?;
 
-    let is_dnsaddr = |addr: &Multiaddr| addr.iter().any(|p| matches!(p, Protocol::Dnsaddr(_)));
+        info!(
+            bootnodes = bootnodes.len(),
+            trusted = trusted_peers.len(),
+            "Resolving dnsaddr entries for bootnodes..."
+        );
 
-    let needs_resolution = bootnodes.iter().any(is_dnsaddr);
-    let literal_trusted: Vec<Multiaddr> = trusted_peers
-        .into_iter()
-        .filter(|a| !is_dnsaddr(a))
-        .collect();
-    let literal_bootnodes: Vec<Multiaddr> = bootnodes
-        .iter()
-        .filter(|a| !is_dnsaddr(a))
-        .cloned()
-        .collect();
-
-    if !needs_resolution {
-        return None;
+        Some(Box::pin(async move {
+            let bootnodes = resolver.resolve_all(bootnodes.iter()).await;
+            let trusted = resolver.resolve_all(trusted_peers.iter()).await;
+            let min_ttl = match (bootnodes.min_ttl, trusted.min_ttl) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (a, b) => a.or(b),
+            };
+            ResolvedBootnodes {
+                bootnodes: bootnodes.addrs,
+                trusted: trusted.addrs,
+                min_ttl,
+            }
+        }))
     }
 
-    info!(
-        bootnodes = bootnodes.len(),
-        "Resolving dnsaddr bootnodes over DNS-over-HTTPS..."
-    );
+    /// Start resolving `/dnsaddr/` bootnodes over DNS-over-HTTPS for the
+    /// browser client.
+    ///
+    /// A browser cannot issue raw DNS TXT lookups, so the mainnet `/dnsaddr/`
+    /// indirection is resolved over DoH (Cloudflare by default) with the
+    /// embedded wss snapshot ([`vertex_swarm_spec::mainnet_wss_bootnodes`]) as
+    /// the fallback whenever the live path yields nothing. DoH responses carry
+    /// no TTL through this path, so re-resolution runs on the fallback
+    /// interval. Trusted peers are expected to be literal browser-dialable
+    /// multiaddrs; any `/dnsaddr/` trusted entry is dropped because the
+    /// browser resolves only the mainnet name.
+    ///
+    /// Returns `None` when no bootnode needs resolution so the caller dials
+    /// the literal addresses directly.
+    #[cfg(target_arch = "wasm32")]
+    fn start_bootnode_resolution(
+        &mut self,
+        bootnodes: Vec<Multiaddr>,
+        trusted_peers: Vec<Multiaddr>,
+    ) -> Option<BootnodeResolutionFuture> {
+        use libp2p::multiaddr::Protocol;
+        use vertex_net_dnsaddr_doh::{DohClient, resolve_mainnet_wss_bootnodes};
 
-    Some(Box::pin(async move {
-        let client = DohClient::default();
-        let mut resolved =
-            resolve_mainnet_wss_bootnodes(&client, vertex_swarm_spec::mainnet_wss_bootnodes())
-                .await;
-        resolved.extend(literal_bootnodes);
-        (resolved, literal_trusted)
-    }))
+        let is_dnsaddr = |addr: &Multiaddr| addr.iter().any(|p| matches!(p, Protocol::Dnsaddr(_)));
+
+        let needs_resolution = bootnodes.iter().any(is_dnsaddr);
+        let literal_trusted: Vec<Multiaddr> = trusted_peers
+            .into_iter()
+            .filter(|a| !is_dnsaddr(a))
+            .collect();
+        let literal_bootnodes: Vec<Multiaddr> = bootnodes
+            .iter()
+            .filter(|a| !is_dnsaddr(a))
+            .cloned()
+            .collect();
+
+        if !needs_resolution {
+            return None;
+        }
+
+        info!(
+            bootnodes = bootnodes.len(),
+            "Resolving dnsaddr bootnodes over DNS-over-HTTPS..."
+        );
+
+        Some(Box::pin(async move {
+            let client = DohClient::default();
+            let mut resolved =
+                resolve_mainnet_wss_bootnodes(&client, vertex_swarm_spec::mainnet_wss_bootnodes())
+                    .await;
+            resolved.extend(literal_bootnodes);
+            ResolvedBootnodes {
+                bootnodes: resolved,
+                trusted: literal_trusted,
+                min_ttl: None,
+            }
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashSet;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    use libp2p::swarm::ToSwarm;
+    use vertex_swarm_api::{
+        DefaultPeerConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
+    };
+    use vertex_swarm_identity::Identity;
+    use vertex_swarm_primitives::SwarmNodeType;
+
+    use crate::TopologyBehaviourBuilder;
+    use crate::kademlia::KademliaConfig;
+
+    /// Minimal network configuration: no listeners, so the node is dial-only
+    /// and its capability is pinned to dual-stack (bootnode dials pass the
+    /// reachability filter).
+    struct DialTestConfig {
+        peers: DefaultPeerConfig,
+        routing: KademliaConfig,
+        empty_addrs: Vec<Multiaddr>,
+    }
+
+    impl DialTestConfig {
+        fn new() -> Self {
+            Self {
+                peers: DefaultPeerConfig::default(),
+                routing: KademliaConfig::default(),
+                empty_addrs: Vec::new(),
+            }
+        }
+    }
+
+    impl SwarmNetworkConfig for DialTestConfig {
+        fn listen_addrs(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn bootnodes(&self) -> &[Multiaddr] {
+            &self.empty_addrs
+        }
+        fn discovery_enabled(&self) -> bool {
+            true
+        }
+        fn max_peers(&self) -> usize {
+            32
+        }
+        fn idle_timeout(&self) -> Duration {
+            Duration::from_secs(60)
+        }
+    }
+
+    impl SwarmPeerConfig for DialTestConfig {
+        type Peers = DefaultPeerConfig;
+        fn peers(&self) -> &Self::Peers {
+            &self.peers
+        }
+    }
+
+    impl SwarmRoutingConfig for DialTestConfig {
+        type Routing = KademliaConfig;
+        fn routing(&self) -> &Self::Routing {
+            &self.routing
+        }
+    }
+
+    fn test_behaviour() -> TopologyBehaviour<Identity> {
+        let identity = Identity::random(vertex_swarm_spec::init_testnet(), SwarmNodeType::Client);
+        let (behaviour, _handle) = TopologyBehaviourBuilder::new(identity, &DialTestConfig::new())
+            .try_build()
+            .expect("build without runtime");
+        behaviour
+    }
+
+    /// A public bootnode multiaddr carrying `/p2p/{peer_id}`.
+    fn bootnode_addr(peer_id: PeerId, n: u8) -> Multiaddr {
+        format!("/ip4/203.0.113.{n}/tcp/1634/p2p/{peer_id}")
+            .parse()
+            .expect("valid bootnode multiaddr")
+    }
+
+    /// Drain every queued dial action and return the peer ids dialed.
+    fn drain_dials(behaviour: &mut TopologyBehaviour<Identity>) -> Vec<PeerId> {
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut dialed = Vec::new();
+        loop {
+            match libp2p::swarm::NetworkBehaviour::poll(behaviour, &mut cx) {
+                Poll::Ready(ToSwarm::Dial { opts }) => {
+                    if let Some(peer_id) = opts.get_peer_id() {
+                        dialed.push(peer_id);
+                    }
+                }
+                Poll::Ready(_) => {}
+                Poll::Pending => break,
+            }
+        }
+        dialed
+    }
+
+    /// A completed connect-resolution dials every resolved address, records
+    /// the resolved set, and arms the TTL refresh timer.
+    #[tokio::test]
+    async fn connect_resolution_dials_all_and_arms_refresh() {
+        let mut behaviour = test_behaviour();
+        let (peer_a, peer_b) = (PeerId::random(), PeerId::random());
+        let (addr_a, addr_b) = (bootnode_addr(peer_a, 1), bootnode_addr(peer_b, 2));
+
+        behaviour.on_bootnode_resolution_complete(
+            ResolvedBootnodes {
+                bootnodes: vec![addr_a.clone(), addr_b.clone()],
+                trusted: vec![],
+                min_ttl: Some(Duration::from_secs(120)),
+            },
+            false,
+        );
+
+        let dialed = drain_dials(&mut behaviour);
+        assert!(dialed.contains(&peer_a) && dialed.contains(&peer_b));
+        assert_eq!(
+            behaviour.resolved_bootnode_addrs,
+            HashSet::from([addr_a, addr_b])
+        );
+        assert!(
+            behaviour.dnsaddr_refresh_timer.is_some(),
+            "a completed resolution must arm the re-resolution timer"
+        );
+    }
+
+    /// A completed refresh dials only addresses absent from the previous
+    /// resolution and replaces the recorded set, so a rotated-away address
+    /// is not redialed on the next refresh.
+    #[tokio::test]
+    async fn refresh_dials_only_new_addresses() {
+        let mut behaviour = test_behaviour();
+        let (peer_old, peer_new) = (PeerId::random(), PeerId::random());
+        let (addr_old, addr_new) = (bootnode_addr(peer_old, 1), bootnode_addr(peer_new, 2));
+
+        // The previous resolution produced only the old address, and its dial
+        // is no longer tracked (completed or failed since).
+        behaviour.resolved_bootnode_addrs = HashSet::from([addr_old.clone()]);
+
+        behaviour.on_bootnode_resolution_complete(
+            ResolvedBootnodes {
+                bootnodes: vec![addr_old.clone(), addr_new.clone()],
+                trusted: vec![],
+                min_ttl: None,
+            },
+            true,
+        );
+
+        let dialed = drain_dials(&mut behaviour);
+        assert!(
+            dialed.contains(&peer_new),
+            "the rotated-in address is dialed"
+        );
+        assert!(
+            !dialed.contains(&peer_old),
+            "an address from the previous resolution is not redialed"
+        );
+        assert_eq!(
+            behaviour.resolved_bootnode_addrs,
+            HashSet::from([addr_old, addr_new])
+        );
+        assert!(behaviour.dnsaddr_refresh_timer.is_some());
+    }
+
+    /// A refresh whose result dropped an address forgets it, so the address
+    /// counts as new again if a later rotation brings it back.
+    #[tokio::test]
+    async fn refresh_forgets_rotated_away_addresses() {
+        let mut behaviour = test_behaviour();
+        let (peer_old, peer_new) = (PeerId::random(), PeerId::random());
+        let (addr_old, addr_new) = (bootnode_addr(peer_old, 1), bootnode_addr(peer_new, 2));
+        behaviour.resolved_bootnode_addrs = HashSet::from([addr_old]);
+
+        behaviour.on_bootnode_resolution_complete(
+            ResolvedBootnodes {
+                bootnodes: vec![addr_new.clone()],
+                trusted: vec![],
+                min_ttl: None,
+            },
+            true,
+        );
+
+        assert_eq!(behaviour.resolved_bootnode_addrs, HashSet::from([addr_new]));
+    }
+
+    /// The refresh interval honours the reported TTL inside sane bounds and
+    /// falls back to a fixed interval when no TTL is known.
+    #[test]
+    fn refresh_interval_honours_ttl_within_bounds() {
+        assert_eq!(
+            dnsaddr_refresh_interval(Some(Duration::from_secs(120))),
+            Duration::from_secs(120)
+        );
+        assert_eq!(
+            dnsaddr_refresh_interval(Some(Duration::from_secs(1))),
+            DNSADDR_REFRESH_MIN
+        );
+        assert_eq!(
+            dnsaddr_refresh_interval(Some(Duration::from_secs(86_400))),
+            DNSADDR_REFRESH_MAX
+        );
+        assert_eq!(dnsaddr_refresh_interval(None), DNSADDR_REFRESH_FALLBACK);
+    }
 }

--- a/docs/agents/libp2p-networking.md
+++ b/docs/agents/libp2p-networking.md
@@ -43,7 +43,7 @@ Peer state is Arc-per-peer via a registry. Obtain `Arc<PeerEntry>` once; afterwa
 
 ### 6. Dialer discipline
 
-`vertex-net-dialer` owns candidate selection, tracking, and exponential backoff with jitter (`crates/net/dialer/src/{backoff,tracker,prepare}.rs`). Bootstrap is a three-phase flow: parallel bootnode dials, hive discovery, Kademlia bin filling. mDNS is not used in production; `dnsaddr` is for bootnode and operator discovery only and is resolved recursively (`vertex-net-dnsaddr` follows all TXT records, unlike libp2p's DNS transport). DHT-style discovery is performed via the hive protocol, not Kademlia content routing. See `docs/networking/peer-dialing-strategy.md`.
+`vertex-net-dialer` owns candidate selection, tracking, and exponential backoff with jitter (`crates/net/dialer/src/{backoff,tracker,prepare}.rs`). Bootstrap is a three-phase flow: parallel bootnode dials, hive discovery, Kademlia bin filling. mDNS is not used in production; `dnsaddr` is for bootnode and operator discovery only and is resolved recursively (`vertex-net-dnsaddr` follows all TXT records, unlike libp2p's DNS transport) over one shared TTL-caching resolver, with periodic TTL-aware re-resolution scheduled by the topology behaviour. DHT-style discovery is performed via the hive protocol, not Kademlia content routing. See `docs/networking/peer-dialing-strategy.md`.
 
 ### 7. Address management
 

--- a/docs/networking/peer-dialing-strategy.md
+++ b/docs/networking/peer-dialing-strategy.md
@@ -103,6 +103,8 @@ In-flight dials are tracked by `DialTracker` (`vertex-net-dialer`), whose pendin
 
 Bootstrap is not a special mode of the evaluator: bootnodes and trusted peers from configuration are dialed directly at startup (with dnsaddr resolution where needed) as `DialTarget::Unknown`, since their overlay addresses are not yet known and no capacity reservation applies. Everything after that first contact flows through gossip supply and the evaluation loop above.
 
+Dnsaddr resolution runs over one shared resolver, so responses cache per record TTL across calls, and re-runs periodically on an interval derived from the earliest remaining TTL (clamped, with a fixed fallback when no TTL is known). A periodic re-resolution dials only addresses that were absent from the previous resolution, so a healthy node picks up a rotated bootnode address without redialing the stable set; a connect (startup, capability transition, isolation probe) still dials everything resolved.
+
 ## Handle surface: forced re-evaluation and dial state
 
 The `TopologyHandle` exposes two read-mostly introspection points over the mpsc command channel, for the gRPC operator surface, FFI, and tests. Neither changes dial policy.


### PR DESCRIPTION
## What

Implements periodic, TTL-aware re-resolution of `/dnsaddr/` bootnode and trusted-peer entries, backed by a shared resolver.

- `crates/net/dnsaddr/src/lib.rs`: replaces the per-call resolver construction with a `DnsaddrResolver` wrapping a single `hickory` `TokioResolver` (`Clone`, a cheap handle), so lookups cache per record TTL across calls instead of re-querying every time. `resolve_all` now returns a `Resolution { addrs, min_ttl }`, where `min_ttl` is the earliest remaining validity of the consulted DNS records (`Lookup::valid_until` minus now), so a cached response schedules re-resolution at its true expiry rather than a full TTL from now.
- `crates/swarm/topology`: `BootnodeResolutionFuture` now yields a `ResolvedBootnodes { bootnodes, trusted, min_ttl }`. `pending_bootnode_resolution` is tagged connect-vs-refresh via `PendingBootnodeResolution`. Every completed resolution arms a `vertex_tasks::time::sleep` timer (runtime clock, pausable) for the TTL, clamped to 30s..1h, falling back to 300s when no TTL is known (a failed resolution, or the wasm DNS-over-HTTPS path, which carries no TTL). A refresh dials only addresses absent from the previous resolution, so a healthy node picks up a rotated bootnode address without redialing the stable set; a connect dials every resolved address.
- Documentation updates in `docs/agents/libp2p-networking.md` and `docs/networking/peer-dialing-strategy.md` reflecting the new resolution behaviour.

Closes #769

## Why

`/dnsaddr/` bootnode addresses were only ever resolved once, at startup. If an operator rotated the underlying `A`/`AAAA`/`TXT` records after that (e.g. bootnode IP change), a running node would never observe the change and would keep dialing the stale address until restarted.

## Testing

Independent verification was carried out on the branch, detached at `af774d11` (single commit, based on `origin/main`). Changed files: `crates/net/dnsaddr/src/lib.rs`, `crates/swarm/topology/src/{behaviour,builder,dialing}.rs`, `docs/agents/libp2p-networking.md`, `docs/networking/peer-dialing-strategy.md`.

- `cargo fmt --all -- --check`: clean.
- `nix develop -c cargo clippy --workspace --all-features -- -D warnings`: clean (zero warnings across all library/binary code, including both touched crates).
- `nix develop -c cargo clippy -p vertex-net-dnsaddr --all-features --tests -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`: clean.

A red-team pass reviewed the refresh state machine and found no blocking or major defects: the TTL timer is armed unconditionally on every resolution completion (a self-sustaining chain, with at most one pending resolution and one timer, no double-arm, no dead chain); a refresh yields to an in-flight connect, which re-arms the timer on its own completion; `next_resolved` is captured before the refresh `retain` filter, so the recorded resolved-address set stays complete; the capability-unknown startup drop is recovered by the explicit `refresh=false` connect on the unknown-to-known capability edge.

## AI Assistance

Claude (Anthropic) was used for implementation, red-teaming, and independent verification of this change, and for drafting this PR description.
