### PR TITLE
chore(deps): pin nectar to the s187 train tip and sweep address aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Rules that catch the most review comments. None of these bend.
 
 Vertex owns the **node**: libp2p protocols, peer management, topology, storage backend, observability, CLI, the binary. `nectar` (https://github.com/nxm-rs/nectar) owns the **primitives and layer-2 constructs**: anything another Swarm consumer (light client, indexer, web tool, contract verifier) would want without a libp2p stack. Both repos are under nxm-rs control, so moving code across the boundary is a same-org PR.
 
-Belongs in `nectar`: chunk types (`CAC`, `SOC`), span encoding, BMT hash and proofs; address types (`SwarmAddress`, `OverlayAddress` derivation), proximity order, bin math; manifests (mantaray nodes, traversal, edge encoding); feeds (epoch grid, lookup, SOC-based mutability); postage (batch contract decode, stamp signing and verification, bucket math); erasure coding, redundancy, recovery; any pure-data validation needing neither network nor database.
+Belongs in `nectar`: chunk types (`CAC`, `SOC`), span encoding, BMT hash and proofs; address types (`OverlayAddress` derivation, `ChunkAddress`), proximity order, bin math; manifests (mantaray nodes, traversal, edge encoding); feeds (epoch grid, lookup, SOC-based mutability); postage (batch contract decode, stamp signing and verification, bucket math); erasure coding, redundancy, recovery; any pure-data validation needing neither network nor database.
 
 Belongs in `vertex`: libp2p `NetworkBehaviour`s and wire protocols; peer manager, topology, scoring, backoff, dialer; storage abstractions (`vertex-storage`) and backends (`vertex-storage-redb`); storer reserve, chunk store, redistribution agent; node lifecycle, builder, CLI, observability, RPC.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2714,7 +2714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3947,7 +3947,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4908,7 +4908,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 [[package]]
 name = "nectar-contracts"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=ef89a5df57178fb96f86544c05e14a6b7c0b34d9#ef89a5df57178fb96f86544c05e14a6b7c0b34d9"
+source = "git+https://github.com/nxm-rs/nectar?rev=118b66b97305c8fbd6511c37acc4917e9b822bef#118b66b97305c8fbd6511c37acc4917e9b822bef"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4918,12 +4918,13 @@ dependencies = [
 [[package]]
 name = "nectar-postage"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=ef89a5df57178fb96f86544c05e14a6b7c0b34d9#ef89a5df57178fb96f86544c05e14a6b7c0b34d9"
+source = "git+https://github.com/nxm-rs/nectar?rev=118b66b97305c8fbd6511c37acc4917e9b822bef#118b66b97305c8fbd6511c37acc4917e9b822bef"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "arbitrary",
  "byteorder",
+ "derive_more",
  "k256",
  "nectar-primitives",
  "serde",
@@ -4934,7 +4935,7 @@ dependencies = [
 [[package]]
 name = "nectar-primitives"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=ef89a5df57178fb96f86544c05e14a6b7c0b34d9#ef89a5df57178fb96f86544c05e14a6b7c0b34d9"
+source = "git+https://github.com/nxm-rs/nectar?rev=118b66b97305c8fbd6511c37acc4917e9b822bef#118b66b97305c8fbd6511c37acc4917e9b822bef"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -4950,7 +4951,6 @@ dependencies = [
  "hybrid-array",
  "js-sys",
  "keccak-batch",
- "once_cell",
  "parking_lot",
  "rand 0.10.1",
  "rayon",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "nectar-swarms"
 version = "0.4.0"
-source = "git+https://github.com/nxm-rs/nectar?rev=ef89a5df57178fb96f86544c05e14a6b7c0b34d9#ef89a5df57178fb96f86544c05e14a6b7c0b34d9"
+source = "git+https://github.com/nxm-rs/nectar?rev=118b66b97305c8fbd6511c37acc4917e9b822bef#118b66b97305c8fbd6511c37acc4917e9b822bef"
 dependencies = [
  "alloy-chains",
  "num_enum",
@@ -6667,7 +6667,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6725,7 +6725,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7478,7 +7478,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,17 +142,18 @@ indexing_slicing = "warn"
 # Track nectar via a single shared git source so the workspace resolves one
 # copy of shared nectar types; Cargo.lock pins the exact commit.
 #
-# Tracks nectar `main`, which carries the synchronous
-# BatchStore/StoreValidator/SnapshotStore conversion plus nectar-mantaray and
-# nectar-postage-usage's `client`/`issuer`/`seal` features that the browser
-# upload/download path (bin/swarm-demo) depends on.
-nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
-nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
+# Pins the tip of nectar's in-flight 0.5.0 train: the typed address world
+# (distinct ChunkAddress, BatchId and SocId newtypes, the SwarmAddress ->
+# OverlayAddress rename) plus the `arbitrary` feature on nectar-primitives
+# and nectar-postage that the fuzz harnesses consume. Re-pin to a main SHA
+# once the train merges.
+nectar-contracts = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
+nectar-swarms = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
 
 digest = "0.10"
 

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -60,18 +60,18 @@ async-trait = "0.1"
 # `parallel`/`wasm-threads`, keeping the single-threaded wasm profile (the demo
 # never calls `initThreadPool`, so there is no rayon worker pool and no shared
 # memory).
-nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
-nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
+nectar-primitives = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
+nectar-postage = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
 # `local-signer` brings the alloy-signer-local re-export for the in-browser key.
-nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
+nectar-postage-issuer = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
 # `issuer` + `seal` give signed content stamps (SnapshotIssuer) and the
 # usage-persistence seal path; default `std` is implied.
-nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9", features = [
+nectar-postage-usage = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef", features = [
     "issuer",
     "seal",
     "client",
 ] }
-nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "ef89a5df57178fb96f86544c05e14a6b7c0b34d9" }
+nectar-mantaray = { git = "https://github.com/nxm-rs/nectar", rev = "118b66b97305c8fbd6511c37acc4917e9b822bef" }
 
 # Chequebook address parsing for the optional SWAP config input and chain
 # types/signing for the browser. alloy-sol-types decodes the BatchCreated log

--- a/bin/swarm-demo/src/client/chain.rs
+++ b/bin/swarm-demo/src/client/chain.rs
@@ -85,7 +85,7 @@ impl DiscoveredBatch {
     /// Reconstruct a [`Batch`] from the discovered on-chain geometry.
     pub fn to_batch(&self) -> Batch {
         Batch::new(
-            self.batch_id,
+            self.batch_id.into(),
             0,
             0,
             self.owner,

--- a/bin/swarm-demo/src/client/download.rs
+++ b/bin/swarm-demo/src/client/download.rs
@@ -395,12 +395,12 @@ pub async fn walk(
     cache: &MemoryCache,
 ) -> Result<Vec<u8>, JsValue> {
     let getter = NetworkChunkGet::new(provider.clone(), cache.snapshot_map());
-    let mut manifest: PlainManifest<RetryGetter> =
-        PlainManifest::open(root, retrying(getter.clone()));
-    let result = manifest.lookup(path).await;
+    let manifest: PlainManifest<RetryGetter> = PlainManifest::open(root, retrying(getter.clone()));
+    let result = manifest.get(path).await;
     publish(&getter, cache);
-    let entry: Entry =
-        result.map_err(|e| JsValue::from_str(&format!("manifest lookup '{path}': {e}")))?;
+    let entry: Entry = result
+        .map_err(|e| JsValue::from_str(&format!("manifest lookup '{path}': {e}")))?
+        .ok_or_else(|| JsValue::from_str(&format!("manifest lookup '{path}': not found")))?;
 
     let file_root = entry
         .address()

--- a/bin/swarm-demo/src/client/mod.rs
+++ b/bin/swarm-demo/src/client/mod.rs
@@ -214,7 +214,7 @@ impl SwarmClient {
 /// Build an immutable [`Batch`] from the default geometry (discovery fallback).
 fn default_batch(batch_id: alloy_primitives::B256, owner: alloy_primitives::Address) -> Batch {
     Batch::new(
-        batch_id,
+        batch_id.into(),
         0,
         0,
         owner,

--- a/bin/swarm-demo/src/client/usage.rs
+++ b/bin/swarm-demo/src/client/usage.rs
@@ -7,7 +7,7 @@ use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage::Batch;
 use nectar_postage_usage::{
-    PublishedSequence, RootInfo, SealedChunk, Snapshot, SnapshotSink, SnapshotSource, SwarmAddress,
+    ChunkAddress, PublishedSequence, RootInfo, SealedChunk, Snapshot, SnapshotSink, SnapshotSource,
     seal_plan, usage_chunk_address,
 };
 use nectar_primitives::AnyChunk;
@@ -50,7 +50,7 @@ impl BrowserUsageSource {
 impl SnapshotSource for BrowserUsageSource {
     type Error = UsageAdapterError;
 
-    async fn fetch(&self, address: &SwarmAddress) -> Result<Option<Bytes>, Self::Error> {
+    async fn fetch(&self, address: &ChunkAddress) -> Result<Option<Bytes>, Self::Error> {
         match self.provider.retrieve_chunk(address).await {
             // A retrieved chunk is already address-validated (owner + signature
             // for a single-owner chunk). Its data payload is the snapshot payload

--- a/crates/storage/src/codecs.rs
+++ b/crates/storage/src/codecs.rs
@@ -1,7 +1,9 @@
 //! Codec implementations for fixed-byte key types.
 
 #[cfg(feature = "nectar")]
-crate::impl_fixed_codec!(nectar_primitives::SwarmAddress, 32);
+crate::impl_fixed_codec!(nectar_primitives::OverlayAddress, 32);
+#[cfg(feature = "nectar")]
+crate::impl_fixed_codec!(nectar_primitives::ChunkAddress, 32);
 
 #[cfg(feature = "alloy")]
 crate::impl_fixed_codec!(alloy_primitives::Address, 20);
@@ -13,29 +15,43 @@ mod tests {
     #[cfg(feature = "nectar")]
     mod nectar {
         use super::*;
-        use nectar_primitives::SwarmAddress;
+        use nectar_primitives::{ChunkAddress, OverlayAddress};
 
         #[test]
-        fn test_swarm_address_roundtrip() {
-            let addr = SwarmAddress::from([0x42u8; 32]);
+        fn test_overlay_address_roundtrip() {
+            let addr = OverlayAddress::from([0x42u8; 32]);
             let encoded = addr.encode();
-            let decoded = SwarmAddress::decode(&encoded).unwrap();
+            let decoded = OverlayAddress::decode(&encoded).unwrap();
             assert_eq!(decoded, addr);
         }
 
         #[test]
-        fn test_swarm_address_zero() {
-            let addr = SwarmAddress::from([0u8; 32]);
+        fn test_overlay_address_zero() {
+            let addr = OverlayAddress::from([0u8; 32]);
             let encoded = addr.encode();
-            let decoded = SwarmAddress::decode(&encoded).unwrap();
+            let decoded = OverlayAddress::decode(&encoded).unwrap();
             assert_eq!(decoded, addr);
         }
 
         #[test]
-        fn test_swarm_address_decode_wrong_length() {
-            assert!(SwarmAddress::decode(&[0u8; 31]).is_err());
-            assert!(SwarmAddress::decode(&[0u8; 33]).is_err());
-            assert!(SwarmAddress::decode(&[]).is_err());
+        fn test_overlay_address_decode_wrong_length() {
+            assert!(OverlayAddress::decode(&[0u8; 31]).is_err());
+            assert!(OverlayAddress::decode(&[0u8; 33]).is_err());
+            assert!(OverlayAddress::decode(&[]).is_err());
+        }
+
+        #[test]
+        fn test_chunk_address_roundtrip() {
+            let addr = ChunkAddress::from([0x42u8; 32]);
+            let encoded = addr.encode();
+            let decoded = ChunkAddress::decode(&encoded).unwrap();
+            assert_eq!(decoded, addr);
+        }
+
+        #[test]
+        fn test_chunk_address_decode_wrong_length() {
+            assert!(ChunkAddress::decode(&[0u8; 31]).is_err());
+            assert!(ChunkAddress::decode(&[]).is_err());
         }
     }
 

--- a/crates/swarm/accounting/pricing/src/fixed.rs
+++ b/crates/swarm/accounting/pricing/src/fixed.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use nectar_primitives::{ChunkAddress, SwarmAddress};
+use nectar_primitives::{ChunkAddress, XorMetric};
 use vertex_swarm_api::{Au, SwarmPricing};
 use vertex_swarm_primitives::OverlayAddress;
 use vertex_swarm_spec::SwarmSpec;
@@ -36,9 +36,7 @@ impl<S: SwarmSpec + Send + Sync + 'static> SwarmPricing for FixedPricer<S> {
     }
 
     fn peer_price(&self, peer: &OverlayAddress, chunk: &ChunkAddress) -> Au {
-        let peer_addr: &SwarmAddress = peer;
-        let chunk_addr: &SwarmAddress = chunk;
-        let proximity = peer_addr.proximity(chunk_addr);
+        let proximity = peer.proximity(chunk);
         // Saturating: a spec reporting a lower max_po than the proximity cap
         // would otherwise underflow into a giant factor.
         let factor = u64::from(self.spec.max_po()).saturating_sub(u64::from(proximity.get())) + 1;

--- a/crates/swarm/api/src/identity.rs
+++ b/crates/swarm/api/src/identity.rs
@@ -3,7 +3,7 @@
 use crate::SwarmSpec;
 use alloy_primitives::Address;
 use alloy_signer::{Signer, SignerSync};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use std::sync::Arc;
 use vertex_swarm_primitives::{OverlaySigner, SwarmNodeType};
 
@@ -31,7 +31,7 @@ pub trait SwarmIdentity: OverlaySigner + Send + Sync + 'static {
     fn node_type(&self) -> SwarmNodeType;
 
     /// Overlay address for Kademlia routing (the [`OverlaySigner`] facet).
-    fn overlay_address(&self) -> SwarmAddress {
+    fn overlay_address(&self) -> OverlayAddress {
         self.overlay()
     }
 

--- a/crates/swarm/builder/examples/upload_chunk.rs
+++ b/crates/swarm/builder/examples/upload_chunk.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use alloy_primitives::B256;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use nectar_postage::{Stamp, StampDigest, StampIndex};
+use nectar_postage::{BatchId, Stamp, StampDigest, StampIndex};
 use vertex_node_builder::NodeBuilder;
 use vertex_node_core::dirs::DataDirs;
 use vertex_swarm_api::{
@@ -36,7 +36,7 @@ use vertex_tasks::{TaskExecutor, TaskManager};
 /// postage batch.
 fn sign_stamp(address: &ChunkAddress) -> Result<Stamp, Box<dyn std::error::Error>> {
     let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11))?;
-    let batch = B256::repeat_byte(0x22);
+    let batch = BatchId::from(B256::repeat_byte(0x22));
     let index = StampIndex::new(0, 0);
     let timestamp = 1_700_000_000u64;
     let prehash = StampDigest::new(*address, batch, index, timestamp).to_prehash();

--- a/crates/swarm/builder/src/launch.rs
+++ b/crates/swarm/builder/src/launch.rs
@@ -699,7 +699,7 @@ mod tests {
     /// debits the serving peer exactly once through the reservation path.
     #[tokio::test]
     async fn builder_wiring_debits_an_origin_delivery() {
-        use nectar_primitives::{AnyChunk, ChunkAddress, ContentChunk};
+        use nectar_primitives::{AnyChunk, ContentChunk, OverlayAddress};
         use tokio::sync::mpsc;
         use vertex_swarm_api::{
             OriginAccounting, SwarmAccounting, SwarmPeerAccounting, SwarmPricing,
@@ -721,7 +721,7 @@ mod tests {
             .expect("valid content chunk")
             .into();
         let address = *chunk.address();
-        let overlay = ChunkAddress::from([0x5cu8; 32]);
+        let overlay = OverlayAddress::from([0x5cu8; 32]);
         let price = accounting.pricing().peer_price(&overlay, &address);
         assert!(price > Au::ZERO, "the per-chunk price is non-zero");
 

--- a/crates/swarm/builder/src/storer.rs
+++ b/crates/swarm/builder/src/storer.rs
@@ -648,7 +648,7 @@ mod tests {
             .expect("valid content chunk")
             .into();
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
         let cached = CachedChunk::new(chunk, Some(stamp));
         let address = *cached.address();
 

--- a/crates/swarm/builder/src/storer/composite.rs
+++ b/crates/swarm/builder/src/storer/composite.rs
@@ -75,7 +75,7 @@ mod tests {
 
     fn stamp_at(timestamp: u64) -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, timestamp, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, timestamp, sig)
     }
 
     fn content(payload: &'static [u8]) -> CachedChunk {
@@ -87,7 +87,7 @@ mod tests {
 
     fn soc(id: u8, payload: &'static [u8], stamp_ns: u64) -> CachedChunk {
         let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("signer");
-        let chunk: AnyChunk = SingleOwnerChunk::new(B256::repeat_byte(id), payload, &signer)
+        let chunk: AnyChunk = SingleOwnerChunk::new(B256::repeat_byte(id).into(), payload, &signer)
             .expect("valid soc")
             .into();
         CachedChunk::new(chunk, Some(stamp_at(stamp_ns)))

--- a/crates/swarm/client-behaviour/src/forward.rs
+++ b/crates/swarm/client-behaviour/src/forward.rs
@@ -24,7 +24,7 @@
 //! requester is never charged for a delivery it did not receive.
 
 use futures::future::BoxFuture;
-use nectar_primitives::{AnyChunk, ChunkAddress};
+use nectar_primitives::{AnyChunk, ChunkAddress, XorMetric};
 use vertex_swarm_api::{CommitOnWrite, SwarmTopologyRouting};
 use vertex_swarm_net_pushsync::Receipt;
 use vertex_swarm_primitives::{OverlayAddress, Stamp, StampedChunk};
@@ -280,7 +280,7 @@ mod tests {
     /// A stamped content chunk and its content-derived address.
     fn stamped() -> StampedChunk {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
         let chunk: AnyChunk = ContentChunk::new(&b"forwarded payload"[..])
             .expect("valid content chunk")
             .into();
@@ -291,7 +291,7 @@ mod tests {
     /// its proximity to the address is exactly `leading_bits` (the next bit is
     /// flipped). Used to place a peer at a controlled distance from the target.
     fn overlay_at_proximity(address: &ChunkAddress, leading_bits: usize) -> OverlayAddress {
-        let mut bytes = address.0.0;
+        let mut bytes = <[u8; 32]>::from(*address);
         // Flip the bit immediately after the shared prefix so the proximity is
         // exactly `leading_bits`: the first differing bit caps proximity.
         let byte = leading_bits / 8;

--- a/crates/swarm/client-behaviour/src/handler.rs
+++ b/crates/swarm/client-behaviour/src/handler.rs
@@ -1142,7 +1142,7 @@ mod tests {
 
     fn stamped(payload: &'static [u8]) -> StampedChunk {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
         let chunk: AnyChunk = ContentChunk::new(payload)
             .expect("valid content chunk")
             .into();

--- a/crates/swarm/identity/src/lib.rs
+++ b/crates/swarm/identity/src/lib.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{Address, B256, ChainId, Signature};
 use alloy_signer::SignerSync;
 use alloy_signer::k256::ecdsa::SigningKey;
 use alloy_signer_local::LocalSigner;
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use std::sync::Arc;
 use vertex_swarm_api::{SwarmIdentity, SwarmIdentityConfig, SwarmNodeType};
 use vertex_swarm_primitives::{NetworkId, Nonce, OverlaySigner, compute_overlay};
@@ -50,7 +50,7 @@ pub struct Identity {
     signer: Arc<LocalSigner<SigningKey>>,
     nonce: Nonce,
     /// Cached at construction time.
-    overlay: SwarmAddress,
+    overlay: OverlayAddress,
     node_type: SwarmNodeType,
     welcome_message: Option<String>,
     /// True if this identity was created from a random ephemeral signer rather
@@ -148,7 +148,7 @@ impl OverlaySigner for Identity {
     }
 
     /// Returns the overlay cached at construction rather than recomputing it.
-    fn overlay(&self) -> SwarmAddress {
+    fn overlay(&self) -> OverlayAddress {
         self.overlay
     }
 }

--- a/crates/swarm/localstore/src/backend/indexeddb.rs
+++ b/crates/swarm/localstore/src/backend/indexeddb.rs
@@ -27,7 +27,7 @@ struct AddrKey([u8; 32]);
 impl From<&ChunkAddress> for AddrKey {
     fn from(addr: &ChunkAddress) -> Self {
         let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(addr.as_slice());
+        bytes.copy_from_slice(addr.as_bytes());
         Self(bytes)
     }
 }
@@ -179,7 +179,7 @@ mod tests {
 
     fn stamp_at(timestamp: u64) -> Stamp {
         let sig = alloy_primitives::Signature::from_raw(&[1u8; 65]).expect("signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, timestamp, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, timestamp, sig)
     }
 
     fn cache_value(chunk: AnyChunk, stamp: Option<Stamp>) -> CacheValue {
@@ -203,9 +203,10 @@ mod tests {
     #[wasm_bindgen_test]
     fn stamped_single_owner_round_trips() {
         let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("signer");
-        let chunk: AnyChunk = SingleOwnerChunk::new(B256::repeat_byte(0x22), &b"soc"[..], &signer)
-            .expect("soc")
-            .into();
+        let chunk: AnyChunk =
+            SingleOwnerChunk::new(B256::repeat_byte(0x22).into(), &b"soc"[..], &signer)
+                .expect("soc")
+                .into();
         let value = cache_value(chunk, Some(stamp_at(42)));
         let decoded = decode_value(&encode_value(&value)).expect("decode");
         assert_eq!(decoded.0, value.0);

--- a/crates/swarm/localstore/src/chunk_store.rs
+++ b/crates/swarm/localstore/src/chunk_store.rs
@@ -231,7 +231,7 @@ mod tests {
 
     fn stamp_at(timestamp: u64) -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, timestamp, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, timestamp, sig)
     }
 
     fn content(payload: &'static [u8]) -> CachedChunk {
@@ -250,9 +250,10 @@ mod tests {
 
     fn soc(payload: &'static [u8], stamp_ns: u64) -> CachedChunk {
         let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("signer");
-        let chunk: AnyChunk = SingleOwnerChunk::new(B256::repeat_byte(0x22), payload, &signer)
-            .expect("valid soc")
-            .into();
+        let chunk: AnyChunk =
+            SingleOwnerChunk::new(B256::repeat_byte(0x22).into(), payload, &signer)
+                .expect("valid soc")
+                .into();
         CachedChunk::new(chunk, Some(stamp_at(stamp_ns)))
     }
 

--- a/crates/swarm/net/handshake/src/admission.rs
+++ b/crates/swarm/net/handshake/src/admission.rs
@@ -31,7 +31,7 @@
 
 use std::sync::Arc;
 
-use vertex_swarm_peer::{SwarmAddress, SwarmNodeType};
+use vertex_swarm_peer::{OverlayAddress, SwarmNodeType};
 
 pub use vertex_net_peer_registry::ConnectionDirection;
 
@@ -72,7 +72,7 @@ pub trait HandshakeAdmissionControl: Send + Sync + 'static {
     /// Evaluate a peer that just identified itself during the handshake.
     fn evaluate(
         &self,
-        peer_overlay: &SwarmAddress,
+        peer_overlay: &OverlayAddress,
         node_type: SwarmNodeType,
         direction: ConnectionDirection,
     ) -> AdmissionDecision;
@@ -85,7 +85,7 @@ pub struct AlwaysAccept;
 impl HandshakeAdmissionControl for AlwaysAccept {
     fn evaluate(
         &self,
-        _peer_overlay: &SwarmAddress,
+        _peer_overlay: &OverlayAddress,
         _node_type: SwarmNodeType,
         _direction: ConnectionDirection,
     ) -> AdmissionDecision {
@@ -96,7 +96,7 @@ impl HandshakeAdmissionControl for AlwaysAccept {
 impl<T: HandshakeAdmissionControl + ?Sized> HandshakeAdmissionControl for Arc<T> {
     fn evaluate(
         &self,
-        peer_overlay: &SwarmAddress,
+        peer_overlay: &OverlayAddress,
         node_type: SwarmNodeType,
         direction: ConnectionDirection,
     ) -> AdmissionDecision {
@@ -121,7 +121,7 @@ mod tests {
     fn always_accept_returns_accept() {
         let ac = AlwaysAccept;
         let decision = ac.evaluate(
-            &SwarmAddress::with_first_byte(0xaa),
+            &OverlayAddress::with_first_byte(0xaa),
             SwarmNodeType::Storer,
             ConnectionDirection::Inbound,
         );
@@ -132,7 +132,7 @@ mod tests {
     fn arc_delegates() {
         let ac: SharedAdmissionControl = default_admission_control();
         let decision = ac.evaluate(
-            &SwarmAddress::with_first_byte(0x01),
+            &OverlayAddress::with_first_byte(0x01),
             SwarmNodeType::Client,
             ConnectionDirection::Outbound,
         );

--- a/crates/swarm/net/handshake/src/codec/ack.rs
+++ b/crates/swarm/net/handshake/src/codec/ack.rs
@@ -1,6 +1,6 @@
 //! Ack message encoding/decoding for handshake protocol (15.0.0).
 
-use nectar_primitives::{NetworkId, Nonce, SwarmAddress, Timestamp};
+use nectar_primitives::{NetworkId, Nonce, OverlayAddress, Timestamp};
 use tracing::debug;
 use vertex_swarm_peer::{SwarmNodeType, SwarmPeer, SwarmPeerWire};
 
@@ -56,7 +56,7 @@ pub(crate) fn encode_swarm_peer(peer: &SwarmPeer) -> vertex_swarm_net_proto::han
     vertex_swarm_net_proto::handshake::SwarmPeer {
         multiaddrs: peer.serialize_multiaddrs(),
         signature: peer.signature().as_bytes().to_vec(),
-        overlay: peer.overlay().to_vec(),
+        overlay: peer.overlay().as_bytes().to_vec(),
         nonce: peer.nonce().as_slice().to_vec(),
         timestamp: peer.timestamp().get(),
         chequebook_address: peer
@@ -74,7 +74,7 @@ pub(crate) fn swarm_peer_from_proto(
 ) -> Result<SwarmPeer, HandshakeError> {
     let proto = proto.ok_or(HandshakeError::MissingField("address"))?;
 
-    let overlay = SwarmAddress::from_slice(proto.overlay.as_slice())
+    let overlay = OverlayAddress::from_slice(proto.overlay.as_slice())
         .inspect_err(|e| debug!(error = ?e, "invalid overlay in handshake address"))
         .map_err(|_| HandshakeError::InvalidOverlay)?;
 

--- a/crates/swarm/net/hive/benches/peer_cache.rs
+++ b/crates/swarm/net/hive/benches/peer_cache.rs
@@ -26,7 +26,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, 
 use dashmap::DashMap;
 use hashlink::LruCache;
 use parking_lot::{Mutex, RwLock};
-use vertex_swarm_peer::{Nonce, SwarmAddress, SwarmPeer, Timestamp};
+use vertex_swarm_peer::{Nonce, OverlayAddress, SwarmPeer, Timestamp};
 
 /// Mirrors the capacity documented in `src/cache.rs`.
 const CAPACITY: usize = 256;
@@ -39,12 +39,12 @@ const BATCHES_PER_THREAD: usize = 100;
 
 /// The cache operations the validation path needs.
 trait Cache: Sync {
-    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer>;
-    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer);
+    fn get(&self, overlay: &OverlayAddress, signature: &Signature) -> Option<SwarmPeer>;
+    fn insert(&self, overlay: OverlayAddress, peer: SwarmPeer);
 }
 
 /// One mutex around the whole LRU cache.
-struct SingleMutex(Mutex<LruCache<SwarmAddress, SwarmPeer>>);
+struct SingleMutex(Mutex<LruCache<OverlayAddress, SwarmPeer>>);
 
 impl SingleMutex {
     fn new() -> Self {
@@ -53,7 +53,7 @@ impl SingleMutex {
 }
 
 impl Cache for SingleMutex {
-    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+    fn get(&self, overlay: &OverlayAddress, signature: &Signature) -> Option<SwarmPeer> {
         let mut guard = self.0.lock();
         guard
             .get(overlay)
@@ -61,13 +61,13 @@ impl Cache for SingleMutex {
             .cloned()
     }
 
-    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+    fn insert(&self, overlay: OverlayAddress, peer: SwarmPeer) {
         self.0.lock().insert(overlay, peer);
     }
 }
 
 /// Read-write lock; the read path peeks without refreshing LRU order.
-struct RwLockPeek(RwLock<LruCache<SwarmAddress, SwarmPeer>>);
+struct RwLockPeek(RwLock<LruCache<OverlayAddress, SwarmPeer>>);
 
 impl RwLockPeek {
     fn new() -> Self {
@@ -76,7 +76,7 @@ impl RwLockPeek {
 }
 
 impl Cache for RwLockPeek {
-    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+    fn get(&self, overlay: &OverlayAddress, signature: &Signature) -> Option<SwarmPeer> {
         self.0
             .read()
             .peek(overlay)
@@ -84,7 +84,7 @@ impl Cache for RwLockPeek {
             .cloned()
     }
 
-    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+    fn insert(&self, overlay: OverlayAddress, peer: SwarmPeer) {
         self.0.write().insert(overlay, peer);
     }
 }
@@ -92,7 +92,7 @@ impl Cache for RwLockPeek {
 /// Per-shard mutexes selected by the last overlay byte (the `src/cache.rs`
 /// layout, generalized over shard count).
 struct ShardedMutex {
-    shards: Vec<Mutex<LruCache<SwarmAddress, SwarmPeer>>>,
+    shards: Vec<Mutex<LruCache<OverlayAddress, SwarmPeer>>>,
     mask: usize,
 }
 
@@ -107,13 +107,13 @@ impl ShardedMutex {
         }
     }
 
-    fn shard(&self, overlay: &SwarmAddress) -> &Mutex<LruCache<SwarmAddress, SwarmPeer>> {
-        &self.shards[usize::from(overlay.0[31]) & self.mask]
+    fn shard(&self, overlay: &OverlayAddress) -> &Mutex<LruCache<OverlayAddress, SwarmPeer>> {
+        &self.shards[usize::from(<[u8; 32]>::from(*overlay)[31]) & self.mask]
     }
 }
 
 impl Cache for ShardedMutex {
-    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+    fn get(&self, overlay: &OverlayAddress, signature: &Signature) -> Option<SwarmPeer> {
         let mut shard = self.shard(overlay).lock();
         shard
             .get(overlay)
@@ -121,7 +121,7 @@ impl Cache for ShardedMutex {
             .cloned()
     }
 
-    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+    fn insert(&self, overlay: OverlayAddress, peer: SwarmPeer) {
         self.shard(&overlay).lock().insert(overlay, peer);
     }
 }
@@ -133,7 +133,7 @@ struct AgedEntry {
 
 /// Concurrent sharded map with timestamp aging and scan-eviction.
 struct DashMapAged {
-    map: DashMap<SwarmAddress, AgedEntry>,
+    map: DashMap<OverlayAddress, AgedEntry>,
     clock: AtomicU64,
 }
 
@@ -147,7 +147,7 @@ impl DashMapAged {
 }
 
 impl Cache for DashMapAged {
-    fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+    fn get(&self, overlay: &OverlayAddress, signature: &Signature) -> Option<SwarmPeer> {
         let entry = self.map.get(overlay)?;
         if entry.peer.signature() != signature {
             return None;
@@ -159,7 +159,7 @@ impl Cache for DashMapAged {
         Some(entry.peer.clone())
     }
 
-    fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+    fn insert(&self, overlay: OverlayAddress, peer: SwarmPeer) {
         let stamp = self.clock.fetch_add(1, Ordering::Relaxed);
         self.map.insert(
             overlay,
@@ -169,7 +169,7 @@ impl Cache for DashMapAged {
             },
         );
         while self.map.len() > CAPACITY {
-            let mut oldest: Option<(SwarmAddress, u64)> = None;
+            let mut oldest: Option<(OverlayAddress, u64)> = None;
             for entry in self.map.iter() {
                 let used = entry.value().last_used.load(Ordering::Relaxed);
                 if oldest.is_none_or(|(_, o)| used < o) {
@@ -184,11 +184,11 @@ impl Cache for DashMapAged {
 
 /// Deterministic overlay; the last byte spreads keys evenly across shards,
 /// matching the uniform distribution of real (hash-output) overlays.
-fn overlay(i: u64) -> SwarmAddress {
+fn overlay(i: u64) -> OverlayAddress {
     let mut bytes = [0u8; 32];
     bytes[..8].copy_from_slice(&i.to_le_bytes());
     bytes[31] = i as u8;
-    SwarmAddress::from(B256::from(bytes))
+    OverlayAddress::from(B256::from(bytes))
 }
 
 fn signature() -> Signature {

--- a/crates/swarm/net/hive/src/cache.rs
+++ b/crates/swarm/net/hive/src/cache.rs
@@ -19,7 +19,7 @@
 use alloy_primitives::Signature;
 use hashlink::LruCache;
 use parking_lot::Mutex;
-use vertex_swarm_peer::{SwarmAddress, SwarmPeer};
+use vertex_swarm_peer::{OverlayAddress, SwarmPeer};
 
 /// Maximum validated peers to cache across all shards (bounds memory).
 pub(crate) const PEER_CACHE_CAPACITY: usize = 256;
@@ -45,7 +45,7 @@ const _: () = {
 /// an equal slice of it and ages its entries with its own LRU list, so
 /// eviction is approximate global LRU.
 pub(crate) struct PeerCache {
-    shards: [Mutex<LruCache<SwarmAddress, SwarmPeer>>; SHARD_COUNT],
+    shards: [Mutex<LruCache<OverlayAddress, SwarmPeer>>; SHARD_COUNT],
 }
 
 impl Default for PeerCache {
@@ -61,8 +61,8 @@ impl Default for PeerCache {
 impl PeerCache {
     /// Shard owning the given overlay address.
     #[allow(clippy::indexing_slicing)] // byte 31 of a 32-byte address; index masked below SHARD_COUNT
-    fn shard(&self, overlay: &SwarmAddress) -> &Mutex<LruCache<SwarmAddress, SwarmPeer>> {
-        let index = usize::from(overlay.0[31]) & (SHARD_COUNT - 1);
+    fn shard(&self, overlay: &OverlayAddress) -> &Mutex<LruCache<OverlayAddress, SwarmPeer>> {
+        let index = usize::from(<[u8; 32]>::from(*overlay)[31]) & (SHARD_COUNT - 1);
         &self.shards[index]
     }
 
@@ -72,7 +72,7 @@ impl PeerCache {
     /// A hit refreshes the entry's LRU position within its shard. A cached
     /// record with a different signature is treated as a miss; the caller
     /// re-validates and overwrites via [`Self::insert`].
-    pub(crate) fn get(&self, overlay: &SwarmAddress, signature: &Signature) -> Option<SwarmPeer> {
+    pub(crate) fn get(&self, overlay: &OverlayAddress, signature: &Signature) -> Option<SwarmPeer> {
         let mut shard = self.shard(overlay).lock();
         shard
             .get(overlay)
@@ -82,7 +82,7 @@ impl PeerCache {
 
     /// Store a validated record, evicting the least recently used entry of
     /// its shard when the shard is full.
-    pub(crate) fn insert(&self, overlay: SwarmAddress, peer: SwarmPeer) {
+    pub(crate) fn insert(&self, overlay: OverlayAddress, peer: SwarmPeer) {
         self.shard(&overlay).lock().insert(overlay, peer);
     }
 
@@ -106,12 +106,12 @@ mod tests {
         Signature::from_raw(&raw).unwrap()
     }
 
-    fn overlay(index: usize) -> SwarmAddress {
+    fn overlay(index: usize) -> OverlayAddress {
         let mut bytes = [0u8; 32];
         bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
         // Spread the low byte so shards fill evenly.
         bytes[31] = (index % 251) as u8;
-        SwarmAddress::from(B256::from(bytes))
+        OverlayAddress::from(B256::from(bytes))
     }
 
     fn peer(index: usize, sig: Signature) -> SwarmPeer {
@@ -157,7 +157,7 @@ mod tests {
 
         // Insert a hot set, then keep it warm while flooding with three times
         // the total capacity of one-shot entries.
-        let hot: Vec<SwarmAddress> = (0..16).map(overlay).collect();
+        let hot: Vec<OverlayAddress> = (0..16).map(overlay).collect();
         for (i, key) in hot.iter().enumerate() {
             cache.insert(*key, peer(i, sig));
         }

--- a/crates/swarm/net/hive/src/codec.rs
+++ b/crates/swarm/net/hive/src/codec.rs
@@ -9,7 +9,7 @@ pub(crate) fn encode_peers(peers: &[SwarmPeer]) -> vertex_swarm_net_proto::hive:
         .map(|p| vertex_swarm_net_proto::hive::SwarmPeer {
             multiaddrs: p.serialize_multiaddrs(),
             signature: p.signature().as_bytes().to_vec(),
-            overlay: p.overlay().as_slice().to_vec(),
+            overlay: p.overlay().as_bytes().to_vec(),
             nonce: p.nonce().as_slice().to_vec(),
             timestamp: p.timestamp().get(),
             chequebook_address: p

--- a/crates/swarm/net/hive/src/protocol.rs
+++ b/crates/swarm/net/hive/src/protocol.rs
@@ -14,7 +14,7 @@ use vertex_swarm_api::{SwarmIdentity, SwarmSpec};
 use vertex_swarm_net_headers::{
     HeaderedInbound, HeaderedOutbound, HeaderedStream, Outbound, ProtocolStreamError,
 };
-use vertex_swarm_peer::{SwarmAddress, SwarmPeer, Timestamp};
+use vertex_swarm_peer::{OverlayAddress, SwarmPeer, Timestamp};
 use vertex_swarm_primitives::{NetworkId, Nonce};
 use vertex_tasks::TaskExecutor;
 use vertex_util_runtime::time::Instant;
@@ -146,7 +146,7 @@ impl<I: SwarmIdentity> HeaderedInbound for HiveInner<I> {
 async fn validate_batch_blocking(
     raw_peers: Vec<vertex_swarm_net_proto::hive::SwarmPeer>,
     network_id: NetworkId,
-    local_overlay: SwarmAddress,
+    local_overlay: OverlayAddress,
     cache: Arc<PeerCache>,
 ) -> (Vec<SwarmPeer>, usize, usize) {
     let Ok(executor) = TaskExecutor::try_current() else {
@@ -168,7 +168,7 @@ async fn validate_batch_blocking(
 fn validate_batch(
     raw_peers: Vec<vertex_swarm_net_proto::hive::SwarmPeer>,
     network_id: NetworkId,
-    local_overlay: &SwarmAddress,
+    local_overlay: &OverlayAddress,
     cache: &PeerCache,
 ) -> (Vec<SwarmPeer>, usize, usize) {
     let validation_start = Instant::now();
@@ -206,13 +206,13 @@ fn validate_batch(
 fn validate_proto_peer(
     p: vertex_swarm_net_proto::hive::SwarmPeer,
     network_id: NetworkId,
-    local_overlay: &SwarmAddress,
+    local_overlay: &OverlayAddress,
     cache: &PeerCache,
 ) -> Result<SwarmPeer, ValidationFailure> {
     let overlay = B256::try_from(p.overlay.as_slice()).map_err(ValidationFailure::OverlayLength)?;
 
     // Reject our own overlay address to prevent self-dial
-    let peer_overlay = SwarmAddress::from(overlay);
+    let peer_overlay = OverlayAddress::from(overlay);
     if peer_overlay == *local_overlay {
         debug!("Hive: rejected self-overlay from peer exchange");
         return Err(ValidationFailure::SelfOverlay);

--- a/crates/swarm/net/pullsync/src/codec.rs
+++ b/crates/swarm/net/pullsync/src/codec.rs
@@ -123,15 +123,15 @@ impl ChunkDescriptor {
 
     fn into_proto(self) -> vertex_swarm_net_proto::pullsync::Chunk {
         vertex_swarm_net_proto::pullsync::Chunk {
-            address: self.address.to_vec(),
-            batch_id: self.batch_id.to_vec(),
+            address: self.address.as_bytes().to_vec(),
+            batch_id: self.batch_id.as_slice().to_vec(),
             stamp_hash: self.stamp_hash.to_vec(),
         }
     }
 
     fn from_proto(proto: vertex_swarm_net_proto::pullsync::Chunk) -> Result<Self, PullsyncError> {
         let address = ChunkAddress::from_slice(&proto.address)?;
-        let batch_id = b256_from_slice(&proto.batch_id, "batch_id")?;
+        let batch_id = BatchId::from(b256_from_slice(&proto.batch_id, "batch_id")?);
         let stamp_hash = b256_from_slice(&proto.stamp_hash, "stamp_hash")?;
         Ok(Self {
             address,
@@ -256,7 +256,7 @@ impl ProtoMessage for Delivery {
         let address = *self.chunk.address();
         let (chunk, stamp) = (*self.chunk).into_parts();
         Ok(vertex_swarm_net_proto::pullsync::Delivery {
-            address: address.to_vec(),
+            address: address.as_bytes().to_vec(),
             data: chunk.into_bytes().to_vec(),
             stamp: stamp.to_bytes().to_vec(),
         })
@@ -287,7 +287,7 @@ mod tests {
 
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig)
     }
 
     fn test_stamped_chunk() -> StampedChunk {
@@ -300,7 +300,7 @@ mod tests {
     fn descriptor() -> ChunkDescriptor {
         ChunkDescriptor::new(
             ChunkAddress::new([0x11; 32]),
-            B256::repeat_byte(0x22),
+            B256::repeat_byte(0x22).into(),
             B256::repeat_byte(0x33),
         )
     }
@@ -425,7 +425,9 @@ mod proptests {
 
     fn chunk_descriptor() -> impl Strategy<Value = ChunkDescriptor> {
         (arb::<ChunkAddress>(), any::<B256>(), any::<B256>()).prop_map(
-            |(address, batch_id, stamp_hash)| ChunkDescriptor::new(address, batch_id, stamp_hash),
+            |(address, batch_id, stamp_hash)| {
+                ChunkDescriptor::new(address, batch_id.into(), stamp_hash)
+            },
         )
     }
 

--- a/crates/swarm/net/pullsync/src/protocol.rs
+++ b/crates/swarm/net/pullsync/src/protocol.rs
@@ -381,7 +381,7 @@ mod tests {
             7,
             vec![ChunkDescriptor::new(
                 ChunkAddress::new([0; 32]),
-                B256::ZERO,
+                B256::ZERO.into(),
                 B256::ZERO,
             )],
         );

--- a/crates/swarm/net/pullsync/tests/interop.rs
+++ b/crates/swarm/net/pullsync/tests/interop.rs
@@ -39,7 +39,7 @@ where
 fn descriptor(addr: u8, batch: u8, hash: u8) -> ChunkDescriptor {
     ChunkDescriptor::new(
         ChunkAddress::new([addr; 32]),
-        B256::repeat_byte(batch),
+        B256::repeat_byte(batch).into(),
         B256::repeat_byte(hash),
     )
 }
@@ -148,7 +148,7 @@ fn want_bitvector_is_lsb_first_fixed_bytes() {
 #[test]
 fn delivery_fixed_bytes_and_roundtrip() {
     let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
     let chunk: AnyChunk = ContentChunk::new(&b"pullsync payload"[..])
         .expect("valid content chunk")
         .into();
@@ -173,7 +173,7 @@ fn delivery_fixed_bytes_and_roundtrip() {
 
     // Reconstructs to the requested address.
     let proto = vertex_swarm_net_proto::pullsync::Delivery {
-        address: address.to_vec(),
+        address: address.as_bytes().to_vec(),
         data: wire_data.to_vec(),
         stamp: stamp.to_bytes().to_vec(),
     };

--- a/crates/swarm/net/pushsync/src/codec.rs
+++ b/crates/swarm/net/pushsync/src/codec.rs
@@ -46,7 +46,7 @@ impl ProtoMessage for Delivery {
         let address = *self.chunk.address();
         let (chunk, stamp) = (*self.chunk).into_parts();
         Ok(vertex_swarm_net_proto::pushsync::Delivery {
-            address: address.to_vec(),
+            address: address.as_bytes().to_vec(),
             data: chunk.into_bytes().to_vec(),
             stamp: stamp.to_bytes().to_vec(),
         })
@@ -144,7 +144,7 @@ impl ProtoMessage for ReceiptResponse {
             // symmetry with the decode path and carries no meaningful payload.
             Self::Failed => Ok(vertex_swarm_net_proto::pushsync::Receipt::default()),
             Self::Stored(receipt) => Ok(vertex_swarm_net_proto::pushsync::Receipt {
-                address: receipt.address.to_vec(),
+                address: receipt.address.as_bytes().to_vec(),
                 signature: receipt.signature.as_bytes().to_vec(),
                 nonce: receipt.nonce.as_slice().to_vec(),
                 storage_radius: u32::from(receipt.storage_radius.get()),
@@ -196,7 +196,7 @@ mod tests {
     /// A stamp with a deterministic, well-formed signature for roundtrip tests.
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig)
     }
 
     fn test_stamped_chunk() -> StampedChunk {

--- a/crates/swarm/net/pushsync/src/receipt.rs
+++ b/crates/swarm/net/pushsync/src/receipt.rs
@@ -16,7 +16,7 @@
 //! credible local floor it returns [`DepthVerdict::Unverifiable`] rather than
 //! trusting the radius alone.
 
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, XorMetric};
 use vertex_swarm_primitives::{
     NeighborhoodDepth, NetworkId, Nonce, OverlayAddress, OverlaySigner, StorageRadius,
     compute_overlay,

--- a/crates/swarm/net/retrieval/src/codec.rs
+++ b/crates/swarm/net/retrieval/src/codec.rs
@@ -40,7 +40,7 @@ impl ProtoMessage for Request {
 
     fn into_proto(self) -> Result<Self::Proto, Self::EncodeError> {
         Ok(vertex_swarm_net_proto::retrieval::Request {
-            addr: self.address.to_vec(),
+            addr: self.address.as_bytes().to_vec(),
         })
     }
 
@@ -221,7 +221,7 @@ mod tests {
     /// A stamp with a deterministic, well-formed signature for roundtrip tests.
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig)
     }
 
     fn content_stamped() -> StampedChunk {
@@ -235,7 +235,7 @@ mod tests {
         use alloy_signer_local::PrivateKeySigner;
         let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("valid signer");
         let chunk: AnyChunk =
-            SingleOwnerChunk::new(B256::repeat_byte(0x22), &b"soc payload"[..], &signer)
+            SingleOwnerChunk::new(B256::repeat_byte(0x22).into(), &b"soc payload"[..], &signer)
                 .expect("valid soc")
                 .into();
         StampedChunk::new(chunk, test_stamp())

--- a/crates/swarm/net/retrieval/src/protocol.rs
+++ b/crates/swarm/net/retrieval/src/protocol.rs
@@ -214,7 +214,7 @@ mod tests {
     /// signature plus the fixed batch id, indices, and timestamp.
     fn full_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xab), 11, 22, 33, sig)
+        Stamp::new(B256::repeat_byte(0xab).into(), 11, 22, 33, sig)
     }
 
     /// The largest legitimate delivery: a single-owner chunk (the biggest chunk
@@ -223,7 +223,8 @@ mod tests {
     fn maximal_delivery() -> StampedChunk {
         let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("valid signer");
         let body = vec![0x5au8; DEFAULT_BODY_SIZE];
-        let soc = SingleOwnerChunk::new(B256::repeat_byte(0x22), body, &signer).expect("valid soc");
+        let soc = SingleOwnerChunk::new(B256::repeat_byte(0x22).into(), body, &signer)
+            .expect("valid soc");
         let chunk: AnyChunk = soc.into();
         StampedChunk::new(chunk, full_stamp())
     }

--- a/crates/swarm/node/src/chunks/providers.rs
+++ b/crates/swarm/node/src/chunks/providers.rs
@@ -141,7 +141,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use nectar_primitives::SwarmAddress;
+    use nectar_primitives::OverlayAddress;
 
     use super::*;
 
@@ -179,7 +179,7 @@ mod tests {
         /// topology mock.
         async fn race_over_handle(
             handle: ClientHandle,
-            candidates: Vec<SwarmAddress>,
+            candidates: Vec<OverlayAddress>,
             address: ChunkAddress,
         ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
             race_candidates(candidates, RETRIEVAL_STAGGER, move |peer| {
@@ -195,8 +195,8 @@ mod tests {
             let handle = ClientHandle::new(tx);
 
             let address = address(0xaa);
-            let peer_a = SwarmAddress::from([1u8; 32]);
-            let peer_b = SwarmAddress::from([2u8; 32]);
+            let peer_a = OverlayAddress::from([1u8; 32]);
+            let peer_b = OverlayAddress::from([2u8; 32]);
 
             let start = Instant::now();
             let race = tokio::spawn(race_over_handle(handle, vec![peer_a, peer_b], address));
@@ -262,7 +262,10 @@ mod tests {
             let handle = ClientHandle::new(tx);
 
             let address = address(0xbb);
-            let candidates = vec![SwarmAddress::from([1u8; 32]), SwarmAddress::from([2u8; 32])];
+            let candidates = vec![
+                OverlayAddress::from([1u8; 32]),
+                OverlayAddress::from([2u8; 32]),
+            ];
 
             let outcome = race_over_handle(handle, candidates, address).await;
             assert!(
@@ -312,8 +315,8 @@ mod tests {
             None => unreachable!(),
         };
 
-        fn overlay(n: u8) -> SwarmAddress {
-            SwarmAddress::from([n; 32])
+        fn overlay(n: u8) -> OverlayAddress {
+            OverlayAddress::from([n; 32])
         }
 
         fn test_chunk() -> nectar_primitives::AnyChunk {
@@ -328,7 +331,7 @@ mod tests {
         async fn race_with_limiter(
             handle: ClientHandle,
             limiter: Arc<PeerInflightLimiter>,
-            candidates: Vec<SwarmAddress>,
+            candidates: Vec<OverlayAddress>,
             address: ChunkAddress,
         ) -> Result<RetrievalResult, RaceFailure<ChunkTransferError>> {
             let (candidates, _enforce_cap) = limiter.available(candidates);
@@ -354,7 +357,7 @@ mod tests {
             let handle = ClientHandle::new(tx);
             let limiter = Arc::new(PeerInflightLimiter::new(CAP_ONE));
 
-            let pool: Vec<SwarmAddress> = (1..=16).map(overlay).collect();
+            let pool: Vec<OverlayAddress> = (1..=16).map(overlay).collect();
             let (candidates, _enforce_cap) = limiter.available(pool);
             assert_eq!(candidates.len(), 16, "all 16 peers have a free slot");
 

--- a/crates/swarm/node/src/client_service.rs
+++ b/crates/swarm/node/src/client_service.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, XorMetric};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use vertex_swarm_api::{
@@ -1528,7 +1528,7 @@ mod tests {
         raw[..64].fill(1);
         raw[64] = 27;
         let sig = Signature::try_from(&raw[..]).expect("valid signature bytes");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig)
     }
 
     #[test]

--- a/crates/swarm/node/src/dispatch.rs
+++ b/crates/swarm/node/src/dispatch.rs
@@ -24,7 +24,7 @@ use std::pin::pin;
 use futures::future::{Either, select};
 use futures_timer::Delay;
 use metrics::{counter, histogram};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::XorMetric;
 use tokio::sync::OwnedSemaphorePermit;
 use tracing::{debug, warn};
 use vertex_swarm_api::{
@@ -701,7 +701,7 @@ where
     async fn race_attempts(
         &self,
         candidates: Vec<OverlayAddress>,
-        chunk_address: SwarmAddress,
+        chunk_address: ChunkAddress,
         bounds: RaceBounds,
         enforce_cap: bool,
         attempts: &AtomicUsize,
@@ -742,7 +742,7 @@ where
     /// [`SwarmError::RetrievalExhausted`]; the attempt count and last error stay
     /// in the metrics and debug log, never the error variant.
     pub async fn retrieve(&self, address: &ChunkAddress) -> SwarmResult<ChunkRetrievalResult> {
-        let chunk_address = SwarmAddress::new(address.0.into());
+        let chunk_address = *address;
         let attempts = AtomicUsize::new(0);
 
         // PRIMARY: bin-bucket proximity route. Route the chunk to its Kademlia
@@ -1006,14 +1006,14 @@ where
 /// entry point. Within every bin the peers are ordered closest-to-chunk first.
 /// `peers_in_bin` returns connected peers only; retrieval never dials.
 pub(crate) fn bin_routed_order(
-    chunk: &SwarmAddress,
-    local: &SwarmAddress,
+    chunk: &ChunkAddress,
+    local: &OverlayAddress,
     max_bin: u8,
     width: usize,
-    peers_in_bin: impl Fn(Bin) -> Vec<SwarmAddress>,
-) -> Vec<SwarmAddress> {
+    peers_in_bin: impl Fn(Bin) -> Vec<OverlayAddress>,
+) -> Vec<OverlayAddress> {
     let b = chunk.proximity(local).get().min(max_bin);
-    let mut order: Vec<SwarmAddress> = Vec::with_capacity(width);
+    let mut order: Vec<OverlayAddress> = Vec::with_capacity(width);
     for bin_index in spill_bins(b, max_bin) {
         if order.len() >= width {
             break;
@@ -1213,7 +1213,7 @@ impl RelayOp for PushRelay {
 ///   caller treats the push as unconfirmed.
 fn accept_origin_receipt(
     receipt: &Receipt,
-    peer: SwarmAddress,
+    peer: OverlayAddress,
     local_depth: NeighborhoodDepth,
     neighbourhood_credible: bool,
     reporter: &dyn PeerReporter,
@@ -1248,13 +1248,13 @@ mod tests {
 
         #[derive(Default)]
         struct RecordingReporter {
-            reports: Mutex<Vec<(SwarmAddress, SwarmScoringEvent, ReportSource)>>,
+            reports: Mutex<Vec<(OverlayAddress, SwarmScoringEvent, ReportSource)>>,
         }
 
         impl PeerReporter for RecordingReporter {
             fn report_peer(
                 &self,
-                overlay: &SwarmAddress,
+                overlay: &OverlayAddress,
                 event: SwarmScoringEvent,
                 source: ReportSource,
             ) {
@@ -1264,7 +1264,7 @@ mod tests {
 
         impl RecordingReporter {
             /// Return the single recorded report, asserting exactly one exists.
-            fn single(&self) -> (SwarmAddress, SwarmScoringEvent, ReportSource) {
+            fn single(&self) -> (OverlayAddress, SwarmScoringEvent, ReportSource) {
                 let reports = self.reports.lock().unwrap();
                 assert_eq!(reports.len(), 1, "expected exactly one report");
                 *reports.first().expect("one report")
@@ -1329,7 +1329,7 @@ mod tests {
             let addr = address(0xff);
             let receipt = signed_receipt(&signer, &addr, 8, radius(8));
             let reporter = RecordingReporter::default();
-            let peer = SwarmAddress::from([0x11; 32]);
+            let peer = OverlayAddress::from([0x11; 32]);
 
             assert_eq!(
                 accept_origin_receipt(&receipt, peer, depth(8), true, &reporter),
@@ -1347,7 +1347,7 @@ mod tests {
             // rejects it regardless of the claimed radius.
             let receipt = signed_receipt(&signer, &addr, 0, radius(8));
             let reporter = RecordingReporter::default();
-            let peer = SwarmAddress::from([0x22; 32]);
+            let peer = OverlayAddress::from([0x22; 32]);
 
             let DepthVerdict::Shallow(_) =
                 accept_origin_receipt(&receipt, peer, depth(12), true, &reporter)
@@ -1370,7 +1370,7 @@ mod tests {
             let addr = address(0xff);
             let receipt = signed_receipt(&signer, &addr, 0, radius(0));
             let reporter = RecordingReporter::default();
-            let peer = SwarmAddress::from([0x55; 32]);
+            let peer = OverlayAddress::from([0x55; 32]);
 
             assert!(
                 matches!(
@@ -1392,7 +1392,7 @@ mod tests {
             let addr = address(0xff);
             let receipt = signed_receipt(&signer, &addr, 0, radius(0));
             let reporter = RecordingReporter::default();
-            let peer = SwarmAddress::from([0x66; 32]);
+            let peer = OverlayAddress::from([0x66; 32]);
 
             assert_eq!(
                 accept_origin_receipt(&receipt, peer, depth(0), false, &reporter),
@@ -1411,15 +1411,22 @@ mod tests {
         use std::collections::HashMap;
 
         use super::super::{bin_routed_order, spill_bins};
-        use nectar_primitives::SwarmAddress;
+        use nectar_primitives::{ChunkAddress, OverlayAddress, XorMetric};
         use vertex_swarm_api::Bin;
 
         /// An address with `byte0` set, the rest zero, so its proximity to the
         /// zero local overlay is controllable.
-        fn addr(byte0: u8) -> SwarmAddress {
+        fn addr(byte0: u8) -> OverlayAddress {
             let mut bytes = [0u8; 32];
             bytes[0] = byte0;
-            SwarmAddress::from(bytes)
+            OverlayAddress::from(bytes)
+        }
+
+        /// A chunk address with `byte0` set, the rest zero.
+        fn chunk_addr(byte0: u8) -> ChunkAddress {
+            let mut bytes = [0u8; 32];
+            bytes[0] = byte0;
+            ChunkAddress::from(bytes)
         }
 
         #[test]
@@ -1441,13 +1448,13 @@ mod tests {
             // local is the zero overlay; chunk 0x08 (0000_1000) shares its first
             // four bits with local, so the forwarding bin is 4.
             let local = addr(0x00);
-            let chunk = addr(0x08);
+            let chunk = chunk_addr(0x08);
             // One sentinel peer per bin, encoding the bin index in byte 1.
             let peers = |bin: Bin| {
                 let mut bytes = [0u8; 32];
                 bytes[1] = bin.get();
                 bytes[2] = 0x01; // distinguish from local/chunk
-                vec![SwarmAddress::from(bytes)]
+                vec![OverlayAddress::from(bytes)]
             };
 
             let order = bin_routed_order(&chunk, &local, 8, 32, peers);
@@ -1465,7 +1472,7 @@ mod tests {
         #[test]
         fn orders_within_a_bin_by_closeness_to_the_chunk() {
             let local = addr(0x00);
-            let chunk = addr(0x08);
+            let chunk = chunk_addr(0x08);
             let near = addr(0x08); // shares the chunk's prefix: high proximity
             let far = addr(0xff); // diverges at the first bit: proximity 0
             let b = chunk.proximity(&local).get();
@@ -1489,7 +1496,7 @@ mod tests {
         #[test]
         fn respects_the_width_cap() {
             let local = addr(0x00);
-            let chunk = addr(0x08);
+            let chunk = chunk_addr(0x08);
             // Three peers in every bin; a width of 5 takes only the first five.
             let peers = |bin: Bin| {
                 (0u8..3)
@@ -1497,7 +1504,7 @@ mod tests {
                         let mut bytes = [0u8; 32];
                         bytes[1] = bin.get();
                         bytes[2] = i + 1;
-                        SwarmAddress::from(bytes)
+                        OverlayAddress::from(bytes)
                     })
                     .collect::<Vec<_>>()
             };
@@ -1508,8 +1515,8 @@ mod tests {
         #[test]
         fn empty_bins_yield_no_candidates() {
             let local = addr(0x00);
-            let chunk = addr(0x08);
-            let empty: HashMap<u8, Vec<SwarmAddress>> = HashMap::new();
+            let chunk = chunk_addr(0x08);
+            let empty: HashMap<u8, Vec<OverlayAddress>> = HashMap::new();
             let order = bin_routed_order(&chunk, &local, 8, 32, |bin| {
                 empty.get(&bin.get()).cloned().unwrap_or_default()
             });
@@ -1518,14 +1525,14 @@ mod tests {
     }
 
     mod null_objects {
-        use nectar_primitives::SwarmAddress;
+        use nectar_primitives::OverlayAddress;
         use vertex_swarm_api::ChunkAddress;
         use vertex_tasks::time::Duration;
 
         use super::super::{CandidateOrdering, LatencyHint, NoLatencyHint, ProximityOnly};
 
-        fn overlay(n: u8) -> SwarmAddress {
-            SwarmAddress::from([n; 32])
+        fn overlay(n: u8) -> OverlayAddress {
+            OverlayAddress::from([n; 32])
         }
 
         #[test]
@@ -1559,7 +1566,7 @@ mod tests {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
-        use nectar_primitives::SwarmAddress;
+        use nectar_primitives::OverlayAddress;
 
         use super::super::{
             InflightLimit, RETRIEVE_ATTEMPT_BUDGET, RETRIEVE_DEADLINE, RETRIEVE_MAX_IN_FLIGHT,
@@ -1572,8 +1579,8 @@ mod tests {
             None => unreachable!(),
         };
 
-        fn overlay(n: u8) -> SwarmAddress {
-            SwarmAddress::from([n; 32])
+        fn overlay(n: u8) -> OverlayAddress {
+            OverlayAddress::from([n; 32])
         }
 
         #[test]
@@ -1651,7 +1658,7 @@ mod tests {
                     deadline: RETRIEVE_SPILL_DEADLINE,
                     stagger: RETRIEVAL_STAGGER,
                 },
-                |peer: SwarmAddress| {
+                |peer: OverlayAddress| {
                     counted.fetch_add(1, Ordering::SeqCst);
                     // Best-effort dispatch: the busy holder has no free permit, but
                     // the enforce-off race still contacts it.
@@ -1847,7 +1854,7 @@ mod tests {
         /// An overlay sharing exactly `leading_bits` leading bits with `address`
         /// (the next bit is flipped), placing a peer at a controlled proximity.
         fn overlay_at_proximity(address: &ChunkAddress, leading_bits: usize) -> OverlayAddress {
-            let mut bytes = address.0.0;
+            let mut bytes = <[u8; 32]>::from(*address);
             let byte = leading_bits / 8;
             let bit = 7 - (leading_bits % 8);
             if let Some(b) = bytes.get_mut(byte) {

--- a/crates/swarm/node/src/node/base.rs
+++ b/crates/swarm/node/src/node/base.rs
@@ -3,7 +3,7 @@
 use eyre::Result;
 use libp2p::connection_limits::{self, ConnectionLimits};
 use libp2p::{Multiaddr, PeerId, Swarm, swarm::NetworkBehaviour, swarm::SwarmEvent};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use tracing::{debug, info, trace, warn};
 use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig};
 use vertex_swarm_net_identify as identify;
@@ -83,7 +83,7 @@ impl<I: SwarmIdentity, B: NetworkBehaviour> BaseNode<I, B> {
         self.swarm.local_peer_id()
     }
 
-    pub fn overlay_address(&self) -> SwarmAddress {
+    pub fn overlay_address(&self) -> OverlayAddress {
         self.identity.overlay_address()
     }
 

--- a/crates/swarm/node/src/node/bootnode.rs
+++ b/crates/swarm/node/src/node/bootnode.rs
@@ -14,7 +14,7 @@ use eyre::Result;
 use futures::StreamExt;
 use libp2p::connection_limits;
 use libp2p::{PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use tracing::{info, warn};
 use vertex_swarm_api::{
     SwarmIdentity, SwarmIdentityConfig, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig,
@@ -168,7 +168,7 @@ impl<I: SwarmIdentity + Clone> BootNode<I> {
         self.base.local_peer_id()
     }
 
-    pub fn overlay_address(&self) -> SwarmAddress {
+    pub fn overlay_address(&self) -> OverlayAddress {
         self.base.overlay_address()
     }
 

--- a/crates/swarm/node/src/node/client.rs
+++ b/crates/swarm/node/src/node/client.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 use futures::StreamExt;
 use libp2p::connection_limits;
 use libp2p::{Multiaddr, PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 use vertex_swarm_api::{SwarmIdentity, SwarmNetworkConfig, SwarmPeerConfig, SwarmRoutingConfig};
@@ -183,7 +183,7 @@ impl<I: SwarmIdentity + Clone> ClientNode<I> {
         self.base.local_peer_id()
     }
 
-    pub fn overlay_address(&self) -> SwarmAddress {
+    pub fn overlay_address(&self) -> OverlayAddress {
         self.base.overlay_address()
     }
 

--- a/crates/swarm/node/src/node/launch.rs
+++ b/crates/swarm/node/src/node/launch.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use eyre::Result;
 use libp2p::{Multiaddr, PeerId};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use vertex_net_peer_store::PeerSnapshotStore;
 use vertex_swarm_accounting::DefaultAccountingConfig;
 use vertex_swarm_api::{SwarmLocalStore, SwarmNodeType};
@@ -323,7 +323,7 @@ impl ClientLauncher {
             })
         });
 
-        let parts: ClientNodeParts<(SwarmAddress, PeerId)> = tail.finish(
+        let parts: ClientNodeParts<(OverlayAddress, PeerId)> = tail.finish(
             &executor,
             NodeRunParts {
                 topology,
@@ -390,7 +390,7 @@ pub struct LaunchedClient {
     accounting: SharedAccounting,
     chunks: NativeChunkProvider,
     store: Arc<dyn SwarmLocalStore>,
-    overlay: SwarmAddress,
+    overlay: OverlayAddress,
     peer_id: PeerId,
 }
 
@@ -432,7 +432,7 @@ impl LaunchedClient {
     }
 
     /// The node's overlay address.
-    pub fn overlay_address(&self) -> SwarmAddress {
+    pub fn overlay_address(&self) -> OverlayAddress {
         self.overlay
     }
 

--- a/crates/swarm/node/src/node/storer.rs
+++ b/crates/swarm/node/src/node/storer.rs
@@ -14,7 +14,7 @@ use eyre::Result;
 use futures::StreamExt;
 use libp2p::connection_limits;
 use libp2p::{Multiaddr, PeerId, identity::PublicKey, swarm::NetworkBehaviour, swarm::SwarmEvent};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 use vertex_swarm_api::{
@@ -256,7 +256,7 @@ impl<I: SwarmIdentity + Clone> StorerNode<I> {
         self.base.local_peer_id()
     }
 
-    pub fn overlay_address(&self) -> SwarmAddress {
+    pub fn overlay_address(&self) -> OverlayAddress {
         self.base.overlay_address()
     }
 

--- a/crates/swarm/node/src/protocol/behaviour_tests.rs
+++ b/crates/swarm/node/src/protocol/behaviour_tests.rs
@@ -15,7 +15,7 @@ use alloy_primitives::{B256, Signature};
 use alloy_signer_local::PrivateKeySigner;
 use libp2p::{PeerId, Swarm};
 use nectar_postage::Stamp;
-use nectar_primitives::{AnyChunk, ContentChunk, SingleOwnerChunk};
+use nectar_primitives::{AnyChunk, ContentChunk, SingleOwnerChunk, XorMetric};
 use tokio::sync::oneshot;
 use vertex_swarm_api::{StorageRadius, SwarmLocalStore};
 use vertex_swarm_localstore::{ChunkStore, Clock};
@@ -43,7 +43,7 @@ impl Clock for FixedClock {
 
 fn content_chunk(payload: &'static [u8]) -> StampedChunk {
     let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
     let chunk: AnyChunk = ContentChunk::new(payload)
         .expect("valid content chunk")
         .into();
@@ -52,9 +52,9 @@ fn content_chunk(payload: &'static [u8]) -> StampedChunk {
 
 fn soc_chunk(payload: &'static [u8], stamp_ns: u64) -> StampedChunk {
     let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, stamp_ns, sig);
+    let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, stamp_ns, sig);
     let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("signer");
-    let chunk: AnyChunk = SingleOwnerChunk::new(B256::repeat_byte(0x22), payload, &signer)
+    let chunk: AnyChunk = SingleOwnerChunk::new(B256::repeat_byte(0x22).into(), payload, &signer)
         .expect("valid soc")
         .into();
     StampedChunk::new(chunk, stamp)
@@ -539,7 +539,7 @@ fn overlay_at_proximity(
     address: &nectar_primitives::ChunkAddress,
     leading_bits: usize,
 ) -> OverlayAddress {
-    let mut bytes = address.0.0;
+    let mut bytes = <[u8; 32]>::from(*address);
     let byte = leading_bits / 8;
     let bit = 7 - (leading_bits % 8);
     if let Some(b) = bytes.get_mut(byte) {

--- a/crates/swarm/node/src/protocol/forward.rs
+++ b/crates/swarm/node/src/protocol/forward.rs
@@ -121,7 +121,7 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use nectar_postage::Stamp;
-    use nectar_primitives::{AnyChunk, ContentChunk, NetworkId, Nonce, compute_overlay};
+    use nectar_primitives::{AnyChunk, ContentChunk, NetworkId, Nonce, XorMetric, compute_overlay};
     use tokio::sync::mpsc;
     use vertex_swarm_accounting::{
         Accounting, ClientAccounting, DefaultAccountingConfig, FixedPricer,
@@ -245,7 +245,7 @@ mod tests {
     /// A stamped content chunk and its content-derived address.
     fn stamped() -> StampedChunk {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
         let chunk: AnyChunk = ContentChunk::new(&b"forwarded payload"[..])
             .expect("valid content chunk")
             .into();
@@ -256,7 +256,7 @@ mod tests {
     /// its proximity to the address is exactly `leading_bits` (the next bit is
     /// flipped). Used to place a peer at a controlled distance from the target.
     fn overlay_at_proximity(address: &ChunkAddress, leading_bits: usize) -> OverlayAddress {
-        let mut bytes = address.0.0;
+        let mut bytes = <[u8; 32]>::from(*address);
         // Flip the bit immediately after the shared prefix so the proximity is
         // exactly `leading_bits`: the first differing bit caps proximity.
         let byte = leading_bits / 8;

--- a/crates/swarm/peers/peer-manager/src/entry.rs
+++ b/crates/swarm/peers/peer-manager/src/entry.rs
@@ -110,8 +110,8 @@ pub(crate) fn unix_timestamp_secs() -> u64 {
 }
 
 pub(crate) fn jitter_seed_from_overlay(overlay: &OverlayAddress) -> u64 {
-    // OverlayAddress is B256 (32 bytes); first 8 bytes always exist.
-    let b = &overlay.0;
+    // OverlayAddress is 32 bytes; first 8 bytes always exist.
+    let b = <[u8; 32]>::from(*overlay);
     u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
 }
 
@@ -296,7 +296,7 @@ impl PeerEntry {
     /// handshake completes (its addresses may have gone stale while the
     /// node was down).
     pub(crate) fn from_snapshot(snapshot: PeerSnapshot, config: Arc<SwarmScoringConfig>) -> Self {
-        let overlay = OverlayAddress::from(*snapshot.peer.overlay());
+        let overlay = *snapshot.peer.overlay();
         Self {
             node_type: NodeTypeCell::provisional(snapshot.node_type),
             peer: RwLock::new(snapshot.peer),
@@ -605,7 +605,7 @@ mod tests {
 
     fn test_entry(n: u8, node_type: SwarmNodeType) -> PeerEntry {
         let peer = test_swarm_peer(n);
-        let overlay = OverlayAddress::from(*peer.overlay());
+        let overlay = *peer.overlay();
         PeerEntry::with_config(
             peer,
             node_type,

--- a/crates/swarm/peers/peer-manager/src/maintenance.rs
+++ b/crates/swarm/peers/peer-manager/src/maintenance.rs
@@ -149,7 +149,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
         let total = records.len();
         let mut loaded = 0usize;
         for snapshot in records {
-            let overlay = OverlayAddress::from(*snapshot.peer.overlay());
+            let overlay = *snapshot.peer.overlay();
             if self.index.add(overlay).is_err() {
                 continue;
             }

--- a/crates/swarm/peers/peer-manager/src/manager.rs
+++ b/crates/swarm/peers/peer-manager/src/manager.rs
@@ -471,7 +471,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
     /// unverified and dialable; candidate selection may dial them, and the
     /// first completed handshake verifies the record in the same round trip.
     pub fn store_discovered_peer(&self, swarm_peer: SwarmPeer) -> OverlayAddress {
-        let overlay = OverlayAddress::from(*swarm_peer.overlay());
+        let overlay = *swarm_peer.overlay();
         if let Some(entry) = self.peers.get(&overlay) {
             // Known peer - resolve the gossip timestamp against the stored
             // record before overwriting, then update addresses.
@@ -557,7 +557,7 @@ impl<I: SwarmIdentity> PeerManager<I> {
         direction: ConnectionDirection,
         trust: TrustLevel,
     ) {
-        let overlay = OverlayAddress::from(*swarm_peer.overlay());
+        let overlay = *swarm_peer.overlay();
         debug!(?overlay, ?node_type, %direction, %trust, "peer connected");
 
         let Some(entry) = self.insert_peer(overlay, swarm_peer, node_type) else {
@@ -842,6 +842,7 @@ mod tests {
     use super::*;
     use vertex_net_peer_store::MemoryPeerStore;
     use vertex_swarm_api::DisconnectReason;
+    use vertex_swarm_primitives::XorMetric;
     use vertex_swarm_test_utils::{
         MockIdentity, make_swarm_peer_minimal, test_overlay, test_swarm_peer,
         test_swarm_peer_with_timestamp,
@@ -1284,7 +1285,7 @@ mod tests {
             pm.store_discovered_peer(make_swarm_peer_minimal(byte));
         }
 
-        let p1 = OverlayAddress::from(*make_swarm_peer_minimal(0x80).overlay());
+        let p1 = *make_swarm_peer_minimal(0x80).overlay();
         pm.ban(&p1, BanCause::Requested, None);
 
         let dialable: Vec<_> = pm.dialable_overlays_in_bin(Bin::new(0).unwrap()).collect();
@@ -1377,10 +1378,10 @@ mod tests {
 
         // The two freshest (0xc0 @ 4000, 0xb0 @ 3000) survive the per-bin cap,
         // ordered freshest-first so the dial queue biases toward them.
-        let freshest = OverlayAddress::from(*make_swarm_peer_minimal(0xc0).overlay());
-        let next = OverlayAddress::from(*make_swarm_peer_minimal(0xb0).overlay());
-        let stale = OverlayAddress::from(*make_swarm_peer_minimal(0xa0).overlay());
-        let stalest = OverlayAddress::from(*make_swarm_peer_minimal(0x80).overlay());
+        let freshest = *make_swarm_peer_minimal(0xc0).overlay();
+        let next = *make_swarm_peer_minimal(0xb0).overlay();
+        let stale = *make_swarm_peer_minimal(0xa0).overlay();
+        let stalest = *make_swarm_peer_minimal(0x80).overlay();
 
         assert_eq!(
             pm.index().peers_in_bin(bin0),
@@ -1487,8 +1488,8 @@ mod tests {
         // Two disconnected bin-0 peers.
         pm.store_discovered_peer(make_swarm_peer_minimal(0x80));
         pm.store_discovered_peer(make_swarm_peer_minimal(0xc0));
-        let low = OverlayAddress::from(*make_swarm_peer_minimal(0x80).overlay());
-        let high = OverlayAddress::from(*make_swarm_peer_minimal(0xc0).overlay());
+        let low = *make_swarm_peer_minimal(0x80).overlay();
+        let high = *make_swarm_peer_minimal(0xc0).overlay();
 
         // Drive one peer's score down.
         for _ in 0..2 {
@@ -1501,7 +1502,7 @@ mod tests {
 
         // Newcomer must displace the lowest-score disconnected peer.
         pm.store_discovered_peer(make_swarm_peer_minimal(0xa0));
-        let newcomer = OverlayAddress::from(*make_swarm_peer_minimal(0xa0).overlay());
+        let newcomer = *make_swarm_peer_minimal(0xa0).overlay();
 
         assert!(pm.swarm_peer(&newcomer).is_some());
         assert!(pm.swarm_peer(&high).is_some());
@@ -1521,8 +1522,8 @@ mod tests {
 
         pm.store_discovered_peer(make_swarm_peer_minimal(0x80));
         pm.store_discovered_peer(make_swarm_peer_minimal(0xc0));
-        let stale = OverlayAddress::from(*make_swarm_peer_minimal(0x80).overlay());
-        let low_score = OverlayAddress::from(*make_swarm_peer_minimal(0xc0).overlay());
+        let stale = *make_swarm_peer_minimal(0x80).overlay();
+        let low_score = *make_swarm_peer_minimal(0xc0).overlay();
 
         // `stale` accumulates 48 dial failures (stale, but each failure is
         // score-neutral); `low_score` has a worse score but stays fresh.
@@ -1538,7 +1539,7 @@ mod tests {
         }
 
         pm.store_discovered_peer(make_swarm_peer_minimal(0xa0));
-        let newcomer = OverlayAddress::from(*make_swarm_peer_minimal(0xa0).overlay());
+        let newcomer = *make_swarm_peer_minimal(0xa0).overlay();
 
         assert!(pm.swarm_peer(&newcomer).is_some());
         assert!(pm.swarm_peer(&stale).is_none(), "stale replaced first");
@@ -1567,12 +1568,12 @@ mod tests {
 
         // Newcomer is rejected: every slot is connected.
         pm.store_discovered_peer(make_swarm_peer_minimal(0xa0));
-        let newcomer = OverlayAddress::from(*make_swarm_peer_minimal(0xa0).overlay());
+        let newcomer = *make_swarm_peer_minimal(0xa0).overlay();
 
         assert!(pm.swarm_peer(&newcomer).is_none());
         assert!(!pm.index().exists(&newcomer));
         for byte in [0x80, 0xc0] {
-            let overlay = OverlayAddress::from(*make_swarm_peer_minimal(byte).overlay());
+            let overlay = *make_swarm_peer_minimal(byte).overlay();
             assert!(pm.swarm_peer(&overlay).is_some());
         }
     }
@@ -1596,11 +1597,11 @@ mod tests {
             TrustLevel::Normal,
         );
         pm.store_discovered_peer(make_swarm_peer_minimal(0xc0));
-        let connected = OverlayAddress::from(*make_swarm_peer_minimal(0x80).overlay());
-        let disconnected = OverlayAddress::from(*make_swarm_peer_minimal(0xc0).overlay());
+        let connected = *make_swarm_peer_minimal(0x80).overlay();
+        let disconnected = *make_swarm_peer_minimal(0xc0).overlay();
 
         pm.store_discovered_peer(make_swarm_peer_minimal(0xa0));
-        let newcomer = OverlayAddress::from(*make_swarm_peer_minimal(0xa0).overlay());
+        let newcomer = *make_swarm_peer_minimal(0xa0).overlay();
 
         assert!(pm.swarm_peer(&connected).is_some(), "connected kept");
         assert!(pm.swarm_peer(&newcomer).is_some());

--- a/crates/swarm/peers/peer-manager/src/proximity_index.rs
+++ b/crates/swarm/peers/peer-manager/src/proximity_index.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use hashlink::LinkedHashSet;
 use metrics::gauge;
 use parking_lot::RwLock;
-use vertex_swarm_primitives::{Bin, OverlayAddress};
+use vertex_swarm_primitives::{Bin, OverlayAddress, XorMetric};
 
 /// Error returned when adding a peer to the index fails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error, strum::IntoStaticStr)]

--- a/crates/swarm/peers/peer/src/lib.rs
+++ b/crates/swarm/peers/peer/src/lib.rs
@@ -7,7 +7,7 @@
 //! [`nectar_primitives::signing::sign_data`].
 //!
 //! `Nonce` and `Timestamp` are re-exported from nectar (canonical Swarm
-//! primitives); `SwarmAddress` and `SwarmNodeType` are likewise re-exported
+//! primitives); `OverlayAddress` and `SwarmNodeType` are likewise re-exported
 //! for ergonomics.
 
 pub mod error;
@@ -22,7 +22,7 @@ pub use timestamp_policy::{
     MAX_CLOCK_SKEW, MIN_UPDATE_INTERVAL, TimestampRejection, check_timestamp,
 };
 
-pub use nectar_primitives::SwarmAddress;
+pub use nectar_primitives::OverlayAddress;
 pub use nectar_swarms::{NamedSwarm, Swarm, SwarmKind};
 pub use vertex_net_local::AddressScope;
 pub use vertex_swarm_primitives::SwarmNodeType;

--- a/crates/swarm/peers/peer/src/swarm_peer.rs
+++ b/crates/swarm/peers/peer/src/swarm_peer.rs
@@ -18,7 +18,7 @@ use crate::serde_multiaddr::{deserialize_multiaddrs, serialize_multiaddrs};
 use alloy_primitives::{Address, Signature};
 use libp2p::Multiaddr;
 use nectar_primitives::signing::sign_data;
-use nectar_primitives::{NetworkId, SwarmAddress, compute_overlay};
+use nectar_primitives::{NetworkId, OverlayAddress, compute_overlay};
 pub use nectar_primitives::{Nonce, Timestamp};
 use std::time::Duration;
 use vertex_net_local::{AddressScope, IpCapability, classify_multiaddr};
@@ -38,7 +38,7 @@ pub struct SwarmPeerWire<'a> {
     /// 65-byte secp256k1 signature over the EIP-191 sign-data.
     pub signature: Signature,
     /// Claimed overlay address; validated against the recovered signer.
-    pub overlay: SwarmAddress,
+    pub overlay: OverlayAddress,
     /// Handshake nonce.
     pub nonce: Nonce,
     /// Wall-clock timestamp in seconds since the Unix epoch.
@@ -63,7 +63,7 @@ pub struct SwarmPeerWire<'a> {
 pub struct SwarmPeer {
     multiaddrs: Vec<Multiaddr>,
     signature: Signature,
-    overlay: SwarmAddress,
+    overlay: OverlayAddress,
     nonce: Nonce,
     timestamp: Timestamp,
     chequebook: Option<Address>,
@@ -221,7 +221,7 @@ impl SwarmPeer {
 
     /// Overlay address.
     #[inline]
-    pub fn overlay(&self) -> &SwarmAddress {
+    pub fn overlay(&self) -> &OverlayAddress {
         &self.overlay
     }
 
@@ -269,7 +269,7 @@ impl SwarmPeer {
     pub fn from_parts(
         multiaddrs: Vec<Multiaddr>,
         signature: Signature,
-        overlay: SwarmAddress,
+        overlay: OverlayAddress,
         nonce: Nonce,
         timestamp: Timestamp,
         chequebook: Option<Address>,
@@ -641,7 +641,7 @@ mod tests {
         let network_id = NetworkId::new(1);
         let nonce = Nonce::from([0u8; 32]);
         let signer = PrivateKeySigner::random();
-        let bogus_overlay = SwarmAddress::new([0xFF; 32]);
+        let bogus_overlay = OverlayAddress::new([0xFF; 32]);
         let multiaddrs: Vec<Multiaddr> = vec!["/ip4/127.0.0.1/tcp/1234".parse().unwrap()];
         let timestamp = Timestamp::from_seconds(now_secs());
 

--- a/crates/swarm/peers/peer/tests/interop.rs
+++ b/crates/swarm/peers/peer/tests/interop.rs
@@ -88,7 +88,7 @@ fn overlay_derivation_matches_swarm_spec() {
         let eth = Address::from(hex_array::<20>(v.eth_address_hex));
         let nonce = Nonce::from(hex_array::<32>(v.nonce_hex));
         let got = compute_overlay(&eth, NetworkId::new(v.network_id), &nonce);
-        cx.assert_bytes_eq_hex("overlay", got.as_slice(), v.expected_overlay_hex);
+        cx.assert_bytes_eq_hex("overlay", got.as_bytes(), v.expected_overlay_hex);
     });
 }
 
@@ -181,7 +181,7 @@ fn handshake_15_sign_produces_pinned_signature_and_overlay() {
         );
 
         let overlay = compute_overlay(&signer.address(), network_id, &nonce);
-        cx.assert_bytes_eq_hex("overlay", overlay.as_slice(), v.expected_overlay_hex);
+        cx.assert_bytes_eq_hex("overlay", overlay.as_bytes(), v.expected_overlay_hex);
 
         let identity = vector_identity(signer, network_id, nonce);
         let peer = SwarmPeer::sign(&identity, vec![multiaddr], timestamp, chequebook)

--- a/crates/swarm/postage/Cargo.toml
+++ b/crates/swarm/postage/Cargo.toml
@@ -15,14 +15,14 @@ workspace = true
 ## nectar (re-exported public surface; do not redefine these types)
 # The `serde` feature is required so `Batch` satisfies the vertex-storage
 # `Value` bound (Serialize + DeserializeOwned) for the `Batches` table, and so
-# `ChunkAddress` (a `nectar_primitives::SwarmAddress`) is serialisable when it
-# is stored in the stamp-index entry value.
+# `ChunkAddress` is serialisable when it is stored in the stamp-index entry
+# value.
 nectar-postage = { workspace = true, features = ["serde"] }
 nectar-primitives = { workspace = true, features = ["serde"] }
 
 ## vertex
 # The `alloy` feature provides the fixed-size codec for `Address`; `BatchId`
-# (a `B256`) is encoded by a local newtype codec in this crate.
+# is encoded by a local newtype codec in this crate.
 vertex-storage = { workspace = true, features = ["alloy"] }
 
 ## misc

--- a/crates/swarm/postage/src/admission.rs
+++ b/crates/swarm/postage/src/admission.rs
@@ -113,7 +113,15 @@ mod tests {
     /// Batch owned by `owner`, depth 18 / bucket depth 16, with ample value so it
     /// is not expired against a zero cumulative payout.
     fn batch_for(owner: Address) -> Batch {
-        Batch::new(B256::repeat_byte(0x11), 1_000_000, 0, owner, 18, 16, false)
+        Batch::new(
+            B256::repeat_byte(0x11).into(),
+            1_000_000,
+            0,
+            owner,
+            18,
+            16,
+            false,
+        )
     }
 
     /// Sign a stamp for `address` under `batch`, using a bucket/index consistent

--- a/crates/swarm/postage/src/stampindex.rs
+++ b/crates/swarm/postage/src/stampindex.rs
@@ -94,7 +94,7 @@ impl Decode for StampSlotKey {
 // because serde implements arrays only up to length 32.
 impl serde::Serialize for StampSlotKey {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let parts: ([u8; 32], [u8; 8]) = (self.batch_id.0, self.stamp_index.to_be_bytes());
+        let parts: ([u8; 32], [u8; 8]) = (self.batch_id.into(), self.stamp_index.to_be_bytes());
         serde::Serialize::serialize(&parts, serializer)
     }
 }
@@ -309,7 +309,7 @@ mod tests {
     }
 
     fn batch(b: u8) -> BatchId {
-        B256::repeat_byte(b)
+        B256::repeat_byte(b).into()
     }
 
     fn addr(b: u8) -> ChunkAddress {

--- a/crates/swarm/postage/src/store.rs
+++ b/crates/swarm/postage/src/store.rs
@@ -23,7 +23,7 @@ table!(pub(crate) Batches, "postage_batches", BatchIdKey, Batch);
 table!(pub(crate) ContextTable, "postage_context", ContextKey, PostageContext, compressed = false);
 
 /// Key newtype carrying the 32-byte big-endian [`BatchId`] for the [`Batches`]
-/// table (local newtype works around the orphan rule on the foreign `B256`).
+/// table (local newtype works around the orphan rule on the foreign `BatchId`).
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
@@ -33,7 +33,7 @@ impl Encode for BatchIdKey {
     type Encoded = [u8; 32];
 
     fn encode(self) -> Self::Encoded {
-        self.0.0
+        self.0.into()
     }
 }
 
@@ -238,7 +238,7 @@ mod tests {
 
     fn sample_batch(id_byte: u8, value: u128, depth: u8) -> Batch {
         Batch::new(
-            B256::repeat_byte(id_byte),
+            B256::repeat_byte(id_byte).into(),
             value,
             100,
             Address::repeat_byte(0x11),
@@ -309,9 +309,9 @@ mod tests {
         assert_eq!(
             ids,
             vec![
-                B256::repeat_byte(0x01),
-                B256::repeat_byte(0x02),
-                B256::repeat_byte(0x03),
+                BatchId::from(B256::repeat_byte(0x01)),
+                BatchId::from(B256::repeat_byte(0x02)),
+                BatchId::from(B256::repeat_byte(0x03)),
             ]
         );
     }
@@ -367,7 +367,7 @@ mod tests {
         assert_eq!(store.get(&id).unwrap().unwrap().value(), 5000);
 
         // Top-up for an unknown batch is a no-op.
-        let unknown = B256::repeat_byte(0xff);
+        let unknown = BatchId::from(B256::repeat_byte(0xff));
         store
             .handle_event(BatchEvent::TopUp {
                 batch_id: unknown,
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn batch_id_key_codec_roundtrip() {
-        let k = BatchIdKey(B256::repeat_byte(0x7e));
+        let k = BatchIdKey(B256::repeat_byte(0x7e).into());
         assert_eq!(BatchIdKey::decode(k.encode().as_ref()).unwrap(), k);
         assert!(BatchIdKey::decode(&[0u8; 31]).is_err());
     }

--- a/crates/swarm/primitives/src/lib.rs
+++ b/crates/swarm/primitives/src/lib.rs
@@ -47,11 +47,11 @@ pub use validated::{ValidatedChunk, ValidationError};
 // Re-export canonical Swarm primitives from nectar. See the crate-level docs
 // for the ProximityOrder / Bin / NeighborhoodDepth distinction.
 pub use nectar_postage::{BatchId, Stamp, StampError};
-pub use nectar_primitives::{Bin, NetworkId, Nonce, ProximityOrder, Timestamp, compute_overlay};
+pub use nectar_primitives::{
+    Bin, NetworkId, Nonce, OverlayAddress, ProximityOrder, Timestamp, XorMetric, compute_overlay,
+};
 
 use core::fmt;
-
-use nectar_primitives::SwarmAddress;
 
 /// The neighborhood-depth boundary: bins at or beyond `depth` are the
 /// neighborhood (the node's area of responsibility), shallower bins are
@@ -187,9 +187,6 @@ pub fn neighborhood_bins(
 ) -> impl DoubleEndedIterator<Item = Bin> + Clone {
     (depth.get()..=max.get()).map(|po| Bin::new(po).unwrap_or(Bin::MAX))
 }
-
-/// Overlay address for Swarm routing and peer identification.
-pub type OverlayAddress = SwarmAddress;
 
 /// Swarm node type determining capabilities and protocols.
 #[derive(

--- a/crates/swarm/primitives/src/signer.rs
+++ b/crates/swarm/primitives/src/signer.rs
@@ -1,7 +1,7 @@
 //! The node identity's overlay-derivation facet over alloy's signing trait.
 
 use alloy_primitives::Address;
-use nectar_primitives::{SwarmAddress, compute_overlay};
+use nectar_primitives::{OverlayAddress, compute_overlay};
 
 use crate::{NetworkId, Nonce};
 
@@ -27,7 +27,7 @@ pub trait OverlaySigner: SignerSync {
     fn nonce(&self) -> Nonce;
 
     /// The overlay this identity derives: `compute_overlay(address, network_id, nonce)`.
-    fn overlay(&self) -> SwarmAddress {
+    fn overlay(&self) -> OverlayAddress {
         compute_overlay(&self.address(), self.network_id(), &self.nonce())
     }
 }

--- a/crates/swarm/primitives/src/stamped.rs
+++ b/crates/swarm/primitives/src/stamped.rs
@@ -129,7 +129,7 @@ mod tests {
 
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig)
     }
 
     fn content_chunk() -> ContentChunk {
@@ -138,7 +138,7 @@ mod tests {
 
     fn single_owner_chunk() -> SingleOwnerChunk {
         let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x11)).expect("valid signer");
-        SingleOwnerChunk::new(B256::repeat_byte(0x22), &b"soc payload"[..], &signer)
+        SingleOwnerChunk::new(B256::repeat_byte(0x22).into(), &b"soc payload"[..], &signer)
             .expect("valid soc")
     }
 

--- a/crates/swarm/puller/src/verifier.rs
+++ b/crates/swarm/puller/src/verifier.rs
@@ -115,7 +115,7 @@ mod tests {
         let mut raw = [0u8; 65];
         raw[64] = 27;
         let sig = alloy_primitives::Signature::try_from(&raw[..]).unwrap();
-        let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+        let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
         StampedChunk::new(chunk.into(), stamp)
     }
 
@@ -192,7 +192,15 @@ mod tests {
 
     /// Batch owned by `owner`, depth 18 / bucket depth 16, with `value` funding.
     fn batch_for(owner: Address, value: u128) -> Batch {
-        Batch::new(B256::repeat_byte(0x11), value, 0, owner, 18, 16, false)
+        Batch::new(
+            B256::repeat_byte(0x11).into(),
+            value,
+            0,
+            owner,
+            18,
+            16,
+            false,
+        )
     }
 
     /// Build a stamped chunk whose stamp is signed for `chunk` under `batch`,

--- a/crates/swarm/puller/tests/loop.rs
+++ b/crates/swarm/puller/tests/loop.rs
@@ -169,7 +169,7 @@ fn stamped(seed: u8) -> StampedChunk {
     raw[..64].fill(1);
     raw[64] = 27;
     let sig = Signature::try_from(&raw[..]).unwrap();
-    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
     StampedChunk::new(chunk.into(), stamp)
 }
 

--- a/crates/swarm/redistribution/benches/redistribution.rs
+++ b/crates/swarm/redistribution/benches/redistribution.rs
@@ -16,7 +16,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, 
 
 use nectar_primitives::{
     ChunkAddress, DEFAULT_BODY_SIZE, DefaultAnyChunk, DefaultContentChunk, DefaultSingleOwnerChunk,
-    SwarmAddress,
+    OverlayAddress,
 };
 
 use vertex_swarm_postage::{BatchId, Stamp, StampIndex};
@@ -54,7 +54,7 @@ fn next_b256(state: &mut u64) -> B256 {
 fn address_pool(count: usize) -> Vec<ChunkAddress> {
     let mut state = 0x0DDB_1A5E_5EED_0042u64;
     (0..count)
-        .map(|_| SwarmAddress::from(next_b256(&mut state)))
+        .map(|_| ChunkAddress::from(next_b256(&mut state)))
         .collect()
 }
 
@@ -88,7 +88,7 @@ fn soc_chunk(n: u64) -> DefaultAnyChunk {
         .expect("deterministic signer key is valid");
     let mut id_state = n ^ 0xABCD_EF12;
     let id = next_b256(&mut id_state);
-    DefaultSingleOwnerChunk::new(id, cac_body(n), &signer)
+    DefaultSingleOwnerChunk::new(id.into(), cac_body(n), &signer)
         .map(DefaultAnyChunk::from)
         .expect("SOC chunk builds")
 }
@@ -100,7 +100,7 @@ fn soc_chunk(n: u64) -> DefaultAnyChunk {
 fn fixture_stamp(n: u64) -> Stamp {
     let mut bytes = [0u8; 32];
     bytes[..8].copy_from_slice(&n.wrapping_mul(0x9E37_79B9_7F4A_7C15).to_le_bytes());
-    let batch: BatchId = B256::from(bytes);
+    let batch: BatchId = BatchId::from(bytes);
     let index = StampIndex::new(n as u32, n as u32);
     let sig = alloy_primitives::Signature::test_signature();
     Stamp::with_index(batch, index, 1, sig)
@@ -148,7 +148,7 @@ fn bench_transformed_address(c: &mut Criterion) {
                     .iter()
                     .map(|ch| ch.transformed_address(ANCHOR_BYTES))
                     .collect();
-                addrs.sort_unstable_by(|a, c| a.as_slice().cmp(c.as_slice()));
+                addrs.sort_unstable_by(|a, c| a.as_bytes().cmp(c.as_bytes()));
                 black_box(&addrs);
             });
         });
@@ -209,7 +209,7 @@ fn bench_make_inclusion_proofs(c: &mut Criterion) {
 /// The committed-depth membership filter. `depth_0_all` admits every address;
 /// `depth_1_half` keeps roughly half the keyspace.
 fn bench_canonical_neighbourhood(c: &mut Criterion) {
-    let anchor = SwarmAddress::zero();
+    let anchor = OverlayAddress::zero();
     let depth_0 = CommittedDepth::ZERO;
     let depth_1 = CommittedDepth::try_from(1).expect("depth 1 is in range");
     let mut group = c.benchmark_group("canonical_neighbourhood");

--- a/crates/swarm/redistribution/src/filter.rs
+++ b/crates/swarm/redistribution/src/filter.rs
@@ -190,7 +190,7 @@ mod tests {
     }
 
     fn batch_id(byte: u8) -> BatchId {
-        B256::repeat_byte(byte)
+        B256::repeat_byte(byte).into()
     }
 
     fn anchor() -> SampleAnchor {

--- a/crates/swarm/redistribution/src/neighbourhood.rs
+++ b/crates/swarm/redistribution/src/neighbourhood.rs
@@ -2,7 +2,7 @@
 
 use core::fmt;
 
-use nectar_primitives::{Bin, ChunkAddress, SwarmAddress};
+use nectar_primitives::{Bin, ChunkAddress, OverlayAddress, XorMetric};
 use vertex_swarm_api::StorageRadius;
 
 /// The per-round, on-chain-derived depth at which a storer's reserve is sampled.
@@ -142,19 +142,19 @@ impl TryFrom<u8> for CommittedDepth {
 ///
 /// ```
 /// use vertex_swarm_redistribution::{CommittedDepth, canonical_neighbourhood};
-/// use nectar_primitives::SwarmAddress;
+/// use nectar_primitives::OverlayAddress;
 /// use alloy_primitives::B256;
 ///
-/// let anchor = SwarmAddress::zero();
-/// let near = SwarmAddress::from(B256::ZERO);
-/// let far = SwarmAddress::from(B256::repeat_byte(0xff));
+/// let anchor = OverlayAddress::zero();
+/// let near = OverlayAddress::from(B256::ZERO);
+/// let far = OverlayAddress::from(B256::repeat_byte(0xff));
 /// let depth = CommittedDepth::try_from(1).unwrap();
 /// let hood = canonical_neighbourhood(&anchor, depth, [near, far]);
 /// assert_eq!(hood, vec![near]);
 /// ```
 #[must_use]
 pub fn canonical_neighbourhood(
-    anchor: &SwarmAddress,
+    anchor: &OverlayAddress,
     depth: CommittedDepth,
     addrs: impl IntoIterator<Item = ChunkAddress>,
 ) -> Vec<ChunkAddress> {
@@ -175,7 +175,7 @@ mod tests {
     use nectar_primitives::MAX_PO;
 
     fn addr(byte: u8) -> ChunkAddress {
-        SwarmAddress::from(B256::repeat_byte(byte))
+        ChunkAddress::from(B256::repeat_byte(byte))
     }
 
     fn depth(n: u8) -> CommittedDepth {
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn canonical_neighbourhood_filters_by_depth() {
-        let anchor = SwarmAddress::zero();
+        let anchor = OverlayAddress::zero();
         let near = addr(0x00);
         let far = addr(0xff);
 
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn canonical_neighbourhood_preserves_input_order() {
-        let anchor = SwarmAddress::zero();
+        let anchor = OverlayAddress::zero();
         let addrs = vec![addr(0x01), addr(0x02), addr(0x03)];
         let hood = canonical_neighbourhood(&anchor, depth(0), addrs.clone());
         assert_eq!(hood, addrs);

--- a/crates/swarm/redistribution/src/neighbourhood.rs
+++ b/crates/swarm/redistribution/src/neighbourhood.rs
@@ -142,12 +142,12 @@ impl TryFrom<u8> for CommittedDepth {
 ///
 /// ```
 /// use vertex_swarm_redistribution::{CommittedDepth, canonical_neighbourhood};
-/// use nectar_primitives::OverlayAddress;
+/// use nectar_primitives::{ChunkAddress, OverlayAddress};
 /// use alloy_primitives::B256;
 ///
 /// let anchor = OverlayAddress::zero();
-/// let near = OverlayAddress::from(B256::ZERO);
-/// let far = OverlayAddress::from(B256::repeat_byte(0xff));
+/// let near = ChunkAddress::from(B256::ZERO);
+/// let far = ChunkAddress::from(B256::repeat_byte(0xff));
 /// let depth = CommittedDepth::try_from(1).unwrap();
 /// let hood = canonical_neighbourhood(&anchor, depth, [near, far]);
 /// assert_eq!(hood, vec![near]);

--- a/crates/swarm/redistribution/src/sample.rs
+++ b/crates/swarm/redistribution/src/sample.rs
@@ -92,7 +92,7 @@ fn insert_sample_item(sample: &mut Vec<SampleItem>, item: SampleItem) {
     // First slot not strictly smaller than `key`: a tie or the insertion point.
     let Some(pos) = sample
         .iter()
-        .position(|s| s.transformed_address.as_slice() >= key.as_slice())
+        .position(|s| s.transformed_address.as_bytes() >= key.as_bytes())
     else {
         // Larger than every incumbent: append only while not yet full.
         if sample.len() < SAMPLE_SIZE {
@@ -125,8 +125,8 @@ fn insert_sample_item(sample: &mut Vec<SampleItem>, item: SampleItem) {
 pub fn reserve_commitment_content(items: &[SampleItem]) -> Vec<u8> {
     let mut content = Vec::with_capacity(items.len() * 64);
     for it in items {
-        content.extend_from_slice(it.chunk_address().as_slice());
-        content.extend_from_slice(it.transformed_address.as_slice());
+        content.extend_from_slice(it.chunk_address().as_bytes());
+        content.extend_from_slice(it.transformed_address.as_bytes());
     }
     content
 }
@@ -155,7 +155,7 @@ mod tests {
         use nectar_primitives::DefaultSingleOwnerChunk;
         let signer = alloy_signer_local::PrivateKeySigner::from_slice(&[0x42u8; 32]).unwrap();
         let soc = DefaultSingleOwnerChunk::new(
-            alloy_primitives::B256::ZERO,
+            alloy_primitives::B256::ZERO.into(),
             b"single owner payload".to_vec(),
             &signer,
         )
@@ -177,7 +177,7 @@ mod tests {
         // Ascending transformed-address order.
         for w in sample.windows(2) {
             assert!(
-                w[0].transformed_address.as_slice() < w[1].transformed_address.as_slice(),
+                w[0].transformed_address.as_bytes() < w[1].transformed_address.as_bytes(),
                 "sample must be strictly ascending by transformed address"
             );
         }
@@ -187,7 +187,7 @@ mod tests {
             .iter()
             .map(|i| i.transformed_address)
             .collect::<Vec<_>>();
-        all.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+        all.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
         let want: Vec<_> = all.into_iter().take(SAMPLE_SIZE).collect();
         let got: Vec<_> = sample.iter().map(|i| i.transformed_address).collect();
         assert_eq!(got, want);

--- a/crates/swarm/redistribution/tests/conformance.rs
+++ b/crates/swarm/redistribution/tests/conformance.rs
@@ -28,7 +28,6 @@ use vertex_swarm_redistribution::{
 
 use nectar_primitives::{
     Chunk, DefaultAnyChunk, DefaultContentChunk, DefaultHasher, DefaultSingleOwnerChunk,
-    SwarmAddress,
 };
 
 use vertex_swarm_postage::{BatchId, Stamp, StampIndex};
@@ -39,7 +38,7 @@ use vertex_swarm_test_utils::vectors::{assert_bytes_eq_hex, hex_array, hex_vec};
 /// never feeds the RC/OG/TR BMT geometry, so the byte-for-byte proof vectors are
 /// unaffected.
 fn fixture_stamp(slot: usize) -> Stamp {
-    let batch: BatchId = B256::repeat_byte(0xc0 + slot as u8);
+    let batch: BatchId = B256::repeat_byte(0xc0 + slot as u8).into();
     let index = StampIndex::new(slot as u32, slot as u32);
     let sig = alloy_primitives::Signature::test_signature();
     Stamp::with_index(batch, index, 1, sig)
@@ -63,7 +62,7 @@ fn cac_transformed_address_matches_reference_vector() {
     let chunk = DefaultContentChunk::new(content).unwrap();
     assert_bytes_eq_hex(
         "chunk address must match the reference vector",
-        chunk.address().as_slice(),
+        chunk.address().as_bytes(),
         WANT_CHUNK_ADDR,
     );
 
@@ -71,7 +70,7 @@ fn cac_transformed_address_matches_reference_vector() {
     let tr = any.transformed_address(ANCHOR_CAC);
     assert_bytes_eq_hex(
         "transformed address must match the reference vector",
-        tr.as_slice(),
+        tr.as_bytes(),
         WANT_TRANSFORMED,
     );
 }
@@ -168,7 +167,7 @@ fn rebuild_items(oracle: &Oracle, sample: SampleAnchor) -> Vec<SampleItem> {
             let chunk = parse_chunk(it);
             assert_bytes_eq_hex(
                 "parsed chunk address must match the reference",
-                chunk.address().as_slice(),
+                chunk.address().as_bytes(),
                 &it.chunk_address,
             );
 
@@ -178,7 +177,7 @@ fn rebuild_items(oracle: &Oracle, sample: SampleAnchor) -> Vec<SampleItem> {
                     "recomputed transformed address must match the reference for {}",
                     it.chunk_address,
                 ),
-                item.transformed_address.as_slice(),
+                item.transformed_address.as_bytes(),
                 &it.transformed_address,
             );
             item
@@ -346,7 +345,7 @@ fn same_content_multi_batch_ties_to_one_slot_with_stable_commitment() {
             .into();
 
     let stamp_a = {
-        let batch: BatchId = B256::repeat_byte(0xa1);
+        let batch: BatchId = B256::repeat_byte(0xa1).into();
         Stamp::with_index(
             batch,
             StampIndex::new(1, 1),
@@ -355,7 +354,7 @@ fn same_content_multi_batch_ties_to_one_slot_with_stable_commitment() {
         )
     };
     let stamp_b = {
-        let batch: BatchId = B256::repeat_byte(0xb2);
+        let batch: BatchId = B256::repeat_byte(0xb2).into();
         Stamp::with_index(
             batch,
             StampIndex::new(2, 2),
@@ -486,13 +485,13 @@ fn witness_proofs_self_verify() {
         (&proofs.0[2], idx.last),
     ] {
         assert!(
-            p.rc_proof.verify(rc_root.as_slice()).expect("rc verify"),
+            p.rc_proof.verify(&rc_root).expect("rc verify"),
             "RC proof must verify against the reserve-commitment root",
         );
 
         assert!(
             p.og_proof
-                .verify(plain_root(&items[require].chunk).as_slice())
+                .verify(&plain_root(&items[require].chunk))
                 .expect("og verify"),
             "OG proof must verify against the chunk's plain BMT root",
         );
@@ -502,7 +501,7 @@ fn witness_proofs_self_verify() {
         // against the prefixed root directly.
         assert!(
             p.tr_proof
-                .verify(prefixed_root(&items[require].chunk, sample.as_bytes()).as_slice())
+                .verify(&prefixed_root(&items[require].chunk, sample.as_bytes()))
                 .expect("tr verify"),
             "TR proof must verify against the anchor-prefixed BMT root",
         );
@@ -511,19 +510,19 @@ fn witness_proofs_self_verify() {
 
 /// The plain BMT root of the witnessed chunk body. For a CAC this is the chunk
 /// address; for a SOC it is the wrapped CAC's address.
-fn plain_root(chunk: &DefaultAnyChunk) -> SwarmAddress {
+fn plain_root(chunk: &DefaultAnyChunk) -> B256 {
     let mut hasher = DefaultHasher::new();
     hasher.set_span(chunk.span());
     hasher.update(chunk.data());
-    SwarmAddress::from(hasher.sum())
+    hasher.sum()
 }
 
 /// The anchor-prefixed BMT root of the witnessed chunk body (the TR proof's
 /// root). For a CAC this equals the transformed address; for a SOC it is its
 /// inner component.
-fn prefixed_root(chunk: &DefaultAnyChunk, anchor: &[u8]) -> SwarmAddress {
+fn prefixed_root(chunk: &DefaultAnyChunk, anchor: &[u8]) -> B256 {
     let mut hasher = DefaultHasher::with_prefix(anchor);
     hasher.set_span(chunk.span());
     hasher.update(chunk.data());
-    SwarmAddress::from(hasher.sum())
+    hasher.sum()
 }

--- a/crates/swarm/storer-behaviour/tests/composite.rs
+++ b/crates/swarm/storer-behaviour/tests/composite.rs
@@ -24,7 +24,7 @@ use vertex_swarm_test_utils::harness::{HarnessNode, connect_and_activate, seeded
 
 fn content(payload: &'static [u8]) -> StampedChunk {
     let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
     let chunk: AnyChunk = ContentChunk::new(payload)
         .expect("valid content chunk")
         .into();

--- a/crates/swarm/storer-behaviour/tests/round_trip.rs
+++ b/crates/swarm/storer-behaviour/tests/round_trip.rs
@@ -18,7 +18,7 @@ use vertex_swarm_test_utils::harness::{HarnessNode, connect_and_activate, seeded
 
 fn content(payload: &'static [u8]) -> StampedChunk {
     let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-    let stamp = Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig);
+    let stamp = Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig);
     let chunk: AnyChunk = ContentChunk::new(payload)
         .expect("valid content chunk")
         .into();

--- a/crates/swarm/storer/src/db_intervals.rs
+++ b/crates/swarm/storer/src/db_intervals.rs
@@ -44,7 +44,7 @@ impl Encode for PeerBinKey {
 
     fn encode(self) -> Self::Encoded {
         let mut out = [0u8; 33];
-        out[..32].copy_from_slice(self.peer.as_slice());
+        out[..32].copy_from_slice(self.peer.as_bytes());
         out[32] = self.bin;
         out
     }

--- a/crates/swarm/storer/src/db_reserve/consensus_spec.rs
+++ b/crates/swarm/storer/src/db_reserve/consensus_spec.rs
@@ -20,7 +20,7 @@ use alloy_primitives::Address;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use nectar_postage::{Batch, PostageContext, StampDigest, StampIndex};
-use nectar_primitives::{Bin, Chunk, DefaultContentChunk as ContentChunk};
+use nectar_primitives::{Bin, Chunk, DefaultContentChunk as ContentChunk, XorMetric};
 use std::sync::Arc;
 use vertex_storage_redb::RedbDatabase;
 use vertex_swarm_api::SwarmIdentity as _;
@@ -38,7 +38,7 @@ fn signer() -> PrivateKeySigner {
 }
 
 /// Ample value so it is not expired against a zero cumulative payout.
-fn batch_for(owner: Address, id: B256) -> Batch {
+fn batch_for(owner: Address, id: BatchId) -> Batch {
     Batch::new(id, 1_000_000, 0, owner, DEPTH, BUCKET_DEPTH, false)
 }
 
@@ -54,7 +54,7 @@ fn content_chunk_in_bucket0(seed: u64) -> (nectar_primitives::AnyChunk, ChunkAdd
         let payload = format!("vertex reserve consensus fixture {seed}/{n}").into_bytes();
         let chunk = ContentChunk::new(payload).expect("valid content chunk");
         let addr = *chunk.address();
-        if addr.as_slice()[0] & 0x80 == 0 {
+        if addr.as_bytes()[0] & 0x80 == 0 {
             return (chunk.into(), addr);
         }
     }
@@ -65,7 +65,7 @@ fn content_chunk_in_bucket0(seed: u64) -> (nectar_primitives::AnyChunk, ChunkAdd
 /// its proximity order to the zero overlay is `target_po`. Lets a test place
 /// chunks at chosen distances to assert furthest-first eviction.
 fn content_chunk_at_po(seed: u64, target_po: u8) -> (nectar_primitives::AnyChunk, ChunkAddress) {
-    let overlay = ChunkAddress::with_first_byte(0x00);
+    let overlay = ChunkAddress::ZERO;
     for n in 0..1_000_000u64 {
         let payload = format!("vertex reserve po fixture {seed}/{target_po}/{n}").into_bytes();
         let chunk = ContentChunk::new(payload).expect("valid content chunk");
@@ -109,17 +109,17 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
-        Self::with_batches(&[B256::repeat_byte(0x11)])
+        Self::with_batches(&[BatchId::new([0x11; 32])])
     }
 
     /// All batches are owned by the shared signer, with the live context persisted.
-    fn with_batches(batch_ids: &[B256]) -> Self {
+    fn with_batches(batch_ids: &[BatchId]) -> Self {
         Self::with_capacity(batch_ids, 10_000)
     }
 
     /// As [`with_batches`](Self::with_batches), at a chosen reserve capacity so the
     /// furthest-eviction trigger can be exercised at a small bound.
-    fn with_capacity(batch_ids: &[B256], capacity: u64) -> Self {
+    fn with_capacity(batch_ids: &[BatchId], capacity: u64) -> Self {
         let db = RedbDatabase::in_memory().unwrap().into_arc();
         let batches = DbBatchStore::new(Arc::clone(&db)).unwrap();
         let signer = signer();
@@ -152,7 +152,7 @@ impl Fixture {
     }
 
     fn batch_id(&self) -> BatchId {
-        BatchId::repeat_byte(0x11)
+        BatchId::new([0x11; 32])
     }
 
     /// Stamp `chunk` under `batch_id` at `(index, timestamp)` and put it.
@@ -187,9 +187,9 @@ fn reserve_size_counts_stamped_entries_not_addresses() {
     // (batchID, stampIndex, address)), not 1. Size feeds the consensus-committed
     // storage_radius.
     let ids = [
-        B256::repeat_byte(0x11),
-        B256::repeat_byte(0x22),
-        B256::repeat_byte(0x33),
+        BatchId::new([0x11; 32]),
+        BatchId::new([0x22; 32]),
+        BatchId::new([0x33; 32]),
     ];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(1);
@@ -277,7 +277,7 @@ fn refcounted_payload_survives_partial_eviction() {
     // Same content under two batches: one Payload row at refcnt 2; the second
     // put bumps the refcount without rewriting the body. Evicting one entry
     // leaves the body (refcnt 1); evicting the last drops it.
-    let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
+    let ids = [BatchId::new([0x11; 32]), BatchId::new([0x22; 32])];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(3);
 
@@ -389,7 +389,7 @@ fn get_returns_exact_admitting_stamp() {
 fn removal_fully_compacts_all_tables_no_tombstones() {
     // remove() deletes every row of every stamped entry for an address across
     // all six tables, leaving no tombstone.
-    let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
+    let ids = [BatchId::new([0x11; 32]), BatchId::new([0x22; 32])];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(5);
 
@@ -406,7 +406,7 @@ fn removal_fully_compacts_all_tables_no_tombstones() {
     assert_eq!(fx.row_count::<Replay>(), 0, "no Replay tombstones");
     assert_eq!(fx.row_count::<Payload>(), 0, "no Payload tombstones");
     // The arbiter slot is cleared, so it does not pin a stale newest timestamp.
-    let slot0 = StampSlotKey::new(BatchId::from(ids[0]), StampIndex::new(0, 0));
+    let slot0 = StampSlotKey::new(ids[0], StampIndex::new(0, 0));
     assert!(
         fx.db
             .view(|tx| tx.get::<StampIndexTable>(slot0))
@@ -433,7 +433,7 @@ fn unknown_batch_and_stampless_puts_are_rejected() {
 
     // Sign under a batch id the store does not hold.
     let unknown = Batch::new(
-        B256::repeat_byte(0x99),
+        BatchId::new([0x99; 32]),
         1_000_000,
         0,
         fx.signer.address(),
@@ -454,7 +454,7 @@ fn unknown_batch_and_stampless_puts_are_rejected() {
 fn bin_scan_replays_entries_in_insertion_order() {
     // The Replay table surfaces each entry's (address, batch, stampHash) in
     // per-bin insertion order without a body read.
-    let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
+    let ids = [BatchId::new([0x11; 32]), BatchId::new([0x22; 32])];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(7);
     let bin = addr.bin(&fx.overlay);
@@ -491,8 +491,8 @@ fn batch_expiry_sweep_evicts_only_the_expired_batch() {
 
     // Two batches with distinct content addresses, so neither eviction touches
     // the other's refcounted payload.
-    let live_id = B256::repeat_byte(0x11);
-    let expiring_id = B256::repeat_byte(0x22);
+    let live_id = BatchId::new([0x11; 32]);
+    let expiring_id = BatchId::new([0x22; 32]);
     let fx = Fixture::with_batches(&[live_id, expiring_id]);
     let (chunk_a, addr_a) = content_chunk_in_bucket0(101);
     let (chunk_b, addr_b) = content_chunk_in_bucket0(202);
@@ -621,7 +621,7 @@ fn nothing_evicted_when_no_batch_is_expired() {
     use crate::expiry::ExpirySweep;
 
     // Both batches retain ample value against a zero cumulative payout.
-    let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
+    let ids = [BatchId::new([0x11; 32]), BatchId::new([0x22; 32])];
     let fx = Fixture::with_batches(&ids);
     let (chunk, addr) = content_chunk_in_bucket0(303);
     fx.put(&chunk, &addr, ids[0], 0, 100).unwrap();
@@ -645,7 +645,7 @@ fn expired_event_evicts_reserve_before_store_removal() {
     use crate::expiry::ExpirySweep;
     use std::cell::Cell;
 
-    let expiring_id = B256::repeat_byte(0x33);
+    let expiring_id = BatchId::new([0x33; 32]);
     let fx = Fixture::with_batches(&[expiring_id]);
     let (chunk, addr) = content_chunk_in_bucket0(404);
     fx.put(&chunk, &addr, expiring_id, 0, 100).unwrap();
@@ -681,7 +681,7 @@ fn expired_event_does_not_acknowledge_when_eviction_fails_is_skipped() {
     // so the caller can retry the removal.
     use crate::expiry::ExpirySweep;
 
-    let expiring_id = B256::repeat_byte(0x44);
+    let expiring_id = BatchId::new([0x44; 32]);
     let fx = Fixture::with_batches(&[expiring_id]);
     let (chunk, addr) = content_chunk_in_bucket0(505);
     fx.put(&chunk, &addr, expiring_id, 0, 100).unwrap();
@@ -710,7 +710,7 @@ fn expired_event_does_not_acknowledge_when_eviction_fails_is_skipped() {
 fn evict_to_capacity_drops_the_furthest_entries_first() {
     // Capacity 2, three entries at distinct proximity orders. The two furthest
     // (lowest proximity) are evicted; the closest survives.
-    let id = B256::repeat_byte(0x11);
+    let id = BatchId::new([0x11; 32]);
     let fx = Fixture::with_capacity(&[id], 2);
     let batch_id = fx.batch_id();
 
@@ -758,7 +758,7 @@ fn evict_to_capacity_does_not_rewind_bin_cursors() {
     // A bin's monotonic insertion cursor must survive eviction so a pull-sync
     // resume point stays valid: a scan from a sequence past the evicted entry
     // still resolves the survivor.
-    let id = B256::repeat_byte(0x11);
+    let id = BatchId::new([0x11; 32]);
     let fx = Fixture::with_capacity(&[id], 1);
     let batch_id = fx.batch_id();
 
@@ -818,7 +818,7 @@ fn evict_to_capacity_frees_the_body_only_on_the_last_reference() {
     // One content address under two batches: the shared payload survives the
     // first entry's eviction (refcnt 2 -> 1) and is freed only when the last
     // referencing entry goes.
-    let ids = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
+    let ids = [BatchId::new([0x11; 32]), BatchId::new([0x22; 32])];
     let fx = Fixture::with_capacity(&ids, 1);
     let (chunk, addr) = content_chunk_at_po(1, 4);
 

--- a/crates/swarm/storer/src/db_reserve/schema.rs
+++ b/crates/swarm/storer/src/db_reserve/schema.rs
@@ -136,7 +136,7 @@ impl Encode for EntryKey {
         out[0] = self.po;
         out[1..33].copy_from_slice(self.batch.as_slice());
         out[33..65].copy_from_slice(self.stamp_hash.as_slice());
-        out[65..].copy_from_slice(self.addr.as_slice());
+        out[65..].copy_from_slice(self.addr.as_bytes());
         out
     }
 }
@@ -202,7 +202,7 @@ impl Encode for BatchGroupKey {
         let mut out = [0u8; 97];
         out[..32].copy_from_slice(self.batch.as_slice());
         out[32] = self.po;
-        out[33..65].copy_from_slice(self.addr.as_slice());
+        out[33..65].copy_from_slice(self.addr.as_bytes());
         out[65..].copy_from_slice(self.stamp_hash.as_slice());
         out
     }
@@ -299,7 +299,7 @@ mod key_codec_tests {
     fn entry_key_round_trips_and_orders_proximity_major() {
         let k = EntryKey::new(
             7,
-            BatchId::repeat_byte(0x11),
+            BatchId::new([0x11; 32]),
             B256::repeat_byte(0x22),
             ChunkAddress::from([0x33u8; 32]),
         );
@@ -308,7 +308,7 @@ mod key_codec_tests {
         // Smaller po sorts first regardless of trailing fields.
         let far = EntryKey::new(
             1,
-            BatchId::repeat_byte(0xff),
+            BatchId::new([0xff; 32]),
             B256::repeat_byte(0xff),
             ChunkAddress::from([0xffu8; 32]),
         )
@@ -323,7 +323,7 @@ mod key_codec_tests {
             EntryKey::new(po, BatchId::ZERO, B256::ZERO, ChunkAddress::from([0u8; 32])).encode();
         let b = EntryKey::new(
             po,
-            BatchId::repeat_byte(0x01),
+            BatchId::new([0x01; 32]),
             B256::ZERO,
             ChunkAddress::from([0u8; 32]),
         )
@@ -334,18 +334,18 @@ mod key_codec_tests {
     #[test]
     fn batch_group_key_orders_batch_major_then_bin() {
         let k = BatchGroupKey::new(
-            BatchId::repeat_byte(0xab),
+            BatchId::new([0xab; 32]),
             9,
             ChunkAddress::from([0xcdu8; 32]),
             B256::repeat_byte(0xef),
         );
         assert_eq!(BatchGroupKey::decode(k.encode().as_ref()).unwrap(), k);
 
-        let batch = BatchId::repeat_byte(0x07);
+        let batch = BatchId::new([0x07; 32]);
         let lo = BatchGroupKey::new(batch, 1, ChunkAddress::from([0u8; 32]), B256::ZERO).encode();
         let hi = BatchGroupKey::new(batch, 2, ChunkAddress::from([0u8; 32]), B256::ZERO).encode();
         let other = BatchGroupKey::new(
-            BatchId::repeat_byte(0x08),
+            BatchId::new([0x08; 32]),
             0,
             ChunkAddress::from([0u8; 32]),
             B256::ZERO,

--- a/crates/swarm/storer/src/db_reserve/store.rs
+++ b/crates/swarm/storer/src/db_reserve/store.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use alloy_primitives::B256;
-use nectar_primitives::{Bin, ChunkAddress, ProximityOrder};
+use nectar_primitives::{Bin, ChunkAddress, ProximityOrder, XorMetric};
 use tracing::debug;
 use vertex_storage::{Database, DatabaseError, DbCursorRO, DbTx, DbTxMut, Table};
 use vertex_swarm_api::{

--- a/crates/swarm/storer/src/db_reserve/tx.rs
+++ b/crates/swarm/storer/src/db_reserve/tx.rs
@@ -4,7 +4,7 @@
 //! atomically.
 
 use nectar_postage::Stamp;
-use nectar_primitives::ChunkAddress;
+use nectar_primitives::{ChunkAddress, XorMetric};
 use vertex_storage::{DatabaseError, DbTxMut};
 use vertex_swarm_api::SwarmError;
 use vertex_swarm_postage::{StampIndexTable, StampSlotKey};

--- a/crates/swarm/storer/src/reserve.rs
+++ b/crates/swarm/storer/src/reserve.rs
@@ -3,7 +3,7 @@
 //! The [`Reserve`] tracks storage capacity and handles eviction
 //! when the store is full.
 
-use nectar_primitives::{ChunkAddress, ProximityOrder};
+use nectar_primitives::{ChunkAddress, ProximityOrder, XorMetric};
 use parking_lot::RwLock;
 use tracing::{debug, warn};
 use vertex_swarm_api::SwarmIdentity;

--- a/crates/swarm/stream/src/lib.rs
+++ b/crates/swarm/stream/src/lib.rs
@@ -597,7 +597,7 @@ mod tests {
 
     fn test_stamp() -> Stamp {
         let sig = Signature::from_raw(&[1u8; 65]).expect("valid signature");
-        Stamp::new(B256::repeat_byte(0xaa), 3, 7, 42, sig)
+        Stamp::new(B256::repeat_byte(0xaa).into(), 3, 7, 42, sig)
     }
 
     /// A content chunk seeded so each test chunk has a unique address.

--- a/crates/swarm/test-utils/src/cluster.rs
+++ b/crates/swarm/test-utils/src/cluster.rs
@@ -63,7 +63,7 @@ use std::time::Duration;
 use alloy_signer::k256::ecdsa::SigningKey;
 use eyre::{Result, WrapErr};
 use libp2p::{Multiaddr, PeerId};
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use tokio::task::JoinHandle;
 use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
 use vertex_swarm_identity::Identity;
@@ -107,7 +107,7 @@ pub struct ClusterNodeHandle {
     /// Role this node was constructed with.
     pub role: NodeRole,
     /// Overlay address (stable for the lifetime of the cluster).
-    pub overlay: SwarmAddress,
+    pub overlay: OverlayAddress,
     /// libp2p peer id (stable for the lifetime of the cluster).
     pub peer_id: PeerId,
     /// Listen multiaddr including `/p2p/<peer_id>`.

--- a/crates/swarm/test-utils/src/identity.rs
+++ b/crates/swarm/test-utils/src/identity.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{Address, B256, ChainId, Signature};
 use alloy_signer::SignerSync;
 use alloy_signer_local::LocalSigner;
-use nectar_primitives::SwarmAddress;
+use nectar_primitives::OverlayAddress;
 use std::sync::Arc;
 use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
 use vertex_swarm_identity::Identity;
@@ -30,7 +30,7 @@ use vertex_swarm_spec::{Spec, SwarmSpec};
 /// ```
 #[derive(Clone)]
 pub struct MockIdentity {
-    overlay: SwarmAddress,
+    overlay: OverlayAddress,
     signer: Arc<LocalSigner<alloy_signer::k256::ecdsa::SigningKey>>,
     spec: Arc<Spec>,
     node_type: SwarmNodeType,
@@ -48,7 +48,7 @@ impl std::fmt::Debug for MockIdentity {
 
 impl MockIdentity {
     /// Create a mock identity with the given overlay address.
-    pub fn with_overlay(overlay: SwarmAddress) -> Self {
+    pub fn with_overlay(overlay: OverlayAddress) -> Self {
         let signer = LocalSigner::random();
         Self {
             overlay,
@@ -64,7 +64,7 @@ impl MockIdentity {
     /// Useful for testing Kademlia distance calculations where you need
     /// to control XOR distances between peers.
     pub fn with_first_byte(byte: u8) -> Self {
-        Self::with_overlay(SwarmAddress::with_first_byte(byte))
+        Self::with_overlay(OverlayAddress::with_first_byte(byte))
     }
 
     /// Set the node type for this mock identity.
@@ -113,7 +113,7 @@ impl OverlaySigner for MockIdentity {
     }
 
     /// Returns the test-controlled overlay, which need not match the signer.
-    fn overlay(&self) -> SwarmAddress {
+    fn overlay(&self) -> OverlayAddress {
         self.overlay
     }
 }
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_mock_identity_with_overlay() {
-        let overlay = SwarmAddress::with_first_byte(0x42);
+        let overlay = OverlayAddress::with_first_byte(0x42);
         let mock = MockIdentity::with_overlay(overlay);
 
         assert_eq!(mock.overlay_address(), overlay);

--- a/crates/swarm/test-utils/src/peer.rs
+++ b/crates/swarm/test-utils/src/peer.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use alloy_primitives::{Address, B256, Signature, U256};
 use libp2p::{Multiaddr, PeerId};
-use nectar_primitives::SwarmAddress;
 use vertex_swarm_api::SwarmNodeType;
 use vertex_swarm_identity::Identity;
 use vertex_swarm_peer::{SwarmPeer, Timestamp};
@@ -87,7 +86,7 @@ pub fn test_peer_id(n: u8) -> PeerId {
 /// // peer has multiaddr /ip4/127.0.0.5/tcp/1634/p2p/{peer_id}
 /// ```
 pub fn test_swarm_peer(n: u8) -> SwarmPeer {
-    let overlay = SwarmAddress::from(B256::repeat_byte(n));
+    let overlay = OverlayAddress::from(B256::repeat_byte(n));
     let peer_id = test_peer_id(n);
     let multiaddrs = vec![
         format!("/ip4/127.0.0.{}/tcp/1634/p2p/{}", n, peer_id)
@@ -112,7 +111,7 @@ pub fn test_swarm_peer(n: u8) -> SwarmPeer {
 /// timestamp and a `port`-tagged multiaddr, so conflict-resolution tests can
 /// tell which record won by inspecting the stored multiaddrs.
 pub fn test_swarm_peer_with_timestamp(n: u8, timestamp: i64, port: u16) -> SwarmPeer {
-    let overlay = SwarmAddress::from(B256::repeat_byte(n));
+    let overlay = OverlayAddress::from(B256::repeat_byte(n));
     let peer_id = test_peer_id(n);
     let multiaddrs = vec![
         format!("/ip4/127.0.0.{}/tcp/{}/p2p/{}", n, port, peer_id)
@@ -146,7 +145,7 @@ pub fn test_signed_swarm_peer(
     SwarmPeer::sign(&identity, multiaddrs, timestamp, None).expect("sign test peer")
 }
 
-/// Create a SwarmAddress with a specific first byte.
+/// Create a OverlayAddress with a specific first byte.
 ///
 /// The first byte is set to `byte`, remaining bytes are zero.
 /// This is useful for Kademlia routing tests where you need to control
@@ -160,8 +159,8 @@ pub fn test_signed_swarm_peer(
 /// let overlay = make_overlay(0x80);
 /// // overlay == [0x80, 0x00, 0x00, ..., 0x00]
 /// ```
-pub fn make_overlay(byte: u8) -> SwarmAddress {
-    SwarmAddress::with_first_byte(byte)
+pub fn make_overlay(byte: u8) -> OverlayAddress {
+    OverlayAddress::with_first_byte(byte)
 }
 
 /// Create a minimal SwarmPeer for testing (no multiaddrs).
@@ -198,16 +197,16 @@ mod tests {
     #[test]
     fn test_overlay_helpers() {
         let overlay = test_overlay(0xff);
-        assert_eq!(overlay.as_slice(), &[0xff; 32]);
+        assert_eq!(overlay.as_bytes(), &[0xff; 32]);
 
         let peer = test_peer();
-        assert_eq!(peer.as_slice(), &[1u8; 32]);
+        assert_eq!(peer.as_bytes(), &[1u8; 32]);
     }
 
     #[test]
     fn test_swarm_peer_creation() {
         let peer = test_swarm_peer(5);
-        assert_eq!(peer.overlay().as_slice(), &[5u8; 32]);
+        assert_eq!(peer.overlay().as_bytes(), &[5u8; 32]);
         assert_eq!(peer.multiaddrs().len(), 1);
 
         // Verify multiaddr contains /p2p/ component
@@ -221,7 +220,7 @@ mod tests {
     #[test]
     fn test_make_overlay_first_byte() {
         let overlay = make_overlay(0x80);
-        assert_eq!(overlay.as_slice()[0], 0x80);
-        assert!(overlay.as_slice()[1..].iter().all(|&b| b == 0));
+        assert_eq!(overlay.as_bytes()[0], 0x80);
+        assert!(overlay.as_bytes()[1..].iter().all(|&b| b == 0));
     }
 }

--- a/crates/swarm/test-utils/src/storage.rs
+++ b/crates/swarm/test-utils/src/storage.rs
@@ -39,11 +39,11 @@ impl MockStorage {
         let mut index = HashMap::with_capacity(chunks.len());
         for (i, chunk) in chunks.into_iter().enumerate() {
             let address = *chunk.address();
-            let stamp_hash = B256::from_slice(address.as_slice());
+            let stamp_hash = B256::from_slice(address.as_bytes());
             items.push(BinScanItem {
                 seq: i as u64 + 1,
                 address,
-                batch_id: BatchId::repeat_byte(0xbb),
+                batch_id: BatchId::new([0xbb; 32]),
                 stamp_hash,
             });
             index.insert(address, chunk);

--- a/crates/swarm/test-utils/src/topology.rs
+++ b/crates/swarm/test-utils/src/topology.rs
@@ -1,6 +1,6 @@
 //! Mock topology implementations for testing.
 
-use nectar_primitives::{ChunkAddress, NetworkId, SwarmAddress};
+use nectar_primitives::{ChunkAddress, NetworkId};
 use std::sync::Arc;
 use vertex_swarm_api::{
     PeerReporter, ReportSource, SwarmIdentity, SwarmNodeType, SwarmScoringEvent, SwarmSpec,
@@ -142,8 +142,8 @@ impl MockTopology {
         self
     }
 
-    /// Get the overlay address as SwarmAddress.
-    pub fn overlay(&self) -> SwarmAddress {
+    /// Get the overlay address as OverlayAddress.
+    pub fn overlay(&self) -> OverlayAddress {
         self.identity.overlay_address()
     }
 

--- a/crates/swarm/topology/benches/topology_benchmarks.rs
+++ b/crates/swarm/topology/benches/topology_benchmarks.rs
@@ -122,7 +122,7 @@ fn bench_lock_patterns(c: &mut Criterion) {
                 let keys: HashSet<OverlayAddress> = map.read().keys().copied().collect();
                 let mut count = 0;
                 for key in keys {
-                    if key.as_slice()[0] > 128 {
+                    if key.as_bytes()[0] > 128 {
                         count += 1;
                     }
                 }
@@ -136,7 +136,7 @@ fn bench_lock_patterns(c: &mut Criterion) {
                 let guard = map.read();
                 let mut count = 0;
                 for (key, _) in guard.iter() {
-                    if key.as_slice()[0] > 128 {
+                    if key.as_bytes()[0] > 128 {
                         count += 1;
                     }
                 }

--- a/crates/swarm/topology/src/behaviour.rs
+++ b/crates/swarm/topology/src/behaviour.rs
@@ -32,7 +32,7 @@ use vertex_swarm_net_hive::MAX_BATCH_SIZE;
 use vertex_swarm_net_identify as identify;
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::{PeerManager, PeerSnapshot, TrustLevel};
-use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress, all_bins};
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress, XorMetric, all_bins};
 
 use crate::DialReason;
 use crate::dial_state::{DialBinState, DialState};
@@ -104,7 +104,7 @@ impl DialTarget {
     /// Get the overlay address if known.
     pub(crate) fn overlay(&self) -> Option<OverlayAddress> {
         match self {
-            Self::Known(peer) => Some(OverlayAddress::from(*peer.overlay())),
+            Self::Known(peer) => Some(*peer.overlay()),
             Self::Unknown(_) => None,
         }
     }
@@ -1123,7 +1123,7 @@ mod tests {
     use crate::kademlia::KademliaConfig;
 
     use alloy_primitives::{Address, B256, Signature};
-    use nectar_primitives::SwarmAddress;
+    use nectar_primitives::OverlayAddress;
     use vertex_swarm_peer::Timestamp;
     use vertex_swarm_primitives::Nonce;
 
@@ -1131,7 +1131,7 @@ mod tests {
         SwarmPeer::from_parts(
             vec![addr.parse().expect("valid multiaddr")],
             Signature::test_signature(),
-            SwarmAddress::from(B256::repeat_byte(1)),
+            OverlayAddress::from(B256::repeat_byte(1)),
             Nonce::ZERO,
             Timestamp::from_seconds(1),
             None,
@@ -1690,7 +1690,7 @@ mod tests {
         fn two_pending_activation_does_not_leak_pending() {
             let mut behaviour = test_behaviour();
             let peer = test_swarm_peer(1);
-            let overlay = OverlayAddress::from(*peer.overlay());
+            let overlay = *peer.overlay();
             let completing_peer = test_peer_id(1);
             let placeholder_peer = test_peer_id(9);
             let c_out = ConnectionId::new_unchecked(1);
@@ -1726,7 +1726,7 @@ mod tests {
         fn refused_duplicate_then_success_does_not_underflow_pending() {
             let mut behaviour = test_behaviour();
             let peer = test_swarm_peer(1);
-            let overlay = OverlayAddress::from(*peer.overlay());
+            let overlay = *peer.overlay();
             let peer_id = test_peer_id(1);
             let c1 = ConnectionId::new_unchecked(1);
             let c2 = ConnectionId::new_unchecked(2);
@@ -1761,7 +1761,7 @@ mod tests {
         fn replacement_keeps_active_gauge_at_truth() {
             let mut behaviour = test_behaviour();
             let peer = test_swarm_peer(1);
-            let overlay = OverlayAddress::from(*peer.overlay());
+            let overlay = *peer.overlay();
             let completing_peer = test_peer_id(1);
             let incumbent_peer = test_peer_id(9);
             let c1 = ConnectionId::new_unchecked(1);
@@ -2000,7 +2000,7 @@ mod tests {
         /// Store a dialable loopback peer and queue it as a dial candidate.
         fn queue_candidate(behaviour: &TopologyBehaviour<Identity>, n: u8) {
             let peer = test_swarm_peer(n);
-            let overlay = OverlayAddress::from(*peer.overlay());
+            let overlay = *peer.overlay();
             behaviour.peer_manager.store_discovered_peer(peer);
             behaviour.routing.requeue_candidate(overlay);
         }
@@ -2258,7 +2258,7 @@ mod tests {
             // Two dialable candidates queued in bin 0.
             for n in [0xC0u8, 0xC1] {
                 let peer = test_swarm_peer(n);
-                let overlay = OverlayAddress::from(*peer.overlay());
+                let overlay = *peer.overlay();
                 behaviour.peer_manager.store_discovered_peer(peer);
                 behaviour.routing.requeue_candidate(overlay);
             }

--- a/crates/swarm/topology/src/dialing.rs
+++ b/crates/swarm/topology/src/dialing.rs
@@ -28,7 +28,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
     ///
     /// Checks routing capacity and filters before dialing.
     pub fn dial_swarm_peer(&mut self, swarm_peer: SwarmPeer) -> bool {
-        let overlay = vertex_swarm_primitives::OverlayAddress::from(*swarm_peer.overlay());
+        let overlay = *swarm_peer.overlay();
 
         // Check if banned or in backoff
         if self.peer_manager.is_banned(&overlay) || self.peer_manager.peer_is_in_backoff(&overlay) {

--- a/crates/swarm/topology/src/gossip/engine.rs
+++ b/crates/swarm/topology/src/gossip/engine.rs
@@ -17,7 +17,7 @@ use tracing::{debug, trace};
 use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::PeerManager;
-use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress};
+use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress, XorMetric};
 use vertex_util_runtime::time::Instant;
 
 use super::GossipConfig;
@@ -198,7 +198,7 @@ impl<I: SwarmIdentity> GossipEngine<I> {
     pub(crate) fn on_peers_received(&mut self, gossiper: OverlayAddress, peers: Vec<SwarmPeer>) {
         let peers: Vec<_> = peers
             .into_iter()
-            .filter(|p| OverlayAddress::from(*p.overlay()) != self.local_overlay)
+            .filter(|p| *p.overlay() != self.local_overlay)
             .collect();
         if peers.is_empty() {
             return;
@@ -344,7 +344,7 @@ impl<I: SwarmIdentity> GossipEngine<I> {
     ) -> Vec<GossipAction> {
         self.last_depth = depth;
 
-        let new_peer_overlay = OverlayAddress::from(*peer.overlay());
+        let new_peer_overlay = *peer.overlay();
 
         if !node_type.requires_storage() {
             // A connecting client cannot grow past its bootnodes without
@@ -502,7 +502,7 @@ impl<I: SwarmIdentity> GossipEngine<I> {
                 // Exclude the neighbor itself from the result
                 let peers: Vec<SwarmPeer> = filtered
                     .into_iter()
-                    .filter(|p| OverlayAddress::from(*p.overlay()) != neighbor)
+                    .filter(|p| *p.overlay() != neighbor)
                     .cloned()
                     .collect();
 
@@ -654,7 +654,7 @@ mod tests {
     /// Register `n` as a known, actively connected client.
     fn connect_client(ctx: &TopologyTestContext, n: u8) -> OverlayAddress {
         let peer = test_swarm_peer(n);
-        let overlay = OverlayAddress::from(*peer.overlay());
+        let overlay = *peer.overlay();
         ctx.peer_manager.on_peer_connected(
             peer,
             SwarmNodeType::Client,
@@ -674,7 +674,7 @@ mod tests {
     /// announcement sample).
     fn connect_storer(ctx: &TopologyTestContext, n: u8) -> OverlayAddress {
         let peer = test_swarm_peer(n);
-        let overlay = OverlayAddress::from(*peer.overlay());
+        let overlay = *peer.overlay();
         ctx.peer_manager.on_peer_connected(
             peer,
             SwarmNodeType::Storer,
@@ -702,7 +702,7 @@ mod tests {
         let bin2 = connect_storer(&ctx, 0x20);
 
         let newcomer = test_swarm_peer(0x80);
-        let newcomer_overlay = OverlayAddress::from(*newcomer.overlay());
+        let newcomer_overlay = *newcomer.overlay();
         let actions = engine.on_peer_authenticated(&newcomer, SwarmNodeType::Storer, 3);
 
         for recipient in [bin1, bin2] {
@@ -923,7 +923,7 @@ mod tests {
             let mut engine = test_engine(&ctx);
 
             let client = test_swarm_peer(0xC1);
-            let client_overlay = OverlayAddress::from(*client.overlay());
+            let client_overlay = *client.overlay();
             ctx.peer_manager.on_peer_connected(
                 client.clone(),
                 SwarmNodeType::Client,
@@ -939,9 +939,7 @@ mod tests {
             assert!(!action.peers.is_empty(), "the client receives a peer list");
             assert!(
                 action.peers.iter().all(|p| {
-                    ctx.peer_manager
-                        .node_type(&OverlayAddress::from(*p.overlay()))
-                        == Some(SwarmNodeType::Storer)
+                    ctx.peer_manager.node_type(p.overlay()) == Some(SwarmNodeType::Storer)
                 }),
                 "the payload carries storers only"
             );
@@ -976,10 +974,9 @@ mod tests {
 
             assert!(!actions.is_empty());
             assert!(
-                actions.iter().all(|a| a
-                    .peers
+                actions
                     .iter()
-                    .all(|p| OverlayAddress::from(*p.overlay()) != client_overlay)),
+                    .all(|a| a.peers.iter().all(|p| *p.overlay() != client_overlay)),
                 "clients are recipients only, never subjects"
             );
         }

--- a/crates/swarm/topology/src/gossip/filter.rs
+++ b/crates/swarm/topology/src/gossip/filter.rs
@@ -68,7 +68,7 @@ pub(crate) fn filter_peers_for_recipient<'a, I: SwarmIdentity>(
     peers
         .iter()
         .filter(|peer| {
-            let peer_overlay = OverlayAddress::from(*peer.overlay());
+            let peer_overlay = *peer.overlay();
             let cap = peer_capability(peer_manager, &peer_overlay);
             recipient.capability.can_reach(&cap)
                 && scope_eligible_for_recipient(peer, recipient.scope)
@@ -89,7 +89,7 @@ pub(crate) fn select_peers_for_distant<I: SwarmIdentity>(
     candidates
         .into_iter()
         .filter(|(peer, _bin)| {
-            let peer_overlay = OverlayAddress::from(*peer.overlay());
+            let peer_overlay = *peer.overlay();
             let cap = peer_capability(peer_manager, &peer_overlay);
             recipient.capability.can_reach(&cap)
                 && scope_eligible_for_recipient(peer, recipient.scope)

--- a/crates/swarm/topology/src/gossip/intake.rs
+++ b/crates/swarm/topology/src/gossip/intake.rs
@@ -89,7 +89,7 @@ impl GossipIntake {
             return Err(GossipCheckError::NoPeerId);
         }
 
-        let overlay = OverlayAddress::from(*gossiped_peer.overlay());
+        let overlay = *gossiped_peer.overlay();
         let now = Instant::now();
         let fingerprint = multiaddrs_fingerprint(gossiped_peer);
 

--- a/crates/swarm/topology/src/kademlia/admission.rs
+++ b/crates/swarm/topology/src/kademlia/admission.rs
@@ -13,7 +13,7 @@ use vertex_swarm_net_handshake::{
     AdmissionDecision, AdmissionRejection, ConnectionDirection, HandshakeAdmissionControl,
     SharedAdmissionControl,
 };
-use vertex_swarm_peer::{SwarmAddress, SwarmNodeType};
+use vertex_swarm_peer::{OverlayAddress, SwarmNodeType};
 
 use super::KademliaRouting;
 
@@ -34,7 +34,7 @@ impl<I: SwarmIdentity> KademliaAdmissionControl<I> {
 impl<I: SwarmIdentity> HandshakeAdmissionControl for KademliaAdmissionControl<I> {
     fn evaluate(
         &self,
-        peer_overlay: &SwarmAddress,
+        peer_overlay: &OverlayAddress,
         _node_type: SwarmNodeType,
         direction: ConnectionDirection,
     ) -> AdmissionDecision {
@@ -71,7 +71,7 @@ mod tests {
     use vertex_swarm_test_utils::MockIdentity;
 
     fn make_routing(
-        base: SwarmAddress,
+        base: OverlayAddress,
         config: KademliaConfig,
     ) -> Arc<KademliaRouting<MockIdentity>> {
         let identity = MockIdentity::with_overlay(base);
@@ -81,12 +81,12 @@ mod tests {
 
     #[test]
     fn accepts_when_routing_has_capacity() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let routing = make_routing(base, KademliaConfig::default());
         let ac = KademliaAdmissionControl::new(routing);
 
         let decision = ac.evaluate(
-            &SwarmAddress::with_first_byte(0x80),
+            &OverlayAddress::with_first_byte(0x80),
             SwarmNodeType::Storer,
             ConnectionDirection::Inbound,
         );
@@ -97,7 +97,7 @@ mod tests {
     fn inbound_accepts_at_ceiling_minus_one() {
         // Capacity 1 (nominal=1, headroom=0). With zero peers reserved
         // the in-flight inbound peer fills the only slot exactly.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
@@ -107,7 +107,7 @@ mod tests {
         let routing = make_routing(base, config);
 
         let ac = KademliaAdmissionControl::new(routing);
-        let peer = SwarmAddress::with_first_byte(0x80);
+        let peer = OverlayAddress::with_first_byte(0x80);
         let decision = ac.evaluate(&peer, SwarmNodeType::Storer, ConnectionDirection::Inbound);
         assert!(matches!(decision, AdmissionDecision::Accept));
     }
@@ -117,7 +117,7 @@ mod tests {
         // Capacity 1 and one peer already reserved into po=0. The
         // in-flight inbound peer (also po=0) would push the bin over
         // ceiling.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
@@ -126,11 +126,11 @@ mod tests {
             .with_saturation(1);
         let routing = make_routing(base, config);
 
-        let occupied = SwarmAddress::with_first_byte(0xc0);
+        let occupied = OverlayAddress::with_first_byte(0xc0);
         RoutingCapacity::reserve_inbound(&*routing, &occupied);
 
         let ac = KademliaAdmissionControl::new(routing);
-        let peer = SwarmAddress::with_first_byte(0x80);
+        let peer = OverlayAddress::with_first_byte(0x80);
         let decision = ac.evaluate(&peer, SwarmNodeType::Storer, ConnectionDirection::Inbound);
         assert!(matches!(
             decision,
@@ -143,7 +143,7 @@ mod tests {
         // Capacity 1. The outbound peer reserved its slot via
         // `try_reserve_dial`, so `effective_count` already includes it.
         // Admission must accept because the slot it occupies is its own.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
@@ -152,7 +152,7 @@ mod tests {
             .with_saturation(1);
         let routing = make_routing(base, config);
 
-        let peer = SwarmAddress::with_first_byte(0x80);
+        let peer = OverlayAddress::with_first_byte(0x80);
         assert!(RoutingCapacity::try_reserve_dial(
             &*routing,
             &peer,
@@ -170,7 +170,7 @@ mod tests {
         // ceiling=1. The second peer should have been rejected by
         // `try_reserve_dial` already, but if a stale caller passes it
         // to the gate we still want a clean reject.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default()
             .with_nominal(1)
             .with_inbound_headroom(0)
@@ -179,8 +179,8 @@ mod tests {
             .with_saturation(1);
         let routing = make_routing(base, config);
 
-        let peer1 = SwarmAddress::with_first_byte(0x80);
-        let peer2 = SwarmAddress::with_first_byte(0xc0);
+        let peer1 = OverlayAddress::with_first_byte(0x80);
+        let peer2 = OverlayAddress::with_first_byte(0xc0);
         assert!(RoutingCapacity::try_reserve_dial(
             &*routing,
             &peer1,
@@ -202,21 +202,21 @@ mod tests {
     fn neighborhood_bin_always_accepts() {
         // Bins inside the neighborhood (ceiling = usize::MAX) accept
         // unconditionally; oversaturation there is a separate concern.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default().with_nominal(1);
         let routing = make_routing(base, config);
 
         for i in 0..3 {
             let mut bytes = [0u8; 32];
             bytes[0] = 0x01 + i;
-            RoutingCapacity::reserve_inbound(&*routing, &SwarmAddress::from(bytes));
+            RoutingCapacity::reserve_inbound(&*routing, &OverlayAddress::from(bytes));
         }
 
         let ac = KademliaAdmissionControl::new(routing);
         let mut bytes = [0u8; 32];
         bytes[0] = 0x01;
         let decision = ac.evaluate(
-            &SwarmAddress::from(bytes),
+            &OverlayAddress::from(bytes),
             SwarmNodeType::Storer,
             ConnectionDirection::Inbound,
         );
@@ -225,11 +225,11 @@ mod tests {
 
     #[test]
     fn shared_handle_dispatches() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let routing = make_routing(base, KademliaConfig::default());
         let handle = kademlia_admission_control(routing);
         let decision = handle.evaluate(
-            &SwarmAddress::with_first_byte(0x42),
+            &OverlayAddress::with_first_byte(0x42),
             SwarmNodeType::Client,
             ConnectionDirection::Outbound,
         );

--- a/crates/swarm/topology/src/kademlia/candidate_queues.rs
+++ b/crates/swarm/topology/src/kademlia/candidate_queues.rs
@@ -109,12 +109,12 @@ mod tests {
     fn b(n: u8) -> Bin {
         Bin::new(n).expect("valid bin")
     }
-    use nectar_primitives::SwarmAddress;
+    use nectar_primitives::OverlayAddress;
 
     #[test]
     fn test_push_and_drain() {
         let queues = CandidateQueues::new(32, 16);
-        let peer = SwarmAddress::with_first_byte(0x80);
+        let peer = OverlayAddress::with_first_byte(0x80);
 
         assert!(queues.push(b(0), peer));
         // Dedup: second push returns false
@@ -131,8 +131,8 @@ mod tests {
     #[test]
     fn test_drain_highest_first() {
         let queues = CandidateQueues::new(32, 16);
-        let lo = SwarmAddress::with_first_byte(0x80);
-        let hi = SwarmAddress::with_first_byte(0x40);
+        let lo = OverlayAddress::with_first_byte(0x80);
+        let hi = OverlayAddress::with_first_byte(0x40);
 
         queues.push(b(0), lo);
         queues.push(b(1), hi);
@@ -148,9 +148,9 @@ mod tests {
     fn test_per_bin_cap() {
         let queues = CandidateQueues::new(32, 2);
 
-        let p1 = SwarmAddress::with_first_byte(0x80);
-        let p2 = SwarmAddress::with_first_byte(0x81);
-        let p3 = SwarmAddress::with_first_byte(0x82);
+        let p1 = OverlayAddress::with_first_byte(0x80);
+        let p2 = OverlayAddress::with_first_byte(0x81);
+        let p3 = OverlayAddress::with_first_byte(0x82);
 
         assert!(queues.push(b(0), p1));
         assert!(queues.push(b(0), p2));
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_invalid_bin() {
         let queues = CandidateQueues::new(4, 16);
-        let peer = SwarmAddress::with_first_byte(0x80);
+        let peer = OverlayAddress::with_first_byte(0x80);
 
         // Bin 5 doesn't exist (only 0-3)
         assert!(!queues.push(b(5), peer));
@@ -177,8 +177,8 @@ mod tests {
     #[test]
     fn test_pop_next_highest_bin_first() {
         let queues = CandidateQueues::new(32, 16);
-        let lo = SwarmAddress::with_first_byte(0x80);
-        let hi = SwarmAddress::with_first_byte(0x40);
+        let lo = OverlayAddress::with_first_byte(0x80);
+        let hi = OverlayAddress::with_first_byte(0x40);
 
         queues.push(b(0), lo);
         queues.push(b(1), hi);

--- a/crates/swarm/topology/src/kademlia/peer_selection.rs
+++ b/crates/swarm/topology/src/kademlia/peer_selection.rs
@@ -5,7 +5,9 @@ use std::collections::{BTreeMap, HashSet};
 use vertex_swarm_api::{SwarmIdentity, SwarmNodeType};
 use vertex_swarm_peer::SwarmPeer;
 use vertex_swarm_peer_manager::PeerManager;
-use vertex_swarm_primitives::{Bin, NeighborhoodDepth, OverlayAddress, neighborhood_bins};
+use vertex_swarm_primitives::{
+    Bin, NeighborhoodDepth, OverlayAddress, XorMetric, neighborhood_bins,
+};
 
 use crate::behaviour::ConnectionRegistry;
 

--- a/crates/swarm/topology/src/kademlia/routing.rs
+++ b/crates/swarm/topology/src/kademlia/routing.rs
@@ -16,7 +16,7 @@ use super::{
     slot_of,
 };
 use crate::metrics::{phase, record_phase_transition, record_topology_phase_change};
-use nectar_primitives::{ChunkAddress, recompute_neighborhood_depth};
+use nectar_primitives::{ChunkAddress, XorMetric, recompute_neighborhood_depth};
 use parking_lot::{Mutex, RwLock};
 use tracing::{debug, info, trace, warn};
 use vertex_net_peer_registry::ConnectionDirection;
@@ -1235,7 +1235,7 @@ impl<I: SwarmIdentity + 'static> KademliaRouting<I> {
 mod tests {
     #![allow(clippy::indexing_slicing)]
     use super::*;
-    use nectar_primitives::SwarmAddress;
+    use nectar_primitives::OverlayAddress;
     use vertex_swarm_peer_manager::PeerManagerConfig;
     use vertex_swarm_test_utils::{MockIdentity, make_swarm_peer_minimal};
 
@@ -1262,7 +1262,7 @@ mod tests {
 
     #[test]
     fn test_routing_creation() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default();
         let (routing, _pm) = make_routing(base, config);
 
@@ -1272,12 +1272,12 @@ mod tests {
 
     #[test]
     fn test_add_and_connect_peers() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default();
         let (routing, pm) = make_routing(base, config);
 
-        let peer1 = SwarmAddress::with_first_byte(0x80);
-        let peer2 = SwarmAddress::with_first_byte(0x40);
+        let peer1 = OverlayAddress::with_first_byte(0x80);
+        let peer2 = OverlayAddress::with_first_byte(0x40);
 
         // Add peers via PeerManager (not routing.add_peers which is now no-op)
         pm.store_discovered_peer(make_swarm_peer_minimal(0x80));
@@ -1294,7 +1294,7 @@ mod tests {
 
     #[test]
     fn test_capacity_reserve_and_release() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Pin the depth-0 bootstrap target to 2 so the capacity mechanism is
         // exercised with small numbers (default bootstrap fill is generous).
         // Pin oversaturation to the target too, so the retention floor equals
@@ -1307,9 +1307,9 @@ mod tests {
             .with_oversaturation_peers(2);
         let (routing, _pm) = make_routing(base, config);
 
-        let peer1 = SwarmAddress::with_first_byte(0x80); // bin=0
-        let peer2 = SwarmAddress::with_first_byte(0xc0); // bin=0
-        let peer3 = SwarmAddress::with_first_byte(0xa0); // bin=0
+        let peer1 = OverlayAddress::with_first_byte(0x80); // bin=0
+        let peer2 = OverlayAddress::with_first_byte(0xc0); // bin=0
+        let peer3 = OverlayAddress::with_first_byte(0xa0); // bin=0
 
         // First reserve succeeds (effective=0 < target=2)
         assert!(routing.try_reserve_dial(&peer1, SwarmNodeType::Storer));
@@ -1329,11 +1329,11 @@ mod tests {
 
     #[test]
     fn test_capacity_state_transitions() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default().with_nominal(2);
         let (routing, _pm) = make_routing(base, config);
 
-        let peer = SwarmAddress::with_first_byte(0x80); // bin=0
+        let peer = OverlayAddress::with_first_byte(0x80); // bin=0
 
         // Reserve dial
         assert!(routing.try_reserve_dial(&peer, SwarmNodeType::Storer));
@@ -1355,11 +1355,11 @@ mod tests {
 
     #[test]
     fn test_disconnect_and_reconnect() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default();
         let (routing, pm) = make_routing(base, config);
 
-        let peer = SwarmAddress::with_first_byte(0x80);
+        let peer = OverlayAddress::with_first_byte(0x80);
 
         // Add peer to PeerManager
         pm.store_discovered_peer(make_swarm_peer_minimal(0x80));
@@ -1387,7 +1387,7 @@ mod tests {
         // depth frontier is the shallowest unsaturated bin (0), so depth stays
         // 0 - the corrected algorithm does not jump to the deepest populated
         // bin the way the old deepest-bin scan did.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
         assert_eq!(routing.depth().get(), 0);
@@ -1403,7 +1403,7 @@ mod tests {
         // empty, and bin 8 holds several peers. The old scan reported depth 8;
         // the corrected algorithm caps depth at the shallowest unsaturated bin
         // (bin 1, just past the saturated frontier at bin 0).
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
         for idx in 0..8 {
@@ -1424,7 +1424,7 @@ mod tests {
     fn test_depth_climbs_with_saturated_bins() {
         // Bins 0,1,2 saturated (>= 8) with bin 3 holding the low-watermark (3)
         // anchors the neighborhood at bin 3.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
         for bin in 0..3 {
@@ -1456,7 +1456,7 @@ mod tests {
 
     #[test]
     fn test_neighborhood_stability_tracks_saturation() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
         assert!(
@@ -1484,7 +1484,7 @@ mod tests {
         // remove_peer (the ban path) bypasses the disconnect bookkeeping but
         // still shrinks the neighborhood; the clock must observe it. Three
         // removals (9 -> 6) exceed the dip tolerance and clear immediately.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
         saturate_to_depth_one(&routing);
@@ -1502,7 +1502,7 @@ mod tests {
     /// restarting the anchor.
     #[test]
     fn test_stability_clock_survives_boundary_peer_flap() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
         saturate_to_depth_one(&routing);
 
@@ -1540,7 +1540,7 @@ mod tests {
     /// clock: the damping is a delay, not a mask.
     #[test]
     fn test_marginal_dip_clears_after_window_expiry() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
         saturate_to_depth_one(&routing);
         SwarmRouting::on_peer_disconnected(&*routing, &addr_in_bin(1, 0));
@@ -1563,7 +1563,7 @@ mod tests {
     /// clock, and the anchor keeps its original start.
     #[test]
     fn test_resaturation_cancels_pending_dip() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
         saturate_to_depth_one(&routing);
         let peer = addr_in_bin(1, 0);
@@ -1589,7 +1589,7 @@ mod tests {
         // bin0=8, bin1=5, bin2=3, bin3=1: depth anchors at 1 and the
         // neighborhood (bins >= 1, holding 9) is saturated, so the stability
         // clock is anchored at depth 1.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
         saturate_to_depth_one(&routing);
         assert_eq!(routing.depth().get(), 1);
@@ -1636,7 +1636,7 @@ mod tests {
     /// Depth-3 fixture: bins 0..=2 saturated (8 peers each, the default
     /// saturation), bin 3 holding the low watermark (3 peers).
     fn routing_at_depth_3() -> Arc<KademliaRouting<MockIdentity>> {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
         for bin in 0..3 {
             for idx in 0..8 {
@@ -1760,7 +1760,7 @@ mod tests {
 
     #[test]
     fn test_phase_starts_bootstrap_and_converges_on_depth_climb() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let (routing, _pm) = make_routing(base, KademliaConfig::default());
 
         assert_eq!(routing.phase_status().0, TopologyPhase::Bootstrap);
@@ -1797,7 +1797,7 @@ mod tests {
         // A zero stability window makes the time gate pass immediately, so
         // the saturation condition alone drives Converging vs Stable and
         // the lifecycle is testable without simulated clocks.
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default().with_phase_stability_window(Duration::ZERO);
         let (routing, _pm) = make_routing(base, config);
 
@@ -1838,13 +1838,13 @@ mod tests {
 
     #[test]
     fn test_closest_to() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default();
         let (routing, _pm) = make_routing(base, config);
 
-        let peer_po0 = SwarmAddress::with_first_byte(0x80);
-        let peer_po1 = SwarmAddress::with_first_byte(0x40);
-        let peer_po2 = SwarmAddress::with_first_byte(0x20);
+        let peer_po0 = OverlayAddress::with_first_byte(0x80);
+        let peer_po1 = OverlayAddress::with_first_byte(0x40);
+        let peer_po2 = OverlayAddress::with_first_byte(0x20);
 
         SwarmRouting::connected(&*routing, peer_po0);
         SwarmRouting::connected(&*routing, peer_po1);
@@ -1861,12 +1861,12 @@ mod tests {
 
     #[test]
     fn test_neighbors() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default().with_nominal(1);
         let (routing, _pm) = make_routing(base, config);
 
-        let peer_po0 = SwarmAddress::with_first_byte(0x80);
-        let peer_po1 = SwarmAddress::with_first_byte(0x40);
+        let peer_po0 = OverlayAddress::with_first_byte(0x80);
+        let peer_po1 = OverlayAddress::with_first_byte(0x40);
         let peer_po5 = {
             let mut bytes = [0x00u8; 32];
             bytes[0] = 0x04;
@@ -1887,7 +1887,7 @@ mod tests {
 
     #[test]
     fn test_inbound_capacity() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // With bootstrap and oversaturation pinned to 2 and headroom 0, the
         // depth-0 inbound ceiling = 2
         let config = KademliaConfig::default()
@@ -1898,9 +1898,9 @@ mod tests {
             .with_saturation(2);
         let (routing, _pm) = make_routing(base, config);
 
-        let peer1 = SwarmAddress::with_first_byte(0x80);
-        let peer2 = SwarmAddress::with_first_byte(0xc0);
-        let peer3 = SwarmAddress::with_first_byte(0xa0);
+        let peer1 = OverlayAddress::with_first_byte(0x80);
+        let peer2 = OverlayAddress::with_first_byte(0xc0);
+        let peer3 = OverlayAddress::with_first_byte(0xa0);
 
         // Can accept first inbound
         assert!(routing.should_accept_inbound(&peer1, SwarmNodeType::Storer));
@@ -1928,7 +1928,7 @@ mod tests {
 
     #[test]
     fn test_depth_aware_targets() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default();
         let (routing, _pm) = make_routing(base, config);
 
@@ -1947,7 +1947,7 @@ mod tests {
 
     #[test]
     fn test_eviction_candidates_no_surplus() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default().with_nominal(3);
         let (routing, _pm) = make_routing(base, config);
 
@@ -1956,7 +1956,7 @@ mod tests {
         assert!(candidates.is_empty());
 
         // Add peers below nominal - still no surplus
-        let peer1 = SwarmAddress::with_first_byte(0x80); // bin=0
+        let peer1 = OverlayAddress::with_first_byte(0x80); // bin=0
         SwarmRouting::connected(&*routing, peer1);
         let candidates = routing.eviction_candidates(|_| 1);
         assert!(candidates.is_empty());
@@ -1987,7 +1987,7 @@ mod tests {
 
     #[test]
     fn wrong_phase_release_leaves_counters_consistent() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         let config = KademliaConfig::default().with_nominal(2);
         let (routing, _pm) = make_routing(base, config);
 
@@ -1995,7 +1995,7 @@ mod tests {
 
         // Case 1: a handshaking peer wrongly released as a dial stays put; the
         // matching release_handshake then drains it.
-        let peer_a = SwarmAddress::with_first_byte(0x80); // bin 0
+        let peer_a = OverlayAddress::with_first_byte(0x80); // bin 0
         let bin_a = routing.bin_for(&peer_a);
         force_handshaking(&routing, peer_a);
         routing.release_dial(&peer_a);
@@ -2009,7 +2009,7 @@ mod tests {
 
         // Case 2: an active peer is untouched by either release; only the
         // authoritative disconnected() drains it.
-        let peer_b = SwarmAddress::with_first_byte(0x40); // bin 1
+        let peer_b = OverlayAddress::with_first_byte(0x40); // bin 1
         let bin_b = routing.bin_for(&peer_b);
         force_active(&routing, peer_b);
         routing.release_dial(&peer_b);
@@ -2024,7 +2024,7 @@ mod tests {
 
         // Case 3: a dialing peer wrongly released as a handshake stays put; the
         // matching release_dial then drains it.
-        let peer_c = SwarmAddress::with_first_byte(0x20); // bin 2
+        let peer_c = OverlayAddress::with_first_byte(0x20); // bin 2
         let bin_c = routing.bin_for(&peer_c);
         assert!(routing.try_reserve_dial(&peer_c, SwarmNodeType::Storer));
         routing.release_handshake(&peer_c);
@@ -2039,7 +2039,7 @@ mod tests {
         // Case 4: an inbound handshaking peer (no outbound tally) wrongly
         // released as a dial stays put; release_handshake drains handshaking
         // only, leaving the outbound count at zero throughout.
-        let peer_d = SwarmAddress::with_first_byte(0x10); // bin 3
+        let peer_d = OverlayAddress::with_first_byte(0x10); // bin 3
         let bin_d = routing.bin_for(&peer_d);
         routing.reserve_inbound(&peer_d);
         routing.release_dial(&peer_d);
@@ -2054,7 +2054,7 @@ mod tests {
 
     #[test]
     fn test_eviction_candidates_handshaking_first() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Pin the trim floor (oversaturation_peers) and saturation to 4 so
         // a small bin-0 population yields a surplus and the depth-8 bin-0
         // target stays at 4 as the original scenario assumed.
@@ -2102,7 +2102,7 @@ mod tests {
 
     #[test]
     fn test_eviction_candidates_active_lowest_score() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
         let config = KademliaConfig::default()
             .with_bootstrap_target(4)
@@ -2135,7 +2135,7 @@ mod tests {
 
     #[test]
     fn test_eviction_ignores_in_flight_dials() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
         let config = KademliaConfig::default()
             .with_bootstrap_target(4)
@@ -2177,7 +2177,7 @@ mod tests {
 
     #[test]
     fn test_eviction_prefers_least_reachable() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
         let (routing, _pm) = make_routing(
             base,
@@ -2221,7 +2221,7 @@ mod tests {
     fn test_eviction_local_tiebreak_keeps_local_over_equal_remote() {
         use crate::PeerReachability;
 
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
         let (routing, _pm) = make_routing(
             base,
@@ -2265,7 +2265,7 @@ mod tests {
     fn test_eviction_remote_reachable_outranks_local_unreachable() {
         use crate::PeerReachability;
 
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
         let (routing, _pm) = make_routing(
             base,
@@ -2314,11 +2314,12 @@ mod tests {
         // (0xC0 and 0xE0, mutual proximity 2). With every (rank, score) equal,
         // both victims must come from the tight cluster so the kept set still
         // covers both sub-tries.
-        let cluster: Vec<OverlayAddress> =
-            (0x80..=0x83u8).map(SwarmAddress::with_first_byte).collect();
+        let cluster: Vec<OverlayAddress> = (0x80..=0x83u8)
+            .map(OverlayAddress::with_first_byte)
+            .collect();
         let spread = [
-            SwarmAddress::with_first_byte(0xc0),
-            SwarmAddress::with_first_byte(0xe0),
+            OverlayAddress::with_first_byte(0xc0),
+            OverlayAddress::with_first_byte(0xe0),
         ];
 
         let pool: Vec<(OverlayAddress, u8, f64)> = cluster
@@ -2342,9 +2343,9 @@ mod tests {
         // The diversity tie-break never overrides the primary order: a
         // prefix-diverse peer with the worst rank (or, at equal rank, the
         // lowest score) is still evicted first.
-        let clustered_a = SwarmAddress::with_first_byte(0x80);
-        let clustered_b = SwarmAddress::with_first_byte(0x81);
-        let diverse = SwarmAddress::with_first_byte(0xc0);
+        let clustered_a = OverlayAddress::with_first_byte(0x80);
+        let clustered_b = OverlayAddress::with_first_byte(0x81);
+        let diverse = OverlayAddress::with_first_byte(0xc0);
 
         // Worst rank loses despite being the diversity-preferred keep.
         let pool = vec![
@@ -2368,10 +2369,12 @@ mod tests {
         // Two equally tight clusters and one victim slot per round: the
         // incremental recompute alternates clusters instead of draining one,
         // keeping the survivors spread.
-        let cluster_a: Vec<OverlayAddress> =
-            (0x80..=0x81u8).map(SwarmAddress::with_first_byte).collect();
-        let cluster_b: Vec<OverlayAddress> =
-            (0xc0..=0xc1u8).map(SwarmAddress::with_first_byte).collect();
+        let cluster_a: Vec<OverlayAddress> = (0x80..=0x81u8)
+            .map(OverlayAddress::with_first_byte)
+            .collect();
+        let cluster_b: Vec<OverlayAddress> = (0xc0..=0xc1u8)
+            .map(OverlayAddress::with_first_byte)
+            .collect();
 
         let pool: Vec<(OverlayAddress, u8, f64)> = cluster_a
             .iter()
@@ -2390,7 +2393,7 @@ mod tests {
 
     #[test]
     fn test_eviction_tiebreak_keeps_bin_prefix_spread() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Trim floor pinned to 4; see test_eviction_candidates_handshaking_first.
         let (routing, _pm) = make_routing(
             base,
@@ -2404,11 +2407,12 @@ mod tests {
         // spread peers (0xC0, 0xE0). At depth 8 the target is 4, so surplus is
         // 2. All ranks and scores are equal, so prefix diversity decides: both
         // victims come from the cluster and the kept set covers both sub-tries.
-        let cluster: Vec<OverlayAddress> =
-            (0x80..=0x83u8).map(SwarmAddress::with_first_byte).collect();
+        let cluster: Vec<OverlayAddress> = (0x80..=0x83u8)
+            .map(OverlayAddress::with_first_byte)
+            .collect();
         let spread = [
-            SwarmAddress::with_first_byte(0xc0),
-            SwarmAddress::with_first_byte(0xe0),
+            OverlayAddress::with_first_byte(0xc0),
+            OverlayAddress::with_first_byte(0xe0),
         ];
         for peer in cluster.iter().chain(spread.iter()) {
             force_active(&routing, *peer);
@@ -2430,7 +2434,7 @@ mod tests {
 
     #[test]
     fn test_eviction_candidates_neighborhood_never_evicted() {
-        let base = SwarmAddress::with_first_byte(0x00);
+        let base = OverlayAddress::with_first_byte(0x00);
         // Trim floor pinned to the saturation default (8); dialing alone can
         // never exceed it, so the overflow that yields eviction candidates
         // must arrive through the inbound headroom band.

--- a/crates/swarm/topology/src/kademlia/sim/mod.rs
+++ b/crates/swarm/topology/src/kademlia/sim/mod.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use alloy_primitives::{Address, Signature, U256};
-use nectar_primitives::recompute_neighborhood_depth;
+use nectar_primitives::{XorMetric, recompute_neighborhood_depth};
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use vertex_net_peer_registry::ConnectionDirection;
 use vertex_swarm_api::{DisconnectReason, SwarmIdentity, SwarmSpec};
@@ -395,7 +395,7 @@ impl SimWorld {
             .collect();
         // Sort before the seeded shuffle so the selection is reproducible
         // regardless of the hash-map iteration order.
-        active.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+        active.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
         active.shuffle(&mut self.rng);
         let take = ((active.len() as f64) * fraction) as usize;
         for overlay in active.into_iter().take(take) {

--- a/crates/swarm/topology/src/protocol_handlers.rs
+++ b/crates/swarm/topology/src/protocol_handlers.rs
@@ -57,7 +57,7 @@ impl<I: SwarmIdentity + Clone> TopologyBehaviour<I> {
         connection_id: ConnectionId,
         info: vertex_swarm_net_handshake::HandshakeInfo,
     ) {
-        let overlay = OverlayAddress::from(*info.swarm_peer.overlay());
+        let overlay = *info.swarm_peer.overlay();
         let node_type = info.node_type;
 
         debug!(

--- a/crates/swarm/topology/src/test_support.rs
+++ b/crates/swarm/topology/src/test_support.rs
@@ -51,7 +51,7 @@ impl TopologyTestContext {
 /// count-based fill for populations built with this helper.
 pub(crate) fn overlay_in_bin(base: OverlayAddress, bin: u8, idx: u8) -> OverlayAddress {
     let mut bytes = [0u8; 32];
-    bytes.copy_from_slice(base.as_slice());
+    bytes.copy_from_slice(base.as_bytes());
     // Flip the bit at position `bin`: bits before it still match `base`, so the
     // first differing bit (the proximity order) is exactly `bin`.
     bytes[(bin / 8) as usize] ^= 0x80 >> (bin % 8);
@@ -71,7 +71,7 @@ pub(crate) fn overlay_in_bin_with_slot(
     idx: u8,
 ) -> OverlayAddress {
     let mut bytes = [0u8; 32];
-    bytes.copy_from_slice(base.as_slice());
+    bytes.copy_from_slice(base.as_bytes());
     bytes[(bin / 8) as usize] ^= 0x80 >> (bin % 8);
     for i in 0..BIT_SUFFIX_LENGTH {
         let pos = bin as usize + 1 + i as usize;

--- a/docs/agents/rust-idiomatic.md
+++ b/docs/agents/rust-idiomatic.md
@@ -42,7 +42,7 @@ Order of preference when reaching for a derive: `thiserror` then `strum` then `d
 - Prefer enum dispatch (`AdmissionDecision`, `TopologyEvent`, `AdmissionRejection`) over `Box<dyn Trait>` for closed sets. Exhaustive `match` is the contract.
 - Use sealed traits (`mod private { pub trait Sealed {} }`) for extension points the workspace controls but third parties must not implement.
 - Push invariants into the type system with const generics where the dimension is known at compile time. The chunk-size const-generic plan in `docs/design/chunk-size-const-generic.md` is the model: a single `const BODY_SIZE: usize` flows from `ChunkTypeSet` through `AnyChunk` to `SwarmSpec`. Add new compile-time dimensions the same way; do not pass them as runtime `usize` fields.
-- Newtypes for protocol identifiers (`OverlayAddress`, `SwarmAddress`). Do not pass raw `[u8; 32]` across module boundaries.
+- Newtypes for protocol identifiers (`OverlayAddress`, `ChunkAddress`). Do not pass raw `[u8; 32]` across module boundaries.
 
 ### Module discipline
 


### PR DESCRIPTION
## What

Re-pins all seven `nectar-*` git dependencies in the root `Cargo.toml` (nectar-contracts, nectar-postage, nectar-postage-issuer, nectar-postage-usage, nectar-primitives, nectar-mantaray, nectar-swarms) from `ef89a5d` to `118b66b97305c8fbd6511c37acc4917e9b822bef`, the tip of nectar's in-flight s187/0.5.0 train (typed `ChunkAddress`/`BatchId`/`SocId` newtypes, the `SwarmAddress` -> `OverlayAddress` rename, and the `arbitrary` feature the fuzz harnesses need). The dependency comment is rewritten to describe this pin instead of the previous `main`-tracking rationale.

`cargo update` was run so `Cargo.lock` records `118b66b` for `nectar-contracts`, `nectar-postage`, `nectar-primitives` and `nectar-swarms`; the other three nectar crates are consumed only by the workspace-excluded `bin/swarm-demo`, whose own `Cargo.toml` pins were bumped separately.

`SwarmAddress` is swept to `OverlayAddress` workspace-wide (92 files changed): `crates/swarm/primitives/src/lib.rs` now re-exports `nectar_primitives::OverlayAddress` directly instead of defining a local `pub type OverlayAddress = SwarmAddress` alias, and every call site (signer.rs, redistribution, topology, hive, postage, net protocol codecs, node dispatch, test-utils, etc.) is updated to the new type names, including the split between `OverlayAddress` (peer/anchor addressing) and `ChunkAddress` (content addressing) where both were previously the same alias.

A follow-up fix commit corrects a broken doctest in `crates/swarm/redistribution/src/neighbourhood.rs`: the `SwarmAddress` -> `{OverlayAddress, ChunkAddress}` split had left the `canonical_neighbourhood` rustdoc example passing an `OverlayAddress` into the `ChunkAddress`-typed `addrs` iterator, which failed `cargo test --doc`. `near`/`far` are now typed as `ChunkAddress` and `anchor` stays `OverlayAddress`, matching the unit-test helper below it.

## Why

Closes #969

nectar's 0.5.0 train introduces distinct address newtypes instead of a single aliased `SwarmAddress`, and vertex's fuzz harnesses need the `arbitrary` feature that ships on that train tip. Re-pinning lets vertex build against the typed address world ahead of the train merging to nectar `main`.

## Testing

All commands were run inside `nix develop` (Rust 1.92.0, edition 2024) with `--config build.target-dir` pointed at the shared vertex target. The branch is a descendant of `origin/main` with two commits: the pin/sweep itself (`568b05c1`) and the doctest fix (`1d98d292`).

`cargo test --doc` initially failed with rustc E0271/E0277 in the `canonical_neighbourhood` doctest (exit 101) due to the address-type split described above; fixed and re-verified green.

## AI Assistance

AI Assistance: Claude Sonnet 5 (Anthropic) used for implementation, red-team review and gate verification of this change.
