### PR TITLE
feat(net): gate circuit-relay addresses from advertisement and reachability

### DIFF
--- a/crates/net/local/src/transport.rs
+++ b/crates/net/local/src/transport.rs
@@ -31,8 +31,12 @@ pub enum TransportRequirement {
     /// websocket stacks carry none, so a self-signed record advertising one is
     /// rejected pre-dial rather than admitted for a dial that always fails.
     Memory,
-    /// Anything else (legacy draft QUIC, WebTransport, relay-only); dialable
-    /// by no transport stack vertex currently assembles.
+    /// Relayed circuit (`/p2p-circuit`). Dialable only through a relay client
+    /// transport, never by a bare platform suite, so the circuit component
+    /// dominates whatever suite the relay leg rides.
+    Relay,
+    /// Anything else (legacy draft QUIC, WebTransport); dialable by no
+    /// transport stack vertex currently assembles.
     Other,
 }
 
@@ -50,6 +54,7 @@ impl TransportRequirement {
         for proto in addr.iter() {
             match proto {
                 Protocol::Memory(_) => return Self::Memory,
+                Protocol::P2pCircuit => return Self::Relay,
                 Protocol::Tcp(_) => saw_tcp = true,
                 Protocol::Tls => saw_tls = true,
                 Protocol::QuicV1 => saw_quic = true,
@@ -87,6 +92,7 @@ fn advertise_rank(addr: &Multiaddr) -> u8 {
         TransportRequirement::SecureWebsocket => 2,
         TransportRequirement::Websocket
         | TransportRequirement::Memory
+        | TransportRequirement::Relay
         | TransportRequirement::Other => 3,
     }
 }
@@ -147,7 +153,9 @@ impl TransportCapability {
     /// websockets). A `/memory/<port>` address is never dialable through the
     /// platform stack; memory admission is a property of the combined
     /// [`DialCapability::allow_memory`] bit, set only when an in-process memory
-    /// transport is injected.
+    /// transport is injected. A `/p2p-circuit` address is likewise never
+    /// dialable here: circuit dialability is a property of an injected relay
+    /// client transport, not of the static suite.
     pub fn can_dial(&self, addr: &Multiaddr) -> bool {
         matches!(
             (self, TransportRequirement::of(addr)),
@@ -320,6 +328,44 @@ mod tests {
             TransportRequirement::of(&with_peer),
             TransportRequirement::Memory
         );
+    }
+
+    #[test]
+    fn relay_classification_dominates_the_relay_leg() {
+        // The circuit component wins regardless of the suite the relay leg
+        // rides, and a target /p2p/ suffix does not change it.
+        let cases = [
+            "/ip4/1.2.3.4/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg/p2p-circuit",
+            "/ip4/1.2.3.4/udp/1634/quic-v1/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg/p2p-circuit",
+            "/ip4/1.2.3.4/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg/p2p-circuit/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N",
+            "/p2p-circuit",
+        ];
+        for s in cases {
+            assert_eq!(
+                TransportRequirement::of(&addr(s)),
+                TransportRequirement::Relay,
+                "{s}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_platform_stack_dials_a_relayed_address() {
+        let relayed = addr(
+            "/ip4/1.2.3.4/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg/p2p-circuit",
+        );
+        assert!(!TransportCapability::Tcp.can_dial(&relayed));
+        assert!(!TransportCapability::TcpQuic.can_dial(&relayed));
+        assert!(!TransportCapability::SecureWebsocket.can_dial(&relayed));
+    }
+
+    #[test]
+    fn relayed_address_ranks_last_for_advertisement() {
+        let tcp = addr("/ip4/8.8.8.8/tcp/1634");
+        let relayed = addr(
+            "/ip4/1.2.3.4/tcp/1634/p2p/QmfEugihe2Pm78YomGupdxSt46Uxgg4DLpjkzgzzeouiKg/p2p-circuit",
+        );
+        assert_eq!(transport_order(&tcp, &relayed), std::cmp::Ordering::Less);
     }
 
     #[test]

--- a/crates/swarm/topology/src/nat_discovery.rs
+++ b/crates/swarm/topology/src/nat_discovery.rs
@@ -113,6 +113,22 @@ impl LocalAddressManager {
         nat_addrs: Vec<Multiaddr>,
         reachability: ReachabilityTracker,
     ) -> Self {
+        // A configured `/p2p-circuit` proves relay reachability, not public
+        // reachability, so it must not reach any direct-address consumer:
+        // is_reachable, the external-address emission that feeds identify, the
+        // signed handshake record, or hive gossip. Drop it at intake so every
+        // nat_addrs reader stays circuit-free; a relay reservation is a runtime
+        // signal (on_external_addr_confirmed), not static operator config.
+        let nat_addrs = nat_addrs
+            .into_iter()
+            .filter(|addr| {
+                if is_relayed(addr) {
+                    warn!(%addr, "Ignoring configured relayed circuit NAT address");
+                    return false;
+                }
+                true
+            })
+            .collect();
         Self {
             local,
             nat_addrs,
@@ -959,6 +975,20 @@ mod tests {
         let addrs = manager.addresses_for_peer(&parse_addr("/ip4/8.8.8.8/tcp/5000"));
         assert!(!has_circuit(&addrs));
         assert!(addrs.iter().any(|a| a.to_string().contains("203.0.113.50")));
+    }
+
+    #[test]
+    fn test_lone_configured_circuit_nat_addr_is_not_reachability() {
+        // A relay reservation is not public reachability, so a node whose only
+        // configured address is a circuit must not report itself reachable,
+        // advertise it, or expose it as an external address (the identify
+        // channel). The circuit is dropped at intake, so nat_addrs is empty.
+        let manager = create_manager(vec![circuit_addr(PeerId::random())]);
+
+        assert!(!manager.is_reachable());
+        assert!(!manager.has_confirmed_reachability());
+        assert!(manager.nat_addrs().is_empty());
+        assert!(!has_circuit(&manager.all_addresses()));
     }
 
     #[test]

--- a/crates/swarm/topology/src/nat_discovery.rs
+++ b/crates/swarm/topology/src/nat_discovery.rs
@@ -11,8 +11,8 @@ use parking_lot::Mutex;
 use strum::IntoEnumIterator;
 use tracing::{debug, info, warn};
 use vertex_net_local::{
-    AddressScope, IpCapability, LocalCapabilities, advertise_filter, classify_multiaddr,
-    family_order, transport_order,
+    AddressScope, IpCapability, LocalCapabilities, TransportRequirement, advertise_filter,
+    classify_multiaddr, family_order, transport_order,
 };
 use vertex_swarm_net_handshake::AddressProvider;
 
@@ -22,6 +22,23 @@ fn strip_peer_id(addr: &Multiaddr) -> Multiaddr {
     addr.iter()
         .filter(|p| !matches!(p, Protocol::P2p(_)))
         .collect()
+}
+
+/// Drop a trailing `/p2p/..` component only. Unlike [`strip_peer_id`] this
+/// preserves an inner relay identity, so a circuit address keeps the relay it
+/// routes through.
+fn strip_trailing_peer_id(addr: &Multiaddr) -> Multiaddr {
+    let mut addr = addr.clone();
+    if matches!(addr.iter().last(), Some(Protocol::P2p(_))) {
+        addr.pop();
+    }
+    addr
+}
+
+/// A `/p2p-circuit` address is reachable only through a relay client, so it
+/// must never ride the handshake record or hive gossip.
+fn is_relayed(addr: &Multiaddr) -> bool {
+    TransportRequirement::of(addr) == TransportRequirement::Relay
 }
 
 /// Total order within a trust tier: IPv6 before IPv4, TCP before QUIC within
@@ -70,6 +87,11 @@ pub struct LocalAddressManager {
     /// so a node whose only public path was a mapping that expired stops
     /// reporting itself reachable.
     confirmed_external_addrs: Mutex<HashSet<Multiaddr>>,
+    /// Confirmed relayed circuit addresses (relay reservations). Kept apart
+    /// from the direct external set: a circuit proves relay reachability, not
+    /// public reachability, and is served only through
+    /// [`Self::relayed_addresses`], never the handshake record.
+    relayed_addrs: Mutex<HashSet<Multiaddr>>,
     /// Per-peer reachability bridge. AutoNAT v2 dial-back confirmations
     /// forwarded via [`LocalAddressManager::on_autonat_peer_confirmed`] flow
     /// into this tracker so the kademlia routing layer can score peers by
@@ -97,6 +119,7 @@ impl LocalAddressManager {
             local_peer_id: OnceLock::new(),
             observed_reachable: AtomicBool::new(false),
             confirmed_external_addrs: Mutex::new(HashSet::new()),
+            relayed_addrs: Mutex::new(HashSet::new()),
             reachability,
         }
     }
@@ -187,6 +210,12 @@ impl LocalAddressManager {
 
     /// Record an observed address; sets the reachability flag if the observed address is public-scope.
     pub fn on_observed_addr(&self, addr: &Multiaddr) {
+        // An observation through a circuit carries the relay's IP, not ours,
+        // so it says nothing about our public reachability.
+        if is_relayed(addr) {
+            return;
+        }
+
         // Strip /p2p/ suffix if present for classification
         let addr_for_classify = strip_peer_id(addr);
 
@@ -205,6 +234,19 @@ impl LocalAddressManager {
     /// public address is tracked (reversibly) and enables dials to other public
     /// peers.
     pub fn on_external_addr_confirmed(&self, addr: &Multiaddr) {
+        // A relayed circuit address (relay reservation) is tracked apart: it
+        // is not public reachability and never enters the advertised set.
+        if is_relayed(addr) {
+            if self
+                .relayed_addrs
+                .lock()
+                .insert(strip_trailing_peer_id(addr))
+            {
+                debug!(%addr, "Confirmed relayed circuit address");
+            }
+            return;
+        }
+
         let addr_for_classify = strip_peer_id(addr);
 
         if classify_multiaddr(&addr_for_classify) == Some(AddressScope::Public)
@@ -224,6 +266,17 @@ impl LocalAddressManager {
     /// signal clears; the node may still be public via static NAT addresses,
     /// public listen addresses, or the weak observed signal.
     pub fn on_external_addr_expired(&self, addr: &Multiaddr) {
+        if is_relayed(addr) {
+            if self
+                .relayed_addrs
+                .lock()
+                .remove(&strip_trailing_peer_id(addr))
+            {
+                debug!(%addr, "Relayed circuit address expired");
+            }
+            return;
+        }
+
         let addr_for_classify = strip_peer_id(addr);
         if self
             .confirmed_external_addrs
@@ -255,6 +308,11 @@ impl LocalAddressManager {
     /// order also decides which addresses survive the handshake's pre-encoding
     /// bound, so the operator-configured tier is never truncated in favour of
     /// an assumed one and a family's TCP leaf outlives its QUIC siblings.
+    ///
+    /// Relayed `/p2p-circuit` addresses never enter this set: it feeds the
+    /// signed handshake record and hive gossip, whose consumers dial direct
+    /// suites only. Relay-capable consumers read
+    /// [`Self::relayed_addresses`] instead.
     pub fn addresses_for_peer(&self, peer_addr: &Multiaddr) -> Vec<Multiaddr> {
         let peer_scope = classify_multiaddr(peer_addr).unwrap_or(AddressScope::Public);
 
@@ -270,6 +328,7 @@ impl LocalAddressManager {
                 addrs.sort_by(tier_order);
                 addrs
             })
+            .filter(|addr| !is_relayed(addr))
             .filter(|addr| seen.insert(addr.clone()))
             .collect();
 
@@ -303,6 +362,17 @@ impl LocalAddressManager {
                 self.local.addresses_for_scope(peer_scope, Some(peer_addr))
             }
         }
+    }
+
+    /// Confirmed relayed circuit addresses, `/p2p/{local_peer_id}` appended,
+    /// for consumers that dial through a relay client.
+    ///
+    /// Kept out of [`Self::addresses_for_peer`] and therefore out of the
+    /// signed handshake record and hive gossip.
+    pub fn relayed_addresses(&self) -> Vec<Multiaddr> {
+        let mut addrs: Vec<Multiaddr> = self.relayed_addrs.lock().iter().cloned().collect();
+        addrs.sort_by(tier_order);
+        self.with_peer_id(addrs)
     }
 
     /// Append /p2p/{local_peer_id} to addresses if local PeerId is set.
@@ -807,6 +877,99 @@ mod tests {
 
         assert!(manager.is_reachable());
         assert!(manager.has_confirmed_reachability());
+    }
+
+    fn circuit_addr(relay: PeerId) -> Multiaddr {
+        parse_addr(&format!(
+            "/ip4/203.0.113.9/tcp/1634/p2p/{relay}/p2p-circuit"
+        ))
+    }
+
+    fn has_circuit(addrs: &[Multiaddr]) -> bool {
+        addrs
+            .iter()
+            .any(|a| a.iter().any(|p| matches!(p, Protocol::P2pCircuit)))
+    }
+
+    #[test]
+    fn test_relayed_confirmed_addr_never_advertised() {
+        let local = Arc::new(LocalCapabilities::new());
+        local.on_new_listen_addr(parse_addr("/ip4/8.8.4.4/tcp/1634"));
+        let manager = LocalAddressManager::new(local, vec![]);
+
+        let relayed = circuit_addr(PeerId::random());
+        manager.on_external_addr_confirmed(&relayed);
+
+        let addrs = manager.addresses_for_peer(&parse_addr("/ip4/8.8.8.8/tcp/5000"));
+        assert!(!has_circuit(&addrs));
+        // The relayed set holds it for relay-capable consumers.
+        assert_eq!(manager.relayed_addresses(), vec![relayed]);
+    }
+
+    #[test]
+    fn test_relayed_confirmed_addr_is_not_public_reachability() {
+        let local = Arc::new(LocalCapabilities::new());
+        local.on_new_listen_addr(parse_addr("/ip4/192.168.1.1/tcp/1634"));
+        let manager = LocalAddressManager::new(local, vec![]);
+
+        manager.on_external_addr_confirmed(&circuit_addr(PeerId::random()));
+
+        assert!(!manager.has_confirmed_reachability());
+        assert!(!manager.is_reachable());
+    }
+
+    #[test]
+    fn test_relayed_addr_expiry_removes_it() {
+        let manager = create_manager(vec![]);
+        let relayed = circuit_addr(PeerId::random());
+
+        manager.on_external_addr_confirmed(&relayed);
+        assert_eq!(manager.relayed_addresses().len(), 1);
+
+        manager.on_external_addr_expired(&relayed);
+        assert!(manager.relayed_addresses().is_empty());
+    }
+
+    #[test]
+    fn test_relayed_addresses_keep_relay_identity_and_append_ours() {
+        let manager = create_manager(vec![]);
+        let local_id = PeerId::random();
+        manager.register_local_peer_id(local_id);
+
+        let relay = PeerId::random();
+        // Confirmation may arrive with our own trailing /p2p/ component; it is
+        // normalized away and re-appended on serve.
+        let confirmed = circuit_addr(relay).with(Protocol::P2p(local_id));
+        manager.on_external_addr_confirmed(&confirmed);
+
+        let addrs = manager.relayed_addresses();
+        assert_eq!(
+            addrs,
+            vec![circuit_addr(relay).with(Protocol::P2p(local_id))]
+        );
+        // The inner relay identity survives normalization.
+        assert!(addrs[0].to_string().contains(&relay.to_string()));
+    }
+
+    #[test]
+    fn test_configured_circuit_nat_addr_not_advertised() {
+        let relayed = circuit_addr(PeerId::random());
+        let manager = create_manager(vec![relayed, parse_addr("/ip4/203.0.113.50/tcp/1634")]);
+
+        let addrs = manager.addresses_for_peer(&parse_addr("/ip4/8.8.8.8/tcp/5000"));
+        assert!(!has_circuit(&addrs));
+        assert!(addrs.iter().any(|a| a.to_string().contains("203.0.113.50")));
+    }
+
+    #[test]
+    fn test_observed_relayed_addr_does_not_flip_reachable() {
+        let manager = create_manager(vec![]);
+
+        // Observed through a circuit: the public IP belongs to the relay.
+        manager.on_observed_addr(&circuit_addr(PeerId::random()));
+
+        assert!(!manager.is_reachable());
+        assert!(!manager.has_confirmed_reachability());
     }
 
     #[test]

--- a/docs/networking/address-management.md
+++ b/docs/networking/address-management.md
@@ -61,6 +61,8 @@ Advertised addresses are ordered by the `AddressTrust` tier of their source, hig
 
 The tier order also decides what survives the handshake's pre-encoding bound (see "What we put in our signed record" below): bounding truncates from the low-trust tail.
 
+Relayed `/p2p-circuit` addresses (classified `TransportRequirement::Relay` in `vertex-net-local`) are excluded from every tier: a confirmed circuit address (a relay reservation) is tracked in its own set, does not count as public reachability, and is served only through `LocalAddressManager::relayed_addresses` for consumers that dial through a relay client. The signed handshake record and hive gossip never carry a circuit address, since their consumers dial direct suites only.
+
 ### Scope-Based Selection
 
 When selecting addresses for a peer during handshake:


### PR DESCRIPTION
## What

Adds circuit-relay gating on top of the relay/DCUtR stack.

In `crates/net/local/src/transport.rs`, adds `TransportRequirement::Relay`, classified via an early return on `Protocol::P2pCircuit` in `TransportRequirement::of` so the circuit component dominates whatever suite the relay leg rides (an inner `/tcp` or `/quic-v1` hop, or a target `/p2p/` suffix, does not change the classification). `Relay` ranks last in `advertise_rank` and `transport_order`, alongside `Websocket`/`Memory`/`Other`. `TransportCapability::can_dial` continues to reject a `/p2p-circuit` address under every static suite, documented as a property of an injected relay client transport, mirroring the existing memory-transport pattern. New tests cover classification dominance across suites and target-suffix variants, per-capability dial rejection, and advertisement rank ordering.

In `crates/swarm/topology/src/nat_discovery.rs`, `LocalAddressManager` gains a dedicated `relayed_addrs` set, kept apart from `confirmed_external_addrs`. `on_external_addr_confirmed`/`on_external_addr_expired` branch on the new `is_relayed` classifier (backed by `TransportRequirement::Relay`) and route a confirmed circuit address into `relayed_addrs` instead of the direct-external set, normalizing away a trailing local `/p2p/` component while preserving the inner relay identity via `strip_trailing_peer_id`. `on_observed_addr` ignores a relayed observation outright, since it carries the relay's IP rather than ours. `addresses_for_peer` filters out any relayed address, so the signed handshake record and hive gossip never carry a circuit address. A new `relayed_addresses()` accessor serves the confirmed set (with `/p2p/{local_peer_id}` appended) to relay-capable consumers. `LocalAddressManager::new` also filters any configured `nat_addrs` entry that classifies as relayed, logging a warning and dropping it, so a `/p2p-circuit` NAT address can never reach `is_reachable`, the external-address emission that feeds identify, or gossip. `docs/networking/address-management.md` documents this exclusion.

## Why

A relayed circuit address proves reachability through a relay, not public reachability, and no transport stack vertex assembles can dial `/p2p-circuit` directly outside an injected relay client. Without this gating, a circuit address could leak into the signed handshake record, hive gossip, or the reachability signal, misrepresenting the node as directly dialable and contradicting the not-public-reachability invariant the relay/DCUtR stack depends on.

## Testing

270 topology tests and 71 net-local tests pass, covering: relay classification dominance across transport suites and target `/p2p` suffixes, per-`TransportCapability` dial rejection of a relayed address, advertisement rank ordering, confirmed-circuit tracking (insertion, expiry, relay-identity preservation across `/p2p/` normalization), exclusion from `addresses_for_peer` and from public-reachability signals, and the configured-`nat_addrs` case (a `/p2p-circuit` NAT address accepted unfiltered by the CLI is dropped at `LocalAddressManager::new` before it can reach `is_reachable` or the identify external-address emission). wasm build and all-features clippy also verified clean.

Closes #764

## AI Assistance

AI Assistance: Claude (Anthropic) used for implementation, red-teaming, and this PR description.
