### PR TITLE
feat(swarm-node): inject relay-client transport and thread its handle

### DIFF
--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -30,7 +30,7 @@ use vertex_tasks::GracefulShutdown;
 use super::base::{AdmissionLimits, BaseNode};
 use super::builder::BuiltInfrastructure;
 use super::ip_limits::IpConnectionLimits;
-use super::nat::{NatBehaviour, NatEvent};
+use super::nat::{NatBehaviour, NatEvent, RelayClientBehaviour, RelayClientEvent};
 use crate::protocol::{
     BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, ClientEvent, StubForwarder,
 };
@@ -56,6 +56,10 @@ pub(crate) struct BootnodeBehaviour<I: SwarmIdentity + Clone> {
     /// NAT traversal (AutoNAT v2, UPnP), the circuit relay v2 server, and LAN
     /// discovery (mDNS), composed as one sub-behaviour.
     pub(crate) nat: NatBehaviour,
+    /// Relay-client handle paired with the circuit transport; held only so the
+    /// shared swarm assembly stays uniform. A bootnode is publicly reachable
+    /// and never reserves or dials through a relay.
+    pub(crate) relay_client: RelayClientBehaviour,
     /// Before topology: reads the active-peers view at connection close while the
     /// registry entry is live.
     pub(crate) client: ClientBehaviour,
@@ -68,6 +72,7 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
         local_public_key: PublicKey,
         topology: TopologyBehaviour<I>,
         nat: NatBehaviour,
+        relay_client: RelayClientBehaviour,
         limits: AdmissionLimits,
         agent_version: Option<&str>,
     ) -> Self {
@@ -86,6 +91,7 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
                 observed_addresses,
             ),
             nat,
+            relay_client,
             // A bootnode advertises pricing only and never serves retrieval or
             // pushsync, so its cache is never consulted; a zero-budget cache and
             // the stub forwarder keep the behaviour inert.
@@ -115,6 +121,7 @@ impl<I: SwarmIdentity + Clone> BootnodeBehaviour<I> {
 pub enum BootnodeEvent {
     Identify(Box<identify::Event>),
     Nat(NatEvent),
+    RelayClient(RelayClientEvent),
     Topology(()),
     Client(ClientEvent),
 }
@@ -135,6 +142,12 @@ impl From<identify::Event> for BootnodeEvent {
 impl From<NatEvent> for BootnodeEvent {
     fn from(event: NatEvent) -> Self {
         BootnodeEvent::Nat(event)
+    }
+}
+
+impl From<RelayClientEvent> for BootnodeEvent {
+    fn from(event: RelayClientEvent) -> Self {
+        BootnodeEvent::RelayClient(event)
     }
 }
 
@@ -257,6 +270,9 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
                     event,
                 );
             }
