### PR TITLE
feat(swarm-node): add relay-server config knobs

### DIFF
--- a/crates/swarm/api/src/config.rs
+++ b/crates/swarm/api/src/config.rs
@@ -132,6 +132,18 @@ impl PeerConfigValues for DefaultPeerConfig {
 /// address are unaffected.
 pub const DEFAULT_MAX_INBOUND_PER_IP: u32 = 32;
 
+/// Default cap on concurrently active relay reservations.
+pub const DEFAULT_RELAY_MAX_RESERVATIONS: usize = 128;
+
+/// Default cap on concurrently active relayed circuits.
+pub const DEFAULT_RELAY_MAX_CIRCUITS: usize = 16;
+
+/// Default relayed data budget per circuit, in bytes.
+pub const DEFAULT_RELAY_MAX_CIRCUIT_BYTES: u64 = 128 * 1024;
+
+/// Default relay reservation lifetime.
+pub const DEFAULT_RELAY_RESERVATION_TTL: Duration = Duration::from_secs(60 * 60);
+
 /// Configuration for P2P networking.
 ///
 /// Address methods return parsed `Multiaddr` to ensure validation happens early.
@@ -207,6 +219,34 @@ pub trait SwarmNetworkConfig {
     /// bootnodes or NAT configuration. The multicast traffic stays link-local.
     fn mdns_enabled(&self) -> bool {
         true
+    }
+
+    /// Explicit circuit relay v2 server toggle, if any (default: none).
+    ///
+    /// `None` means the node type decides: on for bootnodes and storers,
+    /// which listen on publicly reachable multiaddrs, off for clients.
+    fn relay_server_enabled(&self) -> Option<bool> {
+        None
+    }
+
+    /// Maximum concurrently active relay reservations.
+    fn relay_max_reservations(&self) -> usize {
+        DEFAULT_RELAY_MAX_RESERVATIONS
+    }
+
+    /// Maximum concurrently active relayed circuits.
+    fn relay_max_circuits(&self) -> usize {
+        DEFAULT_RELAY_MAX_CIRCUITS
+    }
+
+    /// Relayed data budget per circuit, in bytes. `0` removes the limit.
+    fn relay_max_circuit_bytes(&self) -> u64 {
+        DEFAULT_RELAY_MAX_CIRCUIT_BYTES
+    }
+
+    /// Lifetime granted to a relay reservation.
+    fn relay_reservation_ttl(&self) -> Duration {
+        DEFAULT_RELAY_RESERVATION_TTL
     }
 
     /// Whether same-subnet / private-LAN peers are protected from

--- a/crates/swarm/api/src/lib.rs
+++ b/crates/swarm/api/src/lib.rs
@@ -50,11 +50,13 @@ pub use self::components::{
 };
 pub use self::config::{
     DEFAULT_MAX_INBOUND_PER_IP, DEFAULT_PEER_BAN_THRESHOLD, DEFAULT_PEER_DISCONNECT_THRESHOLD,
-    DEFAULT_PEER_MAX_PER_BIN, DEFAULT_PEER_WARN_THRESHOLD, DefaultPeerConfig, DefaultStorageConfig,
-    METADATA_OVERHEAD_FACTOR, NodeTask, NodeTaskFn, PeerConfigValues, SwarmBootnodeConfig,
-    SwarmClientConfig, SwarmClientLaunchConfig, SwarmIdentityConfig, SwarmLaunchConfig,
-    SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig, SwarmStorageConfig, SwarmStorerConfig,
-    SwarmStorerLaunchConfig, estimate_chunks_for_bytes, estimate_storage_bytes,
+    DEFAULT_PEER_MAX_PER_BIN, DEFAULT_PEER_WARN_THRESHOLD, DEFAULT_RELAY_MAX_CIRCUIT_BYTES,
+    DEFAULT_RELAY_MAX_CIRCUITS, DEFAULT_RELAY_MAX_RESERVATIONS, DEFAULT_RELAY_RESERVATION_TTL,
+    DefaultPeerConfig, DefaultStorageConfig, METADATA_OVERHEAD_FACTOR, NodeTask, NodeTaskFn,
+    PeerConfigValues, SwarmBootnodeConfig, SwarmClientConfig, SwarmClientLaunchConfig,
+    SwarmIdentityConfig, SwarmLaunchConfig, SwarmNetworkConfig, SwarmPeerConfig,
+    SwarmRoutingConfig, SwarmStorageConfig, SwarmStorerConfig, SwarmStorerLaunchConfig,
+    estimate_chunks_for_bytes, estimate_storage_bytes,
 };
 pub use self::error::{
     AccountingError, ConfigAddressKind, ConfigError, ConfigResult, IdentityError, SwarmError,

--- a/crates/swarm/node/src/args/network.rs
+++ b/crates/swarm/node/src/args/network.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "cli")]
 use vertex_swarm_api::{ConfigAddressKind, ConfigError};
 use vertex_swarm_api::{
-    ConnectionProfile, DEFAULT_MAX_INBOUND_PER_IP, Multiaddr, SwarmNetworkConfig, SwarmPeerConfig,
-    SwarmRoutingConfig,
+    ConnectionProfile, DEFAULT_MAX_INBOUND_PER_IP, DEFAULT_RELAY_MAX_CIRCUIT_BYTES,
+    DEFAULT_RELAY_MAX_CIRCUITS, DEFAULT_RELAY_MAX_RESERVATIONS, DEFAULT_RELAY_RESERVATION_TTL,
+    Multiaddr, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
 };
 use vertex_swarm_topology::KademliaConfig;
 #[cfg(feature = "cli")]
@@ -155,6 +156,48 @@ pub struct NetworkArgs {
     #[serde(default = "default_mdns")]
     pub mdns: bool,
 
+    /// Enable the circuit relay v2 server. Defaults by node mode:
+    /// bootnode/storer = enabled, client = disabled.
+    ///
+    /// Accepts a bare `--network.relay` (enables) or an explicit
+    /// `--network.relay=true`/`--network.relay=false`.
+    #[arg(
+        long = "network.relay",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        action = clap::ArgAction::Set,
+    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay: Option<bool>,
+
+    /// Maximum concurrently active relay reservations.
+    #[arg(
+        long = "network.relay-max-reservations",
+        default_value_t = DEFAULT_RELAY_MAX_RESERVATIONS
+    )]
+    pub relay_max_reservations: usize,
+
+    /// Maximum concurrently active relayed circuits.
+    #[arg(
+        long = "network.relay-max-circuits",
+        default_value_t = DEFAULT_RELAY_MAX_CIRCUITS
+    )]
+    pub relay_max_circuits: usize,
+
+    /// Maximum bytes relayed per circuit. Set to 0 to remove the limit.
+    #[arg(
+        long = "network.relay-max-circuit-bytes",
+        default_value_t = DEFAULT_RELAY_MAX_CIRCUIT_BYTES
+    )]
+    pub relay_max_circuit_bytes: u64,
+
+    /// Relay reservation lifetime in seconds.
+    #[arg(
+        long = "network.relay-reservation-ttl",
+        default_value_t = DEFAULT_RELAY_RESERVATION_TTL.as_secs()
+    )]
+    pub relay_reservation_ttl_secs: u64,
+
     /// Connection pacing profile: aggressive, balanced, or conservative.
     /// Defaults by node mode: client = aggressive, bootnode/storer = balanced.
     #[arg(long = "network.connection-profile", value_name = "PROFILE")]
