### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
What

Bumps the locked `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock`. The change is two lines: the version and its checksum. No manifest constraint moves and no other dependency churn.

Why

`crossbeam-epoch` 0.9.18 is flagged by RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid), which the daily security-audit CI treats as a critical finding and fails on. The crate is not a direct dependency; it enters the graph transitively through `rayon` in `nectar-primitives`. Version 0.9.20 patches the advisory. Landing this first lets the fuzz-epic stack rebase onto a clean audit baseline.

Testing

`cargo update -p crossbeam-epoch --precise 0.9.20` produced the minimal lockfile delta. `cargo audit` locally returns exit 0 with the bump in place; the previously failing RUSTSEC-2026-0204 finding is gone (remaining entries are pre-existing informational warnings, not audit failures).

AI Assistance: Claude (Anthropic) used for the dependency analysis, the lockfile bump, and this PR description.