+            BootnodeEvent::RelayClient(event) => {
+                super::nat::handle_relay_client_event(event);
+            }
             BootnodeEvent::Topology(_) => {}
             BootnodeEvent::Client(event) => {
                 // Bootnodes only accept pricing-receive; observability only.
@@ -353,7 +369,7 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
             network_config,
             "Bootnode",
             self.transport,
-            move |pk, topology| {
+            move |pk, topology, relay_client| {
                 let nat = NatBehaviour::from_config(
                     network_config,
                     pk.to_peer_id(),
@@ -363,6 +379,7 @@ impl<I: SwarmIdentity + Clone> BootNodeBuilder<I> {
                     pk,
                     topology,
                     nat,
+                    relay_client,
                     limits,
                     network_config.agent_version(),
                 )

--- a/crates/swarm/node/src/node/builder.rs
+++ b/crates/swarm/node/src/node/builder.rs
@@ -215,9 +215,11 @@ impl<C: SwarmRoutingConfig> SwarmRoutingConfig for ConfigWithBootnodes<'_, C> {
 /// Handles the common SwarmBuilder pipeline, peer ID logging, and bootnode
 /// connection that all node types share.
 ///
-/// The `behaviour_fn` receives the libp2p public key and the topology behaviour,
-/// and must return both the composed NetworkBehaviour and a reference to its
-/// topology so we can call `register_local_peer_id`.
+/// The `behaviour_fn` receives the libp2p public key, the topology behaviour,
+/// and the relay-client behaviour the transport assembly yields (paired with
+/// the circuit transport, so the composite must hold it), and must return the
+/// composed NetworkBehaviour with its topology so we can call
+/// `register_local_peer_id`.
 pub(crate) async fn build_base_node<I, B, C, F>(
     mut infra: BuiltInfrastructure<I>,
     network_config: &C,
@@ -229,7 +231,7 @@ where
     I: SwarmIdentity + Clone,
     B: NetworkBehaviour,
     C: SwarmNetworkConfig,
-    F: FnOnce(PublicKey, TopologyBehaviour<I>) -> B,
+    F: FnOnce(PublicKey, TopologyBehaviour<I>, super::nat::RelayClientBehaviour) -> B,
 {
     let topology_behaviour = infra
         .take_behaviour()
@@ -239,17 +241,19 @@ where
 
     let topology_cell = std::sync::Mutex::new(Some(topology_behaviour));
 
-    let behaviour_builder = |keypair: &libp2p::identity::Keypair| {
-        let topology = topology_cell
-            .lock()
-            .map_err(|_| NodeBuildError::TopologyCellPoisoned)?
-            .take()
-            .ok_or(NodeBuildError::TopologyBehaviourTaken)?;
-        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(behaviour_fn(
-            keypair.public().clone(),
-            topology,
-        ))
-    };
+    let behaviour_builder =
+        |keypair: &libp2p::identity::Keypair, relay_client: super::nat::RelayClientBehaviour| {
+            let topology = topology_cell
+                .lock()
+                .map_err(|_| NodeBuildError::TopologyCellPoisoned)?
+                .take()
+                .ok_or(NodeBuildError::TopologyBehaviourTaken)?;
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(behaviour_fn(
+                keypair.public().clone(),
+                topology,
+                relay_client,
+            ))
+        };
 
     let swarm = build_swarm(idle_timeout, transport, behaviour_builder)?;
 
@@ -275,8 +279,12 @@ where
 /// authentication, and Yamux multiplexing, plus a QUIC v1 transport
 /// (self-securing and self-multiplexing) that listens and dials next to it;
 /// TCP with Noise and Yamux stays the primary suite for network-wide interop.
-/// A [`TransportOverride`] (tests only) replaces the whole stack with the
-/// supplied transport, which is why
+/// A circuit relay v2 client transport is layered over both, upgraded with the
+/// same Noise and Yamux suite, so relayed connections reach the relay over TCP
+/// or QUIC; its behaviour handle flows into `behaviour_builder`, which must
+/// compose it into the swarm behaviour. A [`TransportOverride`] (tests only)
+/// replaces the base stack with the supplied transport (the relay client still
+/// rides it), which is why
 /// [`TransportCapability::platform`](vertex_net_local::TransportCapability::platform)
 /// keeps mirroring the default TCP+QUIC stack rather than the override.
 #[cfg(not(target_arch = "wasm32"))]
@@ -289,6 +297,7 @@ where
     B: NetworkBehaviour,
     F: FnOnce(
         &libp2p::identity::Keypair,
+        super::nat::RelayClientBehaviour,
     ) -> std::result::Result<B, Box<dyn std::error::Error + Send + Sync>>,
 {
     use libp2p::{SwarmBuilder, noise, tcp, yamux};
@@ -297,6 +306,7 @@ where
         let swarm = SwarmBuilder::with_new_identity()
             .with_tokio()
             .with_other_transport(transport)?
+            .with_relay_client(noise::Config::new, yamux::Config::default)?
             .with_behaviour(behaviour_builder)?
             .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_timeout))
             .build();
@@ -312,6 +322,7 @@ where
         )?
         .with_quic()
         .with_dns()?
+        .with_relay_client(noise::Config::new, yamux::Config::default)?
         .with_behaviour(behaviour_builder)?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_timeout))
         .build();
@@ -349,6 +360,7 @@ where
     B: NetworkBehaviour,
     F: FnOnce(
         &libp2p::identity::Keypair,
+        super::nat::RelayClientBehaviour,
     ) -> std::result::Result<B, Box<dyn std::error::Error + Send + Sync>>,
 {
     use libp2p::{SwarmBuilder, Transport as _, core::upgrade::Version, noise, yamux};
@@ -366,7 +378,12 @@ where
                 .multiplex(yamux::Config::default());
             Ok::<_, Box<dyn std::error::Error + Send + Sync>>(transport)
         })?
-        .with_behaviour(behaviour_builder)?
+        // No relay transport in the browser yet (it arrives with the
+        // WebTransport stack); the inert stand-in keeps behaviour assembly
+        // uniform across targets.
+        .with_behaviour(|keypair| {
+            behaviour_builder(keypair, super::nat::RelayClientBehaviour::new())
+        })?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(idle_timeout))
         .build();
 
