### PR TITLE
fix(fuzz): QA sweep - full matrix, seed guards, ffi panic fix

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,8 +61,31 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          - ffi_entry
+          - framing_decode
+          - handshake_decode
+          - handshake_roundtrip
+          - handshake_uvarint_differential
+          - headers_decode
+          - headers_roundtrip
+          - hive_decode
+          - identify_decode
+          - pricing_decode
+          - pricing_roundtrip
+          - pseudosettle_decode
+          - pseudosettle_roundtrip
+          - pullsync_bitvector
+          - pullsync_decode
+          - pullsync_roundtrip
           - pushsync_decode
           - pushsync_roundtrip
+          - retrieval_decode
+          - retrieval_roundtrip
+          - swap_decode
+          - swap_roundtrip
+          - swarm_peer_parse
+          - swarm_peer_roundtrip
+          - u256_wire
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -101,8 +124,31 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          - ffi_entry
+          - framing_decode
+          - handshake_decode
+          - handshake_roundtrip
+          - handshake_uvarint_differential
+          - headers_decode
+          - headers_roundtrip
+          - hive_decode
+          - identify_decode
+          - pricing_decode
+          - pricing_roundtrip
+          - pseudosettle_decode
+          - pseudosettle_roundtrip
+          - pullsync_bitvector
+          - pullsync_decode
+          - pullsync_roundtrip
           - pushsync_decode
           - pushsync_roundtrip
+          - retrieval_decode
+          - retrieval_roundtrip
+          - swap_decode
+          - swap_roundtrip
+          - swarm_peer_parse
+          - swarm_peer_roundtrip
+          - u256_wire
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/crates/ffi/proptest-regressions/api/logging.txt
+++ b/crates/ffi/proptest-regressions/api/logging.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2541b640cb98ad0fddca7959ab3c80001bd453a47f40abfbd7591ac7794dafc8 # shrinks to directive = "\u{2000}ਓ="