@@ -210,6 +253,11 @@ impl Default for NetworkArgs {
             autonat: true,
             upnp: false,
             mdns: true,
+            relay: None,
+            relay_max_reservations: DEFAULT_RELAY_MAX_RESERVATIONS,
+            relay_max_circuits: DEFAULT_RELAY_MAX_CIRCUITS,
+            relay_max_circuit_bytes: DEFAULT_RELAY_MAX_CIRCUIT_BYTES,
+            relay_reservation_ttl_secs: DEFAULT_RELAY_RESERVATION_TTL.as_secs(),
             connection_profile: None,
             max_peers: DEFAULT_MAX_PEERS,
             max_inbound_per_ip: DEFAULT_MAX_INBOUND_PER_IP,
@@ -267,6 +315,11 @@ pub struct NetworkConfig<R = KademliaConfig> {
     autonat: bool,
     upnp: bool,
     mdns: bool,
+    relay: Option<bool>,
+    relay_max_reservations: usize,
+    relay_max_circuits: usize,
+    relay_max_circuit_bytes: u64,
+    relay_reservation_ttl: Duration,
     discovery_enabled: bool,
     trust_local_peers: bool,
     connection_profile: Option<ConnectionProfile>,
@@ -326,6 +379,11 @@ impl<R> NetworkConfig<R> {
             autonat: self.autonat,
             upnp: self.upnp,
             mdns: self.mdns,
+            relay: self.relay,
+            relay_max_reservations: self.relay_max_reservations,
+            relay_max_circuits: self.relay_max_circuits,
+            relay_max_circuit_bytes: self.relay_max_circuit_bytes,
+            relay_reservation_ttl: self.relay_reservation_ttl,
             discovery_enabled: self.discovery_enabled,
             trust_local_peers: self.trust_local_peers,
             connection_profile: self.connection_profile,
@@ -359,6 +417,12 @@ impl NetworkConfig<KademliaConfig> {
             autonat: false,
             upnp: false,
             mdns: false,
+            // A dial-only node never listens, so it can never serve circuits.
+            relay: Some(false),
+            relay_max_reservations: DEFAULT_RELAY_MAX_RESERVATIONS,
+            relay_max_circuits: DEFAULT_RELAY_MAX_CIRCUITS,
+            relay_max_circuit_bytes: DEFAULT_RELAY_MAX_CIRCUIT_BYTES,
+            relay_reservation_ttl: DEFAULT_RELAY_RESERVATION_TTL,
             discovery_enabled: true,
             trust_local_peers: true,
             connection_profile: None,
@@ -388,6 +452,11 @@ impl Default for NetworkConfig<KademliaConfig> {
             autonat: true,
             upnp: false,
             mdns: true,
+            relay: None,
+            relay_max_reservations: DEFAULT_RELAY_MAX_RESERVATIONS,
+            relay_max_circuits: DEFAULT_RELAY_MAX_CIRCUITS,
+            relay_max_circuit_bytes: DEFAULT_RELAY_MAX_CIRCUIT_BYTES,
+            relay_reservation_ttl: DEFAULT_RELAY_RESERVATION_TTL,
             discovery_enabled: true,
             trust_local_peers: true,
             connection_profile: None,
@@ -469,6 +538,11 @@ impl TryFrom<&NetworkArgs> for NetworkConfig<KademliaConfig> {
             autonat: args.autonat,
             upnp: args.upnp,
             mdns: args.mdns,
+            relay: args.relay,
+            relay_max_reservations: args.relay_max_reservations,
+            relay_max_circuits: args.relay_max_circuits,
+            relay_max_circuit_bytes: args.relay_max_circuit_bytes,
+            relay_reservation_ttl: Duration::from_secs(args.relay_reservation_ttl_secs),
             discovery_enabled: !args.disable_discovery,
             trust_local_peers: !args.no_trust_local_peers,
             connection_profile: args.connection_profile,
@@ -535,6 +609,26 @@ impl<R> SwarmNetworkConfig for NetworkConfig<R> {
         self.mdns
     }
 
+    fn relay_server_enabled(&self) -> Option<bool> {
+        self.relay
+    }
+
+    fn relay_max_reservations(&self) -> usize {
+        self.relay_max_reservations
+    }
+
+    fn relay_max_circuits(&self) -> usize {
+        self.relay_max_circuits
+    }
+
+    fn relay_max_circuit_bytes(&self) -> u64 {
+        self.relay_max_circuit_bytes
+    }
+
+    fn relay_reservation_ttl(&self) -> Duration {
+        self.relay_reservation_ttl
+    }
+
     fn trust_local_peers(&self) -> bool {
         self.trust_local_peers
     }
@@ -580,6 +674,7 @@ mod dial_only_tests {
         assert!(!config.autonat_enabled());
         assert!(!config.upnp_enabled());
         assert!(!config.mdns_enabled());
+        assert_eq!(config.relay_server_enabled(), Some(false));
         assert!(config.trust_local_peers());
         assert_eq!(config.connection_profile(), None);
         assert_eq!(config.agent_version(), None);
@@ -873,6 +968,105 @@ mod tests {
         let config = PeerConfig::from(&args);
 
         assert_eq!(config.max_per_bin(), DEFAULT_PEER_MAX_PER_BIN);
+    }
+
+    #[test]
+    fn relay_flag_default_is_unset() {
+        use clap::Parser;
+
+        // No flag: the toggle stays unset so the node type decides at build
+        // time (bootnode/storer on, client off).
+        let parsed = TestCli::try_parse_from(["test"]).expect("default should parse");
+        assert_eq!(parsed.network.relay, None);
+
+        let config = NetworkConfig::try_from(&parsed.network).expect("valid args");
+        assert_eq!(config.relay_server_enabled(), None);
+    }
+
+    #[test]
+    fn relay_flag_accepts_bare_and_explicit_forms() {
+        use clap::Parser;
+
+        for (argv, expected) in [
+            (vec!["test", "--network.relay"], Some(true)),
+            (vec!["test", "--network.relay=true"], Some(true)),
+            (vec!["test", "--network.relay=false"], Some(false)),
+        ] {
+            let parsed = TestCli::try_parse_from(argv).expect("relay flag should parse");
+            assert_eq!(parsed.network.relay, expected);
+
+            let config = NetworkConfig::try_from(&parsed.network).expect("valid args");
+            assert_eq!(config.relay_server_enabled(), expected);
+        }
+    }
+
+    #[test]
+    fn relay_limits_default_and_propagate() {
+        use vertex_swarm_api::{
+            DEFAULT_RELAY_MAX_CIRCUIT_BYTES, DEFAULT_RELAY_MAX_CIRCUITS,
+            DEFAULT_RELAY_MAX_RESERVATIONS, DEFAULT_RELAY_RESERVATION_TTL,
+        };
+
+        let config =
+            NetworkConfig::try_from(&NetworkArgs::default()).expect("default args should be valid");
+        assert_eq!(
+            config.relay_max_reservations(),
+            DEFAULT_RELAY_MAX_RESERVATIONS
+        );
+        assert_eq!(config.relay_max_circuits(), DEFAULT_RELAY_MAX_CIRCUITS);
+        assert_eq!(
+            config.relay_max_circuit_bytes(),
+            DEFAULT_RELAY_MAX_CIRCUIT_BYTES
+        );
+        assert_eq!(
+            config.relay_reservation_ttl(),
+            DEFAULT_RELAY_RESERVATION_TTL
+        );
+
+        let args = NetworkArgs {
+            relay_max_reservations: 7,
+            relay_max_circuits: 3,
+            relay_max_circuit_bytes: 0,
+            relay_reservation_ttl_secs: 90,
+            ..Default::default()
+        };
+        let config = NetworkConfig::try_from(&args).expect("valid args");
+        assert_eq!(config.relay_max_reservations(), 7);
+        assert_eq!(config.relay_max_circuits(), 3);
+        assert_eq!(config.relay_max_circuit_bytes(), 0, "0 removes the limit");
+        assert_eq!(config.relay_reservation_ttl(), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn relay_limit_flags_parse() {
+        use clap::Parser;
+
+        let parsed = TestCli::try_parse_from([
+            "test",
+            "--network.relay-max-reservations=64",
+            "--network.relay-max-circuits=8",
+            "--network.relay-max-circuit-bytes=4096",
+            "--network.relay-reservation-ttl=600",
+        ])
+        .expect("relay limit flags should parse");
+        assert_eq!(parsed.network.relay_max_reservations, 64);
+        assert_eq!(parsed.network.relay_max_circuits, 8);
+        assert_eq!(parsed.network.relay_max_circuit_bytes, 4096);
+        assert_eq!(parsed.network.relay_reservation_ttl_secs, 600);
+    }
+
+    #[test]
+    fn relay_settings_survive_with_routing() {
+        let args = NetworkArgs {
+            relay: Some(true),
+            relay_max_reservations: 5,
+            ..Default::default()
+        };
+        let config = NetworkConfig::try_from(&args).expect("valid args");
+        // The type-changing routing swap must carry the relay knobs through.
+        let swapped = config.with_routing(KademliaConfig::default());
+        assert_eq!(swapped.relay_server_enabled(), Some(true));
+        assert_eq!(swapped.relay_max_reservations(), 5);
     }
 
     #[test]

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -185,6 +185,26 @@ impl<C: SwarmNetworkConfig> SwarmNetworkConfig for ConfigWithBootnodes<'_, C> {
         self.inner.mdns_enabled()
     }
 
+    fn relay_server_enabled(&self) -> Option<bool> {
+        self.inner.relay_server_enabled()
+    }
+
+    fn relay_max_reservations(&self) -> usize {
+        self.inner.relay_max_reservations()
+    }
+
+    fn relay_max_circuits(&self) -> usize {
+        self.inner.relay_max_circuits()
+    }
+
+    fn relay_max_circuit_bytes(&self) -> u64 {
+        self.inner.relay_max_circuit_bytes()
+    }
+
+    fn relay_reservation_ttl(&self) -> Duration {
+        self.inner.relay_reservation_ttl()
+    }
+
     fn trust_local_peers(&self) -> bool {
         self.inner.trust_local_peers()
     }

--- a/crates/swarm/node/src/node/nat.rs
+++ b/crates/swarm/node/src/node/nat.rs
@@ -42,26 +42,37 @@ impl NatBehaviour {
     /// Build the NAT behaviours from a network configuration.
     ///
     /// AutoNAT v2 and mDNS are enabled by default for every node type; UPnP is
-    /// opt-in. The circuit relay v2 server is off by default and enabled for
-    /// the bootnode and storer node types, which listen on publicly reachable
-    /// multiaddrs; reservations and circuits are bounded by the libp2p relay
-    /// defaults (reservation and circuit caps, per-peer and per-IP rate
-    /// limits, circuit duration and byte limits). mDNS needs the local
-    /// [`PeerId`], so the behaviour is built where the swarm's public key is
-    /// available.
+    /// opt-in. The circuit relay v2 server follows the explicit configuration
+    /// toggle when set and otherwise defaults by node type: on for the
+    /// bootnode and storer node types, which listen on publicly reachable
+    /// multiaddrs, off for clients. The reservation cap and TTL and the
+    /// circuit cap and per-circuit byte budget come from the configuration;
+    /// the remaining bounds (per-peer caps, per-peer and per-IP rate limits,
+    /// circuit duration) stay at the libp2p relay defaults. mDNS needs the
+    /// local [`PeerId`], so the behaviour is built where the swarm's public
+    /// key is available.
     pub(crate) fn from_config(
         config: &impl SwarmNetworkConfig,
         local_peer_id: PeerId,
         node_type: SwarmNodeType,
     ) -> Self {
         let autonat = config.autonat_enabled();
-        let relay_server = matches!(node_type, SwarmNodeType::Bootnode | SwarmNodeType::Storer);
+        let relay_server = config.relay_server_enabled().unwrap_or(matches!(
+            node_type,
+            SwarmNodeType::Bootnode | SwarmNodeType::Storer
+        ));
+        let relay_config = relay::Config {
+            max_reservations: config.relay_max_reservations(),
+            reservation_duration: config.relay_reservation_ttl(),
+            max_circuits: config.relay_max_circuits(),
+            max_circuit_bytes: config.relay_max_circuit_bytes(),
+            ..relay::Config::default()
+        };
         Self {
             autonat_client: Toggle::from(autonat.then(autonat::client::Behaviour::default)),
             autonat_server: Toggle::from(autonat.then(autonat::server::Behaviour::default)),
             relay_server: Toggle::from(
-                relay_server
-                    .then(|| relay::Behaviour::new(local_peer_id, relay::Config::default())),
+                relay_server.then(|| relay::Behaviour::new(local_peer_id, relay_config)),
             ),
             upnp: Toggle::from(config.upnp_enabled().then(upnp::tokio::Behaviour::default)),
             mdns: build_mdns_toggle(config.mdns_enabled(), local_peer_id),
@@ -315,6 +326,7 @@ mod tests {
     #[derive(Default)]
     struct TestConfig {
         addrs: Vec<Multiaddr>,
+        relay: Option<bool>,
     }
 
     impl SwarmNetworkConfig for TestConfig {
@@ -336,6 +348,9 @@ mod tests {
         fn mdns_enabled(&self) -> bool {
             false
         }
+        fn relay_server_enabled(&self) -> Option<bool> {
+            self.relay
+        }
     }
 
     #[test]
@@ -351,6 +366,26 @@ mod tests {
                 nat.relay_server.is_enabled(),
                 enabled,
                 "relay server toggle for {node_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn relay_server_toggle_overrides_node_type() {
+        for (relay, node_type, enabled) in [
+            (Some(true), SwarmNodeType::Client, true),
+            (Some(false), SwarmNodeType::Bootnode, false),
+            (Some(false), SwarmNodeType::Storer, false),
+        ] {
+            let config = TestConfig {
+                relay,
+                ..TestConfig::default()
+            };
+            let nat = NatBehaviour::from_config(&config, random_peer_id(), node_type);
+            assert_eq!(
+                nat.relay_server.is_enabled(),
+                enabled,
+                "explicit toggle {relay:?} for {node_type:?}"
             );
         }
     }


### PR DESCRIPTION
Closes #761

## What

Adds circuit relay v2 server configuration knobs to `SwarmNetworkConfig` and threads them through to the relay behaviour, on top of the relay-server support introduced in #760.

`SwarmNetworkConfig` (`crates/swarm/api/src/config.rs`) gains five defaulted trait methods:

- `relay_server_enabled() -> Option<bool>`: explicit tri-state toggle. `None` defers to the node-type default (bootnode/storer on, client off), mirroring the existing `connection_profile` pattern.
- `relay_max_reservations() -> usize`
- `relay_max_circuits() -> usize`
- `relay_max_circuit_bytes() -> u64` (`0` removes the limit, matching libp2p semantics)
- `relay_reservation_ttl() -> Duration`

Four `DEFAULT_RELAY_*` constants back these defaults (128 reservations, 16 circuits, 128 KiB per circuit, 1 hour TTL, matching `libp2p::relay::Config::default()`) and are re-exported from the `vertex-swarm-api` crate root.

CLI wiring in `crates/swarm/node/src/args/network.rs`:

- `--network.relay`: bare/`=true`/`=false` tri-state `Option<bool>`.
- `--network.relay-max-reservations`, `--network.relay-max-circuits`, `--network.relay-max-circuit-bytes`, `--network.relay-reservation-ttl` (seconds), each defaulted from the new constants.
- Dial-only `NetworkConfig` construction forces `relay: Some(false)`, since a dial-only node never listens and so can never serve circuits.

`crates/swarm/node/src/node/nat.rs` builds a `relay::Config` from the four numeric settings (leaving per-peer caps, per-peer/per-IP rate limits, and circuit duration at the libp2p relay defaults) and resolves `relay_server_enabled()` against the node-type default when unset. A new test, `relay_server_toggle_overrides_node_type`, checks the explicit toggle wins over the node-type default in both directions.

`crates/swarm/node/src/node/builder.rs`'s `ConfigWithBootnodes` wrapper forwards all five new trait methods to its inner config.

## Why

#760 hard-coded relay-server enablement to node type and left reservation/circuit/byte/TTL bounds at the libp2p defaults with no way to tune them. #761 exposes those bounds as configuration and CLI flags, and lets an operator force the relay server on or off regardless of node type, while keeping the previous node-type-based default behaviour when nothing is set explicitly.

## Testing

All commands run inside `nix develop` on the full workspace, rustc 1.92.0.

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --lib --all-features -- -D warnings`: clean.
- `cargo clippy --workspace --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used`: clean.

Note: the justfile `clippy` recipe's bare `--lib` resolves only to the default-member `vertex` binary crate (which has no library target) and errors independently of this branch, so the checks above were run with explicit `--workspace` scoping instead.

The four `DEFAULT_RELAY_*` constants were verified to equal `libp2p::relay::Config::default()` byte-for-byte at the pinned fork revision (`fd9cc0d`), so default-configured operators see no behaviour drift versus the prior hard-coded `relay::Config::default()`.

An adversarial review of the single commit found no blocker or major issues.

## AI Assistance

AI Assistance: Claude (Anthropic) used for implementation, adversarial review, and this PR description.