@@ -425,10 +442,14 @@ mod tests {
         }
 
         let idle = Duration::from_secs(5);
-        let mut listener = build_swarm(idle, Some(memory_override()), |_kp| Ok(dummy::Behaviour))
-            .expect("listener swarm builds over the injected transport");
-        let mut dialer = build_swarm(idle, Some(memory_override()), |_kp| Ok(dummy::Behaviour))
-            .expect("dialer swarm builds over the injected transport");
+        let mut listener = build_swarm(idle, Some(memory_override()), |_kp, _relay_client| {
+            Ok(dummy::Behaviour)
+        })
+        .expect("listener swarm builds over the injected transport");
+        let mut dialer = build_swarm(idle, Some(memory_override()), |_kp, _relay_client| {
+            Ok(dummy::Behaviour)
+        })
+        .expect("dialer swarm builds over the injected transport");
 
         listener
             .listen_on("/memory/0".parse::<Multiaddr>().unwrap())

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -25,7 +25,7 @@ use vertex_swarm_api::SwarmLocalStore;
 use super::base::{AdmissionLimits, BaseNode};
 use super::builder::BuiltInfrastructure;
 use super::ip_limits::IpConnectionLimits;
-use super::nat::{NatBehaviour, NatEvent};
+use super::nat::{NatBehaviour, NatEvent, RelayClientBehaviour, RelayClientEvent};
 use crate::protocol::{
     BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, ClientCommand, ClientEvent,
     PseudosettleEvent, StubForwarder,
@@ -46,6 +46,10 @@ pub(crate) struct ClientNodeBehaviour<I: SwarmIdentity + Clone> {
     /// NAT traversal and LAN discovery as one platform sub-behaviour; a no-op in
     /// the browser, where a wasm client dials over websockets and never listens.
     pub(crate) nat: NatBehaviour,
+    /// Relay-client reservations and relayed circuits, paired with the circuit
+    /// transport assembled into the swarm; inert in the browser, which has no
+    /// relay transport yet.
+    pub(crate) relay_client: RelayClientBehaviour,
     /// Before topology: reads the active-peers view at connection close while the
     /// registry entry is live.
     pub(crate) client: ClientBehaviour,
@@ -57,6 +61,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
         local_public_key: PublicKey,
         topology: TopologyBehaviour<I>,
         nat: NatBehaviour,
+        relay_client: RelayClientBehaviour,
         limits: AdmissionLimits,
         store: Arc<dyn SwarmLocalStore>,
         agent_version: Option<&str>,
@@ -76,6 +81,7 @@ impl<I: SwarmIdentity + Clone> ClientNodeBehaviour<I> {
                 observed_addresses,
             ),
             nat,
+            relay_client,
             // Cache-only client never relays: the stub forwarder resets the
             // substream on cache miss and every inbound pushsync. The real relay
             // is installed by `enable_forwarding`.
@@ -108,7 +114,7 @@ where
         network_config,
         "Client node",
         transport,
-        move |pk, topology| {
+        move |pk, topology, relay_client| {
             let nat = NatBehaviour::from_config(
                 network_config,
                 pk.to_peer_id(),
@@ -118,6 +124,7 @@ where
                 pk,
                 topology,
                 nat,
+                relay_client,
                 limits,
                 store,
                 network_config.agent_version(),
@@ -132,6 +139,7 @@ where
 pub enum ClientNodeEvent {
     Identify(Box<identify::Event>),
     Nat(NatEvent),
+    RelayClient(RelayClientEvent),
     Topology(()),
     Client(ClientEvent),
 }
@@ -152,6 +160,12 @@ impl From<identify::Event> for ClientNodeEvent {
 impl From<NatEvent> for ClientNodeEvent {
     fn from(event: NatEvent) -> Self {
         ClientNodeEvent::Nat(event)
+    }
+}
+
+impl From<RelayClientEvent> for ClientNodeEvent {
+    fn from(event: RelayClientEvent) -> Self {
+        ClientNodeEvent::RelayClient(event)
     }
 }
 
@@ -390,6 +404,9 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
                     &mut self.base.swarm.behaviour_mut().topology,
                     event,
                 );
+            }
+            ClientNodeEvent::RelayClient(event) => {
+                super::nat::handle_relay_client_event(event);
             }
             ClientNodeEvent::Topology(_) => {}
             ClientNodeEvent::Client(event) => {

--- a/crates/swarm/node/src/node/nat.rs
+++ b/crates/swarm/node/src/node/nat.rs
@@ -2,10 +2,13 @@
 //!
 //! [`NatBehaviour`] composes AutoNAT v2 (client + server), UPnP, a circuit
 //! relay v2 server, and mDNS into a single sub-behaviour so the node
-//! composites carry one platform-neutral field. The browser client dials over
+//! composites carry one platform-neutral field. The circuit relay v2 client
+//! ([`RelayClientBehaviour`]) is a sibling composite field rather than a
+//! `NatBehaviour` member because the swarm transport assembly constructs it
+//! together with the relay transport. The browser client dials over
 //! websockets and never listens, so it has no NAT or LAN-discovery surface;
 //! the wasm sibling module (`nat_wasm.rs`) exposes the same item names and
-//! signatures over a no-op behaviour.
+//! signatures over no-op behaviours.
 
 use libp2p::autonat::v2 as autonat;
 use libp2p::mdns;
@@ -19,6 +22,14 @@ use tracing::{debug, info, warn};
 use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
 use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_topology::{TopologyBehaviour, TopologyCommand};
+
+/// Circuit relay v2 client behaviour, paired with the relay transport the
+/// swarm assembly injects. The pair shares state over a channel, so the
+/// handle must be composed into the node behaviour or relayed dials stall.
+pub(crate) type RelayClientBehaviour = relay::client::Behaviour;
+
+/// Events from the relay-client behaviour.
+pub(crate) type RelayClientEvent = relay::client::Event;
 
 /// NAT traversal (AutoNAT v2, UPnP), the circuit relay v2 server, and LAN
 /// discovery (mDNS), composed as one sub-behaviour so the node composites
@@ -278,6 +289,29 @@ fn handle_relay_event(event: relay::Event) {
             debug!(%src_peer_id, %dst_peer_id, ?error, "Relay circuit closed");
         }
         _ => {}
+    }
+}
+
+/// Handle a circuit relay v2 client event: reservation and relayed-circuit
+/// lifecycle, surfaced as counters and debug logs only.
+pub(crate) fn handle_relay_client_event(event: RelayClientEvent) {
+    match event {
+        relay::client::Event::ReservationReqAccepted {
+            relay_peer_id,
+            renewal,
+            ..
+        } => {
+            metrics::counter!("swarm.relay_client.reservations_accepted").increment(1);
+            debug!(%relay_peer_id, renewal, "Relay reservation accepted");
+        }
+        relay::client::Event::OutboundCircuitEstablished { relay_peer_id, .. } => {
+            metrics::counter!("swarm.relay_client.outbound_circuits").increment(1);
+            debug!(%relay_peer_id, "Outbound relay circuit established");
+        }
+        relay::client::Event::InboundCircuitEstablished { src_peer_id, .. } => {
+            metrics::counter!("swarm.relay_client.inbound_circuits").increment(1);
+            debug!(%src_peer_id, "Inbound relay circuit established");
+        }
     }
 }
 

--- a/crates/swarm/node/src/node/nat_wasm.rs
+++ b/crates/swarm/node/src/node/nat_wasm.rs
@@ -14,6 +14,37 @@ use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
 use vertex_swarm_primitives::SwarmNodeType;
 use vertex_swarm_topology::TopologyBehaviour;
 
+/// No-op relay-client stand-in for the browser client. The browser swarm
+/// assembly injects no relay transport yet (the relayed path arrives with the
+/// WebTransport stack), so the composite carries an inert field on wasm.
+#[derive(NetworkBehaviour)]
+#[behaviour(to_swarm = "RelayClientEvent")]
+pub(crate) struct RelayClientBehaviour {
+    inner: libp2p::swarm::dummy::Behaviour,
+}
+
+impl RelayClientBehaviour {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: libp2p::swarm::dummy::Behaviour,
+        }
+    }
+}
+
+/// Uninhabited: the wasm relay-client stand-in never emits events.
+pub(crate) enum RelayClientEvent {}
+
+impl From<Infallible> for RelayClientEvent {
+    fn from(event: Infallible) -> Self {
+        match event {}
+    }
+}
+
+/// Dispatch a relay-client event; statically unreachable in the browser.
+pub(crate) fn handle_relay_client_event(event: RelayClientEvent) {
+    match event {}
+}
+
 /// No-op NAT sub-behaviour for the browser client.
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "NatEvent")]

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -37,7 +37,7 @@ use vertex_tasks::TaskExecutor;
 use super::base::{AdmissionLimits, BaseNode};
 use super::builder::BuiltInfrastructure;
 use super::ip_limits::IpConnectionLimits;