--- a/crates/ffi/src/api/logging.rs
+++ b/crates/ffi/src/api/logging.rs
@@ -209,7 +209,15 @@ pub fn init_logging(level: String, sink: StreamSink<LogLine>) -> Result<(), FfiE
 /// Parse an `EnvFilter` directive; an unparseable directive is a typed error,
 /// never a panic across the boundary.
 pub(crate) fn parse_filter(level: &str) -> Result<EnvFilter, FfiError> {
-    EnvFilter::try_new(level).map_err(|e| FfiError::Logging {
+    // The upstream directive parser slices the untrimmed directive with
+    // offsets from its trimmed form, which panics on leading whitespace
+    // before a multibyte character; trim each directive up front.
+    let trimmed = level
+        .split(',')
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(",");
+    EnvFilter::try_new(trimmed).map_err(|e| FfiError::Logging {
         reason: format!("invalid log filter {level:?}: {e}"),
     })
 }
@@ -279,6 +287,14 @@ mod tests {
     /// subscriber or a real `StreamSink`.
     struct CaptureSubscriber {
         out: std::sync::Arc<std::sync::Mutex<Option<LogLine>>>,
+    }
+
+    /// Leading whitespace before a multibyte character used to panic inside
+    /// the upstream directive parser; the pre-trim keeps the parse total.
+    #[test]
+    fn filter_parse_survives_whitespace_before_multibyte() {
+        let _ = parse_filter("\u{2000}\u{a13}=");
+        let _ = parse_filter("info, \u{a13}=debug");
     }
 
     mod proptests {

--- a/crates/ffi/src/fuzz.rs
+++ b/crates/ffi/src/fuzz.rs
@@ -119,6 +119,8 @@ fn check_valid_upload(u: &mut Unstructured<'_>) {
         if let Some(byte) = tampered.get_mut(idx) {
             *byte ^= 1 << bit;
         }
+        // Panic-freedom probe only: the flipped bit may land in any field of
+        // the fixed layout, so the parse outcome is unspecified either way.
         let _ = parse_stamp(&tampered);
     }
 

--- a/crates/net/codec/src/framed.rs
+++ b/crates/net/codec/src/framed.rs
@@ -106,6 +106,13 @@ mod tests {
                         "seed {name} must stay an error at cap {cap}"
                     );
                 }
+            } else {
+                // Edge seeds are boundary probes asserted by `check_framing`
+                // alone; anything else is a misnamed seed.
+                assert!(
+                    name.starts_with("edge-"),
+                    "seed {name} matches no known prefix"
+                );
             }
             replayed += 1;
         }

--- a/crates/net/codec/src/utils.rs
+++ b/crates/net/codec/src/utils.rs
@@ -131,6 +131,8 @@ mod tests {
                     decode_u256_be(&data).is_err(),
                     "seed {name} must stay an Err"
                 );
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/handshake/src/codec/mod.rs
+++ b/crates/swarm/net/handshake/src/codec/mod.rs
@@ -79,6 +79,8 @@ mod seed_replay {
                 assert!(ack.is_none(), "seed {name} must stay an ack Err");
             } else if name.starts_with("valid-synack-") {
                 assert!(synack.is_some(), "seed {name} must decode as a synack");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
 
             // The boundary seeds carry their frame size in the name; pin it

--- a/crates/swarm/net/headers/src/codec.rs
+++ b/crates/swarm/net/headers/src/codec.rs
@@ -87,6 +87,8 @@ mod tests {
                 fuzz::check_headers(wire);
             } else if name.starts_with("invalid-") {
                 assert!(headers.is_none(), "seed {name} must stay an Err");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/hive/src/protocol.rs
+++ b/crates/swarm/net/hive/src/protocol.rs
@@ -364,6 +364,8 @@ mod seed_replay {
                 assert!(raw_count > 0, "seed {name}");
             } else if name.starts_with("edge-peers-empty") {
                 assert_eq!(raw_count, 0, "seed {name}");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/identify/src/protocol.rs
+++ b/crates/swarm/net/identify/src/protocol.rs
@@ -261,6 +261,8 @@ mod seed_replay {
                 assert!(info.is_ok(), "seed {name} must convert");
             } else if name.starts_with("invalid-") {
                 assert!(info.is_err(), "seed {name} must stay an Err");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/pricing/src/codec.rs
+++ b/crates/swarm/net/pricing/src/codec.rs
@@ -127,6 +127,8 @@ mod tests {
                 assert!(announce.is_some(), "seed {name} must decode");
             } else if name.starts_with("invalid-") || name.starts_with("crash-") {
                 assert!(announce.is_none(), "seed {name} must stay an Err");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/pseudosettle/src/codec.rs
+++ b/crates/swarm/net/pseudosettle/src/codec.rs
@@ -185,6 +185,13 @@ mod tests {
             } else if name.starts_with("invalid-") || name.starts_with("crash-") {
                 assert!(payment.is_none(), "seed {name} must stay a payment Err");
                 assert!(ack.is_none(), "seed {name} must stay an ack Err");
+            } else {
+                // Edge seeds are boundary probes asserted for panic-freedom
+                // alone; anything else is a misnamed seed.
+                assert!(
+                    name.starts_with("edge-"),
+                    "seed {name} matches no known prefix"
+                );
             }
             replayed += 1;
         }

--- a/crates/swarm/net/pullsync/src/bitvector.rs
+++ b/crates/swarm/net/pullsync/src/bitvector.rs
@@ -211,6 +211,13 @@ mod tests {
                     matches!(outcome, Some(Err(_))),
                     "seed {name} must stay rejected"
                 );
+            } else {
+                // Edge seeds are boundary probes asserted for panic-freedom
+                // alone; anything else is a misnamed seed.
+                assert!(
+                    name.starts_with("edge-"),
+                    "seed {name} matches no known prefix"
+                );
             }
             replayed += 1;
         }

--- a/crates/swarm/net/pullsync/src/codec.rs
+++ b/crates/swarm/net/pullsync/src/codec.rs
@@ -454,6 +454,8 @@ mod tests {
                 assert!(delivery.is_some(), "seed {name} must decode as a delivery");
             } else if name.starts_with("invalid-delivery-") {
                 assert!(delivery.is_none(), "seed {name} must stay a delivery Err");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/pushsync/src/codec.rs
+++ b/crates/swarm/net/pushsync/src/codec.rs
@@ -291,6 +291,13 @@ mod tests {
                 assert!(receipt.is_some(), "seed {name} must decode as a receipt");
             } else if name.starts_with("invalid-receipt-") {
                 assert!(receipt.is_none(), "seed {name} must stay a receipt Err");
+            } else {
+                // Edge seeds are boundary probes asserted for panic-freedom
+                // alone; anything else is a misnamed seed.
+                assert!(
+                    name.starts_with("edge-"),
+                    "seed {name} matches no known prefix"
+                );
             }
             replayed += 1;
         }

--- a/crates/swarm/net/retrieval/src/codec.rs
+++ b/crates/swarm/net/retrieval/src/codec.rs
@@ -430,6 +430,8 @@ mod tests {
                 );
             } else if name.starts_with("invalid-delivery-") {
                 assert!(delivery.is_none(), "seed {name} must stay a delivery Err");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/swap/src/codec.rs
+++ b/crates/swarm/net/swap/src/codec.rs
@@ -145,6 +145,8 @@ mod tests {
                 assert!(cheque.is_none(), "seed {name} must stay a cheque Err");
             } else if name.starts_with("invalid-handshake-") {
                 assert!(handshake.is_none(), "seed {name} must stay a handshake Err");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/crates/swarm/net/swap/src/headers.rs
+++ b/crates/swarm/net/swap/src/headers.rs
@@ -78,6 +78,10 @@ impl SettlementHeaders {
 }
 
 /// Parse a U256 from big-endian bytes (with trimmed leading zeros).
+///
+/// Deliberately laxer than the canonical decode in `vertex-net-codec`:
+/// settlement headers tolerate leading-zero padding (which never changes the
+/// recovered value); only oversize input is refused.
 pub(crate) fn parse_u256_bytes(bytes: &Bytes) -> Option<U256> {
     if bytes.is_empty() {
         return Some(U256::ZERO);

--- a/crates/swarm/peers/peer/src/serde_multiaddr.rs
+++ b/crates/swarm/peers/peer/src/serde_multiaddr.rs
@@ -12,7 +12,10 @@ use libp2p::Multiaddr;
 use std::io::{Cursor, Read};
 
 /// Magic byte prefix for lists of multiple multiaddrs.
-/// Chosen because 0x99 is not a valid multiaddr protocol code.
+/// A conformant single multiaddr starts with an address protocol whose varint
+/// never begins with 0x99; the one collision (a lone /webrtc component, whose
+/// code varint-encodes as 0x99 0x02) is handled by the ambiguity guard the
+/// round-trip oracle consults.
 ///
 /// BEE-COMPAT(SWIP-148): see module docs.
 pub(crate) const MULTIADDR_LIST_PREFIX: u8 = 0x99;
@@ -232,6 +235,8 @@ mod tests {
                 }
             } else if name.starts_with("invalid-") {
                 assert!(decoded.is_err(), "seed {name} must stay an Err");
+            } else {
+                panic!("seed {name} matches no known prefix");
             }
             replayed += 1;
         }

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -63,8 +63,8 @@ invariant is *no panic, no OOM, no hang*:
 | `swap_decode` | the swap `EmitCheque` (the JSON cheque payload path: addresses, the bare-decimal payout across the full 256-bit range, the fixed 65-byte base64 signature) and `Handshake` deserialize + `from_proto` | the cheque JSON parse and the 20-byte beneficiary check never panic, and a decoded cheque stays stable across re-encode (the JSON is value-preserving, not byte-canonical) |
 
 The flat frames are fed raw `&[u8]` straight through the generated reader;
-the nested frames (the handshake `Ack`/`SynAck`, the pullsync `Offer`, the
-headers envelope) go through the real write then read then decode path with
+the nested frames (the handshake `Ack`/`SynAck`, the hive `Peers` batch, the
+pullsync `Offer`, the headers envelope) go through the real write then read then decode path with
 adversarial field content, so the domain decode sees hostile input while the
 reader stays on writer-produced bytes. The generated protobuf reader on raw bytes is
 upstream code and a separate nested-length soundness issue in

--- a/fuzz/fuzz_targets/headers_decode.rs
+++ b/fuzz/fuzz_targets/headers_decode.rs
@@ -7,7 +7,9 @@
 //! envelope goes through the real write then read path with adversarial
 //! entries (arbitrary keys and values, deliberately repeated keys), so the
 //! domain conversion sees hostile input while the reader stays on
-//! writer-produced bytes. The oracle pins the envelope semantics: the map
+//! writer-produced bytes. The envelope is not raw-fed pending the reported
+//! nested-length soundness issue in the upstream `quick-protobuf` reader
+//! (as in the handshake target). The oracle pins the envelope semantics: the map
 //! never exceeds the wire entry count, a duplicate key collapses to its
 //! last occurrence, and re-encoding the decoded value decodes back equal.
 //!

--- a/fuzz/fuzz_targets/hive_decode.rs
+++ b/fuzz/fuzz_targets/hive_decode.rs
@@ -6,7 +6,9 @@
 //! The flat record is fed raw bytes straight through the generated reader;
 //! the nested `Peers` batch goes through the real write then read path with
 //! adversarial field content, so the domain conversion sees hostile input
-//! while the reader stays on writer-produced bytes. The oracle adds the
+//! while the reader stays on writer-produced bytes. The batch is not raw-fed
+//! pending the reported nested-length soundness issue in the upstream
+//! `quick-protobuf` reader (as in the handshake target). The oracle adds the
 //! amplification bound: full-validation successes are proportional to wire
 //! bytes (a surviving record carries at least signature, overlay, and nonce),
 //! so one frame-capped message cannot amplify into unbounded work.

--- a/fuzz/fuzz_targets/pullsync_decode.rs
+++ b/fuzz/fuzz_targets/pullsync_decode.rs
@@ -8,7 +8,9 @@
 //! reconstruction on `Delivery`. The nested `Offer` frame goes through the
 //! real write then read path with adversarial descriptor field content, so
 //! the domain decode (the 32-byte descriptor field checks) sees hostile
-//! input while the reader stays on writer-produced bytes. Any returned `Err`
+//! input while the reader stays on writer-produced bytes. The `Offer` is not
+//! raw-fed pending the reported nested-length soundness issue in the upstream
+//! `quick-protobuf` reader (as in the handshake target). Any returned `Err`
 //! is success; the oracle is "no panic, no OOM, no hang".
 //!
 //! Seeds live in `fuzz/seeds/pullsync_decode/` and are replayed on stable by

--- a/justfile
+++ b/justfile
@@ -102,6 +102,20 @@ check-cone:
         exit 1
     fi
     echo "cone guard: default vertex is free of the swap and chain cone"
+    # The dev-only generator crates stay out of the bare client too: the
+    # `arbitrary` features across the workspace are test and fuzz surfaces.
+    default_dep_tree="$(cargo tree -p vertex -e normal)"
+    default_dev_leaked=""
+    for crate in arbitrary proptest; do
+        if grep -q " $crate v" <<<"$default_dep_tree"; then
+            default_dev_leaked="$default_dev_leaked $crate"
+        fi
+    done
+    if [ -n "$default_dev_leaked" ]; then
+        echo "cone guard: default vertex pulls the dev-only generator crates:$default_dev_leaked" >&2
+        exit 1
+    fi
+    echo "cone guard: default vertex is free of the dev-only generator crates"
 
 build:
     cargo build --all-features


### PR DESCRIPTION
## What

QA sweep fixes for the fuzz phase, stacked on `fuzz/968-ffi`:

- `ci(fuzz)`: consolidated the smoke and nightly matrices in `.github/workflows/fuzz.yml` from 2 targets to all 25 built targets (major, closes the #964 gap; count verified against `fuzz/fuzz_targets/` and `[[bin]]` entries - 25, not the claimed 23).
- `test(fuzz)`: added unmatched-seed-name rejection (terminal `else panic`, with an explicit edge-/crash- probe-only allow-list where such seeds exist) to all 14 name-branching `seed_replay_*` tests: `u256_wire`, `framing_decode`, `swarm_peer_parse`, `swap`, `handshake`, `identify`, `pushsync`, `pseudosettle`, `headers`, `retrieval`, `pricing`, `pullsync_bitvector`, `pullsync`, `hive` (minor, #965; `ffi_entry` exempt - it has no name branching).
- `fix(ffi)`: real panic found by the gate battery itself - the `vertex-ffi` `filter_parse_is_total` proptest hit an upstream `tracing-subscriber` 0.3.23 panic (`Directive::parse` slices the untrimmed directive with trimmed-string offsets, so leading whitespace before a multibyte char is a byte-boundary panic reachable from the FFI `init_logging` boundary); `parse_filter` in `crates/ffi/src/api/logging.rs` now pre-trims each comma-separated directive, the shrunken case is pinned in `crates/ffi/proptest-regressions/api/logging.txt`, and a deterministic unit test covers the whitespace-before-multibyte case.

## Why

Part of #958.

## Testing

Central battery:

- `cargo fmt --all -- --check`: PASS (after rustfmt rewrapped four new asserts).
- `nix develop cargo clippy --all-targets --all-features -D warnings`: PASS.
- Default-cone clippy after `cargo clean -p vertex -p vertex-swarm-builder -p vertex-swarm-node`: PASS.
- `cargo nextest run --all-features` over all 15 phase-delta crates (`vertex-ffi`, `vertex-net-codec`, the 10 swarm-net protocol crates, `vertex-swarm-peer`, `vertex-swarm-primitives`, `vertex-swarm-test-utils`): FAILED on first run - `vertex-ffi` `api::logging` `filter_parse_is_total` found a genuine upstream `tracing-subscriber` panic (char-boundary slice on a leading-whitespace multibyte directive, reachable from the FFI boundary); fixed in-branch (`parse_filter` pre-trim + pinned proptest regression + unit test), re-run 308/308 PASS.
- `wasm32-unknown-unknown` build `-p vertex-swarm-node -p vertex-swarm-peer-manager` (peers/peer changed): PASS.
- `just check-cone`: PASS, all six guards including the new bare-client generator guard.
- `actionlint` on `.github/workflows/fuzz.yml` (the one workflow in the delta): PASS.
- Commit-message sweep `origin/fuzz/969-nectar-pin-address-sweep..HEAD` (19 commits): no attribution strings (Co-Authored-By/Generated/Claude/robot footers), all clean.

## Stacked note

Merge bottom-up; full CI runs again after retarget.

## AI Assistance

This PR was prepared with assistance from Claude Sonnet 5 (Anthropic).

