### PR TITLE
fix(ci): unbreak the security audit lane and clear RUSTSEC-2026-0204

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,6 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # audit-check reuses a cargo-audit that is already on PATH and otherwise
+      # builds it from source under the pinned toolchain, where a transitive
+      # dependency needs a newer rustc than the workspace MSRV. Install the
+      # prebuilt binary so the audit never depends on the pinned toolchain.
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@1b57bc699ba2af96a06eb2a2a0d32b43a7d8e8b8  # v2
+        with:
+          tool: cargo-audit
+
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

Restores the Security Audit lane and clears the one vulnerability it reports.

The lane now installs the prebuilt `cargo-audit` binary with `taiki-e/install-action` before `rustsec/audit-check` runs. The action calls `findOrInstall('cargo-audit')`, so it reuses the binary on PATH and builds nothing.

The lockfile moves `crossbeam-epoch` from 0.9.18 to 0.9.20.

## Why

Every Security Audit run since 2026-07-15 has failed, so no advisory scan has covered the lockfile for two weeks. The action built `cargo-audit` from source under the toolchain that `rust-toolchain.toml` pins, and `cargo-audit 0.22.2` pulls `kstring 2.0.4`, which needs rustc 1.96 against a pinned 1.92. The job exited 101 before it scanned anything. The audit tool has no reason to build under the workspace MSRV, so a prebuilt binary removes the coupling and also drops the `aws-lc-sys` build from the lane.

With the lane running again, `cargo-audit` reports RUSTSEC-2026-0204 against `crossbeam-epoch 0.9.18`, where the `fmt::Pointer` impl for `Atomic` and `Shared` dereferences an invalid pointer. The patched line is `>=0.9.20`, the bump is a lockfile-only patch bump, and the crate MSRV stays at 1.61.

Closes #987
Closes #921

## Testing

- `cargo-audit audit` against the updated lockfile: no vulnerabilities, exit 0. Before the bump the same command reported `1 vulnerability found!`.
- `cargo check --workspace --all-features`: clean.
- The five remaining findings are informational warnings, which the audit check does not fail on: RUSTSEC-2026-0190 (`anyhow`, #590), RUSTSEC-2026-0186 (`memmap2`, #511), RUSTSEC-2026-0002 (`lru`), RUSTSEC-2024-0388 (`derivative`), and RUSTSEC-2023-0089 (`atomic-polyfill`). The scheduled run files an issue for each unreported finding, so expect tracker entries for the three untracked warnings on the next nightly.

## AI Assistance

AI Assistance: Claude Code used for the failure diagnosis, the workflow change, and the PR text.