-use super::nat::{NatBehaviour, NatEvent};
+use super::nat::{NatBehaviour, NatEvent, RelayClientBehaviour, RelayClientEvent};
 use crate::protocol::{
     BehaviourConfig as ClientBehaviourConfig, ClientBehaviour, ClientCommand, ClientEvent,
     PseudosettleEvent, StubForwarder,
@@ -109,6 +109,9 @@ pub(crate) struct StorerNodeBehaviour<I: SwarmIdentity + Clone> {
     /// NAT traversal, the circuit relay v2 server, and LAN discovery, native
     /// only.
     pub(crate) nat: NatBehaviour,
+    /// Relay-client reservations and relayed circuits, paired with the circuit
+    /// transport assembled into the swarm.
+    pub(crate) relay_client: RelayClientBehaviour,
     /// Client protocols plus pullsync, served from the reserve. Before topology:
     /// its client tier reads the active-peers view at connection close while the
     /// registry entry is live.
@@ -117,10 +120,12 @@ pub(crate) struct StorerNodeBehaviour<I: SwarmIdentity + Clone> {
 }
 
 impl<I: SwarmIdentity + Clone> StorerNodeBehaviour<I> {
+    #[allow(clippy::too_many_arguments)]
     fn from_parts(
         local_public_key: PublicKey,
         topology: TopologyBehaviour<I>,
         nat: NatBehaviour,
+        relay_client: RelayClientBehaviour,
         limits: AdmissionLimits,
         store: Arc<dyn SwarmLocalStore>,
         pullsync_storage: Arc<dyn PullStorage>,
@@ -143,6 +148,7 @@ impl<I: SwarmIdentity + Clone> StorerNodeBehaviour<I> {
                 observed_addresses,
             ),
             nat,
+            relay_client,
             storer: StorerBehaviour {
                 client,
                 pullsync: PullsyncBehaviour::new(pullsync_storage),
@@ -171,13 +177,14 @@ where
         network_config,
         "Storer node",
         transport,
-        move |pk, topology| {
+        move |pk, topology, relay_client| {
             let nat =
                 NatBehaviour::from_config(network_config, pk.to_peer_id(), SwarmNodeType::Storer);
             StorerNodeBehaviour::from_parts(
                 pk,
                 topology,
                 nat,
+                relay_client,
                 limits,
                 store,
                 pullsync_storage,
@@ -193,6 +200,7 @@ where
 pub enum StorerNodeEvent {
     Identify(Box<identify::Event>),
     Nat(NatEvent),
+    RelayClient(RelayClientEvent),
     Topology(()),
     Client(ClientEvent),
     Pullsync(PullsyncEvent),
@@ -214,6 +222,12 @@ impl From<identify::Event> for StorerNodeEvent {
 impl From<NatEvent> for StorerNodeEvent {
     fn from(event: NatEvent) -> Self {
         StorerNodeEvent::Nat(event)
+    }
+}
+
+impl From<RelayClientEvent> for StorerNodeEvent {
+    fn from(event: RelayClientEvent) -> Self {
+        StorerNodeEvent::RelayClient(event)
     }
 }
 
@@ -470,6 +484,9 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
                     &mut self.base.swarm.behaviour_mut().topology,
                     event,
                 );
+            }
+            StorerNodeEvent::RelayClient(event) => {
+                super::nat::handle_relay_client_event(event);
             }
             StorerNodeEvent::Topology(_) => {}
             StorerNodeEvent::Client(event) => {


### PR DESCRIPTION
Closes #762

## What

Injects the circuit relay v2 client transport into the native swarm assembly and threads its behaviour handle through the builder.

`build_swarm` now chains `.with_relay_client(noise::Config::new, yamux::Config::default)` after `.with_dns()` on the default TCP+QUIC stack, and also after `.with_other_transport()` on the `TransportOverride` test path, so relayed connections ride the shared Noise/Yamux upgrade over either suite.

`build_base_node`'s `behaviour_fn` signature gained the `relay::client::Behaviour` handle the injection yields (as `super::nat::RelayClientBehaviour`), threaded into `ClientNodeBehaviour`, `StorerNodeBehaviour`, and `BootnodeBehaviour` as a new `relay_client` composite field, placed after `nat` to preserve the client-before-topology `FromSwarm` ordering invariant.

Each composite event enum (`ClientNodeEvent`, `StorerNodeEvent`, `BootnodeEvent`) gained a `RelayClient` variant routed to a new `handle_relay_client_event` in `node/nat.rs`, which emits debug logs and `swarm.relay_client.*` counters for reservation acceptance and inbound/outbound circuit establishment.

The browser build has no relay transport yet (it arrives with the WebTransport stack), so `node/nat_wasm.rs` gains an inert `RelayClientBehaviour`/`RelayClientEvent` stand-in (backed by `libp2p::swarm::dummy::Behaviour`, an uninhabited event enum) purely to keep behaviour assembly uniform across native and wasm targets.

## Why

Circuit relay v2 client support is the transport-side prerequisite for relayed connectivity: without a relay-client behaviour composed into the node, the node cannot hold reservations on a relay or complete relayed circuits, even once a relay server and dial logic exist elsewhere in the stack. This PR is deliberately structural and has no wire-level behavioural impact beyond carrying the new transport and behaviour.

## Testing

- `cargo fmt --all -- --check`: clean.
- Native all-features `clippy` for lib, tests, and benches with `-D warnings`: clean.
- Default-features `clippy` on `vertex-swarm-node` after `cargo clean -p vertex-swarm-node`: clean.
- `just check-cone` guard: pass.
- `wasm32-unknown-unknown` build of `vertex-swarm-node`, exercising the `nat_wasm.rs` relay-client stand-in: clean.
- `cargo nextest run -p vertex-swarm-node --all-features`: 198/198 passed, including seeded/tcp/storer cluster smoke, three-node convergence, autonat dialback (all now carrying the relay client on the transport), and the memory-transport connect test.
- All runs executed inside `nix develop` on rustc 1.92.0.

## AI Assistance

Claude (Anthropic, via Claude Code) was used for the implementation (relay-client transport injection and behaviour threading) and for red-teaming the change prior to opening this PR.
