### PR TITLE
chore(toolchain): raise the pinned channel and MSRV to 1.94

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ The cone guards enforce this split: `just check-cone` and the `features` CI job.
 
 ## Build, test, lint
 
-- The edition is `2024` and the MSRV is `1.92`.
+- The edition is `2024` and the MSRV is `1.94`.
   Do not raise the MSRV without a bump to the workspace `Cargo.toml` in the same commit.
 - `cargo build --release -p vertex` builds the binary into `target/release/vertex`.
 - `cargo nextest run` runs the workspace unit and integration tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.94"
 authors = ["Nexum Contributors"]
 license = "AGPL-3.0-or-later"
 homepage = "https://vtx.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage. Multi-arch clean: buildx sets TARGETPLATFORM, so no architecture
 # is hard-coded here.
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.94-bookworm AS builder
 
 # Build dependencies for the vertex cone:
 # - protobuf-compiler: the gRPC server stack (prost/tonic) generates code from

--- a/bin/swarm-demo/Cargo.toml
+++ b/bin/swarm-demo/Cargo.toml
@@ -10,7 +10,7 @@
 name = "swarm-demo"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.94"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/crates/swarm/rpc/src/grpc/chunk.rs
+++ b/crates/swarm/rpc/src/grpc/chunk.rs
@@ -312,6 +312,7 @@ impl<P: ChunkClient> Chunk for ChunkService<P> {
 
     /// `has_chunk` is a local sync lookup, so each request maps straight to a
     /// response.
+    #[allow(clippy::result_large_err)]
     async fn has_chunks(
         &self,
         request: Request<Streaming<HasChunkRequest>>,

--- a/docs/agents/rust-idiomatic.md
+++ b/docs/agents/rust-idiomatic.md
@@ -4,7 +4,7 @@ This codebase targets a serious P2P client; treat it like `sigp/lighthouse` and 
 
 ### Toolchain and pre-commit
 
-- Edition `2024`, MSRV `1.92` (set in workspace `Cargo.toml`). Do not introduce features that raise MSRV without a workspace bump in the same commit.
+- Edition `2024`, MSRV `1.94` (set in workspace `Cargo.toml`). Do not introduce features that raise MSRV without a workspace bump in the same commit.
 - Before every commit, run `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`. Pushing unformatted code or clippy warnings is a hard fail; treat the justfile/CI as the source of truth, not your editor.
 - New crates inherit `[workspace.lints]` and use `#![cfg_attr(not(test), warn(unused_crate_dependencies))]` at the crate root (see `crates/tasks/src/lib.rs`).
 

--- a/docs/design/node-type-api.md
+++ b/docs/design/node-type-api.md
@@ -102,7 +102,7 @@ Runtime mechanism unchanged (the cleanest seam in the tree): `enable_storage(Arc
 
 Public seam: `StorerNodeBuilder::with_reserve(Arc<dyn ReserveStore>)` and `with_reserve_factory(...)`, the public face of `build_storer_reserve`. Default stays the admission-gated `DbReserve`.
 
-Single-injection: take one injected `Arc<dyn ReserveStore>` and derive the retrieval-serve view by arc-upcast at the call site, exactly as `launch.rs:597-598` already does (`Arc::clone(&reserve) as Arc<dyn SwarmLocalStore>` and `reserve as Arc<dyn ReserveStore>`). The arc-upcast works at MSRV 1.92. Do not add `ReserveStore::into_local_store`; an `Arc<Self>` receiver is incompatible with `auto_impl(&, Arc, Box)`. With the composite of section 2.5, the upcast reserve view becomes the `reserve` leg of `CacheThenReserve`.
+Single-injection: take one injected `Arc<dyn ReserveStore>` and derive the retrieval-serve view by arc-upcast at the call site, exactly as `launch.rs:597-598` already does (`Arc::clone(&reserve) as Arc<dyn SwarmLocalStore>` and `reserve as Arc<dyn ReserveStore>`). The arc-upcast works at the workspace MSRV. Do not add `ReserveStore::into_local_store`; an `Arc<Self>` receiver is incompatible with `auto_impl(&, Arc, Box)`. With the composite of section 2.5, the upcast reserve view becomes the `reserve` leg of `CacheThenReserve`.
 
 Ordering safety (`enable_forwarding` and `enable_storage` run before the event loop) is enforced structurally: `build()` calls them in order; the operator never calls them post-build.
 

--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1768100056,
-        "narHash": "sha256-2GWCrsoWIuEXrzdKR2DPnoDhA5SqW7CGNO+Absni054=",
+        "lastModified": 1785302874,
+        "narHash": "sha256-fpKEww3TJoo1ANHO2q918ei+ayOrp0YEQAO1DuBLOB4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "71a69fd633552550de7cb05cc149e4a99ff6f3b6",
+        "rev": "b99d48435bc3e34309d2c7ae6f7d45e77a156c38",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,13 @@
           inherit system overlays;
         };
 
-        # Rust stable toolchain with rust-analyzer and WASM target
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+        # rust-toolchain.toml pins the channel for CI and for rustup users, so the
+        # dev shell reads it from there rather than tracking latest stable.
+        rustChannel = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
+
+        # The pinned toolchain, plus the editor extensions the shell needs and the
+        # wasm target the client cone builds for.
+        rustToolchain = pkgs.rust-bin.stable.${rustChannel}.default.override {
           extensions = [ "rust-analyzer" "rust-src" "clippy" "rustfmt" ];
           targets = [ "wasm32-unknown-unknown" ];
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92"
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## What

Raises the pinned Rust channel and the MSRV to 1.94, and makes `rust-toolchain.toml` the one source of truth for every consumer of the toolchain.

- `rust-toolchain.toml` pins `channel = "1.94.1"`, the latest 1.94 patch release.
- The workspace `Cargo.toml` and `bin/swarm-demo/Cargo.toml` declare `rust-version = "1.94"`.
- `Dockerfile` builds on `rust:1.94-bookworm`.
- `flake.nix` reads the channel from `rust-toolchain.toml` through `builtins.fromTOML`, and the `rust-overlay` lock moves forward so 1.94.1 resolves.
- MSRV statements in `AGENTS.md`, `docs/agents/rust-idiomatic.md`, and `docs/design/node-type-api.md` follow. The design note now says "the workspace MSRV" instead of naming a version that ages.

One code change comes with the compiler: clippy 1.94 adds `result_large_err` to the `has_chunks` item closure in `vertex-swarm-rpc`, where `tonic::Status` is at least 176 bytes. The stream item type is tonic's `Result<_, Status>`, so the `Err` cannot be boxed without changing the gRPC surface, and the three helpers in the same file already carry the same allow.

## Why

Closes #991

The pin was 1.92, which released in December 2025.

More important, `flake.nix` pinned nothing. It took `pkgs.rust-bin.stable.latest.default`, so `nix develop` gave 1.92.0 only because the locked `rust-overlay` revision was from January 2026. That agreement with CI was a property of the lock date, not a pin, and the next `rust-overlay` update would have moved a contributor's shell off the CI channel without a word. Reading the channel from `rust-toolchain.toml` closes that gap: CI, rustup users, and the nix shell now resolve the same compiler.

1.94 is also the channel `nullislabs/nexum-runtime` pins, so the two repositories share one toolchain.

## Testing

All of the following on 1.94.1 in the updated dev shell (`rustc 1.94.1 (e408947bf 2026-03-25)`, `rustfmt 1.8.0-stable`, `clippy 0.1.94`):

- `cargo fmt --all -- --check`: clean, so rustfmt 1.8 needs no reformat.
- `cargo clippy --workspace --lib --all-features -- -D warnings`: clean.
- `cargo clippy --workspace --tests --benches --all-features -- -D warnings -A clippy::unwrap_used -A clippy::expect_used -A clippy::indexing_slicing`: clean. `result_large_err` was the only new finding in the workspace, in libs or tests.
- `cargo nextest run --workspace --all-features --no-tests=warn`: 1674 tests run, 1674 passed, 4 skipped.
- `cargo test --doc --workspace --all-features`: pass.
- The wasm cone builds for `wasm32-unknown-unknown`: `-p vertex-swarm-node`, the `wasm_client_core` test with `swap-chequebook indexeddb`, `-p vertex-chain --features provider --tests`, and the browser demo from `bin/swarm-demo`.

## Notes

The MSRV is the only channel anything verifies, because CI has no current-stable lane. That gap is recorded in #989.

This is independent of #990. On main today the jobs install stable and then build on the channel the file pins, and after #990 the composite action installs that channel directly. Either way this commit is what selects the compiler.

## AI Assistance

AI Assistance: Claude Code used for the version sweep, the flake change, and the verification run.
